### PR TITLE
Fixes name conflicts in alpaka math functions.

### DIFF
--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto abs(
-                    AbsCudaBuiltIn const & abs,
+                    AbsCudaBuiltIn const & abs_ctx,
                     TArg const & arg)
                 -> decltype(::abs(arg))
                 {
-                    alpaka::ignore_unused(abs);
+                    alpaka::ignore_unused(abs_ctx);
                     return ::abs(arg);
                 }
             };

--- a/include/alpaka/math/abs/AbsHipBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsHipBuiltIn.hpp
@@ -58,11 +58,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto abs(
-                    AbsHipBuiltIn const & /*abs*/,
+                    AbsHipBuiltIn const & abs_ctx,
                     TArg const & arg)
                 -> decltype(::abs(arg))
                 {
-                    //boost::ignore_unused(abs);
+                    alpaka::ignore_unused(abs_ctx);
                     return ::abs(arg);
                 }
             };

--- a/include/alpaka/math/abs/AbsStdLib.hpp
+++ b/include/alpaka/math/abs/AbsStdLib.hpp
@@ -44,11 +44,11 @@ namespace alpaka
                     && std::is_signed<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto abs(
-                    AbsStdLib const & abs,
+                    AbsStdLib const & abs_ctx,
                     TArg const & arg)
                 -> decltype(std::abs(arg))
                 {
-                    alpaka::ignore_unused(abs);
+                    alpaka::ignore_unused(abs_ctx);
                     return std::abs(arg);
                 }
             };

--- a/include/alpaka/math/abs/Traits.hpp
+++ b/include/alpaka/math/abs/Traits.hpp
@@ -40,14 +40,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Abs.
         //! \tparam TArg The arg type.
-        //! \param abs The object specializing Abs.
+        //! \param abs_ctx The object specializing Abs.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto abs(
-            T const & abs,
+            T const & abs_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -55,7 +55,7 @@ namespace alpaka
                 T,
                 TArg>
             ::abs(
-                abs,
+                abs_ctx,
                 arg))
 #endif
         {
@@ -64,7 +64,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::abs(
-                    abs,
+                    abs_ctx,
                     arg);
         }
 
@@ -88,19 +88,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto abs(
-                    T const & abs,
+                    T const & abs_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::abs(
-                        static_cast<typename T::AbsBase const &>(abs),
+                        static_cast<typename T::AbsBase const &>(abs_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::abs(
-                            static_cast<typename T::AbsBase const &>(abs),
+                            static_cast<typename T::AbsBase const &>(abs_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
@@ -51,11 +51,11 @@ namespace alpaka
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 __device__ static auto acos(
-                    AcosCudaBuiltIn const & acos,
+                    AcosCudaBuiltIn const & acos_ctx,
                     TArg const & arg)
                 -> decltype(::acos(arg))
                 {
-                    alpaka::ignore_unused(acos);
+                    alpaka::ignore_unused(acos_ctx);
                     return ::acos(arg);
                 }
             };

--- a/include/alpaka/math/acos/AcosHipBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosHipBuiltIn.hpp
@@ -59,11 +59,11 @@ namespace alpaka
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 __device__ static auto acos(
-                    AcosHipBuiltIn const & /*acos*/,
+                    AcosHipBuiltIn const & acos_ctx,
                     TArg const & arg)
                 -> decltype(::acos(arg))
                 {
-                    //boost::ignore_unused(acos);
+                    alpaka::ignore_unused(acos_ctx);
                     return ::acos(arg);
                 }
             };

--- a/include/alpaka/math/acos/AcosStdLib.hpp
+++ b/include/alpaka/math/acos/AcosStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto acos(
-                    AcosStdLib const & acos,
+                    AcosStdLib const & acos_ctx,
                     TArg const & arg)
                 -> decltype(std::acos(arg))
                 {
-                    alpaka::ignore_unused(acos);
+                    alpaka::ignore_unused(acos_ctx);
                     return std::acos(arg);
                 }
             };

--- a/include/alpaka/math/acos/Traits.hpp
+++ b/include/alpaka/math/acos/Traits.hpp
@@ -37,14 +37,14 @@ namespace alpaka
         //! Computes the principal value of the arc cosine.
         //!
         //! \tparam TArg The arg type.
-        //! \param acos The object specializing Acos.
+        //! \param acos_ctx The object specializing Acos.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto acos(
-            T const & acos,
+            T const & acos_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -52,7 +52,7 @@ namespace alpaka
                 T,
                 TArg>
             ::acos(
-                acos,
+                acos_ctx,
                 arg))
 #endif
         {
@@ -61,7 +61,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::acos(
-                    acos,
+                    acos_ctx,
                     arg);
         }
 
@@ -85,19 +85,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto acos(
-                    T const & acos,
+                    T const & acos_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::acos(
-                        static_cast<typename T::AcosBase const &>(acos),
+                        static_cast<typename T::AcosBase const &>(acos_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::acos(
-                            static_cast<typename T::AcosBase const &>(acos),
+                            static_cast<typename T::AcosBase const &>(acos_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto asin(
-                    AsinCudaBuiltIn const & asin,
+                    AsinCudaBuiltIn const & asin_ctx,
                     TArg const & arg)
                 -> decltype(::asin(arg))
                 {
-                    alpaka::ignore_unused(asin);
+                    alpaka::ignore_unused(asin_ctx);
                     return ::asin(arg);
                 }
             };

--- a/include/alpaka/math/asin/AsinHipBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinHipBuiltIn.hpp
@@ -58,11 +58,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto asin(
-                    AsinHipBuiltIn const & /*asin*/,
+                    AsinHipBuiltIn const & asin_ctx,
                     TArg const & arg)
                 -> decltype(::asin(arg))
                 {
-                    //boost::ignore_unused(asin);
+                    alpaka::ignore_unused(asin_ctx);
                     return ::asin(arg);
                 }
             };

--- a/include/alpaka/math/asin/AsinStdLib.hpp
+++ b/include/alpaka/math/asin/AsinStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto asin(
-                    AsinStdLib const & asin,
+                    AsinStdLib const & asin_ctx,
                     TArg const & arg)
                 -> decltype(std::asin(arg))
                 {
-                    alpaka::ignore_unused(asin);
+                    alpaka::ignore_unused(asin_ctx);
                     return std::asin(arg);
                 }
             };

--- a/include/alpaka/math/asin/Traits.hpp
+++ b/include/alpaka/math/asin/Traits.hpp
@@ -37,14 +37,14 @@ namespace alpaka
         //! Computes the principal value of the arc sine.
         //!
         //! \tparam TArg The arg type.
-        //! \param asin The object specializing Asin.
+        //! \param asin_ctx The object specializing Asin.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto asin(
-            T const & asin,
+            T const & asin_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -52,7 +52,7 @@ namespace alpaka
                 T,
                 TArg>
             ::asin(
-                asin,
+                asin_ctx,
                 arg))
 #endif
         {
@@ -61,7 +61,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::asin(
-                    asin,
+                    asin_ctx,
                     arg);
         }
 
@@ -85,19 +85,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto asin(
-                    T const & asin,
+                    T const & asin_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::asin(
-                        static_cast<typename T::AsinBase const &>(asin),
+                        static_cast<typename T::AsinBase const &>(asin_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::asin(
-                            static_cast<typename T::AsinBase const &>(asin),
+                            static_cast<typename T::AsinBase const &>(asin_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto atan(
-                    AtanCudaBuiltIn const & atan,
+                    AtanCudaBuiltIn const & atan_ctx,
                     TArg const & arg)
                 -> decltype(::atan(arg))
                 {
-                    alpaka::ignore_unused(atan);
+                    alpaka::ignore_unused(atan_ctx);
                     return ::atan(arg);
                 }
             };

--- a/include/alpaka/math/atan/AtanHipBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanHipBuiltIn.hpp
@@ -58,11 +58,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto atan(
-                    AtanHipBuiltIn const & /*atan*/,
+                    AtanHipBuiltIn const & atan_ctx,
                     TArg const & arg)
                 -> decltype(::atan(arg))
                 {
-                    //boost::ignore_unused(atan);
+                    alpaka::ignore_unused(atan_ctx);
                     return ::atan(arg);
                 }
             };

--- a/include/alpaka/math/atan/AtanStdLib.hpp
+++ b/include/alpaka/math/atan/AtanStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto atan(
-                    AtanStdLib const & atan,
+                    AtanStdLib const & atan_ctx,
                     TArg const & arg)
                 -> decltype(std::atan(arg))
                 {
-                    alpaka::ignore_unused(atan);
+                    alpaka::ignore_unused(atan_ctx);
                     return std::atan(arg);
                 }
             };

--- a/include/alpaka/math/atan/Traits.hpp
+++ b/include/alpaka/math/atan/Traits.hpp
@@ -37,14 +37,14 @@ namespace alpaka
         //! Computes the principal value of the arc tangent.
         //!
         //! \tparam TArg The arg type.
-        //! \param atan The object specializing Atan.
+        //! \param atan_ctx The object specializing Atan.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto atan(
-            T const & atan,
+            T const & atan_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -52,7 +52,7 @@ namespace alpaka
                 T,
                 TArg>
             ::atan(
-                atan,
+                atan_ctx,
                 arg))
 #endif
         {
@@ -61,7 +61,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::atan(
-                    atan,
+                    atan_ctx,
                     arg);
         }
 
@@ -85,19 +85,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto atan(
-                    T const & atan,
+                    T const & atan_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::atan(
-                        static_cast<typename T::AtanBase const &>(atan),
+                        static_cast<typename T::AtanBase const &>(atan_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::atan(
-                            static_cast<typename T::AtanBase const &>(atan),
+                            static_cast<typename T::AtanBase const &>(atan_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
@@ -53,12 +53,12 @@ namespace alpaka
                     && std::is_floating_point<Tx>::value>::type>
             {
                 __device__ static auto atan2(
-                    Atan2CudaBuiltIn const & atan2,
+                    Atan2CudaBuiltIn const & atan2_ctx,
                     Ty const & y,
                     Tx const & x)
                 -> decltype(::atan2(y, x))
                 {
-                    alpaka::ignore_unused(atan2);
+                    alpaka::ignore_unused(atan2_ctx);
                     return ::atan2(y, x);
                 }
             };

--- a/include/alpaka/math/atan2/Atan2HipBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2HipBuiltIn.hpp
@@ -62,12 +62,12 @@ namespace alpaka
                     && std::is_floating_point<Tx>::value>::type>
             {
                 __device__ static auto atan2(
-                    Atan2HipBuiltIn const & /*abs*/,
+                    Atan2HipBuiltIn const & atan2_ctx,
                     Ty const & y,
                     Tx const & x)
                 -> decltype(::atan2(y, x))
                 {
-                    //boost::ignore_unused(abs);
+                    alpaka::ignore_unused(atan2_ctx);
                     return ::atan2(y, x);
                 }
             };

--- a/include/alpaka/math/atan2/Traits.hpp
+++ b/include/alpaka/math/atan2/Traits.hpp
@@ -40,7 +40,7 @@ namespace alpaka
         //! \tparam T The type of the object specializing Atan2.
         //! \tparam Ty The y arg type.
         //! \tparam Tx The x arg type.
-        //! \param atan2 The object specializing Atan2.
+        //! \param atan2_ctx The object specializing Atan2.
         //! \param y The y arg.
         //! \param x The x arg.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -49,7 +49,7 @@ namespace alpaka
             typename Ty,
             typename Tx>
         ALPAKA_FN_HOST_ACC auto atan2(
-            T const & atan2,
+            T const & atan2_ctx,
             Ty const & y,
             Tx const & x)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
@@ -59,7 +59,7 @@ namespace alpaka
                 Ty,
                 Tx>
             ::atan2(
-                atan2,
+                atan2_ctx,
                 y,
                 x))
 #endif
@@ -70,7 +70,7 @@ namespace alpaka
                     Ty,
                     Tx>
                 ::atan2(
-                    atan2,
+                    atan2_ctx,
                     y,
                     x);
         }
@@ -97,13 +97,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto atan2(
-                    T const & atan2,
+                    T const & atan2_ctx,
                     Ty const & y,
                     Tx const & x)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::atan2(
-                        static_cast<typename T::Atan2Base const &>(atan2),
+                        static_cast<typename T::Atan2Base const &>(atan2_ctx),
                         y,
                         x))
 #endif
@@ -111,7 +111,7 @@ namespace alpaka
                     // Delegate the call to the base class.
                     return
                         math::atan2(
-                            static_cast<typename T::Atan2Base const &>(atan2),
+                            static_cast<typename T::Atan2Base const &>(atan2_ctx),
                             y,
                             x);
                 }

--- a/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
@@ -49,12 +49,12 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 __device__ static auto cbrt(
-                    CbrtCudaBuiltIn const & cbrt,
+                    CbrtCudaBuiltIn const & cbrt_ctx,
                     TArg const & arg)
-                -> decltype(std::cbrt(arg))
+                -> decltype(::cbrt(arg))
                 {
-                    alpaka::ignore_unused(cbrt);
-                    return std::cbrt(arg);
+                    alpaka::ignore_unused(cbrt_ctx);
+                    return ::cbrt(arg);
                 }
             };
         }

--- a/include/alpaka/math/cbrt/CbrtHipBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtHipBuiltIn.hpp
@@ -59,12 +59,12 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 __device__ static auto cbrt(
-                    CbrtHipBuiltIn const & /*cbrt*/,
+                    CbrtHipBuiltIn const & cbrt_ctx,
                     TArg const & arg)
-                -> decltype(std::cbrt(arg))
+                -> decltype(::cbrt(arg))
                 {
-                    //boost::ignore_unused(cbrt);
-                    return std::cbrt(arg);
+                    alpaka::ignore_unused(cbrt_ctx);
+                    return ::cbrt(arg);
                 }
             };
         }

