### PR TITLE
Clean up unit test includes

### DIFF
--- a/include/alpaka/core/BoostPredef.hpp
+++ b/include/alpaka/core/BoostPredef.hpp
@@ -127,3 +127,12 @@
         #define BOOST_COMP_INTEL BOOST_COMP_INTEL_DETECTION
     #endif
 #endif
+
+//-----------------------------------------------------------------------------
+// clang CUDA compiler detection
+// Currently __CUDA__ is only defined by clang when compiling CUDA code.
+#if defined(__clang__) && defined(__CUDA__)
+    #define BOOST_COMP_CLANG_CUDA BOOST_COMP_CLANG
+#else
+    #define BOOST_COMP_CLANG_CUDA BOOST_VERSION_NUMBER_NOT_AVAILABLE
+#endif

--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -13,20 +13,9 @@
 #include <alpaka/core/BoostPredef.hpp>
 #include <alpaka/core/Debug.hpp>
 
-#include <boost/predef/version_number.h>
-
 // Boost.Uuid errors with VS2017 when intrin.h is not included
 #if defined(_MSC_VER) && _MSC_VER >= 1910
     #include <intrin.h>
-#endif
-
-//-----------------------------------------------------------------------------
-// clang CUDA compiler detection
-// Currently __CUDA__ is only defined by clang when compiling CUDA code.
-#if defined(__clang__) && defined(__CUDA__)
-    #define BOOST_COMP_CLANG_CUDA BOOST_COMP_CLANG
-#else
-    #define BOOST_COMP_CLANG_CUDA BOOST_VERSION_NUMBER_NOT_AVAILABLE
 #endif
 
 //-----------------------------------------------------------------------------

--- a/include/alpaka/core/Cuda.hpp
+++ b/include/alpaka/core/Cuda.hpp
@@ -26,11 +26,6 @@
 #include <alpaka/meta/IntegerSequence.hpp>
 #include <alpaka/meta/Metafunctions.hpp>
 
-#if BOOST_COMP_MSVC
-    #pragma warning(push)
-    #pragma warning(disable: 4505)  // CUDA\v9.2\include\crt/host_runtime.h(265): warning C4505: '__cudaUnregisterBinaryUtil': unreferenced local function has been removed
-#endif
-
 // cuda_runtime_api.h: CUDA Runtime API C-style interface that does not require compiling with nvcc.
 // cuda_runtime.h: CUDA Runtime API  C++-style interface built on top of the C API.
 //  It wraps some of the C API routines, using overloading, references and default arguments.

--- a/include/alpaka/meta/ApplyTuple.hpp
+++ b/include/alpaka/meta/ApplyTuple.hpp
@@ -18,6 +18,7 @@
 #include <boost/config.hpp>
 
 #include <utility>
+#include <tuple>
 #include <type_traits>
 
 namespace alpaka

--- a/test/common/include/alpaka/test/acc/TestAccs.hpp
+++ b/test/common/include/alpaka/test/acc/TestAccs.hpp
@@ -7,10 +7,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
 #pragma once
 
 #include <alpaka/alpaka.hpp>
+
+#include <alpaka/test/dim/TestDims.hpp>
+#include <alpaka/test/idx/TestIdxs.hpp>
 
 #include <tuple>
 #include <type_traits>
@@ -210,45 +212,6 @@ namespace alpaka
                 os << std::endl;
             }
 
