### PR TITLE
Use xenial (16.04) as Travis CI base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@
 #
 
 os: linux
-dist: trusty
+dist: xenial
 language: generic
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ services:
 #   [clang++] ALPAKA_CI_CLANG_LIBSTDCPP_VERSION : {5}
 # CMAKE_BUILD_TYPE                              : {Debug, Release}
 # ALPAKA_CI                                     : {TRAVIS}
-# ALPAKA_CI_DOCKER_BASE_IMAGE_NAME              : {ubuntu:14.04, ubuntu:16.04, ubuntu:17.10, ubuntu:18.04}
+# ALPAKA_CI_DOCKER_BASE_IMAGE_NAME              : {ubuntu:14.04, ubuntu:16.04, ubuntu:18.04}
 # ALPAKA_CI_BOOST_BRANCH                        : {[CXX!=cl.exe&&OS!=osx]:boost-1.62.0, [CXX!=cl.exe&&OS!=osx]:boost-1.63.0, [OS!=osx]boost-1.64.0, boost-1.65.1, boost-1.66.0, boost-1.67.0, boost-1.68.0, boost-1.69.0, boost-1.70.0}
 # ALPAKA_CI_CMAKE_VER                           : {3.11.0, 3.11.4, 3.12.4, 3.13.0, 3.13.4, 3.14.0}
 # ALPAKA_CI_SANITIZERS                          : {ASan, UBsan, TSan, ESan}
@@ -122,7 +122,7 @@ matrix:
     - name: gcc-5 Release
       env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:18.04 CXX=g++     CC=gcc   ALPAKA_CI_GCC_VER=5       CMAKE_BUILD_TYPE=Release ALPAKA_CI_STDLIB=libstdc++ ALPAKA_CI_BOOST_BRANCH=boost-1.66.0 ALPAKA_CI_CMAKE_VER=3.11.0 OMP_NUM_THREADS=3
     - name: gcc-6 Debug c++14
-      env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:17.10 CXX=g++     CC=gcc   ALPAKA_CI_GCC_VER=6       CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_STDLIB=libstdc++ ALPAKA_CI_BOOST_BRANCH=boost-1.70.0 ALPAKA_CI_CMAKE_VER=3.14.0 OMP_NUM_THREADS=2 ALPAKA_CXX_STANDARD=14
+      env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:18.04 CXX=g++     CC=gcc   ALPAKA_CI_GCC_VER=6       CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_STDLIB=libstdc++ ALPAKA_CI_BOOST_BRANCH=boost-1.70.0 ALPAKA_CI_CMAKE_VER=3.14.0 OMP_NUM_THREADS=2 ALPAKA_CXX_STANDARD=14
     - name: gcc-7 Release
       env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:14.04 CXX=g++     CC=gcc   ALPAKA_CI_GCC_VER=7       CMAKE_BUILD_TYPE=Release ALPAKA_CI_STDLIB=libstdc++ ALPAKA_CI_BOOST_BRANCH=boost-1.63.0 ALPAKA_CI_CMAKE_VER=3.13.4 OMP_NUM_THREADS=3
     - name: gcc-8 Debug c++17

--- a/script/travis/docker_run.sh
+++ b/script/travis/docker_run.sh
@@ -127,4 +127,5 @@ if [[ "$(docker images -q ${ALPAKA_CI_DOCKER_IMAGE_NAME} 2> /dev/null)" == "" ]]
     gzip -dc "${ALPAKA_CI_DOCKER_CACHE_IMAGE_FILE_PATH}" | docker load
 fi
 
-docker run -v "$(pwd)":"$(pwd)" -w "$(pwd)" "${ALPAKA_DOCKER_ENV_LIST[@]}" --rm "${ALPAKA_CI_DOCKER_IMAGE_NAME}" /bin/bash ./script/travis/run.sh
+# --cap-add SYS_PTRACE is required for LSAN to work
+docker run --cap-add SYS_PTRACE -v "$(pwd)":"$(pwd)" -w "$(pwd)" "${ALPAKA_DOCKER_ENV_LIST[@]}" --rm "${ALPAKA_CI_DOCKER_IMAGE_NAME}" /bin/bash ./script/travis/run.sh


### PR DESCRIPTION
Travis changed the default build image to Ubuntu 16.04 so I did the explicit switch for our CI plans as well.
We are building within docker images on linux so this does not have an influence on the build itself.