### PR TITLE
Fixes hiprand issue in travis CI.

### DIFF
--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -771,21 +771,23 @@ IF(ALPAKA_ACC_GPU_HIP_ENABLE)
                 ENDIF()
 
                 # random numbers library ( HIP(NVCC) ) /hiprand
+                # HIP_ROOT_DIR is set by FindHIP.cmake
                 FIND_PATH(HIP_RAND_INC
-                    hiprand_kernel.h
-                    PATHS "${HIP_ROOT_DIR}/hiprand" "${HIP_ROOT_DIR}" "hiprand"
+                    NAMES "hiprand_kernel.h"
+                    PATHS "${HIP_ROOT_DIR}/hiprand" "${HIP_ROOT_DIR}/include" "hiprand"
                     PATHS "/opt/rocm/rocrand/hiprand"
-                    ENV HIP_PATH
-                    PATH_SUFFIXES "include")
+                    PATH_SUFFIXES "include" "hiprand")
                 FIND_LIBRARY(HIP_RAND_LIBRARY
-                    hiprand-d
-                    hiprand
+                    NAMES "hiprand-d" "hiprand"
                     PATHS "${HIP_ROOT_DIR}/hiprand" "${HIP_ROOT_DIR}" "hiprand"
                     PATHS "/opt/rocm/rocrand/hiprand"
                     ENV HIP_PATH
                     PATH_SUFFIXES "lib" "lib64")
-                IF(NOT HIP_RAND_INC OR NOT HIP_RAND_LIBRARY)
-                    MESSAGE(FATAL_ERROR "Could not find hipRAND library")
+                IF(NOT HIP_RAND_INC)
+                    MESSAGE(FATAL_ERROR "Could not find hipRAND include (also searched in: HIP_ROOT_DIR=${HIP_ROOT_DIR}).")
+                ENDIF()
+                IF(NOT HIP_RAND_LIBRARY)
+                    MESSAGE(FATAL_ERROR "Could not find hipRAND library (also searched in: HIP_ROOT_DIR=${HIP_ROOT_DIR}).")
                 ENDIF()
                 LIST(APPEND _ALPAKA_INCLUDE_DIRECTORIES_PUBLIC "${HIP_RAND_INC}")
                 LIST(APPEND _ALPAKA_LINK_LIBRARIES_PUBLIC "${HIP_RAND_LIBRARY}")

--- a/script/travis/install_hip.sh
+++ b/script/travis/install_hip.sh
@@ -27,3 +27,15 @@ HIP_SOURCE_DIR=${ALPAKA_CI_HIP_ROOT_DIR}/source-hip/
 
 git clone -b "${ALPAKA_CI_HIP_BRANCH}" --quiet --recursive --single-branch https://github.com/ROCm-Developer-Tools/HIP.git "${HIP_SOURCE_DIR}"
 (cd "${HIP_SOURCE_DIR}"; mkdir -p build; cd build; cmake -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" -DCMAKE_INSTALL_PREFIX="${ALPAKA_CI_HIP_ROOT_DIR}" -DBUILD_TESTING=OFF .. && make && make install)
+
+
+## rocRAND
+export HIP_PLATFORM=nvcc
+export HIP_RUNTIME=nvcc
+export ROCRAND_SOURCE_DIR=${ALPAKA_CI_HIP_ROOT_DIR}/source-rocrand/
+if [ ! -d "${ROCRAND_SOURCE_DIR}" ]
+then
+    # install it into the HIP install dir
+    git clone --quiet --recursive https://github.com/ROCmSoftwarePlatform/rocRAND "${ROCRAND_SOURCE_DIR}"
+    (cd "${ROCRAND_SOURCE_DIR}"; mkdir -p build; cd build; cmake -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" -DCMAKE_INSTALL_PREFIX="${ALPAKA_CI_HIP_ROOT_DIR}" -DBUILD_BENCHMARK=OFF -DBUILD_TEST=OFF -DNVGPU_TARGETS="30" -DCMAKE_MODULE_PATH="${ALPAKA_CI_HIP_ROOT_DIR}/cmake" -DHIP_PLATFORM="${HIP_PLATFORM}" .. && make && make install)
+fi

--- a/script/travis/run.sh
+++ b/script/travis/run.sh
@@ -102,18 +102,10 @@ then
     which hipcc
     hipcc -V
     which hipconfig
+    hipconfig --platform
     hipconfig -v
     # print newline as previous command does not do this
     echo
-
-    ## rocRAND
-    export ROCRAND_SOURCE_DIR=${ALPAKA_CI_HIP_ROOT_DIR}/source-rocrand/
-    if [ ! -d "${ROCRAND_SOURCE_DIR}" ]
-    then
-        # install it into the HIP install dir
-        git clone --quiet --recursive https://github.com/ROCmSoftwarePlatform/rocRAND "${ROCRAND_SOURCE_DIR}"
-        (cd "${ROCRAND_SOURCE_DIR}"; mkdir -p build; cd build; cmake -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" -DCMAKE_INSTALL_PREFIX="${ALPAKA_CI_HIP_ROOT_DIR}" -DBUILD_BENCHMARK=OFF -DBUILD_TEST=OFF -DNVGPU_TARGETS="30" -DCMAKE_MODULE_PATH="${ALPAKA_CI_HIP_ROOT_DIR}/cmake" -DHIP_PLATFORM="${HIP_PLATFORM}" .. && make && make install)
-    fi
 
 fi
 


### PR DESCRIPTION
- fixed search path for hiprand include
- moved hiprand install routine back to `install_hip.sh` (it should still work when we will have more than one platforms to consider)