### PR TITLE
[WIP] Adds bindScope to control host-device context. Adds ALPAKA_LAMBDA.

### DIFF
--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -977,6 +977,8 @@ IF(ALPAKA_ACC_GPU_HIP_ENABLE)
         LIST(APPEND _ALPAKA_LINK_FLAGS_PUBLIC "-Xcompiler ${OpenMP_CXX_FLAGS}")
     ENDIF()
     IF(ALPAKA_HIP_PLATFORM MATCHES "hcc")
+        # https://llvm.org/docs/AMDGPUUsage.html
+        # TODO: provide cmake interface for AMD GPU targets
         # GFX600, GFX601, GFX700, GFX701, GFX702, GFX703, GFX704, GFX801, GFX802, GFX803, GFX810, GFX900, GFX902
         SET(_ALPAKA_LINK_LIBRARIES_PUBLIC "${_ALPAKA_LINK_LIBRARIES_PUBLIC}" "--amdgpu-target=gfx803 --amdgpu-target=gfx900 --amdgpu-target=gfx906")
     ENDIF()

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -69,6 +69,7 @@
 #include <alpaka/core/Assert.hpp>
 #include <alpaka/core/Align.hpp>
 #include <alpaka/core/BarrierThread.hpp>
+#include <alpaka/core/BindScope.hpp>
 #include <alpaka/core/BoostPredef.hpp>
 #include <alpaka/core/ClipCast.hpp>
 #include <alpaka/core/Common.hpp>

