### PR TITLE
Add additional checks for OpenMP executors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,12 +101,12 @@ matrix:
       os: windows
       dist: 1803-containers
       language: cpp
-      env:                                               CXX=cl.exe  CC=cl.exe                          CMAKE_BUILD_TYPE=Release                            ALPAKA_CI_BOOST_BRANCH=boost-1.65.1                            OMP_NUM_THREADS=4 ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=OFF
+      env:                                               CXX=cl.exe  CC=cl.exe                          CMAKE_BUILD_TYPE=Release                            ALPAKA_CI_BOOST_BRANCH=boost-1.65.1                            OMP_NUM_THREADS=4 ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=OFF ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=OFF
     - name: MSVC-2017 Debug
       os: windows
       dist: 1803-containers
       language: cpp
-      env:                                               CXX=cl.exe  CC=cl.exe                          CMAKE_BUILD_TYPE=Debug                              ALPAKA_CI_BOOST_BRANCH=boost-1.64.0                            OMP_NUM_THREADS=4 ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=OFF
+      env:                                               CXX=cl.exe  CC=cl.exe                          CMAKE_BUILD_TYPE=Debug                              ALPAKA_CI_BOOST_BRANCH=boost-1.64.0                            OMP_NUM_THREADS=4 ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=OFF ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=OFF
 
     ### Ubuntu
     ## native


### PR DESCRIPTION
This adds a check that `omp_in_parallel` is true when within a parallel region.
The OpenMP runtime does not necessarily create a parallel region when only one thread is required.

This shows that OpenMP on windows does not work at all right now.