--- a/include/alpaka/math/cbrt/CbrtStdLib.hpp
+++ b/include/alpaka/math/cbrt/CbrtStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto cbrt(
-                    CbrtStdLib const & cbrt,
+                    CbrtStdLib const & cbrt_ctx,
                     TArg const & arg)
                 -> decltype(std::cbrt(arg))
                 {
-                    alpaka::ignore_unused(cbrt);
+                    alpaka::ignore_unused(cbrt_ctx);
                     return std::cbrt(arg);
                 }
             };

--- a/include/alpaka/math/cbrt/Traits.hpp
+++ b/include/alpaka/math/cbrt/Traits.hpp
@@ -38,14 +38,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Cbrt.
         //! \tparam TArg The arg type.
-        //! \param cbrt The object specializing Cbrt.
+        //! \param cbrt_ctx The object specializing Cbrt.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto cbrt(
-            T const & cbrt,
+            T const & cbrt_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -53,7 +53,7 @@ namespace alpaka
                 T,
                 TArg>
             ::cbrt(
-                cbrt,
+                cbrt_ctx,
                 arg))
 #endif
         {
@@ -62,7 +62,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::cbrt(
-                    cbrt,
+                    cbrt_ctx,
                     arg);
         }
 
@@ -86,19 +86,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto cbrt(
-                    T const & cbrt,
+                    T const & cbrt_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::cbrt(
-                        static_cast<typename T::CbrtBase const &>(cbrt),
+                        static_cast<typename T::CbrtBase const &>(cbrt_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::cbrt(
-                            static_cast<typename T::CbrtBase const &>(cbrt),
+                            static_cast<typename T::CbrtBase const &>(cbrt_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto ceil(
-                    CeilCudaBuiltIn const & ceil,
+                    CeilCudaBuiltIn const & ceil_ctx,
                     TArg const & arg)
                 -> decltype(::ceil(arg))
                 {
-                    alpaka::ignore_unused(ceil);
+                    alpaka::ignore_unused(ceil_ctx);
                     return ::ceil(arg);
                 }
             };

--- a/include/alpaka/math/ceil/CeilHipBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilHipBuiltIn.hpp
@@ -59,11 +59,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto ceil(
-                    CeilHipBuiltIn const & /*ceil*/,
+                    CeilHipBuiltIn const & ceil_ctx,
                     TArg const & arg)
                 -> decltype(::ceil(arg))
                 {
-                    //boost::ignore_unused(ceil);
+                    alpaka::ignore_unused(ceil_ctx);
                     return ::ceil(arg);
                 }
             };

--- a/include/alpaka/math/ceil/CeilStdLib.hpp
+++ b/include/alpaka/math/ceil/CeilStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto ceil(
-                    CeilStdLib const & ceil,
+                    CeilStdLib const & ceil_ctx,
                     TArg const & arg)
                 -> decltype(std::ceil(arg))
                 {
-                    alpaka::ignore_unused(ceil);
+                    alpaka::ignore_unused(ceil_ctx);
                     return std::ceil(arg);
                 }
             };

--- a/include/alpaka/math/ceil/Traits.hpp
+++ b/include/alpaka/math/ceil/Traits.hpp
@@ -38,14 +38,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Ceil.
         //! \tparam TArg The arg type.
-        //! \param ceil The object specializing Ceil.
+        //! \param ceil_ctx The object specializing Ceil.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto ceil(
-            T const & ceil,
+            T const & ceil_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -53,7 +53,7 @@ namespace alpaka
                 T,
                 TArg>
             ::ceil(
-                ceil,
+                ceil_ctx,
                 arg))
 #endif
         {
@@ -62,7 +62,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::ceil(
-                    ceil,
+                    ceil_ctx,
                     arg);
         }
 
@@ -86,19 +86,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto ceil(
-                    T const & ceil,
+                    T const & ceil_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::ceil(
-                        static_cast<typename T::CeilBase const &>(ceil),
+                        static_cast<typename T::CeilBase const &>(ceil_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::ceil(
-                            static_cast<typename T::CeilBase const &>(ceil),
+                            static_cast<typename T::CeilBase const &>(ceil_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/cos/CosCudaBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto cos(
-                    CosCudaBuiltIn const & cos,
+                    CosCudaBuiltIn const & cos_ctx,
                     TArg const & arg)
                 -> decltype(::cos(arg))
                 {
-                    alpaka::ignore_unused(cos);
+                    alpaka::ignore_unused(cos_ctx);
                     return ::cos(arg);
                 }
             };

--- a/include/alpaka/math/cos/CosHipBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosHipBuiltIn.hpp
@@ -59,11 +59,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto cos(
-                    CosHipBuiltIn const & /*cos*/,
+                    CosHipBuiltIn const & cos_ctx,
                     TArg const & arg)
                 -> decltype(::cos(arg))
                 {
-                    //boost::ignore_unused(cos);
+                    alpaka::ignore_unused(cos_ctx);
                     return ::cos(arg);
                 }
             };

--- a/include/alpaka/math/cos/CosStdLib.hpp
+++ b/include/alpaka/math/cos/CosStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto cos(
-                    CosStdLib const & cos,
+                    CosStdLib const & cos_ctx,
                     TArg const & arg)
                 -> decltype(std::cos(arg))
                 {
-                    alpaka::ignore_unused(cos);
+                    alpaka::ignore_unused(cos_ctx);
                     return std::cos(arg);
                 }
             };

--- a/include/alpaka/math/cos/Traits.hpp
+++ b/include/alpaka/math/cos/Traits.hpp
@@ -38,14 +38,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Cos.
         //! \tparam TArg The arg type.
-        //! \param cos The object specializing Cos.
+        //! \param cos_ctx The object specializing Cos.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto cos(
-            T const & cos,
+            T const & cos_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -53,7 +53,7 @@ namespace alpaka
                 T,
                 TArg>
             ::cos(
-                cos,
+                cos_ctx,
                 arg))
 #endif
         {
@@ -62,7 +62,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::cos(
-                    cos,
+                    cos_ctx,
                     arg);
         }
 
@@ -86,19 +86,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto cos(
-                    T const & cos,
+                    T const & cos_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::cos(
-                        static_cast<typename T::CosBase const &>(cos),
+                        static_cast<typename T::CosBase const &>(cos_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::cos(
-                            static_cast<typename T::CosBase const &>(cos),
+                            static_cast<typename T::CosBase const &>(cos_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto erf(
-                    ErfCudaBuiltIn const & erf,
+                    ErfCudaBuiltIn const & erf_ctx,
                     TArg const & arg)
                 -> decltype(::erf(arg))
                 {
-                    alpaka::ignore_unused(erf);
+                    alpaka::ignore_unused(erf_ctx);
                     return ::erf(arg);
                 }
             };

--- a/include/alpaka/math/erf/ErfHipBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfHipBuiltIn.hpp
@@ -59,11 +59,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto erf(
-                    ErfHipBuiltIn const & /*erf*/,
+                    ErfHipBuiltIn const & erf_ctx,
                     TArg const & arg)
                 -> decltype(::erf(arg))
                 {
-                    //boost::ignore_unused(erf);
+                    alpaka::ignore_unused(erf_ctx);
                     return ::erf(arg);
                 }
             };

--- a/include/alpaka/math/erf/ErfStdLib.hpp
+++ b/include/alpaka/math/erf/ErfStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto erf(
-                    ErfStdLib const & erf,
+                    ErfStdLib const & erf_ctx,
                     TArg const & arg)
                 -> decltype(std::erf(arg))
                 {
-                    alpaka::ignore_unused(erf);
+                    alpaka::ignore_unused(erf_ctx);
                     return std::erf(arg);
                 }
             };

--- a/include/alpaka/math/erf/Traits.hpp
+++ b/include/alpaka/math/erf/Traits.hpp
@@ -38,14 +38,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Erf.
         //! \tparam TArg The arg type.
-        //! \param erf The object specializing Erf.
+        //! \param erf_ctx The object specializing Erf.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto erf(
-            T const & erf,
+            T const & erf_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -53,7 +53,7 @@ namespace alpaka
                 T,
                 TArg>
             ::erf(
-                erf,
+                erf_ctx,
                 arg))
 #endif
         {
@@ -62,7 +62,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::erf(
-                    erf,
+                    erf_ctx,
                     arg);
         }
 
@@ -86,19 +86,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto erf(
-                    T const & erf,
+                    T const & erf_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::erf(
-                        static_cast<typename T::ErfBase const &>(erf),
+                        static_cast<typename T::ErfBase const &>(erf_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::erf(
-                            static_cast<typename T::ErfBase const &>(erf),
+                            static_cast<typename T::ErfBase const &>(erf_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto exp(
-                    ExpCudaBuiltIn const & exp,
+                    ExpCudaBuiltIn const & exp_ctx,
                     TArg const & arg)
                 -> decltype(::exp(arg))
                 {
-                    alpaka::ignore_unused(exp);
+                    alpaka::ignore_unused(exp_ctx);
                     return ::exp(arg);
                 }
             };

--- a/include/alpaka/math/exp/ExpHipBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpHipBuiltIn.hpp
@@ -59,11 +59,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto exp(
-                    ExpHipBuiltIn const & /*exp*/,
+                    ExpHipBuiltIn const & exp_ctx,
                     TArg const & arg)
                 -> decltype(::exp(arg))
                 {
-                    //boost::ignore_unused(exp);
+                    alpaka::ignore_unused(exp_ctx);
                     return ::exp(arg);
                 }
             };

--- a/include/alpaka/math/exp/ExpStdLib.hpp
+++ b/include/alpaka/math/exp/ExpStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto exp(
-                    ExpStdLib const & exp,
+                    ExpStdLib const & exp_ctx,
                     TArg const & arg)
                 -> decltype(std::exp(arg))
                 {
-                    alpaka::ignore_unused(exp);
+                    alpaka::ignore_unused(exp_ctx);
                     return std::exp(arg);
                 }
             };

--- a/include/alpaka/math/exp/Traits.hpp
+++ b/include/alpaka/math/exp/Traits.hpp
@@ -38,13 +38,13 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Exp.
         //! \tparam TArg The arg type.
-        //! \param exp The object specializing Exp.
+        //! \param exp_ctx The object specializing Exp.
         //! \param arg The arg.
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto exp(
-            T const & exp,
+            T const & exp_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -52,7 +52,7 @@ namespace alpaka
                 T,
                 TArg>
             ::exp(
-                exp,
+                exp_ctx,
                 arg))
 #endif
         {
@@ -61,7 +61,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::exp(
-                    exp,
+                    exp_ctx,
                     arg);
         }
 
@@ -85,19 +85,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto exp(
-                    T const & exp,
+                    T const & exp_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::exp(
-                        static_cast<typename T::ExpBase const &>(exp),
+                        static_cast<typename T::ExpBase const &>(exp_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::exp(
-                            static_cast<typename T::ExpBase const &>(exp),
+                            static_cast<typename T::ExpBase const &>(exp_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto floor(
-                    FloorCudaBuiltIn const & floor,
+                    FloorCudaBuiltIn const & floor_ctx,
                     TArg const & arg)
                 -> decltype(::floor(arg))
                 {
-                    alpaka::ignore_unused(floor);
+                    alpaka::ignore_unused(floor_ctx);
                     return ::floor(arg);
                 }
             };

--- a/include/alpaka/math/floor/FloorHipBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorHipBuiltIn.hpp
@@ -59,11 +59,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto floor(
-                    FloorHipBuiltIn const & /*floor*/,
+                    FloorHipBuiltIn const & floor_ctx,
                     TArg const & arg)
                 -> decltype(::floor(arg))
                 {
-                    //boost::ignore_unused(floor);
+                    alpaka::ignore_unused(floor_ctx);
                     return ::floor(arg);
                 }
             };

--- a/include/alpaka/math/floor/FloorStdLib.hpp
+++ b/include/alpaka/math/floor/FloorStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto floor(
-                    FloorStdLib const & floor,
+                    FloorStdLib const & floor_ctx,
                     TArg const & arg)
                 -> decltype(std::floor(arg))
                 {
-                    alpaka::ignore_unused(floor);
+                    alpaka::ignore_unused(floor_ctx);
                     return std::floor(arg);
                 }
             };

--- a/include/alpaka/math/floor/Traits.hpp
+++ b/include/alpaka/math/floor/Traits.hpp
@@ -38,14 +38,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Floor.
         //! \tparam TArg The arg type.
-        //! \param floor The object specializing Floor.
+        //! \param floor_ctx The object specializing Floor.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto floor(
-            T const & floor,
+            T const & floor_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -53,7 +53,7 @@ namespace alpaka
                 T,
                 TArg>
             ::floor(
-                floor,
+                floor_ctx,
                 arg))
 #endif
         {
@@ -62,7 +62,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::floor(
-                    floor,
+                    floor_ctx,
                     arg);
         }
 
@@ -86,19 +86,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto floor(
-                    T const & floor,
+                    T const & floor_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::floor(
-                        static_cast<typename T::FloorBase const &>(floor),
+                        static_cast<typename T::FloorBase const &>(floor_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::floor(
-                            static_cast<typename T::FloorBase const &>(floor),
+                            static_cast<typename T::FloorBase const &>(floor_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
@@ -53,12 +53,12 @@ namespace alpaka
                     && std::is_floating_point<Ty>::value>::type>
             {
                 __device__ static auto fmod(
-                    FmodCudaBuiltIn const & fmod,
+                    FmodCudaBuiltIn const & fmod_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::fmod(x, y))
                 {
-                    alpaka::ignore_unused(fmod);
+                    alpaka::ignore_unused(fmod_ctx);
                     return ::fmod(x, y);
                 }
             };

--- a/include/alpaka/math/fmod/FmodHipBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodHipBuiltIn.hpp
@@ -62,12 +62,12 @@ namespace alpaka
                     && std::is_floating_point<Ty>::value>::type>
             {
                 __device__ static auto fmod(
-                    FmodHipBuiltIn const & /*fmod*/,
+                    FmodHipBuiltIn const & fmod_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::fmod(x, y))
                 {
-                    //boost::ignore_unused(fmod);
+                    alpaka::ignore_unused(fmod_ctx);
                     return ::fmod(x, y);
                 }
             };

--- a/include/alpaka/math/fmod/FmodStdLib.hpp
+++ b/include/alpaka/math/fmod/FmodStdLib.hpp
@@ -45,12 +45,12 @@ namespace alpaka
                     && std::is_arithmetic<Ty>::value>::type>
             {
                 ALPAKA_FN_HOST static auto fmod(
-                    FmodStdLib const & fmod,
+                    FmodStdLib const & fmod_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(std::fmod(x, y))
                 {
-                    alpaka::ignore_unused(fmod);
+                    alpaka::ignore_unused(fmod_ctx);
                     return std::fmod(x, y);
                 }
             };

--- a/include/alpaka/math/fmod/Traits.hpp
+++ b/include/alpaka/math/fmod/Traits.hpp
@@ -40,7 +40,7 @@ namespace alpaka
         //! \tparam T The type of the object specializing Fmod.
         //! \tparam Tx The type of the first argument.
         //! \tparam Ty The type of the second argument.
-        //! \param fmod The object specializing Fmod.
+        //! \param fmod_ctx The object specializing Fmod.
         //! \param x The first argument.
         //! \param y The second argument.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -49,7 +49,7 @@ namespace alpaka
             typename Tx,
             typename Ty>
         ALPAKA_FN_HOST_ACC auto fmod(
-            T const & fmod,
+            T const & fmod_ctx,
             Tx const & x,
             Ty const & y)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
@@ -59,7 +59,7 @@ namespace alpaka
                 Tx,
                 Ty>
             ::fmod(
-                fmod,
+                fmod_ctx,
                 x,
                 y))
 #endif
@@ -70,7 +70,7 @@ namespace alpaka
                     Tx,
                     Ty>
                 ::fmod(
-                    fmod,
+                    fmod_ctx,
                     x,
                     y);
         }
@@ -95,19 +95,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto fmod(
-                    T const & fmod,
+                    T const & fmod_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::fmod(
-                        static_cast<typename T::FmodBase const &>(fmod),
+                        static_cast<typename T::FmodBase const &>(fmod_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::fmod(
-                            static_cast<typename T::FmodBase const &>(fmod),
+                            static_cast<typename T::FmodBase const &>(fmod_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/log/LogCudaBuiltIn.hpp
+++ b/include/alpaka/math/log/LogCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto log(
-                    LogCudaBuiltIn const & log,
+                    LogCudaBuiltIn const & log_ctx,
                     TArg const & arg)
                 -> decltype(::log(arg))
                 {
-                    alpaka::ignore_unused(log);
+                    alpaka::ignore_unused(log_ctx);
                     return ::log(arg);
                 }
             };

--- a/include/alpaka/math/log/LogHipBuiltIn.hpp
+++ b/include/alpaka/math/log/LogHipBuiltIn.hpp
@@ -59,11 +59,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto log(
-                    LogHipBuiltIn const & /*log*/,
+                    LogHipBuiltIn const & log_ctx,
                     TArg const & arg)
                 -> decltype(::log(arg))
                 {
-                    //boost::ignore_unused(log);
+                    alpaka::ignore_unused(log_ctx);
                     return ::log(arg);
                 }
             };

--- a/include/alpaka/math/log/LogStdLib.hpp
+++ b/include/alpaka/math/log/LogStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto log(
-                    LogStdLib const & log,
+                    LogStdLib const & log_ctx,
                     TArg const & arg)
                 -> decltype(std::log(arg))
                 {
-                    alpaka::ignore_unused(log);
+                    alpaka::ignore_unused(log_ctx);
                     return std::log(arg);
                 }
             };

--- a/include/alpaka/math/log/Traits.hpp
+++ b/include/alpaka/math/log/Traits.hpp
@@ -38,14 +38,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Log.
         //! \tparam TArg The arg type.
-        //! \param log The object specializing Log.
+        //! \param log_ctx The object specializing Log.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto log(
-            T const & log,
+            T const & log_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -53,7 +53,7 @@ namespace alpaka
                 T,
                 TArg>
             ::log(
-                log,
+                log_ctx,
                 arg))
 #endif
         {
@@ -62,7 +62,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::log(
-                    log,
+                    log_ctx,
                     arg);
         }
 
@@ -86,19 +86,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto log(
-                    T const & log,
+                    T const & log_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::log(
-                        static_cast<typename T::LogBase const &>(log),
+                        static_cast<typename T::LogBase const &>(log_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::log(
-                            static_cast<typename T::LogBase const &>(log),
+                            static_cast<typename T::LogBase const &>(log_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/max/MaxCudaBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxCudaBuiltIn.hpp
@@ -53,12 +53,12 @@ namespace alpaka
                     && std::is_integral<Ty>::value>::type>
             {
                 __device__ static auto max(
-                    MaxCudaBuiltIn const & max,
+                    MaxCudaBuiltIn const & max_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::max(x, y))
                 {
-                    alpaka::ignore_unused(max);
+                    alpaka::ignore_unused(max_ctx);
                     return ::max(x, y);
                 }
             };
@@ -78,12 +78,12 @@ namespace alpaka
                         && std::is_integral<Ty>::value)>::type>
             {
                 __device__ static auto max(
-                    MaxCudaBuiltIn const & max,
+                    MaxCudaBuiltIn const & max_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::fmax(x, y))
                 {
-                    alpaka::ignore_unused(max);
+                    alpaka::ignore_unused(max_ctx);
                     return ::fmax(x, y);
                 }
             };

--- a/include/alpaka/math/max/MaxHipBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxHipBuiltIn.hpp
@@ -62,12 +62,12 @@ namespace alpaka
                     && std::is_integral<Ty>::value>::type>
             {
                 __device__ static auto max(
-                    MaxHipBuiltIn const & /*max*/,
+                    MaxHipBuiltIn const & max_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::max(x, y))
                 {
-                    //boost::ignore_unused(max);
+                    alpaka::ignore_unused(max_ctx);
                     return ::max(x, y);
                 }
             };
@@ -87,12 +87,12 @@ namespace alpaka
                         && std::is_integral<Ty>::value)>::type>
             {
                 __device__ static auto max(
-                    MaxHipBuiltIn const & /*max*/,
+                    MaxHipBuiltIn const & max_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::fmax(x, y))
                 {
-                    //boost::ignore_unused(max);
+                    alpaka::ignore_unused(max_ctx);
                     return ::fmax(x, y);
                 }
             };

--- a/include/alpaka/math/max/MaxStdLib.hpp
+++ b/include/alpaka/math/max/MaxStdLib.hpp
@@ -46,12 +46,12 @@ namespace alpaka
                     && std::is_integral<Ty>::value>::type>
             {
                 ALPAKA_FN_HOST static auto max(
-                    MaxStdLib const & max,
+                    MaxStdLib const & max_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(std::max(x, y))
                 {
-                    alpaka::ignore_unused(max);
+                    alpaka::ignore_unused(max_ctx);
                     return std::max(x, y);
                 }
             };
@@ -71,12 +71,12 @@ namespace alpaka
                         && std::is_integral<Ty>::value)>::type>
             {
                 ALPAKA_FN_HOST static auto max(
-                    MaxStdLib const & max,
+                    MaxStdLib const & max_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(std::fmax(x, y))
                 {
-                    alpaka::ignore_unused(max);
+                    alpaka::ignore_unused(max_ctx);
                     return std::fmax(x, y);
                 }
             };

--- a/include/alpaka/math/max/Traits.hpp
+++ b/include/alpaka/math/max/Traits.hpp
@@ -41,7 +41,7 @@ namespace alpaka
         //! \tparam T The type of the object specializing Max.
         //! \tparam Tx The type of the first argument.
         //! \tparam Ty The type of the second argument.
-        //! \param max The object specializing Max.
+        //! \param max_ctx The object specializing Max.
         //! \param x The first argument.
         //! \param y The second argument.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -50,7 +50,7 @@ namespace alpaka
             typename Tx,
             typename Ty>
         ALPAKA_FN_HOST_ACC auto max(
-            T const & max,
+            T const & max_ctx,
             Tx const & x,
             Ty const & y)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
@@ -60,7 +60,7 @@ namespace alpaka
                 Tx,
                 Ty>
             ::max(
-                max,
+                max_ctx,
                 x,
                 y))
 #endif
@@ -71,7 +71,7 @@ namespace alpaka
                     Tx,
                     Ty>
                 ::max(
-                    max,
+                    max_ctx,
                     x,
                     y);
         }
@@ -98,13 +98,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto max(
-                    T const & max,
+                    T const & max_ctx,
                     Tx const & x,
                     Ty const & y)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::max(
-                        static_cast<typename T::MaxBase const &>(max),
+                        static_cast<typename T::MaxBase const &>(max_ctx),
                         x,
                         y))
 #endif
@@ -112,7 +112,7 @@ namespace alpaka
                     // Delegate the call to the base class.
                     return
                         math::max(
-                            static_cast<typename T::MaxBase const &>(max),
+                            static_cast<typename T::MaxBase const &>(max_ctx),
                             x,
                             y);
                 }

--- a/include/alpaka/math/min/MinCudaBuiltIn.hpp
+++ b/include/alpaka/math/min/MinCudaBuiltIn.hpp
@@ -54,12 +54,12 @@ namespace alpaka
                     && std::is_integral<Ty>::value>::type>
             {
                 __device__ static auto min(
-                    MinCudaBuiltIn const & min,
+                    MinCudaBuiltIn const & min_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::min(x, y))
                 {
-                    alpaka::ignore_unused(min);
+                    alpaka::ignore_unused(min_ctx);
                     return ::min(x, y);
                 }
             };
@@ -79,12 +79,12 @@ namespace alpaka
                         && std::is_integral<Ty>::value)>::type>
             {
                 __device__ static auto min(
-                    MinCudaBuiltIn const & min,
+                    MinCudaBuiltIn const & min_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::fmin(x, y))
                 {
-                    alpaka::ignore_unused(min);
+                    alpaka::ignore_unused(min_ctx);
                     return ::fmin(x, y);
                 }
             };

--- a/include/alpaka/math/min/MinHipBuiltIn.hpp
+++ b/include/alpaka/math/min/MinHipBuiltIn.hpp
@@ -63,12 +63,12 @@ namespace alpaka
                     && std::is_integral<Ty>::value>::type>
             {
                 __device__ static auto min(
-                    MinHipBuiltIn const & /*min*/,
+                    MinHipBuiltIn const & min_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::min(x, y))
                 {
-                    //boost::ignore_unused(min);
+                    alpaka::ignore_unused(min_ctx);
                     return ::min(x, y);
                 }
             };
@@ -88,12 +88,12 @@ namespace alpaka
                         && std::is_integral<Ty>::value)>::type>
             {
                 __device__ static auto max(
-                    MinHipBuiltIn const & /*min*/,
+                    MinHipBuiltIn const & min_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::fmin(x, y))
                 {
-                    //boost::ignore_unused(min);
+                    alpaka::ignore_unused(min_ctx);
                     return ::fmin(x, y);
                 }
             };

--- a/include/alpaka/math/min/MinStdLib.hpp
+++ b/include/alpaka/math/min/MinStdLib.hpp
@@ -46,12 +46,12 @@ namespace alpaka
                     && std::is_integral<Ty>::value>::type>
             {
                 ALPAKA_FN_HOST static auto min(
-                    MinStdLib const & min,
+                    MinStdLib const & min_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(std::min(x, y))
                 {
-                    alpaka::ignore_unused(min);
+                    alpaka::ignore_unused(min_ctx);
                     return std::min(x, y);
                 }
             };
@@ -71,12 +71,12 @@ namespace alpaka
                         && std::is_integral<Ty>::value)>::type>
             {
                 ALPAKA_FN_HOST static auto min(
-                    MinStdLib const & min,
+                    MinStdLib const & min_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(std::fmin(x, y))
                 {
-                    alpaka::ignore_unused(min);
+                    alpaka::ignore_unused(min_ctx);
                     return std::fmin(x, y);
                 }
             };

--- a/include/alpaka/math/min/Traits.hpp
+++ b/include/alpaka/math/min/Traits.hpp
@@ -41,7 +41,7 @@ namespace alpaka
         //! \tparam T The type of the object specializing Min.
         //! \tparam Tx The type of the first argument.
         //! \tparam Ty The type of the second argument.
-        //! \param min The object specializing Min.
+        //! \param min_ctx The object specializing Min.
         //! \param x The first argument.
         //! \param y The second argument.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -50,7 +50,7 @@ namespace alpaka
             typename Tx,
             typename Ty>
         ALPAKA_FN_HOST_ACC auto min(
-            T const & min,
+            T const & min_ctx,
             Tx const & x,
             Ty const & y)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
@@ -60,7 +60,7 @@ namespace alpaka
                 Tx,
                 Ty>
             ::min(
-                min,
+                min_ctx,
                 x,
                 y))
 #endif
@@ -71,7 +71,7 @@ namespace alpaka
                     Tx,
                     Ty>
                 ::min(
-                    min,
+                    min_ctx,
                     x,
                     y);
         }
@@ -98,13 +98,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto min(
-                    T const & min,
+                    T const & min_ctx,
                     Tx const & x,
                     Ty const & y)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::min(
-                        static_cast<typename T::MinBase const &>(min),
+                        static_cast<typename T::MinBase const &>(min_ctx),
                         x,
                         y))
 #endif
@@ -112,7 +112,7 @@ namespace alpaka
                     // Delegate the call to the base class.
                     return
                         math::min(
-                            static_cast<typename T::MinBase const &>(min),
+                            static_cast<typename T::MinBase const &>(min_ctx),
                             x,
                             y);
                 }

--- a/include/alpaka/math/pow/PowCudaBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowCudaBuiltIn.hpp
@@ -53,12 +53,12 @@ namespace alpaka
                     && std::is_floating_point<TExp>::value>::type>
             {
                 __device__ static auto pow(
-                    PowCudaBuiltIn const & pow,
+                    PowCudaBuiltIn const & pow_ctx,
                     TBase const & base,
                     TExp const & exp)
                 -> decltype(::pow(base, exp))
                 {
-                    alpaka::ignore_unused(pow);
+                    alpaka::ignore_unused(pow_ctx);
                     return ::pow(base, exp);
                 }
             };

--- a/include/alpaka/math/pow/PowHipBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowHipBuiltIn.hpp
@@ -63,12 +63,12 @@ namespace alpaka
                     && std::is_floating_point<TExp>::value>::type>
             {
                 __device__ static auto pow(
-                    PowHipBuiltIn const & /*pow*/,
+                    PowHipBuiltIn const & pow_ctx,
                     TBase const & base,
                     TExp const & exp)
                 -> decltype(::pow(base, exp))
                 {
-                    //boost::ignore_unused(pow);
+                    alpaka::ignore_unused(pow_ctx);
                     return ::pow(base, exp);
                 }
             };

--- a/include/alpaka/math/pow/PowStdLib.hpp
+++ b/include/alpaka/math/pow/PowStdLib.hpp
@@ -45,12 +45,12 @@ namespace alpaka
                     && std::is_arithmetic<TExp>::value>::type>
             {
                 ALPAKA_FN_HOST static auto pow(
-                    PowStdLib const & pow,
+                    PowStdLib const & pow_ctx,
                     TBase const & base,
                     TExp const & exp)
                 -> decltype(std::pow(base, exp))
                 {
-                    alpaka::ignore_unused(pow);
+                    alpaka::ignore_unused(pow_ctx);
                     return std::pow(base, exp);
                 }
             };

--- a/include/alpaka/math/pow/Traits.hpp
+++ b/include/alpaka/math/pow/Traits.hpp
@@ -40,7 +40,7 @@ namespace alpaka
         //! \tparam T The type of the object specializing Pow.
         //! \tparam TBase The base type.
         //! \tparam TExp The exponent type.
-        //! \param pow The object specializing Pow.
+        //! \param pow_ctx The object specializing Pow.
         //! \param base The base.
         //! \param exp The exponent.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -49,7 +49,7 @@ namespace alpaka
             typename TBase,
             typename TExp>
         ALPAKA_FN_HOST_ACC auto pow(
-            T const & pow,
+            T const & pow_ctx,
             TBase const & base,
             TExp const & exp)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
@@ -59,7 +59,7 @@ namespace alpaka
                 TBase,
                 TExp>
             ::pow(
-                pow,
+                pow_ctx,
                 base,
                 exp))
 #endif
@@ -70,7 +70,7 @@ namespace alpaka
                     TBase,
                     TExp>
                 ::pow(
-                    pow,
+                    pow_ctx,
                     base,
                     exp);
         }
@@ -97,13 +97,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto pow(
-                    T const & pow,
+                    T const & pow_ctx,
                     TBase const & base,
                     TExp const & exp)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::pow(
-                        static_cast<typename T::PowBase const &>(pow),
+                        static_cast<typename T::PowBase const &>(pow_ctx),
                         base,
                         exp))
 #endif
@@ -111,7 +111,7 @@ namespace alpaka
                     // Delegate the call to the base class.
                     return
                         math::pow(
-                            static_cast<typename T::PowBase const &>(pow),
+                            static_cast<typename T::PowBase const &>(pow_ctx),
                             base,
                             exp);
                 }

--- a/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto remainder(
-                    RemainderCudaBuiltIn const & remainder,
+                    RemainderCudaBuiltIn const & remainder_ctx,
                     TArg const & arg)
                 -> decltype(::remainder(arg))
                 {
-                    alpaka::ignore_unused(remainder);
+                    alpaka::ignore_unused(remainder_ctx);
                     return ::remainder(arg);
                 }
             };

--- a/include/alpaka/math/remainder/RemainderHipBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderHipBuiltIn.hpp
@@ -60,11 +60,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto remainder(
-                    RemainderHipBuiltIn const & /*remainder*/,
+                    RemainderHipBuiltIn const & remainder_ctx,
                     TArg const & arg)
                 -> decltype(::remainder(arg))
                 {
-                    //boost::ignore_unused(remainder);
+                    alpaka::ignore_unused(remainder_ctx);
                     return ::remainder(arg);
                 }
             };