-            //#############################################################################
-            //! A std::tuple holding dimensions.
-            using TestDims =
-                std::tuple<
-                    alpaka::dim::DimInt<1u>
-#if !defined(ALPAKA_CUDA_CI)
-                    ,alpaka::dim::DimInt<2u>
-#endif
-                    ,alpaka::dim::DimInt<3u>
-                    // The CUDA & HIP accelerators do not currently support 4D buffers and 4D acceleration.
-#if !(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA)
-  #if !(defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
-                    ,alpaka::dim::DimInt<4u>
-  #endif
-#endif
-                >;
-
-            //#############################################################################
-            //! A std::tuple holding idx types.
-            using TestIdxs =
-                std::tuple<
-                    // size_t is most probably identical to either std::uint64_t or std::uint32_t.
-                    // This would lead to duplicate tests (especially test names) which is not allowed.
-                    //std::size_t,
-#if !defined(ALPAKA_CI)
-                    std::int64_t,
-#endif
-                    std::uint64_t,
-                    std::int32_t,
-#if !defined(ALPAKA_CI)
-                    std::uint32_t,
-                    std::int16_t,
-#endif
-                    std::uint16_t/*,
-                    // When Idx is a 8 bit integer, extents within the tests would be extremely limited
-                    // (especially when Dim is 4). Therefore, we do not test it.
-                    std::int8_t,
-                    std::uint8_t*/>;
-
             namespace detail
             {
                 //#############################################################################
@@ -264,8 +227,8 @@ namespace alpaka
                 using TestDimIdxTuples =
                     alpaka::meta::CartesianProduct<
                         std::tuple,
-                        TestDims,
-                        TestIdxs
+                        dim::TestDims,
+                        idx::TestIdxs
                     >;
 
                 //#############################################################################

--- a/test/common/include/alpaka/test/dim/TestDims.hpp
+++ b/test/common/include/alpaka/test/dim/TestDims.hpp
@@ -1,0 +1,50 @@
+/* Copyright 2019 Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/dim/DimIntegralConst.hpp>
+
+#include <tuple>
+
+// When compiling the tests with CUDA enabled (nvcc or native clang) on the CI infrastructure
+// we have to dramatically reduce the number of tested combinations.
+// Else the log length would be exceeded.
+#if defined(ALPAKA_CI)
+  #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA \
+   || defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP && !BOOST_COMP_HCC
+    #define ALPAKA_CUDA_CI
+  #endif
+#endif
+
+namespace alpaka
+{
+    namespace test
+    {
+        namespace dim
+        {
+            //#############################################################################
+            //! A std::tuple holding dimensions.
+            using TestDims =
+                std::tuple<
+                    alpaka::dim::DimInt<1u>
+#if !defined(ALPAKA_CUDA_CI)
+                    ,alpaka::dim::DimInt<2u>
+#endif
+                    ,alpaka::dim::DimInt<3u>
+                    // The CUDA & HIP accelerators do not currently support 4D buffers and 4D acceleration.
+#if !(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA)
+  #if !(defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+                    ,alpaka::dim::DimInt<4u>
+  #endif
+#endif
+                >;
+        }
+    }
+}

--- a/test/common/include/alpaka/test/idx/TestIdxs.hpp
+++ b/test/common/include/alpaka/test/idx/TestIdxs.hpp
@@ -1,0 +1,48 @@
+/* Copyright 2019 Benjamin Worpitz, Erik Zenker, Matthias Werner
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <tuple>
+
+namespace alpaka
+{
+    //-----------------------------------------------------------------------------
+    //! The test specifics.
+    namespace test
+    {
+        //-----------------------------------------------------------------------------
+        //! The test accelerator specifics.
+        namespace idx
+        {
+            //#############################################################################
+            //! A std::tuple holding idx types.
+            using TestIdxs =
+                std::tuple<
+                    // size_t is most probably identical to either std::uint64_t or std::uint32_t.
+                    // This would lead to duplicate tests (especially test names) which is not allowed.
+                    //std::size_t,
+#if !defined(ALPAKA_CI)
+                    std::int64_t,
+#endif
+                    std::uint64_t,
+                    std::int32_t,
+#if !defined(ALPAKA_CI)
+                    std::uint32_t,
+                    std::int16_t,
+#endif
+                    std::uint16_t/*,
+                    // When Idx is a 8 bit integer, extents within the tests would be extremely limited
+                    // (especially when Dim is 4). Therefore, we do not test it.
+                    std::int8_t,
+                    std::uint8_t*/>;
+        }
+    }
+}

