### PR TITLE
Enable check for TriviallyCopyable for CUDA and HIP backends

### DIFF
--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -165,6 +165,7 @@
 #include <alpaka/meta/IntegerSequence.hpp>
 #include <alpaka/meta/Integral.hpp>
 #include <alpaka/meta/IsStrictBase.hpp>
+#include <alpaka/meta/IsTriviallyCopyable.hpp>
 #include <alpaka/meta/Metafunctions.hpp>
 #include <alpaka/meta/NdLoop.hpp>
 #include <alpaka/meta/Set.hpp>

--- a/include/alpaka/kernel/TaskKernelGpuCudaRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuCudaRt.hpp
@@ -43,10 +43,10 @@
 #include <alpaka/core/Cuda.hpp>
 #include <alpaka/meta/ApplyTuple.hpp>
 #include <alpaka/meta/Metafunctions.hpp>
+#include <alpaka/meta/IsTriviallyCopyable.hpp>
 
 #include <stdexcept>
 #include <tuple>
-#include <type_traits>
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
     #include <iostream>
 #endif
@@ -139,6 +139,16 @@ namespace alpaka
             public workdiv::WorkDivMembers<TDim, TIdx>
         {
         public:
+            static_assert(meta::IsTriviallyCopyable<TKernelFnObj>::value,
+                "The given kernel function object has to fulfill is_trivially_copyable!");
+            static_assert(
+                meta::Conjunction<
+                    std::true_type,
+                    meta::IsTriviallyCopyable<
+                        TArgs>...
+                    >::value,
+                "The given arguments have to fulfill is_trivially_copyable!");
+
             //-----------------------------------------------------------------------------
             template<
                 typename TWorkDiv>

--- a/include/alpaka/kernel/TaskKernelGpuHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuHipRt.hpp
@@ -44,10 +44,10 @@
 #include <alpaka/core/Utility.hpp>
 #include <alpaka/meta/ApplyTuple.hpp>
 #include <alpaka/meta/Metafunctions.hpp>
+#include <alpaka/meta/IsTriviallyCopyable.hpp>
 
 #include <stdexcept>
 #include <tuple>
-#include <type_traits>
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
     #include <iostream>
 #endif
@@ -145,6 +145,16 @@ namespace alpaka
             public workdiv::WorkDivMembers<TDim, TIdx>
         {
         public:
+            static_assert(meta::IsTriviallyCopyable<TKernelFnObj>::value,
+                "The given kernel function object has to fulfill is_trivially_copyable!");
+            static_assert(
+                meta::Conjunction<
+                    std::true_type,
+                    meta::IsTriviallyCopyable<
+                        TArgs>...
+                    >::value,
+                "The given arguments have to fulfill is_trivially_copyable!");
+
             //-----------------------------------------------------------------------------
             //! Constructor.
             template<

--- a/include/alpaka/meta/IsTriviallyCopyable.hpp
+++ b/include/alpaka/meta/IsTriviallyCopyable.hpp
@@ -1,0 +1,51 @@
+/* Copyright 2019 Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/BoostPredef.hpp>
+#include <alpaka/core/Common.hpp>
+
+#include <type_traits>
+
+#if BOOST_LANG_CUDA
+#include <nvfunctional>
+#endif
+
+namespace alpaka
+{
+    namespace meta
+    {
+        template<
+            class T>
+        struct IsTriviallyCopyable
+            : std::integral_constant<bool,
+#if BOOST_LIB_STD_GNU
+                __has_trivial_copy(T)
+#else
+                std::is_trivially_copyable<T>::value
+#endif
+#if BOOST_LANG_CUDA && !BOOST_COMP_CLANG_CUDA
+                || __nv_is_extended_device_lambda_closure_type(T)
+                || __nv_is_extended_host_device_lambda_closure_type(T)
+#endif
+            >
+        {
+        };
+
+#if BOOST_LANG_CUDA
+        template<
+            class T>
+        struct IsTriviallyCopyable<nvstd::function<T>>
+            : std::integral_constant<bool, true>
+        {
+        };
+#endif
+    }
+}

--- a/test/common/include/alpaka/test/mem/view/Iterator.hpp
+++ b/test/common/include/alpaka/test/mem/view/Iterator.hpp
@@ -166,10 +166,10 @@ namespace alpaka
                         }
 
                     private:
-                        Elem * const m_nativePtr;
+                        Elem * m_nativePtr;
                         Idx m_currentIdx;
-                        vec::Vec<Dim, Idx> const m_extents;
-                        vec::Vec<Dim, Idx> const m_pitchBytes;
+                        vec::Vec<Dim, Idx> m_extents;
+                        vec::Vec<Dim, Idx> m_pitchBytes;
                     };
 #if BOOST_COMP_GNUC
     #pragma GCC diagnostic pop

--- a/test/unit/meta/src/IsTriviallyCopyableTest.cpp
+++ b/test/unit/meta/src/IsTriviallyCopyableTest.cpp
@@ -1,0 +1,96 @@
+/* Copyright 2019 Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <alpaka/meta/IsTriviallyCopyable.hpp>
+
+#include <alpaka/meta/ForEachType.hpp>
+
+#include <catch2/catch.hpp>
+
+#include <functional>
+#if BOOST_LANG_CUDA
+#include <nvfunctional>
+#endif
+
+struct A {
+    long long a;
+};
+
+struct B {
+    B(int x): b(x+2) {}
+    B(B const&) = default;
+    int b;
+};
+
+using TriviallyCopyableTypes = std::tuple<char, short, int, long, long long, float, double, A, B, int[], double[]/*, B[]*/, int const, A const/*, B const []*/
+#if BOOST_LANG_CUDA
+        ,nvstd::function<void(bool)>
+#endif
+    >;
+
+//-----------------------------------------------------------------------------
+struct TestTemplateTriviallyCopyable
+{
+    template< typename T >
+    void operator()()
+    {
+        constexpr bool IsTriviallyCopyableResult =
+            alpaka::meta::IsTriviallyCopyable<
+                T
+            >::value;
+
+        constexpr bool IsTriviallyCopyableReference =
+            true;
+
+        static_assert(
+            IsTriviallyCopyableReference == IsTriviallyCopyableResult,
+            "alpaka::meta::IsTriviallyCopyable failed!");
+    }
+};
+
+TEST_CASE( "isTriviallyCopyable", "[memView]")
+{
+    alpaka::meta::forEachType< TriviallyCopyableTypes >( TestTemplateTriviallyCopyable() );
+}
+
+struct C {
+    C(){}
+    C(C const&) {}
+};
+
+struct D {
+    virtual ~D() = default;
+};
+
+using NonTriviallyCopyableTypes = std::tuple<C, D, std::function<void(bool)>>;
+
+//-----------------------------------------------------------------------------
+struct TestTemplateNotTriviallyCopyable
+{
+    template< typename T >
+    void operator()()
+    {
+        constexpr bool IsTriviallyCopyableResult =
+            alpaka::meta::IsTriviallyCopyable<
+                T
+            >::value;
+
+        constexpr bool IsTriviallyCopyableReference =
+            false;
+
+        static_assert(
+            IsTriviallyCopyableReference == IsTriviallyCopyableResult,
+            "alpaka::meta::IsTriviallyCopyable failed!");
+    }
+};
+
+TEST_CASE( "isNotTriviallyCopyable", "[memView]")
+{
+    alpaka::meta::forEachType< NonTriviallyCopyableTypes >( TestTemplateNotTriviallyCopyable() );
+}


### PR DESCRIPTION
Fixes #703

Checks that all parameters and all kernel function objects are trivially copyable.
We do not yet enable it on CPU.