--- a/include/alpaka/math/remainder/RemainderStdLib.hpp
+++ b/include/alpaka/math/remainder/RemainderStdLib.hpp
@@ -45,12 +45,12 @@ namespace alpaka
                     && std::is_integral<Ty>::value>::type>
             {
                 ALPAKA_FN_HOST static auto remainder(
-                    RemainderStdLib const & remainder,
+                    RemainderStdLib const & remainder_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(std::remainder(x, y))
                 {
-                    alpaka::ignore_unused(remainder);
+                    alpaka::ignore_unused(remainder_ctx);
                     return std::remainder(x, y);
                 }
             };

--- a/include/alpaka/math/remainder/Traits.hpp
+++ b/include/alpaka/math/remainder/Traits.hpp
@@ -40,7 +40,7 @@ namespace alpaka
         //! \tparam T The type of the object specializing Remainder.
         //! \tparam Tx The type of the first argument.
         //! \tparam Ty The type of the second argument.
-        //! \param remainder The object specializing Max.
+        //! \param remainder_ctx The object specializing Max.
         //! \param x The first argument.
         //! \param y The second argument.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -49,7 +49,7 @@ namespace alpaka
             typename Tx,
             typename Ty>
         ALPAKA_FN_HOST_ACC auto remainder(
-            T const & remainder,
+            T const & remainder_ctx,
             Tx const & x,
             Ty const & y)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
@@ -59,7 +59,7 @@ namespace alpaka
                 Tx,
                 Ty>
             ::remainder(
-                remainder,
+                remainder_ctx,
                 x,
                 y))
 #endif