--- a/include/alpaka/core/BindScope.hpp
+++ b/include/alpaka/core/BindScope.hpp
@@ -1,0 +1,235 @@
+/* Copyright 2019 Benjamin Worpitz, Matthias Werner
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+
+#pragma once
+
+#include <alpaka/core/Common.hpp>
+#include <alpaka/core/Assert.hpp>
+
+#include <type_traits>
+
+
+namespace alpaka
+{
+    namespace core
+    {
+        /**
+         * Scopes are required for BindScope functor and the bindScope function.
+         */
+        enum class Scope {
+            HostOnly,
+            DeviceOnly,
+            HostDevice,
+            Default
+        };
+
+        /**
+         * BindScope wraps a callable object and executes it only in the given scope.
+         *
+         * A BindScope object can always be created both on host and on device.
+         * The callable is only called when the provided scope matches.
+         * The behaviour is undefined, when a method is called outside the specified scope.
+         *
+         * HIP(HC): BindScope adds missing host or device functions, otherwise HC will complain.
+         * Note, that in HIP/HC the host-device annotations belong to the function signature (attributes are applied to the function type).
+         *
+         * NVCC: BindScope invokes the callable only in the specified scope and the compiler stage,
+         * and calls ALPAKA_ASSERT(false) otherwise.
+         * A lambda still needs host or device annotation, use ALPAKA_LAMBDA.
+         */
+        template<typename TFunc, Scope TScope>
+        struct BindScope;
+
+        /**
+         * Returns BindScope wrapper callable for HIP and CUDA backends.
+         *
+         * For the other backends it just returns the callable itself.
+         */
+        template<Scope TScope, typename TFunc>
+        ALPAKA_FN_INLINE
+#if BOOST_LANG_CUDA || BOOST_LANG_HIP
+        auto bindScope( const TFunc callable ) -> BindScope<TFunc, TScope> {
+            return BindScope<TFunc, TScope>( callable );
+        }
+#else
+        auto bindScope( const TFunc callable ) -> TFunc {
+            // no host-device semantics, so no wrapper needed, just return the callable
+            return callable;
+        }
+#endif
+
+
+
+// --- HIP(NVCC) ---
+#if BOOST_COMP_NVCC || BOOST_COMP_CLANG_CUDA
+
+        // Default NVCC: enable host + device for callable.
+        template<typename TFunc, Scope TScope>
+        struct BindScope {
+            const TFunc m_callable;
+
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_HOST_ACC
+            explicit BindScope(const TFunc callable) : m_callable{callable} {}
+
+            ALPAKA_NO_HOST_ACC_WARNING
+            template<typename... TArgs>
+            ALPAKA_FN_HOST_ACC
+            auto operator()(TArgs&&... args) const -> decltype(m_callable(std::forward<TArgs>(args)...)) {
+                return m_callable(std::forward<TArgs>(args)...);
+            }
+        };
+
+        // HostOnly NVCC:
+        template<typename TFunc>
+        struct BindScope<TFunc, Scope::HostOnly> {
+            const TFunc m_callable;
+
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_HOST_ACC
+            explicit BindScope(const TFunc callable) : m_callable{callable} {}
+
+#if BOOST_ARCH_PTX
+            ALPAKA_NO_HOST_ACC_WARNING
+            template<typename... TArgs>
+            ALPAKA_FN_HOST_ACC
+            auto operator()(TArgs&&... args) const -> void { // void, otherwise callable() must be invoked for decltype()
+                ALPAKA_ASSERT(false);
+                alpaka::ignore_unused(args...);
+            }
+#else
+            ALPAKA_NO_HOST_ACC_WARNING
+            template<typename... TArgs>
+            ALPAKA_FN_HOST_ACC
+            auto operator()(TArgs&&... args) const -> decltype(m_callable(std::forward<TArgs>(args)...)) {
+                return m_callable(std::forward<TArgs>(args)...);
+            }
+#endif
+        };
+
+        // DeviceOnly NVCC: Lambdas must be annotated with __device__ too (see ALPAKA_LAMBDA)
+        template<typename TFunc>
+        struct BindScope<TFunc, Scope::DeviceOnly> {
+            const TFunc m_callable;
+
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_HOST_ACC
+            explicit BindScope(const TFunc callable) : m_callable{callable} {}
+
+#if !BOOST_ARCH_PTX
+            ALPAKA_NO_HOST_ACC_WARNING
+            template<typename... TArgs>
+            ALPAKA_FN_HOST_ACC
+            auto operator()(TArgs&&... args) const -> void { // void, otherwise callable() must be invoked for decltype()
+                ALPAKA_ASSERT(false);
+                alpaka::ignore_unused(args...);
+            }
+#else
+            ALPAKA_NO_HOST_ACC_WARNING
+            template<typename... TArgs>
+            ALPAKA_FN_HOST_ACC
+            auto operator()(TArgs&&... args) const -> decltype(m_callable(std::forward<TArgs>(args)...)) {
+                return m_callable(std::forward<TArgs>(args)...);
+            }
+#endif
+        };
+
+
+
+// --- HIP(HCC) ---
+#elif BOOST_COMP_HCC
+
+        // Default HIP/HCC: let HC decide and just call the callable without host-device annotation.
+        template<typename TFunc, Scope TScope=Scope::Default>
+        struct BindScope {
+            const TFunc m_callable;
+
+            ALPAKA_FN_HOST_ACC
+            explicit BindScope(const TFunc callable) : m_callable{callable} {}
+
+            template<typename... TArgs>
+            auto operator()(TArgs&&... args) const -> decltype(m_callable(std::forward<TArgs>(args)...)) {
+                return m_callable(std::forward<TArgs>(args)...);
+            }
+
+            ALPAKA_FN_HOST_ACC ~BindScope(){} // destructor must reflect host-device annotation of constructors
+        };
+
+        // HostDevice HIP/HCC: explicitly define host+device context
+        template<typename TFunc>
+        struct BindScope<TFunc, Scope::HostDevice> {
+            const TFunc m_callable;
+
+            ALPAKA_FN_HOST_ACC
+            explicit BindScope(const TFunc callable) : m_callable{callable} {}
+
+            template<typename... TArgs>
+            ALPAKA_FN_HOST_ACC
+            auto operator()(TArgs&&... args) const -> decltype(m_callable(std::forward<TArgs>(args)...)) {
+                return m_callable(std::forward<TArgs>(args)...);
+            }
+
+            ALPAKA_FN_HOST_ACC ~BindScope(){} // destructor must reflect host-device annotation of constructors
+        };
+
+        // HostOnly HIP/HCC:
+        template<typename TFunc>
+        struct BindScope<TFunc, Scope::HostOnly> {
+            const TFunc m_callable;
+
+            ALPAKA_FN_HOST_ACC
+            explicit BindScope(const TFunc callable) : m_callable{callable} {}
+
+            template<typename... TArgs>
+            ALPAKA_FN_HOST
+            auto operator()(TArgs&&... args) const -> decltype(m_callable(std::forward<TArgs>(args)...)) {
+                return m_callable(std::forward<TArgs>(args)...);
+            }
+            // do not use decltype for trailing return type, it will break HCC with AMP restricted call in host function
+            template<typename T, typename... TArgs>
+            __device__
+            auto operator()(T&&, TArgs&&... args) const -> void { // void, otherwise callable() must be invoked for decltype()
+                ALPAKA_ASSERT(false);
+                alpaka::ignore_unused(args...);
+            }
+
+            ALPAKA_FN_HOST_ACC ~BindScope(){} // destructor must reflect host-device annotation of constructors
+        };
+
+        template<typename TFunc>
+        struct BindScope<TFunc, Scope::DeviceOnly> {
+            const TFunc m_callable;
+
+            ALPAKA_FN_HOST_ACC
+            explicit BindScope(const TFunc callable) : m_callable{callable} {}
+
+            template<typename... TArgs>
+            ALPAKA_FN_HOST
+            auto operator()(TArgs&&... args) const -> void { // void, otherwise callable() must be invoked for decltype()
+                ALPAKA_ASSERT(false);
+                alpaka::ignore_unused(args...);
+            }
+            template<typename... TArgs>
+            __device__
+            auto operator()(TArgs&&... args) const -> decltype(m_callable(std::forward<TArgs>(args)...)) {
+                return m_callable(std::forward<TArgs>(args)...);
+            }
+
+            ALPAKA_FN_HOST_ACC ~BindScope(){} // destructor must reflect host-device annotation of constructors
+        };
+#endif // HCC
+
+    } // core
+} // alpaka
+
+// macro definitions to provide shortcuts
+#define ALPAKA_FN_SCOPE_HOST alpaka::core::bindScope< alpaka::core::Scope::HostOnly >
+#define ALPAKA_FN_SCOPE_DEVICE alpaka::core::bindScope< alpaka::core::Scope::DeviceOnly >
+#define ALPAKA_FN_SCOPE_HOST_DEVICE alpaka::core::bindScope< alpaka::core::Scope::HostDevice >

