### PR TITLE
Add Headers for standalone usage without CMake

### DIFF
--- a/include/alpaka/standalone/CpuFibers.hpp
+++ b/include/alpaka/standalone/CpuFibers.hpp
@@ -1,0 +1,14 @@
+/* Copyright 2019 Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#ifndef ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLED
+    #define ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLED
+#endif

--- a/include/alpaka/standalone/CpuOmp2Blocks.hpp
+++ b/include/alpaka/standalone/CpuOmp2Blocks.hpp
@@ -1,0 +1,14 @@
+/* Copyright 2019 Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#ifndef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+    #define ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#endif

--- a/include/alpaka/standalone/CpuOmp2Threads.hpp
+++ b/include/alpaka/standalone/CpuOmp2Threads.hpp
@@ -1,0 +1,14 @@
+/* Copyright 2019 Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#ifndef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+    #define ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+#endif

--- a/include/alpaka/standalone/CpuOmp4.hpp
+++ b/include/alpaka/standalone/CpuOmp4.hpp
@@ -1,0 +1,14 @@
+/* Copyright 2019 Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#ifndef ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+    #define ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+#endif

--- a/include/alpaka/standalone/CpuSerial.hpp
+++ b/include/alpaka/standalone/CpuSerial.hpp
@@ -1,0 +1,14 @@
+/* Copyright 2019 Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#ifndef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    #define ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+#endif

--- a/include/alpaka/standalone/CpuTbbBlocks.hpp
+++ b/include/alpaka/standalone/CpuTbbBlocks.hpp
@@ -1,0 +1,14 @@
+/* Copyright 2019 Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#ifndef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+    #define ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+#endif

--- a/include/alpaka/standalone/CpuThreads.hpp
+++ b/include/alpaka/standalone/CpuThreads.hpp
@@ -1,0 +1,14 @@
+/* Copyright 2019 Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+ 
+#pragma once
+
+#ifndef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
+    #define ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
+#endif

--- a/include/alpaka/standalone/GpuCudaRt.hpp
+++ b/include/alpaka/standalone/GpuCudaRt.hpp
@@ -1,0 +1,14 @@
+/* Copyright 2019 Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#ifndef ALPAKA_ACC_GPU_CUDA_ENABLED
+    #define ALPAKA_ACC_GPU_CUDA_ENABLED
+#endif

--- a/include/alpaka/standalone/GpuHipRt.hpp
+++ b/include/alpaka/standalone/GpuHipRt.hpp
@@ -1,0 +1,14 @@
+/* Copyright 2019 Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#ifndef ALPAKA_ACC_GPU_HIP_ENABLED
+    #define ALPAKA_ACC_GPU_HIP_ENABLED
+#endif


### PR DESCRIPTION
Implements standalone headers for #601

Please vote for your favorite:

Folder:
 * `backend`
 * ...

File names:
 * `BackendCpuThreads` (would be consistent with all other classes as they use the folder name as the prefix)
 * `EnableCpuThreads` (might be more natural language)
 * `CpuThreads` 

The defines themselves are already somehow inconsistemt as the include `ACC` but they do not only enable the compilation of an accelerator but a complete backend consisting of accelerator+kernel-execution-task+all other deps.