@@ -70,7 +70,7 @@ namespace alpaka
                     Tx,
                     Ty>
                 ::remainder(
-                    remainder,
+                    remainder_ctx,
                     x,
                     y);
         }
@@ -97,13 +97,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto remainder(
-                    T const & remainder,
+                    T const & remainder_ctx,
                     Tx const & x,
                     Ty const & y)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::remainder(
-                        static_cast<typename T::RemainderBase const &>(remainder),
+                        static_cast<typename T::RemainderBase const &>(remainder_ctx),
                         x,
                         y))
 #endif
@@ -111,7 +111,7 @@ namespace alpaka
                     // Delegate the call to the base class.
                     return
                         math::remainder(
-                            static_cast<typename T::RemainderBase const &>(remainder),
+                            static_cast<typename T::RemainderBase const &>(remainder_ctx),
                             x,
                             y);
                 }

--- a/include/alpaka/math/round/RoundCudaBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto round(
-                    RoundCudaBuiltIn const & round,
+                    RoundCudaBuiltIn const & round_ctx,
                     TArg const & arg)
                 -> decltype(::round(arg))
                 {
-                    alpaka::ignore_unused(round);
+                    alpaka::ignore_unused(round_ctx);
                     return ::round(arg);
                 }
             };
@@ -69,11 +69,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto lround(
-                    RoundCudaBuiltIn const & lround,
+                    RoundCudaBuiltIn const & lround_ctx,
                     TArg const & arg)
                 -> long int
                 {
-                    alpaka::ignore_unused(lround);
+                    alpaka::ignore_unused(lround_ctx);
                     return ::lround(arg);
                 }
             };