--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -126,3 +126,13 @@
 #else
     #define ALPAKA_STATIC_ACC_MEM_CONSTANT
 #endif
+
+
+// ALPAKA_LAMBDA defines compiler dependent host-device annotation and capture
+// - more information: https://github.com/kokkos/kokkos/wiki/Lambda-Dispatch
+#if BOOST_COMP_NVCC || BOOST_COMP_CLANG_CUDA
+    #define ALPAKA_FN_LAMBDA [=] __host__ __device__
+#else // HIP(HCC) and CPU backends
+    // lambdas do not require a host-device attributes
+    #define ALPAKA_FN_LAMBDA [=]
+#endif

--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <alpaka/core/Assert.hpp>
+#include <alpaka/core/BindScope.hpp>
 #include <alpaka/dim/DimIntegralConst.hpp>
 #include <alpaka/extent/Traits.hpp>
 #include <alpaka/mem/view/Traits.hpp>
@@ -169,13 +170,13 @@ namespace alpaka
                             {
                                 meta::ndLoopIncIdx(
                                     extentWithoutInnermost,
-                                    [&](vec::Vec<DimMin1, ExtentSize> const & idx)
-                                    {
-                                        std::memcpy(
-                                            reinterpret_cast<void *>(this->m_dstMemNative + (vec::cast<DstSize>(idx) * dstPitchBytesWithoutOutmost).foldrAll(std::plus<DstSize>())),
-                                            reinterpret_cast<void const *>(this->m_srcMemNative + (vec::cast<SrcSize>(idx) * srcPitchBytesWithoutOutmost).foldrAll(std::plus<SrcSize>())),
-                                            static_cast<std::size_t>(this->m_extentWidthBytes));
-                                    });
+                                    ALPAKA_FN_SCOPE_HOST( [&] (vec::Vec<DimMin1, ExtentSize> const & idx) {
+                                            std::memcpy(
+                                                reinterpret_cast<void *>(this->m_dstMemNative + (vec::cast<DstSize>(idx) * dstPitchBytesWithoutOutmost).foldrAll(std::plus<DstSize>())),
+                                                reinterpret_cast<void const *>(this->m_srcMemNative + (vec::cast<SrcSize>(idx) * srcPitchBytesWithoutOutmost).foldrAll(std::plus<SrcSize>())),
+                                                static_cast<std::size_t>(this->m_extentWidthBytes));
+                                    })
+                              );
                             }
                         }
                     };

