### PR TITLE
check for kernel void return type

### DIFF
--- a/include/alpaka/acc/AccGpuCudaRt.hpp
+++ b/include/alpaka/acc/AccGpuCudaRt.hpp
@@ -235,6 +235,34 @@ namespace alpaka
     }
     namespace kernel
     {
+        namespace detail
+        {
+            //#############################################################################
+            //! specialization of the TKernelFnObj return type evaluation
+            //
+            // It is not possible to determine the result type of a __device__ lambda for CUDA on the host side.
+            // https://github.com/ComputationalRadiationPhysics/alpaka/pull/695#issuecomment-446103194
+            // The executor ExecGpuCudaRt is therefore performing this check on device side.
+            template<
+                typename TDim,
+                typename TIdx>
+            struct CheckFnReturnType<
+                acc::AccGpuCudaRt<
+                    TDim,
+                    TIdx>>
+            {
+                template<
+                    typename TKernelFnObj,
+                    typename... TArgs>
+                void operator()(
+                    TKernelFnObj const &,
+                    TArgs const & ...)
+                {
+
+                }
+            };
+        }
+
         namespace traits
         {
             //#############################################################################

--- a/include/alpaka/acc/AccGpuHipRt.hpp
+++ b/include/alpaka/acc/AccGpuHipRt.hpp
@@ -237,6 +237,34 @@ namespace alpaka
     {
         namespace traits
         {
+            namespace detail
+            {
+                //#############################################################################
+                //! specialization of the TKernelFnObj return type evaluation
+                //
+                // It is not possible to determine the result type of a __device__ lambda for CUDA on the host side.
+                // https://github.com/ComputationalRadiationPhysics/alpaka/pull/695#issuecomment-446103194
+                // The executor ExecGpuHipRt is therefore performing this check on device side.
+                template<
+                    typename TDim,
+                    typename TIdx>
+                struct CheckFnReturnType<
+                    acc::AccGpuHipRt<
+                        TDim,
+                        TIdx>>
+                {
+                    template<
+                        typename TKernelFnObj,
+                        typename... TArgs>
+                    void operator()(
+                        TKernelFnObj const &,
+                        TArgs const & ...)
+                    {
+
+                    }
+                };
+            }
+
             //#############################################################################
             //! The GPU HIP accelerator executor type trait specialization.
             template<

--- a/include/alpaka/exec/ExecGpuCudaRt.hpp
+++ b/include/alpaka/exec/ExecGpuCudaRt.hpp
@@ -87,6 +87,11 @@ namespace alpaka
 #if BOOST_ARCH_PTX && (BOOST_ARCH_PTX < BOOST_VERSION_NUMBER(2, 0, 0))
     #error "Cuda device capability >= 2.0 is required!"
 #endif
+                    static_assert(
+                        std::is_same<typename std::result_of<
+                            TKernelFnObj(acc::AccGpuCudaRt<TDim, TIdx> const &, TArgs const & ...)>::type, void>::value,
+                        "The TKernelFnObj is required to return void!");
+
                     acc::AccGpuCudaRt<TDim, TIdx> acc(threadElemExtent);
 
                     kernelFnObj(

--- a/include/alpaka/exec/ExecGpuCudaRt.hpp
+++ b/include/alpaka/exec/ExecGpuCudaRt.hpp
@@ -87,11 +87,14 @@ namespace alpaka
 #if BOOST_ARCH_PTX && (BOOST_ARCH_PTX < BOOST_VERSION_NUMBER(2, 0, 0))
     #error "Cuda device capability >= 2.0 is required!"
 #endif
+
+// with clang it is not possible to query std::result_of for a pure device lambda created on the host side
+#if !(BOOST_COMP_CLANG_CUDA && BOOST_COMP_CLANG)
                     static_assert(
                         std::is_same<typename std::result_of<
                             TKernelFnObj(acc::AccGpuCudaRt<TDim, TIdx> const &, TArgs const & ...)>::type, void>::value,
                         "The TKernelFnObj is required to return void!");
-
+#endif
                     acc::AccGpuCudaRt<TDim, TIdx> acc(threadElemExtent);
 
                     kernelFnObj(

--- a/include/alpaka/exec/ExecGpuHipRt.hpp
+++ b/include/alpaka/exec/ExecGpuHipRt.hpp
@@ -88,6 +88,11 @@ namespace alpaka
 #if BOOST_ARCH_PTX && (BOOST_ARCH_PTX < BOOST_VERSION_NUMBER(2, 0, 0))
     #error "Cuda device capability >= 2.0 is required!"
 #endif
+                    static_assert(
+                        std::is_same<typename std::result_of<
+                            TKernelFnObj(acc::AccGpuCudaRt<TDim, TIdx> const &, TArgs const & ...)>::type, void>::value,
+                        "The TKernelFnObj is required to return void!");
+                    
                     acc::AccGpuHipRt<TDim, TIdx> acc(threadElemExtent);
 
                     kernelFnObj(


### PR DESCRIPTION
follow up of #695

- reenable the kernel return type evaluation if `ALPAKA_ACC_GPU_CUDA_ONLY_MODE` is used
- add on device return type evaluation for the accelerator `AccGpuCudaRt` and `AccGpuHipRt`
- disable return type check on device side if clang is the device compiler