@@ -88,11 +88,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto llround(
-                    RoundCudaBuiltIn const & llround,
+                    RoundCudaBuiltIn const & llround_ctx,
                     TArg const & arg)
                 -> long int
                 {
-                    alpaka::ignore_unused(llround);
+                    alpaka::ignore_unused(llround_ctx);
                     return ::llround(arg);
                 }
             };

--- a/include/alpaka/math/round/RoundHipBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundHipBuiltIn.hpp
@@ -60,11 +60,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto round(
-                    RoundHipBuiltIn const & /*round*/,
+                    RoundHipBuiltIn const & round_ctx,
                     TArg const & arg)
                 -> decltype(::round(arg))
                 {
-                    //boost::ignore_unused(round);
+                    alpaka::ignore_unused(round_ctx);
                     return ::round(arg);
                 }
             };
@@ -79,11 +79,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto lround(
-                    RoundHipBuiltIn const & /*lround*/,
+                    RoundHipBuiltIn const & lround_ctx,
                     TArg const & arg)
                 -> long int
                 {
-                    //boost::ignore_unused(lround);
+                    alpaka::ignore_unused(lround_ctx);
                     return ::lround(arg);
                 }
             };
@@ -98,11 +98,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto llround(
-                    RoundHipBuiltIn const & /*llround*/,
+                    RoundHipBuiltIn const & llround_ctx,
                     TArg const & arg)
                 -> long int
                 {
-                    //boost::ignore_unused(llround);
+                    alpaka::ignore_unused(llround_ctx);
                     return ::llround(arg);
                 }
             };