--- a/test/unit/kernel/src/KernelBindScopedLambda.cpp
+++ b/test/unit/kernel/src/KernelBindScopedLambda.cpp
@@ -1,0 +1,97 @@
+/* Copyright 2019 Benjamin Worpitz, Matthias Werner
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+// NVCC needs --expt-extended-lambda
+#if !defined(__NVCC__) || \
+    ( defined(__NVCC__) && defined(__CUDACC_EXTENDED_LAMBDA__) )
+
+
+#include <alpaka/core/BindScope.hpp>
+
+#include <alpaka/test/acc/TestAccs.hpp>
+#include <alpaka/test/KernelExecutionFixture.hpp>
+
+#include <catch2/catch.hpp>
+
+//-----------------------------------------------------------------------------
+struct TestTemplateBindScope
+{
+template< typename TAcc >
+void operator()()
+{
+    using Dim = alpaka::dim::Dim<TAcc>;
+    using Idx = alpaka::idx::Idx<TAcc>;
+
+    alpaka::test::KernelExecutionFixture<TAcc> fixture(
+        alpaka::vec::Vec<Dim, Idx>::ones());
+
+    std::uint32_t const arg = 42u;
+
+    REQUIRE(
+        fixture(
+            alpaka::core::bindScope< alpaka::core::Scope::HostDevice > (
+                ALPAKA_FN_LAMBDA
+                (TAcc const & acc,
+                    bool * success,
+                    std::uint32_t const & arg1)
+                -> void
+                {
+                    alpaka::ignore_unused(acc);
+
+                    ALPAKA_CHECK(*success, 42u == arg1);
+                }), arg));
+}
+};
+
+struct TestTemplateBindScopeShortcut
+{
+template< typename TAcc >
+void operator()()
+{
+    using Dim = alpaka::dim::Dim<TAcc>;
+    using Idx = alpaka::idx::Idx<TAcc>;
+
+    alpaka::test::KernelExecutionFixture<TAcc> fixture(
+        alpaka::vec::Vec<Dim, Idx>::ones());
+
+    std::uint32_t const arg = 42u;
+
+    REQUIRE(
+        fixture(
+            ALPAKA_FN_SCOPE_HOST_DEVICE(
+                ALPAKA_FN_LAMBDA
+                (TAcc const & acc,
+                    bool * success,
+                    std::uint32_t const & arg1)
+                -> void
+                {
+                    alpaka::ignore_unused(acc);
+
+                    ALPAKA_CHECK(*success, 42u == arg1);
+                }), arg));
+}
+};
+
+TEST_CASE( "bindScopedLambdaKernelIsWorking", "[kernel]")
+{
+    using TestAccs = alpaka::test::acc::EnabledAccs<
+        alpaka::dim::DimInt<1u>,
+        std::size_t>;
+    alpaka::meta::forEachType< TestAccs >( TestTemplateBindScope() );
+}
+
+TEST_CASE( "bindScopeShortcutLambdaKernelIsWorking", "[kernel]")
+{
+    using TestAccs = alpaka::test::acc::EnabledAccs<
+        alpaka::dim::DimInt<1u>,
+        std::size_t>;
+    alpaka::meta::forEachType< TestAccs >( TestTemplateBindScopeShortcut() );
+}
+
+#endif

--- a/test/unit/mem/view/src/ViewCopy.cpp
+++ b/test/unit/mem/view/src/ViewCopy.cpp
@@ -1,0 +1,100 @@
+/* Copyright 2019 Benjamin Worpitz, Matthias Werner
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <alpaka/test/acc/TestAccs.hpp>
+#include <alpaka/test/queue/Queue.hpp>
+#include <alpaka/test/mem/view/ViewTest.hpp>
+#include <alpaka/test/Extent.hpp>
+#include <alpaka/meta/ForEachType.hpp>
+#include <alpaka/core/BoostPredef.hpp>
+
+#include <catch2/catch.hpp>
+
+#include <type_traits>
+#include <numeric>
+
+//-----------------------------------------------------------------------------
+template<unsigned TDim, unsigned TElemsPerDim, typename TData>
+struct TestTemplateCopy
+{
+template< typename TAcc >
+auto operator()() const -> void
+{
+    using Dim = alpaka::dim::DimInt<TDim>;
+    using Idx = std::size_t;
+    using DevAcc = alpaka::dev::Dev<TAcc>;
+    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
+    using PltfHost = alpaka::pltf::PltfCpu;
+    using QueueAcc = alpaka::test::queue::DefaultQueue<DevAcc>;
+
+    auto const devAcc(alpaka::pltf::getDevByIdx<PltfAcc>(0u));
+    auto const devHost(alpaka::pltf::getDevByIdx<PltfHost>(0u));
+    QueueAcc devQueue{devAcc};
+
+    constexpr Idx nElementsPerDim = TElemsPerDim;
+    using Data = TData;
+    using Vec = alpaka::vec::Vec<Dim, Idx>;
+    const Vec extents{Vec::all(static_cast<Idx>(nElementsPerDim))};
+
+    // Allocate host memory buffers
+    //
+    // The `alloc` method returns a reference counted buffer handle.
+    // When the last such handle is destroyed, the memory is freed automatically.
+    auto hostBuffer1(alpaka::mem::buf::alloc<Data, Idx>(devHost, extents));
+    auto hostBuffer2(alpaka::mem::buf::alloc<Data, Idx>(devHost, extents));
+    auto hostBuffer3(alpaka::mem::buf::alloc<Data, Idx>(devHost, extents));
+
+    // Allocate accelerator memory buffers
+    //
+    // The interface to allocate a buffer is the same on the host and on the device.
+    auto deviceBuffer1(alpaka::mem::buf::alloc<Data, Idx>(devAcc, extents));
+    auto deviceBuffer2(alpaka::mem::buf::alloc<Data, Idx>(devAcc, extents));
+
+    // fill initial host buffer
+    Data * const pHostBuffer1{alpaka::mem::view::getPtrNative(hostBuffer1)};
+    Data * const pHostBuffer3{alpaka::mem::view::getPtrNative(hostBuffer3)};
+
+    for(Idx i{0}; i < extents.prod(); ++i)
+    {
+        pHostBuffer1[i] = static_cast<Data>(i+1);
+        pHostBuffer3[i] = static_cast<Data>(0);
+    }
+    alpaka::mem::view::copy(devQueue, deviceBuffer1, hostBuffer1, extents);
+    alpaka::mem::view::copy(devQueue, deviceBuffer2, deviceBuffer1, extents);
+    alpaka::mem::view::copy(devQueue, hostBuffer2, deviceBuffer2, extents);
+    alpaka::mem::view::copy(devQueue, hostBuffer3, hostBuffer2, extents);
+    alpaka::wait::wait(devQueue);
+
+
+    // This pointer can be used to directly write
+    // some values into the buffer memory.
+    // Mind, that only a host can write on host memory.
+    // The same holds true for device memory.
+    for(Idx i{0}; i < extents.prod(); ++i)
+    {
+        CHECK(pHostBuffer3[i] == static_cast<Data>(i+1));
+    }
+}
+};
+TEST_CASE( "viewCopy", "[memView]")
+{
+    using TestAccs = alpaka::test::acc::EnabledAccs<
+        alpaka::dim::DimInt<1u>,
+        std::size_t>;
+
+    alpaka::meta::forEachType< TestAccs >(
+      TestTemplateCopy<1u,3u,std::uint32_t>()
+      );
+    alpaka::meta::forEachType< TestAccs >(
+      TestTemplateCopy<2u,3u,std::uint32_t>()
+      );
+    alpaka::meta::forEachType< TestAccs >(
+      TestTemplateCopy<3u,3u,std::uint32_t>()
+      );
+}


### PR DESCRIPTION
This PR offers a solution to #736. HCC host-device restrictions tend to ripple through the call hierarchy like the "restrict" keyword from C++AMP. A heterogeneous call hierarchy, like we have, becomes host & device at some point, so callables need proper annotation and overloading of `operator()` to support both HCC and NVCC restrictions. While HCC lambdas must provide both host and device overloads within a host-device call chain, NVCC lambdas must come with host-device annotations directly. Thus, I have added `bindScope()` and `ALPAKA_LAMBDA`.

Note, that this behavior might change in the HIP-clang compiler, but I would not expect this at the moment (compiling HIP-clang still involves HCC, so I guess they will put this behavior into HIP-clang again).

- BindScope wraps a callable object and executes it only in the given scope.
  - bindScope() is no-op for non-HIP/non-CUDA backends
  - (BindScope objects are host-device though)
- ALPAKA_LAMBDA defines compiler-dependent host-device annotation + capture
  - is actually only required for CUDA to support context-embedded lambdas (see [cuda doc](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#extended-lambda))
  - adds compile-define ALPAKA_CXX_STANDARD for ALPAKA_CLASS_LAMBDA for C++17+
    - (ALPAKA_CLASS_LAMBDA currently not used, just referring to kokkos)
- extends lambda in CPU copy with bindScope() and ALPAKA_LAMBDA
- adds viewCopy to memView test
  - tests copying buffers in all directions (H2D, D2D, D2H, H2H)
  - involves bindScope() and ALPAKA_LAMBDA in CPU copy
- adds test for bindScope() and ALPAKA_LAMBDA

Example:
```c++
auto alpaka_callable = 
  alpaka::core::bindScope< alpaka::core::Scope::HostAndDevice > (
  ALPAKA_LAMBDA                           
  (TAcc const & acc,                      
    bool * success,                     
    std::uint32_t const & arg1)         
  -> void                                 
  {                                       
    alpaka::ignore_unused(acc); 
    ALPAKA_CHECK(*success, 42u == arg1);
  });
```

**Edit:** might help #708 (std::function / nvstd::function for existing functions). 
An existing function might be called from a bindScoped Alpaka lambda.
**Edit-2:** todo from travisCI: 
- [ ] fix unused parameters