--- a/test/common/include/alpaka/test/mem/view/Iterator.hpp
+++ b/test/common/include/alpaka/test/mem/view/Iterator.hpp
@@ -131,11 +131,11 @@ namespace alpaka
                         ALPAKA_FN_HOST_ACC auto operator*() const
                         -> Elem &
                         {
-                            using Dim1 = dim::DimInt<1>;
-                            using DimMin1 = dim::DimInt<Dim::value - 1u>;
+                            using Dim1 = alpaka::dim::DimInt<1>;
+                            using DimMin1 = alpaka::dim::DimInt<Dim::value - 1u>;
 
                             vec::Vec<Dim1, Idx> const currentIdxDim1{m_currentIdx};
-                            vec::Vec<Dim, Idx> const currentIdxDimx(idx::mapIdx<Dim::value>(currentIdxDim1, m_extents));
+                            vec::Vec<Dim, Idx> const currentIdxDimx(alpaka::idx::mapIdx<Dim::value>(currentIdxDim1, m_extents));
 
                             // [pz, py, px] -> [py, px]
                             auto const pitchWithoutOutermost(vec::subVecEnd<DimMin1>(m_pitchBytes));

--- a/test/integ/axpy/src/axpy.cpp
+++ b/test/integ/axpy/src/axpy.cpp
@@ -7,12 +7,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <catch2/catch.hpp>
-
 #include <alpaka/alpaka.hpp>
+
 #include <alpaka/test/MeasureKernelRunTime.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/queue/Queue.hpp>
+
+#include <catch2/catch.hpp>
 
 #include <iostream>
 #include <typeinfo>

--- a/test/integ/cudaOnly/src/cudaNativeFunctions.cpp
+++ b/test/integ/cudaOnly/src/cudaNativeFunctions.cpp
@@ -7,8 +7,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
 #include <alpaka/alpaka.hpp>
+
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
 #include <catch2/catch.hpp>

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -7,10 +7,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
 #include <alpaka/alpaka.hpp>
+
 #include <alpaka/test/MeasureKernelRunTime.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 
 #include <catch2/catch.hpp>

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -7,10 +7,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
 #include <alpaka/alpaka.hpp>
+
 #include <alpaka/test/MeasureKernelRunTime.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 
 #include <catch2/catch.hpp>

--- a/test/integ/separableCompilation/src/main.cpp
+++ b/test/integ/separableCompilation/src/main.cpp
@@ -9,11 +9,8 @@
 
 #include "mysqrt.hpp"
 
-#include <catch2/catch.hpp>
-
-#include <alpaka/alpaka.hpp>
 #include <alpaka/test/MeasureKernelRunTime.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 
 #include <catch2/catch.hpp>

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -7,10 +7,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
 #include <alpaka/alpaka.hpp>
+
 #include <alpaka/test/MeasureKernelRunTime.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 
 #include <catch2/catch.hpp>

--- a/test/unit/acc/src/AccNameTest.cpp
+++ b/test/unit/acc/src/AccNameTest.cpp
@@ -8,8 +8,9 @@
  */
 
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/acc/Traits.hpp>
+
+#include <alpaka/test/acc/TestAccs.hpp>
 
 #include <catch2/catch.hpp>
 

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -7,9 +7,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/atomic/Traits.hpp>
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
 #include <catch2/catch.hpp>

--- a/test/unit/block/shared/src/BlockSharedMemDyn.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemDyn.cpp
@@ -7,13 +7,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/block/shared/dyn/Traits.hpp>
 
-#include <catch2/catch.hpp>
-
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
+
+#include <catch2/catch.hpp>
 
 
 //#############################################################################

--- a/test/unit/block/shared/src/BlockSharedMemSt.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemSt.cpp
@@ -7,15 +7,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/block/shared/st/Traits.hpp>
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 #include <alpaka/test/Array.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
 #include <catch2/catch.hpp>
-
 
 //#############################################################################
 class BlockSharedMemStNonNullTestKernel

--- a/test/unit/block/sync/src/BlockSync.cpp
+++ b/test/unit/block/sync/src/BlockSync.cpp
@@ -7,13 +7,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/block/sync/Traits.hpp>
 
-#include <catch2/catch.hpp>
-
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
+#include <catch2/catch.hpp>
 
 //#############################################################################
 class BlockSyncTestKernel

--- a/test/unit/block/sync/src/BlockSyncPredicate.cpp
+++ b/test/unit/block/sync/src/BlockSyncPredicate.cpp
@@ -7,13 +7,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/block/sync/Traits.hpp>
 
-#include <catch2/catch.hpp>
-
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
+#include <catch2/catch.hpp>
 
 //#############################################################################
 class BlockSyncPredicateTestKernel

--- a/test/unit/core/src/BoostPredefTest.cpp
+++ b/test/unit/core/src/BoostPredefTest.cpp
@@ -8,7 +8,7 @@
  */
 
 
-#include <alpaka/alpaka.hpp>
+#include <alpaka/core/BoostPredef.hpp>
 
 #include <catch2/catch.hpp>
 

--- a/test/unit/core/src/ClipCastTest.cpp
+++ b/test/unit/core/src/ClipCastTest.cpp
@@ -7,8 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
-#include <alpaka/alpaka.hpp>
+#include <alpaka/core/ClipCast.hpp>
 
 #include <catch2/catch.hpp>
 

--- a/test/unit/event/src/EventTest.cpp
+++ b/test/unit/event/src/EventTest.cpp
@@ -7,14 +7,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/event/Traits.hpp>
 
-#include <catch2/catch.hpp>
-
-#include <alpaka/alpaka.hpp>
 #include <alpaka/test/event/EventHostManualTrigger.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 #include <alpaka/test/queue/QueueTestFixture.hpp>
 
+#include <catch2/catch.hpp>
 
 //-----------------------------------------------------------------------------
 struct TestTemplateInitTrue

--- a/test/unit/idx/src/MapIdx.cpp
+++ b/test/unit/idx/src/MapIdx.cpp
@@ -7,12 +7,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/idx/Accessors.hpp>
+#include <alpaka/idx/MapIdx.hpp>
+
+#include <alpaka/meta/ForEachType.hpp>
+#include <alpaka/test/dim/TestDims.hpp>
 
 #include <catch2/catch.hpp>
-
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
-
 
 //#############################################################################
 //! 1D: (17)
@@ -56,5 +57,5 @@ void operator()()
 
 TEST_CASE( "mapIdx", "[idx]")
 {
-    alpaka::meta::forEachType< alpaka::test::acc::TestDims >( TestTemplate() );
+    alpaka::meta::forEachType< alpaka::test::dim::TestDims >( TestTemplate() );
 }

--- a/test/unit/kernel/src/KernelGenericLambda.cpp
+++ b/test/unit/kernel/src/KernelGenericLambda.cpp
@@ -7,8 +7,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/kernel/Traits.hpp>
+
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
 #include <catch2/catch.hpp>

--- a/test/unit/kernel/src/KernelLambda.cpp
+++ b/test/unit/kernel/src/KernelLambda.cpp
@@ -10,8 +10,9 @@
 // NVCC needs --expt-extended-lambda
 #if !defined(__NVCC__) || (defined(__NVCC__) && defined(__CUDACC_EXTENDED_LAMBDA__))
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/kernel/Traits.hpp>
+
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 #include <alpaka/core/BoostPredef.hpp>
 

--- a/test/unit/kernel/src/KernelStdFunction.cpp
+++ b/test/unit/kernel/src/KernelStdFunction.cpp
@@ -7,8 +7,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/kernel/Traits.hpp>
+
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 #include <alpaka/core/BoostPredef.hpp>
 

--- a/test/unit/kernel/src/KernelWithAdditionalParam.cpp
+++ b/test/unit/kernel/src/KernelWithAdditionalParam.cpp
@@ -7,8 +7,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/kernel/Traits.hpp>
+
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 #include <alpaka/meta/ForEachType.hpp>
 

--- a/test/unit/kernel/src/KernelWithConstructorAndMember.cpp
+++ b/test/unit/kernel/src/KernelWithConstructorAndMember.cpp
@@ -7,8 +7,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/kernel/Traits.hpp>
+
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 #include <alpaka/meta/ForEachType.hpp>
 

--- a/test/unit/kernel/src/KernelWithHostConstexpr.cpp
+++ b/test/unit/kernel/src/KernelWithHostConstexpr.cpp
@@ -10,8 +10,9 @@
 // NVCC needs --expt-relaxed-constexpr
 #if !defined(__NVCC__) || (defined(__NVCC__) && defined(__CUDACC_RELAXED_CONSTEXPR__))
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/kernel/Traits.hpp>
+
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 #include <alpaka/meta/ForEachType.hpp>
 

--- a/test/unit/kernel/src/KernelWithTemplate.cpp
+++ b/test/unit/kernel/src/KernelWithTemplate.cpp
@@ -7,8 +7,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/kernel/Traits.hpp>
+
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 #include <alpaka/meta/ForEachType.hpp>
 

--- a/test/unit/kernel/src/KernelWithoutTemplatedAccParam.cpp
+++ b/test/unit/kernel/src/KernelWithoutTemplatedAccParam.cpp
@@ -7,7 +7,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-#include <alpaka/alpaka.hpp>
+#include <alpaka/kernel/Traits.hpp>
+
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
 #include <catch2/catch.hpp>

--- a/test/unit/math/sincos/src/sincos.cpp
+++ b/test/unit/math/sincos/src/sincos.cpp
@@ -7,13 +7,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/math/sincos/Traits.hpp>
 
-#include <catch2/catch.hpp>
-
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
+
+#include <catch2/catch.hpp>
 
 // https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
 template <typename TAcc, typename FP>

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -7,14 +7,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/mem/buf/Traits.hpp>
 
-#include <catch2/catch.hpp>
-
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 #include <alpaka/test/mem/view/ViewTest.hpp>
 #include <alpaka/test/Extent.hpp>
+
+#include <catch2/catch.hpp>
 
 #include <type_traits>
 #include <numeric>

--- a/test/unit/mem/p2p/src/P2P.cpp
+++ b/test/unit/mem/p2p/src/P2P.cpp
@@ -8,8 +8,9 @@
  */
 
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/mem/buf/Traits.hpp>
+
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 #include <alpaka/test/mem/view/ViewTest.hpp>
 #include <alpaka/test/Extent.hpp>

--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -7,9 +7,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/mem/view/ViewPlainPtr.hpp>
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 #include <alpaka/test/mem/view/ViewTest.hpp>
 #include <alpaka/test/Extent.hpp>

--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -7,9 +7,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/core/Common.hpp>
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 #include <alpaka/meta/ForEachType.hpp>

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -7,16 +7,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/mem/view/ViewSubView.hpp>
 
-#include <catch2/catch.hpp>
-
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 #include <alpaka/test/mem/view/ViewTest.hpp>
 #include <alpaka/test/Extent.hpp>
 
 #include <alpaka/core/BoostPredef.hpp>
+
+#include <catch2/catch.hpp>
 
 #include <type_traits>
 #include <numeric>

--- a/test/unit/meta/src/ApplyTest.cpp
+++ b/test/unit/meta/src/ApplyTest.cpp
@@ -7,8 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
-#include <alpaka/alpaka.hpp>
+#include <alpaka/meta/Apply.hpp>
 
 #include <catch2/catch.hpp>
 

--- a/test/unit/meta/src/ApplyTupleTest.cpp
+++ b/test/unit/meta/src/ApplyTupleTest.cpp
@@ -7,8 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
-#include <alpaka/alpaka.hpp>
+#include <alpaka/meta/ApplyTuple.hpp>
 
 #include <catch2/catch.hpp>
 
@@ -74,5 +73,5 @@ TEST_CASE("applyTuple", "[meta]")
     REQUIRE(3 == alpaka::meta::apply(add, std::make_tuple(1, 2)));
 
     // intended compilation error: template argument deduction/substitution fails
-    // REQUIRE(5.0 == alpaka::meta::apply(add_generic, std::make_tuple(2.0f, 3.0f)));
+    // REQUIRE(5.0f == alpaka::meta::apply(add_generic, std::make_tuple(2.0f, 3.0f)));
 }

