### PR TITLE
Atomics test reduced to 1D size_t accelerator set

### DIFF
--- a/include/alpaka/atomic/Op.hpp
+++ b/include/alpaka/atomic/Op.hpp
@@ -243,7 +243,17 @@ namespace alpaka
                 {
                     auto const old(*addr);
                     auto & ref(*addr);
+
+// gcc-7.4.0 assumes for an optimization that a signed overflow does not occur here.
+// That's fine, so ignore that warning.
+#if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 4, 0))
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-overflow"
+#endif
                     ref = ((old == compare) ? value : old);
+#if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 4, 0))
+#pragma GCC diagnostic pop
+#endif
                     return old;
                 }
             };

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -950,21 +950,19 @@ struct TestTemplate
     template< typename TAcc >
     void operator()()
     {
-        // This test exceeds the maximum compilation time on MSVC.
-#if !defined(ALPAKA_CI)
         TestAtomicOperations<TAcc, unsigned char>::testAtomicOperations();
         TestAtomicOperations<TAcc, char>::testAtomicOperations();
         TestAtomicOperations<TAcc, unsigned short>::testAtomicOperations();
         TestAtomicOperations<TAcc, short>::testAtomicOperations();
-#endif
+
         TestAtomicOperations<TAcc, unsigned int>::testAtomicOperations();
         TestAtomicOperations<TAcc, int>::testAtomicOperations();
-#if !(defined(ALPAKA_CI) && BOOST_COMP_MSVC)
+
         TestAtomicOperations<TAcc, unsigned long>::testAtomicOperations();
         TestAtomicOperations<TAcc, long>::testAtomicOperations();
         TestAtomicOperations<TAcc, unsigned long long>::testAtomicOperations();
         TestAtomicOperations<TAcc, long long>::testAtomicOperations();
-#endif
+
         // Not all atomic operations are possible with floating point values.
         //TestAtomicOperations<TAcc, float>::testAtomicOperations();
         //TestAtomicOperations<TAcc, double>::testAtomicOperations();

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -973,5 +973,9 @@ struct TestTemplate
 
 TEST_CASE( "atomicOperationsWorking", "[atomic]")
 {
-    alpaka::meta::forEachType< alpaka::test::acc::TestAccs >( TestTemplate() );
+    using TestAccs = alpaka::test::acc::EnabledAccs<
+        alpaka::dim::DimInt<1u>,
+        std::size_t>;
+
+    alpaka::meta::forEachType< TestAccs >( TestTemplate() );
 }


### PR DESCRIPTION
This is actually more a question. Can the accelerator set be reduced to `<Dim=1D, Idx=size_t>` for atomics tests? It would save a lot of compile time. If so, PR would add this fix and it removes the restrictions for CI (in the hope compile-time is now feasible).
