### PR TITLE
Add test that parameters can be passed to a kernel by value and by const&

### DIFF
--- a/test/unit/kernel/src/KernelWithAdditionalParam.cpp
+++ b/test/unit/kernel/src/KernelWithAdditionalParam.cpp
@@ -15,9 +15,8 @@
 
 #include <catch2/catch.hpp>
 
-
 //#############################################################################
-class KernelWithAdditionalParam
+class KernelWithAdditionalParamByValue
 {
 public:
     //-----------------------------------------------------------------------------
@@ -27,7 +26,7 @@ public:
     ALPAKA_FN_ACC auto operator()(
         TAcc const & acc,
         bool * success,
-        std::int32_t const & val) const
+        std::int32_t val) const
     -> void
     {
         alpaka::ignore_unused(acc);
@@ -37,7 +36,7 @@ public:
 };
 
 //-----------------------------------------------------------------------------
-struct TestTemplate
+struct TestTemplateByValue
 {
 template< typename TAcc >
 void operator()()
@@ -48,13 +47,98 @@ void operator()()
     alpaka::test::KernelExecutionFixture<TAcc> fixture(
         alpaka::vec::Vec<Dim, Idx>::ones());
 
-    KernelWithAdditionalParam kernel;
+    KernelWithAdditionalParamByValue kernel;
 
     REQUIRE(fixture(kernel, 42));
-}
+  }
 };
 
-TEST_CASE( "KernelWithAdditionalParam", "[kernel]")
+TEST_CASE("KernelWithAdditionalParamByValue", "[kernel]")
 {
-    alpaka::meta::forEachType< alpaka::test::acc::TestAccs >( TestTemplate() );
+    alpaka::meta::forEachType<alpaka::test::acc::TestAccs>(TestTemplateByValue());
+}
+
+/*
+Passing a parameter by reference to non-const is not allowed.
+There is only one single copy of the parameters on the CPU accelerators.
+They are shared between all threads. Therefore they should not be mutated.
+
+//#############################################################################
+class KernelWithAdditionalParamByRef
+{
+public:
+    //-----------------------------------------------------------------------------
+    ALPAKA_NO_HOST_ACC_WARNING
+    template <typename TAcc>
+    ALPAKA_FN_ACC auto operator()(
+        TAcc const &acc,
+        bool *success,
+        std::int32_t &val) const -> void {
+        alpaka::ignore_unused(acc);
+
+        ALPAKA_CHECK(*success, 42 == val);
+    }
+};
+
+//-----------------------------------------------------------------------------
+struct TestTemplateByRef
+{
+    template <typename TAcc> void operator()()
+    {
+        using Dim = alpaka::dim::Dim<TAcc>;
+        using Idx = alpaka::idx::Idx<TAcc>;
+
+        alpaka::test::KernelExecutionFixture<TAcc> fixture(
+            alpaka::vec::Vec<Dim, Idx>::ones());
+
+        KernelWithAdditionalParamByRef kernel;
+
+        REQUIRE(fixture(kernel, 42));
+    }
+};
+
+TEST_CASE("KernelWithAdditionalParamByRef", "[kernel]")
+{
+    alpaka::meta::forEachType<alpaka::test::acc::TestAccs>(TestTemplateByRef());
+}*/
+
+//#############################################################################
+class KernelWithAdditionalParamByConstRef
+{
+public:
+    //-----------------------------------------------------------------------------
+    ALPAKA_NO_HOST_ACC_WARNING
+    template <typename TAcc>
+    ALPAKA_FN_ACC auto operator()(
+        TAcc const &acc,
+        bool *success,
+        std::int32_t const &val) const -> void
+    {
+        alpaka::ignore_unused(acc);
+
+        ALPAKA_CHECK(*success, 42 == val);
+    }
+};
+
+//-----------------------------------------------------------------------------
+struct TestTemplateByConstRef
+{
+    template <typename TAcc> void operator()()
+    {
+        using Dim = alpaka::dim::Dim<TAcc>;
+        using Idx = alpaka::idx::Idx<TAcc>;
+
+        alpaka::test::KernelExecutionFixture<TAcc> fixture(
+            alpaka::vec::Vec<Dim, Idx>::ones());
+
+        KernelWithAdditionalParamByConstRef kernel;
+
+        REQUIRE(fixture(kernel, 42));
+    }
+};
+
+TEST_CASE("KernelWithAdditionalParamByConstRef", "[kernel]")
+{
+    alpaka::meta::forEachType<alpaka::test::acc::TestAccs>(
+        TestTemplateByConstRef());
 }


### PR DESCRIPTION
Passing values by non-const reference is not allowed.

This does not change anything but it adds explicit tests describing what should be working.