--- a/test/unit/meta/src/CartesianProductTest.cpp
+++ b/test/unit/meta/src/CartesianProductTest.cpp
@@ -7,8 +7,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/meta/CartesianProduct.hpp>
 
-#include <alpaka/alpaka.hpp>
+#include <alpaka/dim/DimIntegralConst.hpp>
 
 #include <catch2/catch.hpp>
 

--- a/test/unit/meta/src/ConcatenateTest.cpp
+++ b/test/unit/meta/src/ConcatenateTest.cpp
@@ -7,8 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
-#include <alpaka/alpaka.hpp>
+#include <alpaka/meta/Concatenate.hpp>
 
 #include <catch2/catch.hpp>
 

--- a/test/unit/meta/src/FilterTest.cpp
+++ b/test/unit/meta/src/FilterTest.cpp
@@ -7,8 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
-#include <alpaka/alpaka.hpp>
+#include <alpaka/meta/Filter.hpp>
 
 #include <catch2/catch.hpp>
 

--- a/test/unit/meta/src/IntegralTest.cpp
+++ b/test/unit/meta/src/IntegralTest.cpp
@@ -7,8 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
-#include <alpaka/alpaka.hpp>
+#include <alpaka/meta/Integral.hpp>
 
 #include <catch2/catch.hpp>
 

