### PR TITLE
fix cuda warning

### DIFF
--- a/include/alpaka/mem/alloc/Traits.hpp
+++ b/include/alpaka/mem/alloc/Traits.hpp
@@ -97,13 +97,6 @@ namespace alpaka
                         && (!std::is_same<typename TAlloc::AllocBase, typename std::decay<TAlloc>::type>::value)>::type>
                 {
                     //-----------------------------------------------------------------------------
-                    // FIXME: compiler switch for the host-device signatures
-#if defined( BOOST_COMP_HCC ) && BOOST_COMP_HCC
-                    ALPAKA_FN_HOST
-#else
-                    ALPAKA_NO_HOST_ACC_WARNING
-                    ALPAKA_FN_HOST_ACC
-#endif
                     static auto alloc(
                         TAlloc const & alloc,
                         std::size_t const & sizeElems)
@@ -131,13 +124,6 @@ namespace alpaka
                         && (!std::is_same<typename TAlloc::AllocBase, typename std::decay<TAlloc>::type>::value)>::type>
                 {
                     //-----------------------------------------------------------------------------
-                    // FIXME: compiler switch for the host-device signatures
-#if defined( BOOST_COMP_HCC ) && BOOST_COMP_HCC
-                    ALPAKA_FN_HOST
-#else
-                    ALPAKA_NO_HOST_ACC_WARNING
-                    ALPAKA_FN_HOST_ACC
-#endif
                     static auto free(
                         TAlloc const & alloc,
                         T const * const ptr)

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -250,11 +250,10 @@ namespace alpaka
 
             //-----------------------------------------------------------------------------
             //! \return The pitch in bytes. This is the distance in bytes between two consecutive elements in the given dimension.
-            ALPAKA_NO_HOST_ACC_WARNING
             template<
                 std::size_t Tidx,
                 typename TView>
-            ALPAKA_FN_HOST_ACC auto getPitchBytes(
+            auto getPitchBytes(
                 TView const & view)
             -> idx::Idx<TView>
             {
@@ -532,7 +531,7 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     template<
                         typename TPitch>
-                    ALPAKA_FN_HOST_ACC static auto create(
+                    static auto create(
                         TPitch const & pitch)
                     -> idx::Idx<TPitch>
                     {
@@ -544,7 +543,7 @@ namespace alpaka
             //! \return The pitch vector.
             template<
                 typename TPitch>
-            ALPAKA_FN_HOST_ACC auto getPitchBytesVec(
+            auto getPitchBytesVec(
                 TPitch const & pitch = TPitch())
             -> vec::Vec<dim::Dim<TPitch>, idx::Idx<TPitch>>
             {
@@ -576,12 +575,11 @@ namespace alpaka
 
             //-----------------------------------------------------------------------------
             //! \return A view to static device memory.
-            ALPAKA_NO_HOST_ACC_WARNING
             template<
                 typename TElem,
                 typename TDev,
                 typename TExtent>
-            ALPAKA_FN_HOST_ACC auto createStaticDevMemView(
+            auto createStaticDevMemView(
                 TElem * pMem,
                 TDev const & dev,
                 TExtent const & extent)

--- a/include/alpaka/mem/view/ViewCompileTimeArray.hpp
+++ b/include/alpaka/mem/view/ViewCompileTimeArray.hpp
@@ -109,8 +109,7 @@ namespace alpaka
                     && (std::extent<TFixedSizeArray, TIdxIntegralConst::value>::value > 0u)>::type>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_NO_HOST_ACC_WARNING
-                ALPAKA_FN_HOST_ACC static constexpr auto getExtent(
+                static constexpr auto getExtent(
                     TFixedSizeArray const & //extent
                 )
                 -> idx::Idx<TFixedSizeArray>
@@ -140,16 +139,14 @@ namespace alpaka
                     using TElem = typename std::remove_all_extent<TFixedSizeArray>::type;
 
                     //-----------------------------------------------------------------------------
-                    ALPAKA_NO_HOST_ACC_WARNING
-                    ALPAKA_FN_HOST_ACC static auto getPtrNative(
+                    static auto getPtrNative(
                         TFixedSizeArray const & view)
                     -> TElem const *
                     {
                         return view;
                     }
                     //-----------------------------------------------------------------------------
-                    ALPAKA_NO_HOST_ACC_WARNING
-                    ALPAKA_FN_HOST_ACC static auto getPtrNative(
+                    static auto getPtrNative(
                         TFixedSizeArray & view)
                     -> TElem *
                     {
@@ -171,8 +168,7 @@ namespace alpaka
                     using TElem = typename std::remove_all_extent<TFixedSizeArray>::type;
 
                     //-----------------------------------------------------------------------------
-                    ALPAKA_NO_HOST_ACC_WARNING
-                    ALPAKA_FN_HOST_ACC static constexpr auto getPitchBytes(
+                    static constexpr auto getPitchBytes(
                         TFixedSizeArray const &)
                     -> idx::Idx<TFixedSizeArray>
                     {
@@ -197,8 +193,7 @@ namespace alpaka
                 typename std::enable_if<std::is_array<TFixedSizeArray>::value>::type>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_NO_HOST_ACC_WARNING
-                ALPAKA_FN_HOST_ACC static auto getOffset(
+                static auto getOffset(
                     TFixedSizeArray const &)
                 -> idx::Idx<TFixedSizeArray>
                 {

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -146,8 +146,7 @@ namespace alpaka
             struct GetDev<
                 mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx>>
             {
-                ALPAKA_NO_HOST_ACC_WARNING
-                ALPAKA_FN_HOST_ACC static auto getDev(
+                static auto getDev(
                     mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx> const & view)
                     -> TDev
                 {
@@ -209,8 +208,7 @@ namespace alpaka
                 mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx>,
                 typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
             {
-                ALPAKA_NO_HOST_ACC_WARNING
-                ALPAKA_FN_HOST_ACC static auto getExtent(
+                static auto getExtent(
                     mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx> const & extent)
                 -> TIdx
                 {
@@ -235,15 +233,13 @@ namespace alpaka
                 struct GetPtrNative<
                     mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx>>
                 {
-                    ALPAKA_NO_HOST_ACC_WARNING
-                    ALPAKA_FN_HOST_ACC static auto getPtrNative(
+                    static auto getPtrNative(
                         mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx> const & view)
                     -> TElem const *
                     {
                         return view.m_pMem;
                     }
-                    ALPAKA_NO_HOST_ACC_WARNING
-                    ALPAKA_FN_HOST_ACC static auto getPtrNative(
+                    static auto getPtrNative(
                         mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx> & view)
                     -> TElem *
                     {
@@ -282,7 +278,7 @@ namespace alpaka
                     template<
                         typename TElem,
                         typename TExtent>
-                    ALPAKA_FN_HOST_ACC static auto createStaticDevMemView(
+                    static auto createStaticDevMemView(
                         TElem * pMem,
                         dev::DevCpu const & dev,
                         TExtent const & extent)
@@ -310,11 +306,10 @@ namespace alpaka
                     dev::DevCudaRt>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_NO_HOST_ACC_WARNING
                     template<
                         typename TElem,
                         typename TExtent>
-                    ALPAKA_FN_HOST_ACC static auto createStaticDevMemView(
+                    static auto createStaticDevMemView(
                         TElem * pMem,
                         dev::DevCudaRt const & dev,
                         TExtent const & extent)
@@ -351,7 +346,7 @@ namespace alpaka
                     template<
                         typename TElem,
                         typename TExtent>
-                    ALPAKA_FN_HOST_ACC static auto createStaticDevMemView(
+                    static auto createStaticDevMemView(
                         TElem * pMem,
                         dev::DevHipRt const & dev,
                         TExtent const & extent)
@@ -405,8 +400,7 @@ namespace alpaka
                 mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx>>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_NO_HOST_ACC_WARNING
-                ALPAKA_FN_HOST_ACC static auto getOffset(
+                static auto getOffset(
                     mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx> const &)
                 -> TIdx
                 {


### PR DESCRIPTION
Fix CUDA warning that a host function is called from a host device function.

- remove in `alpaka/mem` all prefix usage `ALPAKA_FN_HOST_ACC` and the corresponding `ALPAKA_NO_HOST_ACC_WARNING`.

I am not sure why all host functions were prefixed with `ALPAKA_FN_HOST_ACC`. My tests with HIP and CUDA 10.0 and 9.2 shows they are not required.