### PR TITLE
Fixes race-condition HIP/NVCC. HIP/HCC non-blocking queue destructor waits ...

### DIFF
--- a/include/alpaka/queue/QueueHipRtBlocking.hpp
+++ b/include/alpaka/queue/QueueHipRtBlocking.hpp
@@ -146,6 +146,7 @@ namespace alpaka
                 return !((*this) == rhs);
             }
             //-----------------------------------------------------------------------------
+            // NOTE: for HCC streams workaround: no need to sync with spawned tasks as this queue is already syncing in enqueue
             ALPAKA_FN_HOST ~QueueHipRtBlocking() = default;
 
         public:

--- a/include/alpaka/queue/QueueHipRtBlocking.hpp
+++ b/include/alpaka/queue/QueueHipRtBlocking.hpp
@@ -106,9 +106,11 @@ namespace alpaka
                 public:
                     dev::DevHipRt const m_dev;   //!< The device this queue is bound to.
                     hipStream_t m_HipQueue;
-                    //FIXME: workaround for failing stream query
+
+#if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
                     int m_callees = 0;
                     std::mutex m_mutex;
+#endif
                 };
             } // detail
         } // hip
@@ -253,11 +255,13 @@ namespace alpaka
                     TTask const & task)
                 -> void
                 {
+#if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
                     {
                         // thread-safe callee incrementing
                         std::lock_guard<std::mutex> guard(queue.m_spQueueImpl->m_mutex);
                         queue.m_spQueueImpl->m_callees += 1;
                     }
+#endif
 
                     auto pCallbackSynchronizationData = std::make_shared<CallbackSynchronizationData>();
 
@@ -273,10 +277,17 @@ namespace alpaka
                     // The HIP thread is waiting for the std::thread to signal that it is finished executing the task
                     // before it executes the next task in the queue (HIP stream).
                     std::thread t(
-                        [pCallbackSynchronizationData, task, &queue](){
+                        [pCallbackSynchronizationData,
+                         task
+#if BOOST_COMP_HCC // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
+                         ,&queue
+#endif
+                        ](){
 
+#if BOOST_COMP_HCC // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
                             // thread-safe task execution and callee decrementing
                             std::lock_guard<std::mutex> guard(queue.m_spQueueImpl->m_mutex);
+#endif
 
                             // If the callback has not yet been called, we wait for it.
                             {
@@ -298,7 +309,9 @@ namespace alpaka
                             }
                             pCallbackSynchronizationData->m_event.notify_one();
 
+#if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
                             queue.m_spQueueImpl->m_callees -= 1;
+#endif
                         }
                     );
 
@@ -320,8 +333,7 @@ namespace alpaka
 
                     // see: https://github.com/ROCm-Developer-Tools/HIP/blob/roc-1.9.x/tests/src/runtimeApi/stream/hipStreamWaitEvent.cpp
 
-#if BOOST_COMP_HCC
-                    // FIXME: workaround, see m_callees
+#if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
                     return (queue.m_spQueueImpl->m_callees==0);
 #else
                     // Query is allowed even for queues on non current device.
@@ -355,8 +367,7 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-#if BOOST_COMP_HCC
-                    // FIXME: workaround, see m_callees
+#if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
                     while(queue.m_spQueueImpl->m_callees>0) {
                         std::this_thread::sleep_for(std::chrono::milliseconds(100u));
                     }

--- a/include/alpaka/queue/QueueHipRtBlocking.hpp
+++ b/include/alpaka/queue/QueueHipRtBlocking.hpp
@@ -369,7 +369,7 @@ namespace alpaka
 
 #if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
                     while(queue.m_spQueueImpl->m_callees>0) {
-                        std::this_thread::sleep_for(std::chrono::milliseconds(100u));
+                        std::this_thread::sleep_for(std::chrono::milliseconds(10u));
                     }
 #else
                     // Sync is allowed even for queues on non current device.

--- a/include/alpaka/queue/QueueHipRtNonBlocking.hpp
+++ b/include/alpaka/queue/QueueHipRtNonBlocking.hpp
@@ -146,7 +146,12 @@ namespace alpaka
                 return !((*this) == rhs);
             }
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST ~QueueHipRtNonBlocking() = default;
+            ALPAKA_FN_HOST ~QueueHipRtNonBlocking() {
+#if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
+                // we are a non-blocking queue, so we have to wait here with its destruction until all spawned tasks have been processed
+                alpaka::wait::wait(*this);
+#endif
+            }
 
         public:
             std::shared_ptr<hip::detail::QueueHipRtNonBlockingImpl> m_spQueueImpl;

--- a/include/alpaka/queue/QueueHipRtNonBlocking.hpp
+++ b/include/alpaka/queue/QueueHipRtNonBlocking.hpp
@@ -367,7 +367,7 @@ namespace alpaka
 
 #if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
                     while(queue.m_spQueueImpl->m_callees>0) {
-                        std::this_thread::sleep_for(std::chrono::milliseconds(100u));
+                        std::this_thread::sleep_for(std::chrono::milliseconds(10u));
                     }
 #else
                     // Sync is allowed even for queues on non current device.


### PR DESCRIPTION
This closes #805 

- Fixes race-condition HIP/NVCC queue (unneeded workaround removed)
  - queue workaround code only applied to HIP/HCC now,
which avoids race-conditions with blocking HIP/NVCC streams
- Reduces HIP wait-workaround sleep-timer from 100ms to 10ms (for less impact)
- HIP/HCC non-blocking queue destructor waits for tasks.
  - Since the HCC stream is not blocked by callback tasks, a
workaround was previously implemented. Alpaka/HIP tasks however depend
on their queue, which has not been reflected by the queue's destructor
before. Now the destructor of the non-blocking queue is waiting for
all its spawned tasks.

Note, this solution is probably not optimal w.r.t. a stalling destructor, however a queue with pending tasks is not supposed to be destructed, even if it is a fully async task queue. If you rely on RAII and you put heavy tasks in that queue, going out of scope will take as long as the spawned tasks will run. This is different to the other Alpaka queues.

Hope, the documentation is clear, otherwise do not hesitate to complain :)