### PR TITLE
Rename createTaskExec to createTaskKernel

### DIFF
--- a/example/reduce/src/reduce.cpp
+++ b/example/reduce/src/reduce.cpp
@@ -89,8 +89,8 @@ T reduce(DevHost devHost, DevAcc devAcc, QueueAcc queue, uint64_t n, alpaka::mem
                       static_cast<Extent>(blockSize),
                       static_cast<Extent>(1) };
 
-    // execute first kernel
-    auto const exec1(alpaka::kernel::createTaskExec<Acc>(
+    // create main reduction kernel execution task
+    auto const taskKernelReduceMain(alpaka::kernel::createTaskKernel<Acc>(
         workDiv1,
         kernel1,
         alpaka::mem::view::getPtrNative(sourceDeviceMemory),
@@ -98,8 +98,8 @@ T reduce(DevHost devHost, DevAcc devAcc, QueueAcc queue, uint64_t n, alpaka::mem
         n,
         func));
 
-    // reduce the last block
-    auto const exec2(alpaka::kernel::createTaskExec<Acc>(
+    // create last block reduction kernel execution task
+    auto const taskKernelReduceLastBlock(alpaka::kernel::createTaskKernel<Acc>(
         workDiv2,
         kernel2,
         alpaka::mem::view::getPtrNative(destinationDeviceMemory),
@@ -107,9 +107,9 @@ T reduce(DevHost devHost, DevAcc devAcc, QueueAcc queue, uint64_t n, alpaka::mem
         blockCount,
         func));
 
-    // enqueue both kernels
-    alpaka::queue::enqueue(queue, exec1);
-    alpaka::queue::enqueue(queue, exec2);
+    // enqueue both kernel execution tasks
+    alpaka::queue::enqueue(queue, taskKernelReduceMain);
+    alpaka::queue::enqueue(queue, taskKernelReduceLastBlock);
 
     //  download result from GPU
     T resultGpuHost;

--- a/example/vectorAdd/src/main.cpp
+++ b/example/vectorAdd/src/main.cpp
@@ -157,8 +157,8 @@ auto main()
     // Instantiate the kernel function object
     VectorAddKernel kernel;
 
-    // Create the executor task.
-    auto const exec(alpaka::kernel::createTaskExec<Acc>(
+    // Create the kernel execution task.
+    auto const taskKernel(alpaka::kernel::createTaskKernel<Acc>(
         workDiv,
         kernel,
         alpaka::mem::view::getPtrNative(bufAccA),
@@ -167,7 +167,7 @@ auto main()
         numElements));
 
     // Enqueue the kernel executor
-    alpaka::queue::enqueue(queue, exec);
+    alpaka::queue::enqueue(queue, taskKernel);
 
     // Copy back the result
     alpaka::mem::view::copy(queue, bufHostC, bufAccC, extent);

--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -51,6 +51,7 @@
 #include <alpaka/dev/DevCpu.hpp>
 
 #include <memory>
+#include <thread>
 #include <typeinfo>
 
 namespace alpaka
@@ -262,14 +263,14 @@ namespace alpaka
                 typename TWorkDiv,
                 typename TKernelFnObj,
                 typename... TArgs>
-            struct CreateTaskExec<
+            struct CreateTaskKernel<
                 acc::AccCpuFibers<TDim, TIdx>,
                 TWorkDiv,
                 TKernelFnObj,
                 TArgs...>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto createTaskExec(
+                ALPAKA_FN_HOST static auto createTaskKernel(
                     TWorkDiv const & workDiv,
                     TKernelFnObj const & kernelFnObj,
                     TArgs const & ... args)

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -252,14 +252,14 @@ namespace alpaka
                 typename TWorkDiv,
                 typename TKernelFnObj,
                 typename... TArgs>
-            struct CreateTaskExec<
+            struct CreateTaskKernel<
                 acc::AccCpuOmp2Blocks<TDim, TIdx>,
                 TWorkDiv,
                 TKernelFnObj,
                 TArgs...>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto createTaskExec(
+                ALPAKA_FN_HOST static auto createTaskKernel(
                     TWorkDiv const & workDiv,
                     TKernelFnObj const & kernelFnObj,
                     TArgs const & ... args)

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -260,14 +260,14 @@ namespace alpaka
                 typename TWorkDiv,
                 typename TKernelFnObj,
                 typename... TArgs>
-            struct CreateTaskExec<
+            struct CreateTaskKernel<
                 acc::AccCpuOmp2Threads<TDim, TIdx>,
                 TWorkDiv,
                 TKernelFnObj,
                 TArgs...>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto createTaskExec(
+                ALPAKA_FN_HOST static auto createTaskKernel(
                     TWorkDiv const & workDiv,
                     TKernelFnObj const & kernelFnObj,
                     TArgs const & ... args)

--- a/include/alpaka/acc/AccCpuOmp4.hpp
+++ b/include/alpaka/acc/AccCpuOmp4.hpp
@@ -260,14 +260,14 @@ namespace alpaka
                 typename TWorkDiv,
                 typename TKernelFnObj,
                 typename... TArgs>
-            struct CreateTaskExec<
+            struct CreateTaskKernel<
                 acc::AccCpuOmp4<TDim, TIdx>,
                 TWorkDiv,
                 TKernelFnObj,
                 TArgs...>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto createTaskExec(
+                ALPAKA_FN_HOST static auto createTaskKernel(
                     TWorkDiv const & workDiv,
                     TKernelFnObj const & kernelFnObj,
                     TArgs const & ... args)

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -246,14 +246,14 @@ namespace alpaka
                 typename TWorkDiv,
                 typename TKernelFnObj,
                 typename... TArgs>
-            struct CreateTaskExec<
+            struct CreateTaskKernel<
                 acc::AccCpuSerial<TDim, TIdx>,
                 TWorkDiv,
                 TKernelFnObj,
                 TArgs...>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto createTaskExec(
+                ALPAKA_FN_HOST static auto createTaskKernel(
                     TWorkDiv const & workDiv,
                     TKernelFnObj const & kernelFnObj,
                     TArgs const & ... args)

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -245,14 +245,14 @@ namespace alpaka
                 typename TWorkDiv,
                 typename TKernelFnObj,
                 typename... TArgs>
-            struct CreateTaskExec<
+            struct CreateTaskKernel<
                 acc::AccCpuTbbBlocks<TDim, TIdx>,
                 TWorkDiv,
                 TKernelFnObj,
                 TArgs...>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto createTaskExec(
+                ALPAKA_FN_HOST static auto createTaskKernel(
                     TWorkDiv const & workDiv,
                     TKernelFnObj const & kernelFnObj,
                     TArgs const & ... args)

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -263,14 +263,14 @@ namespace alpaka
                 typename TWorkDiv,
                 typename TKernelFnObj,
                 typename... TArgs>
-            struct CreateTaskExec<
+            struct CreateTaskKernel<
                 acc::AccCpuThreads<TDim, TIdx>,
                 TWorkDiv,
                 TKernelFnObj,
                 TArgs...>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto createTaskExec(
+                ALPAKA_FN_HOST static auto createTaskKernel(
                     TWorkDiv const & workDiv,
                     TKernelFnObj const & kernelFnObj,
                     TArgs const & ... args)

--- a/include/alpaka/acc/AccGpuCudaRt.hpp
+++ b/include/alpaka/acc/AccGpuCudaRt.hpp
@@ -273,14 +273,14 @@ namespace alpaka
                 typename TWorkDiv,
                 typename TKernelFnObj,
                 typename... TArgs>
-            struct CreateTaskExec<
+            struct CreateTaskKernel<
                 acc::AccGpuCudaRt<TDim, TIdx>,
                 TWorkDiv,
                 TKernelFnObj,
                 TArgs...>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto createTaskExec(
+                ALPAKA_FN_HOST static auto createTaskKernel(
                     TWorkDiv const & workDiv,
                     TKernelFnObj const & kernelFnObj,
                     TArgs const & ... args)

--- a/include/alpaka/acc/AccGpuHipRt.hpp
+++ b/include/alpaka/acc/AccGpuHipRt.hpp
@@ -272,14 +272,14 @@ namespace alpaka
                 typename TWorkDiv,
                 typename TKernelFnObj,
                 typename... TArgs>
-            struct CreateTaskExec<
+            struct CreateTaskKernel<
                 acc::AccGpuHipRt<TDim, TIdx>,
                 TWorkDiv,
                 TKernelFnObj,
                 TArgs...>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto createTaskExec(
+                ALPAKA_FN_HOST static auto createTaskKernel(
                     TWorkDiv const & workDiv,
                     TKernelFnObj const & kernelFnObj,
                     TArgs const & ... args)

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -57,7 +57,7 @@ namespace alpaka
                 typename TKernelFnObj,
                 typename... TArgs/*,
                 typename TSfinae = void*/>
-            struct CreateTaskExec;
+            struct CreateTaskKernel;
 
             //#############################################################################
             //! The trait for getting the size of the block shared dynamic memory of a kernel.
@@ -188,18 +188,18 @@ namespace alpaka
             typename TWorkDiv,
             typename TKernelFnObj,
             typename... TArgs>
-        ALPAKA_FN_HOST auto createTaskExec(
+        ALPAKA_FN_HOST auto createTaskKernel(
             TWorkDiv const & workDiv,
             TKernelFnObj const & kernelFnObj,
             TArgs const & ... args)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
-            traits::CreateTaskExec<
+            traits::CreateTaskKernel<
                 TAcc,
                 TWorkDiv,
                 TKernelFnObj,
                 TArgs...>
-            ::createTaskExec(
+            ::createTaskKernel(
                 workDiv,
                 kernelFnObj,
                 args...))
@@ -222,11 +222,11 @@ namespace alpaka
                 << std::endl;
 #endif
             return
-                traits::CreateTaskExec<
+                traits::CreateTaskKernel<
                     TAcc,
                     TWorkDiv,
                     TKernelFnObj,
-                    TArgs...>::createTaskExec(
+                    TArgs...>::createTaskKernel(
                         workDiv,
                         kernelFnObj,
                         args...);
@@ -262,7 +262,7 @@ namespace alpaka
         {
             queue::enqueue(
                 queue,
-                kernel::createTaskExec<
+                kernel::createTaskKernel<
                     TAcc>(
                     workDiv,
                     kernelFnObj,

--- a/test/integ/axpy/src/axpy.cpp
+++ b/test/integ/axpy/src/axpy.cpp
@@ -192,8 +192,8 @@ void operator()()
     std::cout << std::endl;
 #endif
 
-    // Create the executor task.
-    auto const exec(alpaka::kernel::createTaskExec<TAcc>(
+    // Create the kernel execution task.
+    auto const taskKernel(alpaka::kernel::createTaskKernel<TAcc>(
         workDiv,
         kernel,
         numElements,
@@ -205,7 +205,7 @@ void operator()()
     std::cout << "Execution time: "
         << alpaka::test::integ::measureTaskRunTimeMs(
             queue,
-            exec)
+            taskKernel)
         << " ms"
         << std::endl;
 

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -388,8 +388,8 @@ void operator()()
     // Copy Host -> Acc.
     alpaka::mem::view::copy(queue, bufColorAcc, bufColorHost, extent);
 
-    // Create the executor task.
-    auto const exec(alpaka::kernel::createTaskExec<TAcc>(
+    // Create the kernel execution task.
+    auto const taskKernel(alpaka::kernel::createTaskKernel<TAcc>(
         workDiv,
         kernel,
         alpaka::mem::view::getPtrNative(bufColorAcc),
@@ -406,7 +406,7 @@ void operator()()
     std::cout << "Execution time: "
         << alpaka::test::integ::measureTaskRunTimeMs(
             queue,
-            exec)
+            taskKernel)
         << " ms"
         << std::endl;
 

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -314,8 +314,8 @@ void operator()()
     alpaka::wait::wait(queueHost);
     alpaka::mem::view::copy(queueAcc, bufCAcc, bufCHost, extentC);
 
-    // Create the executor task.
-    auto const exec(alpaka::kernel::createTaskExec<TAcc>(
+    // Create the kernel execution task.
+    auto const taskKernel(alpaka::kernel::createTaskKernel<TAcc>(
         workDiv,
         kernel,
         m,
@@ -334,7 +334,7 @@ void operator()()
     std::cout << "Execution time: "
         << alpaka::test::integ::measureTaskRunTimeMs(
             queueAcc,
-            exec)
+            taskKernel)
         << " ms"
         << std::endl;
 

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -203,8 +203,8 @@ void operator()()
     auto blockRetValsAcc(alpaka::mem::buf::alloc<Val, Idx>(devAcc, resultElemCount));
     alpaka::mem::view::copy(queue, blockRetValsAcc, blockRetVals, resultElemCount);
 
-    // Create the executor task.
-    auto const exec(alpaka::kernel::createTaskExec<TAcc>(
+    // Create the kernel execution task.
+    auto const taskKernel(alpaka::kernel::createTaskKernel<TAcc>(
         workDiv,
         kernel,
         alpaka::mem::view::getPtrNative(blockRetValsAcc)));
@@ -213,7 +213,7 @@ void operator()()
     std::cout << "Execution time: "
         << alpaka::test::integ::measureTaskRunTimeMs(
             queue,
-            exec)
+            taskKernel)
         << " ms"
         << std::endl;
 


### PR DESCRIPTION
This makes it more consistent to the other tasks (createTaskCopy, createTaskSet) because you now know what the task will be executing (a kernel) and not only that it will execute "something".
Furthermore, this prepares the renaming of the ExecXXX classes to TaskKernelXXX (#693).