### PR TITLE
Execute tests on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,12 +102,12 @@ matrix:
       os: windows
       dist: 1803-containers
       language: cpp
-      env:                                               CXX=cl.exe  CC=cl.exe                          CMAKE_BUILD_TYPE=Release                            ALPAKA_CI_BOOST_BRANCH=boost-1.65.1                            OMP_NUM_THREADS=4
+      env:                                               CXX=cl.exe  CC=cl.exe                          CMAKE_BUILD_TYPE=Release                            ALPAKA_CI_BOOST_BRANCH=boost-1.65.1                            OMP_NUM_THREADS=4 ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=OFF
     - name: MSVC-2017 Debug
       os: windows
       dist: 1803-containers
       language: cpp
-      env:                                               CXX=cl.exe  CC=cl.exe                          CMAKE_BUILD_TYPE=Debug                              ALPAKA_CI_BOOST_BRANCH=boost-1.65.1                            OMP_NUM_THREADS=4
+      env:                                               CXX=cl.exe  CC=cl.exe                          CMAKE_BUILD_TYPE=Debug                              ALPAKA_CI_BOOST_BRANCH=boost-1.65.1                            OMP_NUM_THREADS=4 ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=OFF
 
     ### Ubuntu
     ## native

--- a/script/travis/run.sh
+++ b/script/travis/run.sh
@@ -133,7 +133,4 @@ fi
 
 ./script/travis/run_build.sh
 
-if [ "$TRAVIS_OS_NAME" = "linux" ]
-then
-    if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./script/travis/run_tests.sh ;fi
-fi
+if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./script/travis/run_tests.sh ;fi

--- a/script/travis/run_build.sh
+++ b/script/travis/run_build.sh
@@ -75,8 +75,8 @@ then
     echo "OMP_NUM_THREADS=${OMP_NUM_THREADS}"
 fi
 
-mkdir --parents build/make/
-cd build/make/
+mkdir --parents build/
+cd build/
 
 if [ "$TRAVIS_OS_NAME" = "linux" ]
 then
@@ -107,7 +107,7 @@ cmake -G "${ALPAKA_CI_CMAKE_GENERATOR}" \
     "$(env2cmake ALPAKA_CUDA_NVCC_EXPT_EXTENDED_LAMBDA)" "$(env2cmake ALPAKA_CUDA_NVCC_EXPT_RELAXED_CONSTEXPR)" \
     "$(env2cmake ALPAKA_ACC_GPU_HIP_ENABLE)" "$(env2cmake ALPAKA_HIP_ARCH)" "$(env2cmake ALPAKA_HIP_PLATFORM)" \
     "$(env2cmake ALPAKA_DEBUG)" "$(env2cmake ALPAKA_CI)" "$(env2cmake ALPAKA_CI_ANALYSIS)" \
-    "../../"
+    ".."
 if [ "$TRAVIS_OS_NAME" = "linux" ]
 then
     make VERBOSE=1
@@ -116,4 +116,4 @@ then
     MSBuild.exe "alpakaAll.sln" -p:Configuration=${CMAKE_BUILD_TYPE} -maxcpucount:1 -verbosity:minimal
 fi
 
-cd ../../
+cd ..

--- a/script/travis/run_tests.sh
+++ b/script/travis/run_tests.sh
@@ -25,17 +25,17 @@ source ./script/travis/set.sh
 : ${ALPAKA_ACC_GPU_CUDA_ENABLE?"ALPAKA_ACC_GPU_CUDA_ENABLE must be specified"}
 : ${ALPAKA_ACC_GPU_HIP_ENABLE?"ALPAKA_ACC_GPU_HIP_ENABLE must be specified"}
 
-# https://stackoverflow.com/questions/42218009/how-to-tell-if-any-command-in-bash-script-failed-non-zero-exit-status
-err=0
-trap 'err=1' ERR
-
 if [ "${ALPAKA_ACC_GPU_CUDA_ENABLE}" == "OFF" ] && [ "${ALPAKA_ACC_GPU_HIP_ENABLE}" == "OFF" ];
 then
-    cd build/make/
+    cd build/
 
-    ctest -V
+    if [ "$TRAVIS_OS_NAME" = "linux" ]
+    then
+        ctest -V
+    elif [ "$TRAVIS_OS_NAME" = "windows" ]
+    then
+        ctest -V -C ${CMAKE_BUILD_TYPE}
+    fi
 
-    cd ../..
+    cd ..
 fi
-
-test $err = 0 # Return non-zero if any command failed


### PR DESCRIPTION
It works!
I had to disable the OpenMP 2.0 threads backend for the windows jobs because the tests are failing. I will investigate this separately.