### PR TITLE
Mandelbrot: const inline member

### DIFF
--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -39,7 +39,8 @@ public:
     {}
     //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
-    ALPAKA_FN_HOST_ACC auto absSq()
+    ALPAKA_FN_INLINE
+    ALPAKA_FN_HOST_ACC auto absSq() const
     -> T
     {
         return r*r + i*i;


### PR DESCRIPTION
Mark the complex number method as constant and inline. This helps vectorization for little-tuned compiler flags. As soon as I passed `-mtune=native -march=native -ffast-math` it vectorized the moves (`mov` -> `movq`) in the loop automatically in both ways.

```bash
export CXXFLAGS="-Rpass=loop-vectorize -Rpass-missed=loop-vectorize -Rpass-analysis=loop-vectorize -fvectorize -fslp-vectorize -O3 -fsave-optimization-record -mtune=native -march=native -ffast-math"
```

Tested with sequential backend and `clang++ 6.0`
```
-DALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE=OFF
```