--- a/include/alpaka/math/round/RoundStdLib.hpp
+++ b/include/alpaka/math/round/RoundStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto round(
-                    RoundStdLib const & round,
+                    RoundStdLib const & round_ctx,
                     TArg const & arg)
                 -> decltype(std::round(arg))
                 {
-                    alpaka::ignore_unused(round);
+                    alpaka::ignore_unused(round_ctx);
                     return std::round(arg);
                 }
             };
@@ -61,11 +61,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto lround(
-                    RoundStdLib const & lround,
+                    RoundStdLib const & lround_ctx,
                     TArg const & arg)
                 -> long int
                 {
-                    alpaka::ignore_unused(lround);
+                    alpaka::ignore_unused(lround_ctx);
                     return std::lround(arg);
                 }
             };
@@ -80,11 +80,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto llround(
-                    RoundStdLib const & llround,
+                    RoundStdLib const & llround_ctx,
                     TArg const & arg)
                 -> long int
                 {
-                    alpaka::ignore_unused(llround);
+                    alpaka::ignore_unused(llround_ctx);
                     return std::llround(arg);
                 }
             };

--- a/include/alpaka/math/round/Traits.hpp
+++ b/include/alpaka/math/round/Traits.hpp
@@ -13,6 +13,7 @@
 #include <alpaka/meta/IsStrictBase.hpp>
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <boost/config.hpp>
 