--- a/test/unit/meta/src/IsStrictBaseTest.cpp
+++ b/test/unit/meta/src/IsStrictBaseTest.cpp
@@ -7,8 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
-#include <alpaka/alpaka.hpp>
+#include <alpaka/meta/IsStrictBase.hpp>
 
 #include <catch2/catch.hpp>
 

--- a/test/unit/meta/src/MetafunctionsTest.cpp
+++ b/test/unit/meta/src/MetafunctionsTest.cpp
@@ -7,8 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
-#include <alpaka/alpaka.hpp>
+#include <alpaka/meta/Metafunctions.hpp>
 
 #include <catch2/catch.hpp>
 

--- a/test/unit/meta/src/SetTest.cpp
+++ b/test/unit/meta/src/SetTest.cpp
@@ -7,8 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
-#include <alpaka/alpaka.hpp>
+#include <alpaka/meta/Set.hpp>
 
 #include <catch2/catch.hpp>
 

--- a/test/unit/meta/src/TransformTest.cpp
+++ b/test/unit/meta/src/TransformTest.cpp
@@ -7,8 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
-#include <alpaka/alpaka.hpp>
+#include <alpaka/meta/Transform.hpp>
 
 #include <catch2/catch.hpp>
 

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -7,12 +7,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/queue/Traits.hpp>
 
