### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ This library uses C++11 (or newer when available).
 |TBB|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |CUDA (nvcc)|:white_check_mark: <br/> (CUDA 8.0-10.0)|:white_check_mark: <br/> (CUDA 9.0-10.0)|:white_check_mark: <br/> (CUDA 9.2-10.0) |:x:|:white_check_mark: <br/> (CUDA 9.1-10.0)|:white_check_mark: <br/> (CUDA 10.0)|:white_check_mark: <br/> (CUDA 10.0)|:x:|:x:|
 |CUDA (clang) | - | - | - | - | :white_check_mark: <br/> (CUDA 8.0)| :white_check_mark: <br/> (CUDA 8.0)| :white_check_mark: <br/> (CUDA 8.0-9.0) | :white_check_mark: <br/> (CUDA 8.0-9.2) | - |
-|[HIP](doc/markdown/user/implementation/mapping/HIP.md) (nvcc)<br/>(HIP 1.5.8292+)|:white_check_mark: <br/> (nvcc 8.0-9.2)|:white_check_mark: <br/> (nvcc 9.0-9.2)|:white_check_mark: <br/> (nvcc 9.2)|:x:|:x:|:x:|:x:|:x:|:x:|
+|[HIP](doc/markdown/user/implementation/mapping/HIP.md) (nvcc)|:white_check_mark: <br/> (nvcc 8.0)|:x:|:x:|:x:|:x:|:x:|:x:|:x:|:x:|
+
+Other compilers or combinations marked with :x: in the table above may work but are not tested in CI and are therefore not explicitly supported.
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 =================================================================
 
 [![Travis CI Build Status](https://travis-ci.org/ComputationalRadiationPhysics/alpaka.svg?branch=develop)](https://travis-ci.org/ComputationalRadiationPhysics/alpaka)
-[![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/xjeyugcg1cb0662s/branch/develop?svg=true)](https://ci.appveyor.com/project/BenjaminW3/alpaka-vuiya/branch/develop)
+[![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/55gm6o3f2t9tixl4/branch/develop?svg=true)](https://ci.appveyor.com/project/BenjaminW3/alpaka-t7xmf/branch/develop)
 [![Language](https://img.shields.io/badge/language-C%2B%2B11-orange.svg)](https://isocpp.org/)
 [![Platforms](https://img.shields.io/badge/platform-linux%20%7C%20windows-lightgrey.svg)](https://github.com/ComputationalRadiationPhysics/alpaka)
 [![License](https://img.shields.io/badge/license-LGPLv3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0.de.html)


### PR DESCRIPTION
* Appveyor badge link was wrong #697
* We can not claim to support untested compilers (HIP). We can add this back if we really test this.