### PR TITLE
Improve clang-format support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ append_recursive_files_add_to_src_group("${_ALPAKA_ROOT_DIR}/docs/markdown" "${_
 set_source_files_properties(${_ALPAKA_FILES_DOC} PROPERTIES HEADER_FILE_ONLY TRUE)
 
 append_recursive_files_add_to_src_group("${_ALPAKA_ROOT_DIR}/.github" "${_ALPAKA_ROOT_DIR}" "yml" _ALPAKA_FILES_OTHER)
-list(APPEND _ALPAKA_FILES_OTHER "${_ALPAKA_ROOT_DIR}/.gitignore" "${_ALPAKA_ROOT_DIR}/.zenodo.json" "${_ALPAKA_ROOT_DIR}/LICENSE" "${_ALPAKA_ROOT_DIR}/README.md")
+list(APPEND _ALPAKA_FILES_OTHER "${_ALPAKA_ROOT_DIR}/.clang-format" "${_ALPAKA_ROOT_DIR}/.gitignore" "${_ALPAKA_ROOT_DIR}/.zenodo.json" "${_ALPAKA_ROOT_DIR}/LICENSE" "${_ALPAKA_ROOT_DIR}/README.md")
 set_source_files_properties(${_ALPAKA_FILES_OTHER} PROPERTIES HEADER_FILE_ONLY TRUE)
 
 if(TARGET alpaka)

--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ consider citing us accordingly in your derived work and publications:
 }
 ```
 
+Contributing
+------------
+
+Rules for contributions can be found in [CONTRIBUTING.md](CONTRIBUTING.md)
 
 Authors
 -------

--- a/thirdParty/.clang-format
+++ b/thirdParty/.clang-format
@@ -1,0 +1,4 @@
+---
+DisableFormat: true
+SortIncludes: false
+...


### PR DESCRIPTION
~This PR adds multiple things:~
* ~a `.clang-format` style that matches the current alpaka style as good as I was able to. We can easily change it later.~
* ~a CMake target `clang-format` for applying the `.clang-format` settings on the whole codebase (files in `include`, `test` and `example` folders with `hpp|h|cpp|c` extensions;  it does not format the `thirdParty` or other folders in the project.)~
* ~a CMake target `clang-format-check` which checks if the codebase is correctly formatted~
* ~a `CONTRIBUTING.md` file stating that clang-format is required for formatting the code. We can extend the file with other topics later.~

~Furthermore, the following things have been done:~
* ~the whole codebase was formatted~
* ~the CI will check that the code is correctly formatted, else the build will fail~

~On Windows the files to be formatted are not collected at configure-time because the number of files leads to command line length problems on Windows. Therefore the directories are iterated at runtime of the target. On linux files are collected at configure time.
CMake prints out a warning when the clang-format version is not 10.0 because this is the version enforced by CI.~

Improvements to the existing clang-format usage.