### PR TITLE
HIP: `cpu::Copy`: fix missing suffix

### DIFF
--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -181,12 +181,13 @@ namespace alpaka
                             {
                                 meta::ndLoopIncIdx(
                                     extentWithoutInnermost,
-                                    [&](vec::Vec<DimMin1, ExtentSize> const & idx)
+                                    [&] ALPAKA_FN_HOST_ACC (vec::Vec<DimMin1, ExtentSize> const & idx)
                                     {
-                                        std::memcpy(
-                                            reinterpret_cast<void *>(this->m_dstMemNative + (vec::cast<DstSize>(idx) * dstPitchBytesWithoutOutmost).foldrAll(std::plus<DstSize>())),
-                                            reinterpret_cast<void const *>(this->m_srcMemNative + (vec::cast<SrcSize>(idx) * srcPitchBytesWithoutOutmost).foldrAll(std::plus<SrcSize>())),
-                                            static_cast<std::size_t>(this->m_extentWidthBytes));
+                                        auto dst = reinterpret_cast<uint8_t *>(this->m_dstMemNative + (vec::cast<DstSize>(idx) * dstPitchBytesWithoutOutmost).foldrAll(std::plus<DstSize>()));
+                                        auto const src = reinterpret_cast<uint8_t const *>(this->m_srcMemNative + (vec::cast<SrcSize>(idx) * srcPitchBytesWithoutOutmost).foldrAll(std::plus<SrcSize>()));
+                                        size_t const numBytes = static_cast<std::size_t>(this->m_extentWidthBytes);
+                                        for(size_t b = 0u; b < numBytes; ++b)
+                                            dst[b] = src[b];
                                     });
                             }
                         }


### PR DESCRIPTION
The helper funtion `meta::ndLoopIncIdx` is defined with the suffix `ALPAKA_FN_HOST_ACC`.
This requires that all functors used with the meta function have the same suffix if the HIP backend (on AMD Rocm) is used else the code will not compile.
For cuda we workround it with a proprietary pragma `__pragma(hd_warning_disable)`

This PR set the correct sffix and removes the non backend agnostic function `std::memcpy`.

cc-ing: @tdd11235813 