@@ -54,14 +55,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Round.
         //! \tparam TArg The arg type.
-        //! \param round The object specializing Round.
+        //! \param round_ctx The object specializing Round.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto round(
-            T const & round,
+            T const & round_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -69,7 +70,7 @@ namespace alpaka
                 T,
                 TArg>
             ::round(
-                round,
+                round_ctx,
                 arg))
 #endif
         {
@@ -78,7 +79,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::round(
-                    round,
+                    round_ctx,
                     arg);
         }
         //-----------------------------------------------------------------------------
@@ -86,14 +87,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Round.
         //! \tparam TArg The arg type.
-        //! \param lround The object specializing Round.
+        //! \param lround_ctx The object specializing Round.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto lround(
-            T const & lround,
+            T const & lround_ctx,
             TArg const & arg)
         -> long int
         {
@@ -102,7 +103,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::lround(
-                    lround,
+                    lround_ctx,
                     arg);
         }
         //-----------------------------------------------------------------------------
@@ -110,14 +111,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Round.
         //! \tparam TArg The arg type.
-        //! \param llround The object specializing Round.
+        //! \param llround_ctx The object specializing Round.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto llround(
-            T const & llround,
+            T const & llround_ctx,
             TArg const & arg)
         -> long long int
         {
@@ -126,7 +127,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::llround(
-                    llround,
+                    llround_ctx,
                     arg);
         }
 