-#include <catch2/catch.hpp>
-
-#include <alpaka/alpaka.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 #include <alpaka/test/queue/QueueTestFixture.hpp>
+
+#include <catch2/catch.hpp>
 
 #include <future>
 #include <thread>

--- a/test/unit/rand/src/RandTest.cpp
+++ b/test/unit/rand/src/RandTest.cpp
@@ -7,11 +7,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/rand/Traits.hpp>
 
 #include <catch2/catch.hpp>
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
 //#############################################################################

--- a/test/unit/time/src/ClockTest.cpp
+++ b/test/unit/time/src/ClockTest.cpp
@@ -7,13 +7,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/time/Traits.hpp>
 
-#include <catch2/catch.hpp>
-
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
+#include <catch2/catch.hpp>
 
 //#############################################################################
 class ClockTestKernel

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -7,12 +7,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/vec/Vec.hpp>
 
-#include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/dim/TestDims.hpp>
+#include <alpaka/meta/ForEachType.hpp>
 
 #include <catch2/catch.hpp>
-
 
 //-----------------------------------------------------------------------------
 TEST_CASE("basicVecTraits", "[vec]")
@@ -357,5 +357,5 @@ void operator()()
 
 TEST_CASE( "vecNDConstructionFromNonAlpakaVec", "[vec]")
 {
-    alpaka::meta::forEachType< alpaka::test::acc::TestDims >( TestTemplate() );
+    alpaka::meta::forEachType< alpaka::test::dim::TestDims >( TestTemplate() );
 }


### PR DESCRIPTION
Unit tests should by convention include the header they test as first include.
Not including all of alpaka in each unit test may also reduce build times.