### PR TITLE
Clean up usage of catch2

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,13 +39,16 @@ ENDIF()
 add_library(CatchMain CatchMain.cpp)
 # target_compile_features(CatchMain PUBLIC cxx_std_11)  # min C++11
 set_target_properties(CatchMain PROPERTIES
+    FOLDER "test"
     CXX_STANDARD 11  # exactly C++11
     CXX_EXTENSIONS OFF
     CXX_STANDARD_REQUIRED ON
     POSITION_INDEPENDENT_CODE ON
     WINDOWS_EXPORT_ALL_SYMBOLS ON
 )
-IF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+target_compile_definitions(CatchMain PUBLIC "CATCH_CONFIG_FAST_COMPILE")
+IF(MSVC)
+    target_compile_definitions(CatchMain PUBLIC "CATCH_CONFIG_WINDOWS_CRTDBG")
     target_compile_options(CatchMain PUBLIC "/bigobj")
 ENDIF()
 IF(ALPAKA_USE_INTERNAL_CATCH2)

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -33,7 +33,6 @@ append_recursive_files_add_to_src_group("${_COMMON_SOURCE_DIRECTORY}" "${_COMMON
 INCLUDE("${ALPAKA_ROOT}cmake/dev.cmake")
 LIST(APPEND _COMMON_COMPILE_OPTIONS_PUBLIC ${ALPAKA_DEV_COMPILE_OPTIONS})
 IF(MSVC)
-    LIST(APPEND _COMMON_COMPILE_OPTIONS_PUBLIC "/bigobj")
     LIST(APPEND _COMMON_COMPILE_OPTIONS_PUBLIC "/wd4996")   # This function or variable may be unsafe. Consider using <safe_version> instead.
 ENDIF()
 
@@ -41,11 +40,6 @@ IF(ALPAKA_ACC_GPU_CUDA_ENABLE OR (ALPAKA_ACC_GPU_HIP_ENABLE AND HIP_PLATFORM MAT
     # CUDA driver API is used by EventHostManualTrigger
     LIST(APPEND _COMMON_LINK_LIBRARIES_PUBLIC "general;${CUDA_CUDA_LIBRARY}")
     LIST(APPEND _COMMON_COMPILE_DEFINITIONS_PUBLIC "CUDA_API_PER_THREAD_DEFAULT_STREAM")
-ENDIF()
-
-IF(MSVC)
-    # Disable autolink feature of boost. We explicitly link the required libs.
-    LIST(APPEND _COMMON_COMPILE_DEFINITIONS_PUBLIC "BOOST_ALL_NO_LIB")
 ENDIF()
 
 ADD_LIBRARY(


### PR DESCRIPTION
* Move `CatchMain` project into the `test` folder (for IDEs supporting this)
* Add `CATCH_CONFIG_FAST_COMPILE` define in the hope that it makes the compilation faster
* Add `CATCH_CONFIG_WINDOWS_CRTDBG` define for memory leak checking under windows
* remove unnecessary/duplicate defines