### PR TITLE
fix BlockingQueue multi-thread support

### DIFF
--- a/include/alpaka/queue/QueueCpuBlocking.hpp
+++ b/include/alpaka/queue/QueueCpuBlocking.hpp
@@ -76,7 +76,9 @@ namespace alpaka
             QueueCpuBlocking(
                 dev::DevCpu const & dev) :
                     m_spQueueImpl(std::make_shared<cpu::detail::QueueCpuBlockingImpl>(dev))
-            {}
+            {
+                dev.m_spDevCpuImpl->RegisterBlockingQueue(m_spQueueImpl);
+            }
             //-----------------------------------------------------------------------------
             QueueCpuBlocking(QueueCpuBlocking const &) = default;
             //-----------------------------------------------------------------------------


### PR DESCRIPTION
fix #791

- fix `wait(device)` -> wait for blocking and non blocking queues
- fix event enqueueing -> do not execute an event in a queue which is blocked by an other thread
- fix event waiting for a blocking queue