@@ -150,19 +151,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto round(
-                    T const & round,
+                    T const & round_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::round(
-                        static_cast<typename T::RoundBase const &>(round),
+                        static_cast<typename T::RoundBase const &>(round_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::round(
-                            static_cast<typename T::RoundBase const &>(round),
+                            static_cast<typename T::RoundBase const &>(round_ctx),
                             arg);
                 }
             };
@@ -184,19 +185,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto lround(
-                    T const & lround,
+                    T const & lround_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::lround(
-                        static_cast<typename T::RoundBase const &>(lround),
+                        static_cast<typename T::RoundBase const &>(lround_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::lround(
-                            static_cast<typename T::RoundBase const &>(lround),
+                            static_cast<typename T::RoundBase const &>(lround_ctx),
                             arg);
                 }
             };
@@ -218,19 +219,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto llround(
-                    T const & llround,
+                    T const & llround_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::llround(
-                        static_cast<typename T::RoundBase const &>(llround),
+                        static_cast<typename T::RoundBase const &>(llround_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::llround(
-                            static_cast<typename T::RoundBase const &>(llround),
+                            static_cast<typename T::RoundBase const &>(llround_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 __device__ static auto rsqrt(
-                    RsqrtCudaBuiltIn const & rsqrt,
+                    RsqrtCudaBuiltIn const & rsqrt_ctx,
                     TArg const & arg)
                 -> decltype(::rsqrt(arg))
                 {
-                    alpaka::ignore_unused(rsqrt);
+                    alpaka::ignore_unused(rsqrt_ctx);
                     return ::rsqrt(arg);
                 }
             };

--- a/include/alpaka/math/rsqrt/RsqrtHipBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtHipBuiltIn.hpp
@@ -60,11 +60,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 __device__ static auto rsqrt(
-                    RsqrtHipBuiltIn const & /*rsqrt*/,
+                    RsqrtHipBuiltIn const & rsqrt_ctx,
                     TArg const & arg)
                 -> decltype(::rsqrt(arg))
                 {
-                    //boost::ignore_unused(rsqrt);
+                    alpaka::ignore_unused(rsqrt_ctx);
                     return ::rsqrt(arg);
                 }
             };

--- a/include/alpaka/math/rsqrt/RsqrtStdLib.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto rsqrt(
-                    RsqrtStdLib const & rsqrt,
+                    RsqrtStdLib const & rsqrt_ctx,
                     TArg const & arg)
                 -> decltype(std::sqrt(arg))
                 {
-                    alpaka::ignore_unused(rsqrt);
+                    alpaka::ignore_unused(rsqrt_ctx);
                     return static_cast<TArg>(1)/std::sqrt(arg);
                 }
             };

--- a/include/alpaka/math/rsqrt/Traits.hpp
+++ b/include/alpaka/math/rsqrt/Traits.hpp
@@ -38,14 +38,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Rsqrt.
         //! \tparam TArg The arg type.
-        //! \param rsqrt The object specializing Rsqrt.
+        //! \param rsqrt_ctx The object specializing Rsqrt.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto rsqrt(
-            T const & rsqrt,
+            T const & rsqrt_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -53,7 +53,7 @@ namespace alpaka
                 T,
                 TArg>
             ::rsqrt(
-                rsqrt,
+                rsqrt_ctx,
                 arg))
 #endif
         {
@@ -62,7 +62,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::rsqrt(
-                    rsqrt,
+                    rsqrt_ctx,
                     arg);
         }
 
@@ -86,19 +86,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto rsqrt(
-                    T const & rsqrt,
+                    T const & rsqrt_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::rsqrt(
-                        static_cast<typename T::RsqrtBase const &>(rsqrt),
+                        static_cast<typename T::RsqrtBase const &>(rsqrt_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::rsqrt(
-                            static_cast<typename T::RsqrtBase const &>(rsqrt),
+                            static_cast<typename T::RsqrtBase const &>(rsqrt_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/sin/SinCudaBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto sin(
-                    SinCudaBuiltIn const & sin,
+                    SinCudaBuiltIn const & sin_ctx,
                     TArg const & arg)
                 -> decltype(::sin(arg))
                 {
-                    alpaka::ignore_unused(sin);
+                    alpaka::ignore_unused(sin_ctx);
                     return ::sin(arg);
                 }
             };

--- a/include/alpaka/math/sin/SinHipBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinHipBuiltIn.hpp
@@ -60,11 +60,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto sin(
-                    SinHipBuiltIn const & /*sin*/,
+                    SinHipBuiltIn const & sin_ctx,
                     TArg const & arg)
                 -> decltype(::sin(arg))
                 {
-                    //boost::ignore_unused(sin);
+                    alpaka::ignore_unused(sin_ctx);
                     return ::sin(arg);
                 }
             };

--- a/include/alpaka/math/sin/SinStdLib.hpp
+++ b/include/alpaka/math/sin/SinStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto sin(
-                    SinStdLib const & sin,
+                    SinStdLib const & sin_ctx,
                     TArg const & arg)
                 -> decltype(std::sin(arg))
                 {
-                    alpaka::ignore_unused(sin);
+                    alpaka::ignore_unused(sin_ctx);
                     return std::sin(arg);
                 }
             };

--- a/include/alpaka/math/sin/Traits.hpp
+++ b/include/alpaka/math/sin/Traits.hpp
@@ -38,14 +38,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Sin.
         //! \tparam TArg The arg type.
-        //! \param sin The object specializing Sin.
+        //! \param sin_ctx The object specializing Sin.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto sin(
-            T const & sin,
+            T const & sin_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -53,7 +53,7 @@ namespace alpaka
                 T,
                 TArg>
             ::sin(
-                sin,
+                sin_ctx,
                 arg))
 #endif
         {
@@ -62,7 +62,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::sin(
-                    sin,
+                    sin_ctx,
                     arg);
         }
 
@@ -86,19 +86,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto sin(
-                    T const & sin,
+                    T const & sin_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::sin(
-                        static_cast<typename T::SinBase const &>(sin),
+                        static_cast<typename T::SinBase const &>(sin_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::sin(
-                            static_cast<typename T::SinBase const &>(sin),
+                            static_cast<typename T::SinBase const &>(sin_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto sqrt(
-                    SqrtCudaBuiltIn const & sqrt,
+                    SqrtCudaBuiltIn const & sqrt_ctx,
                     TArg const & arg)
                 -> decltype(::sqrt(arg))
                 {
-                    alpaka::ignore_unused(sqrt);
+                    alpaka::ignore_unused(sqrt_ctx);
                     return ::sqrt(arg);
                 }
             };

--- a/include/alpaka/math/sqrt/SqrtHipBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtHipBuiltIn.hpp
@@ -60,11 +60,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto sqrt(
-                    SqrtHipBuiltIn const & /*sqrt*/,
+                    SqrtHipBuiltIn const & sqrt_ctx,
                     TArg const & arg)
                 -> decltype(::sqrt(arg))
                 {
-                    //boost::ignore_unused(sqrt);
+                    alpaka::ignore_unused(sqrt_ctx);
                     return ::sqrt(arg);
                 }
             };

--- a/include/alpaka/math/sqrt/SqrtStdLib.hpp
+++ b/include/alpaka/math/sqrt/SqrtStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto sqrt(
-                    SqrtStdLib const & sqrt,
+                    SqrtStdLib const & sqrt_ctx,
                     TArg const & arg)
                 -> decltype(std::sqrt(arg))
                 {
-                    alpaka::ignore_unused(sqrt);
+                    alpaka::ignore_unused(sqrt_ctx);
                     return std::sqrt(arg);
                 }
             };

--- a/include/alpaka/math/sqrt/Traits.hpp
+++ b/include/alpaka/math/sqrt/Traits.hpp
@@ -38,14 +38,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Sqrt.
         //! \tparam TArg The arg type.
-        //! \param sqrt The object specializing Sqrt.
+        //! \param sqrt_ctx The object specializing Sqrt.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto sqrt(
-            T const & sqrt,
+            T const & sqrt_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -53,7 +53,7 @@ namespace alpaka
                 T,
                 TArg>
             ::sqrt(
-                sqrt,
+                sqrt_ctx,
                 arg))
 #endif
         {
@@ -62,7 +62,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::sqrt(
-                    sqrt,
+                    sqrt_ctx,
                     arg);
         }
 
@@ -86,19 +86,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto sqrt(
-                    T const & sqrt,
+                    T const & sqrt_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::sqrt(
-                        static_cast<typename T::SqrtBase const &>(sqrt),
+                        static_cast<typename T::SqrtBase const &>(sqrt_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::sqrt(
-                            static_cast<typename T::SqrtBase const &>(sqrt),
+                            static_cast<typename T::SqrtBase const &>(sqrt_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/tan/TanCudaBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto tan(
-                    TanCudaBuiltIn const & tan,
+                    TanCudaBuiltIn const & tan_ctx,
                     TArg const & arg)
                 -> decltype(::tan(arg))
                 {
-                    alpaka::ignore_unused(tan);
+                    alpaka::ignore_unused(tan_ctx);
                     return ::tanf(arg);
                 }
             };

--- a/include/alpaka/math/tan/TanHipBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanHipBuiltIn.hpp
@@ -60,11 +60,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto tan(
-                    TanHipBuiltIn const & /*tan*/,
+                    TanHipBuiltIn const & tan_ctx,
                     TArg const & arg)
                 -> decltype(::tan(arg))
                 {
-                    //boost::ignore_unused(tan);
+                    alpaka::ignore_unused(tan_ctx);
                     return ::tanf(arg);
                 }
             };

--- a/include/alpaka/math/tan/TanStdLib.hpp
+++ b/include/alpaka/math/tan/TanStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto tan(
-                    TanStdLib const & tan,
+                    TanStdLib const & tan_ctx,
                     TArg const & arg)
                 -> decltype(std::tan(arg))
                 {
-                    alpaka::ignore_unused(tan);
+                    alpaka::ignore_unused(tan_ctx);
                     return std::tan(arg);
                 }
             };

--- a/include/alpaka/math/tan/Traits.hpp
+++ b/include/alpaka/math/tan/Traits.hpp
@@ -38,14 +38,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Tan.
         //! \tparam TArg The arg type.
-        //! \param tan The object specializing Tan.
+        //! \param tan_ctx The object specializing Tan.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto tan(
-            T const & tan,
+            T const & tan_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -53,7 +53,7 @@ namespace alpaka
                 T,
                 TArg>
             ::tan(
-                tan,
+                tan_ctx,
                 arg))
 #endif
         {
@@ -62,7 +62,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::tan(
-                    tan,
+                    tan_ctx,
                     arg);
         }
 
@@ -87,19 +87,19 @@ namespace alpaka
                 //
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto tan(
-                    T const & tan,
+                    T const & tan_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::tan(
-                        static_cast<typename T::TanBase const &>(tan),
+                        static_cast<typename T::TanBase const &>(tan_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::tan(
-                            static_cast<typename T::TanBase const &>(tan),
+                            static_cast<typename T::TanBase const &>(tan_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/trunc/Traits.hpp
+++ b/include/alpaka/math/trunc/Traits.hpp
@@ -38,14 +38,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Trunc.
         //! \tparam TArg The arg type.
-        //! \param trunc The object specializing Trunc.
+        //! \param trunc_ctx The object specializing Trunc.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto trunc(
-            T const & trunc,
+            T const & trunc_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -53,7 +53,7 @@ namespace alpaka
                 T,
                 TArg>
             ::trunc(
-                trunc,
+                trunc_ctx,
                 arg))
 #endif
         {
@@ -62,7 +62,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::trunc(
-                    trunc,
+                    trunc_ctx,
                     arg);
         }
 
@@ -86,19 +86,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto trunc(
-                    T const & trunc,
+                    T const & trunc_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::trunc(
-                        static_cast<typename T::TruncBase const &>(trunc),
+                        static_cast<typename T::TruncBase const &>(trunc_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::trunc(
-                            static_cast<typename T::TruncBase const &>(trunc),
+                            static_cast<typename T::TruncBase const &>(trunc_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
@@ -50,11 +50,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto trunc(
-                    TruncCudaBuiltIn const & trunc,
+                    TruncCudaBuiltIn const & trunc_ctx,
                     TArg const & arg)
                 -> decltype(::trunc(arg))
                 {
-                    alpaka::ignore_unused(trunc);
+                    alpaka::ignore_unused(trunc_ctx);
                     return ::trunc(arg);
                 }
             };

--- a/include/alpaka/math/trunc/TruncHipBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncHipBuiltIn.hpp
@@ -59,11 +59,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 __device__ static auto trunc(
-                    TruncHipBuiltIn const & /*trunc*/,
+                    TruncHipBuiltIn const & trunc_ctx,
                     TArg const & arg)
                 -> decltype(::trunc(arg))
                 {
-                    //boost::ignore_unused(trunc);
+                    alpaka::ignore_unused(trunc_ctx);
                     return ::trunc(arg);
                 }
             };

--- a/include/alpaka/math/trunc/TruncStdLib.hpp
+++ b/include/alpaka/math/trunc/TruncStdLib.hpp
@@ -42,11 +42,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_HOST static auto trunc(
-                    TruncStdLib const & trunc,
+                    TruncStdLib const & trunc_ctx,
                     TArg const & arg)
                 -> decltype(std::trunc(arg))
                 {
-                    alpaka::ignore_unused(trunc);
+                    alpaka::ignore_unused(trunc_ctx);
                     return std::trunc(arg);
                 }
             };


### PR DESCRIPTION
Compilers like gcc4.9+nvcc8 failed to distinguish between variable and function names in the math traits:
```c++
// alpaka::math::min(...) in min/Traits.hpp:
        ALPAKA_FN_HOST_ACC auto min(
            T const & min, // <-- changed to min_ctx now
```
```c++
// implementation in min/MinCudaBuiltIn.hpp
__device__ static auto min(
                    MinCudaBuiltIn const & min, // <-- changed to min_ctx now
```

- changed CUDA and HIP, but also Std parts for the sake of consistency
- compiled and run all the tests on HIP+AMD system, although not all math functions are currently tested
  - unit time test only fails to build when the too old AMD GPU target '--amdgpu-target=gfx701' is used in alpakaConfig.cmake (is ToDo to provide a more convenient AMD GPU target selector via cmake)

The error you previously received:
> /home/travis/build/ComputationalRadiationPhysics/alpaka/include/alpaka/math/sin/SinCudaBuiltIn.hpp(58): error: expression preceding parentheses of apparent call must have (pointer-to-) function type

Edit: updated the doxygen parts, rerunning travis
Edit2: did not have time to update yet ...