### PR TITLE
support external queue implementations

### DIFF
--- a/include/alpaka/dev/cpu/Wait.hpp
+++ b/include/alpaka/dev/cpu/Wait.hpp
@@ -29,19 +29,16 @@ namespace alpaka
                 )
                 ->void
                 {
-
-                    // Enqueue an event in every non-blocking queue on the device.
-                    // \FIXME: This should be done atomically for all queues.
                     // Furthermore there should not even be a chance to enqueue something between getting the queues and adding our wait events!
-                    std::vector<event::EventCpu> vEventsNonBlocking;
+                    std::vector<event::EventCpu> vEvents;
                     for(auto && spQueue : vQueues)
                     {
-                        vEventsNonBlocking.emplace_back(dev);
-                        queue::enqueue(spQueue, vEventsNonBlocking.back());
+                        vEvents.emplace_back(dev);
+                        spQueue->enqueue(spQueue, vEvents.back());
                     }
 
                     // Now wait for all the events.
-                    for(auto && event : vEventsNonBlocking)
+                    for(auto && event : vEvents)
                     {
                         wait::wait(event);
                     }
@@ -65,14 +62,10 @@ namespace alpaka
 
                     // Get all the queues on the device at the time of invocation.
                     // All queues added afterwards are ignored.
-                    auto vspQueuesNonBlocking(
-                        dev.m_spDevCpuImpl->GetAllNonBlockingQueueImpls());
+                    auto vspQueues(
+                        dev.m_spDevCpuImpl->GetAllQueues());
 
-                    auto vspQueuesBlocking(
-                        dev.m_spDevCpuImpl->GetAllBlockingQueueImpls());
-
-                    detail::currentThreadWaitForDevice(dev, vspQueuesNonBlocking);
-                    detail::currentThreadWaitForDevice(dev, vspQueuesBlocking);
+                    detail::currentThreadWaitForDevice(dev, vspQueues);
                 }
             };
         }

--- a/include/alpaka/dev/cpu/Wait.hpp
+++ b/include/alpaka/dev/cpu/Wait.hpp
@@ -34,7 +34,7 @@ namespace alpaka
                     for(auto && spQueue : vQueues)
                     {
                         vEvents.emplace_back(dev);
-                        spQueue->enqueue(spQueue, vEvents.back());
+                        spQueue->enqueue(vEvents.back());
                     }
 
                     // Now wait for all the events.

--- a/include/alpaka/event/EventCpu.hpp
+++ b/include/alpaka/event/EventCpu.hpp
@@ -23,6 +23,7 @@
 
 #include <mutex>
 #include <condition_variable>
+#include <future>
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
     #include <iostream>
 #endif
@@ -455,23 +456,14 @@ namespace alpaka
                 {
                     // Get all the queues on the device at the time of invocation.
                     // All queues added afterwards are ignored.
-                    auto vspQueuesNonBlocking(
-                        dev.m_spDevCpuImpl->GetAllNonBlockingQueueImpls());
-                    auto vspQueuesBlocking(
-                        dev.m_spDevCpuImpl->GetAllBlockingQueueImpls());
+                    auto vspQueues(
+                        dev.m_spDevCpuImpl->GetAllQueues());
 
                     // Let all the queues wait for this event.
-                    // \TODO: This should be done atomically for all queues.
                     // Furthermore there should not even be a chance to enqueue something between getting the queues and adding our wait events!
-                    for(auto && spQueue : vspQueuesNonBlocking)
+                    for(auto && spQueue : vspQueues)
                     {
-                        wait::wait(spQueue, event);
-                    }
-
-                    // wait for blocking queues
-                    for(auto && spQueue : vspQueuesBlocking)
-                    {
-                        wait::wait(spQueue, event);
+                        spQueue->wait(spQueue, event);
                     }
                 }
             };

--- a/include/alpaka/queue/QueueCpuBlocking.hpp
+++ b/include/alpaka/queue/QueueCpuBlocking.hpp
@@ -61,17 +61,15 @@ namespace alpaka
                     ~QueueCpuBlockingImpl() = default;
 
                     //-----------------------------------------------------------------------------
-                    void enqueue(std::shared_ptr<cpu::ICpuQueue> & iQueue, event::EventCpu & ev) final
+                    void enqueue(event::EventCpu & ev) final
                     {
-                        auto spQueueImpl = std::static_pointer_cast<QueueCpuBlockingImpl>(iQueue);
-                        queue::enqueue(spQueueImpl, ev);
+                        queue::enqueue(*this, ev);
                     }
 
                     //-----------------------------------------------------------------------------
-                    void wait(std::shared_ptr<cpu::ICpuQueue> & iQueue, event::EventCpu const & ev) final
+                    void wait(event::EventCpu const & ev) final
                     {
-                        auto spQueueImpl = std::static_pointer_cast<QueueCpuBlockingImpl>(iQueue);
-                        wait::wait(spQueueImpl, ev);
+                        wait::wait(*this, ev);
                     }
 
                 public:

--- a/include/alpaka/queue/QueueCpuBlocking.hpp
+++ b/include/alpaka/queue/QueueCpuBlocking.hpp
@@ -38,9 +38,18 @@ namespace alpaka
         {
             namespace detail
             {
+#if BOOST_COMP_CLANG
+    // avoid diagnostic warning: "has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit [-Werror,-Wweak-vtables]"
+    // https://stackoverflow.com/a/29288300
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
                 //#############################################################################
                 //! The CPU device queue implementation.
                 class QueueCpuBlockingImpl final : public cpu::ICpuQueue
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic pop
+#endif
                 {
                 public:
                     //-----------------------------------------------------------------------------
@@ -57,8 +66,6 @@ namespace alpaka
                     auto operator=(QueueCpuBlockingImpl const &) -> QueueCpuBlockingImpl & = delete;
                     //-----------------------------------------------------------------------------
                     auto operator=(QueueCpuBlockingImpl &&) -> QueueCpuBlockingImpl & = delete;
-                    //-----------------------------------------------------------------------------
-                    ~QueueCpuBlockingImpl() = default;
 
                     //-----------------------------------------------------------------------------
                     void enqueue(event::EventCpu & ev) final

--- a/include/alpaka/queue/QueueCpuNonBlocking.hpp
+++ b/include/alpaka/queue/QueueCpuNonBlocking.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <alpaka/dev/DevCpu.hpp>
+#include <alpaka/queue/cpu/ICpuQueue.hpp>
 
 #include <alpaka/dev/Traits.hpp>
 #include <alpaka/event/Traits.hpp>
@@ -42,7 +43,7 @@ namespace alpaka
             {
                 //#############################################################################
                 //! The CPU device queue implementation.
-                class QueueCpuNonBlockingImpl final
+                class QueueCpuNonBlockingImpl final : public cpu::ICpuQueue
                 {
                 private:
                     //#############################################################################
@@ -73,6 +74,20 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     ~QueueCpuNonBlockingImpl() = default;
 
+                    //-----------------------------------------------------------------------------
+                    void enqueue(std::shared_ptr<cpu::ICpuQueue> & iQueue, event::EventCpu & ev) final
+                    {
+                        auto spQueueImpl = std::static_pointer_cast<QueueCpuNonBlockingImpl>(iQueue);
+                        queue::enqueue(spQueueImpl, ev);
+                    }
+
+                    //-----------------------------------------------------------------------------
+                    void wait(std::shared_ptr<cpu::ICpuQueue> & iQueue, event::EventCpu const & ev) final
+                    {
+                        auto spQueueImpl = std::static_pointer_cast<QueueCpuNonBlockingImpl>(iQueue);
+                        wait::wait(spQueueImpl, ev);
+                    }
+
                 public:
                     dev::DevCpu const m_dev;            //!< The device this queue is bound to.
 
@@ -91,7 +106,7 @@ namespace alpaka
                 dev::DevCpu const & dev) :
                     m_spQueueImpl(std::make_shared<cpu::detail::QueueCpuNonBlockingImpl>(dev))
             {
-                dev.m_spDevCpuImpl->RegisterNonBlockingQueue(m_spQueueImpl);
+                dev.m_spDevCpuImpl->RegisterQueue(m_spQueueImpl);
             }
             //-----------------------------------------------------------------------------
             QueueCpuNonBlocking(QueueCpuNonBlocking const &) = default;
@@ -211,3 +226,5 @@ namespace alpaka
         }
     }
 }
+
+#include <alpaka/event/EventCpu.hpp>

--- a/include/alpaka/queue/QueueCpuNonBlocking.hpp
+++ b/include/alpaka/queue/QueueCpuNonBlocking.hpp
@@ -41,9 +41,18 @@ namespace alpaka
         {
             namespace detail
             {
+#if BOOST_COMP_CLANG
+    // avoid diagnostic warning: "has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit [-Werror,-Wweak-vtables]"
+    // https://stackoverflow.com/a/29288300
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
                 //#############################################################################
                 //! The CPU device queue implementation.
                 class QueueCpuNonBlockingImpl final : public cpu::ICpuQueue
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic pop
+#endif
                 {
                 private:
                     //#############################################################################
@@ -71,8 +80,6 @@ namespace alpaka
                     auto operator=(QueueCpuNonBlockingImpl const &) -> QueueCpuNonBlockingImpl & = delete;
                     //-----------------------------------------------------------------------------
                     auto operator=(QueueCpuNonBlockingImpl &&) -> QueueCpuNonBlockingImpl & = delete;
-                    //-----------------------------------------------------------------------------
-                    ~QueueCpuNonBlockingImpl() = default;
 
                     //-----------------------------------------------------------------------------
                     void enqueue(event::EventCpu & ev) final

--- a/include/alpaka/queue/QueueCpuNonBlocking.hpp
+++ b/include/alpaka/queue/QueueCpuNonBlocking.hpp
@@ -75,17 +75,15 @@ namespace alpaka
                     ~QueueCpuNonBlockingImpl() = default;
 
                     //-----------------------------------------------------------------------------
-                    void enqueue(std::shared_ptr<cpu::ICpuQueue> & iQueue, event::EventCpu & ev) final
+                    void enqueue(event::EventCpu & ev) final
                     {
-                        auto spQueueImpl = std::static_pointer_cast<QueueCpuNonBlockingImpl>(iQueue);
-                        queue::enqueue(spQueueImpl, ev);
+                        queue::enqueue(*this, ev);
                     }
 
                     //-----------------------------------------------------------------------------
-                    void wait(std::shared_ptr<cpu::ICpuQueue> & iQueue, event::EventCpu const & ev) final
+                    void wait(event::EventCpu const & ev) final
                     {
-                        auto spQueueImpl = std::static_pointer_cast<QueueCpuNonBlockingImpl>(iQueue);
-                        wait::wait(spQueueImpl, ev);
+                        wait::wait(*this, ev);
                     }
 
                 public:

--- a/include/alpaka/queue/cpu/ICpuQueue.hpp
+++ b/include/alpaka/queue/cpu/ICpuQueue.hpp
@@ -1,0 +1,46 @@
+/* Copyright 2019 Axel Huebl, Benjamin Worpitz, Matthias Werner
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+
+#pragma once
+
+#include <memory>
+
+namespace alpaka
+{
+    namespace event
+    {
+        class EventCpu;
+    }
+}
+
+namespace alpaka
+{
+    namespace queue
+    {
+        namespace cpu
+        {
+
+            //#############################################################################
+            //! The CPU queue interface
+            class ICpuQueue
+            {
+            public:
+                //-----------------------------------------------------------------------------
+                ICpuQueue() = default;
+                //! enqueue the event into the given queue ------------------------------------
+                virtual void enqueue(std::shared_ptr<ICpuQueue> &, event::EventCpu &) = 0;
+                //! the given queue is waiting for the event-----------------------------------
+                virtual void wait(std::shared_ptr<ICpuQueue> &, event::EventCpu const &) = 0;
+                //-----------------------------------------------------------------------------
+                virtual ~ICpuQueue() = default;
+            };
+        }
+    }
+}

--- a/include/alpaka/queue/cpu/ICpuQueue.hpp
+++ b/include/alpaka/queue/cpu/ICpuQueue.hpp
@@ -7,10 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
 #pragma once
-
-#include <memory>
 
 namespace alpaka
 {
@@ -34,10 +31,12 @@ namespace alpaka
             public:
                 //-----------------------------------------------------------------------------
                 ICpuQueue() = default;
-                //! enqueue the event into the given queue ------------------------------------
-                virtual void enqueue(std::shared_ptr<ICpuQueue> &, event::EventCpu &) = 0;
-                //! the given queue is waiting for the event-----------------------------------
-                virtual void wait(std::shared_ptr<ICpuQueue> &, event::EventCpu const &) = 0;
+                //-----------------------------------------------------------------------------
+                //! enqueue the event
+                virtual void enqueue(event::EventCpu &) = 0;
+                //-----------------------------------------------------------------------------
+                //! waiting for the event
+                virtual void wait(event::EventCpu const &) = 0;
                 //-----------------------------------------------------------------------------
                 virtual ~ICpuQueue() = default;
             };

--- a/include/alpaka/queue/cpu/ICpuQueue.hpp
+++ b/include/alpaka/queue/cpu/ICpuQueue.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <alpaka/core/BoostPredef.hpp>
+
 namespace alpaka
 {
     namespace event
@@ -24,13 +26,19 @@ namespace alpaka
         namespace cpu
         {
 
+
+#if BOOST_COMP_CLANG
+    // avoid diagnostic warning: "has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit [-Werror,-Wweak-vtables]"
+    // https://stackoverflow.com/a/29288300
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
             //#############################################################################
             //! The CPU queue interface
             class ICpuQueue
             {
             public:
-                //-----------------------------------------------------------------------------
-                ICpuQueue() = default;
                 //-----------------------------------------------------------------------------
                 //! enqueue the event
                 virtual void enqueue(event::EventCpu &) = 0;
@@ -40,6 +48,9 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 virtual ~ICpuQueue() = default;
             };
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic pop
+#endif
         }
     }
 }

--- a/test/common/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
+++ b/test/common/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
@@ -71,16 +71,14 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     ~QueueCpuOmp2CollectiveImpl() = default;
                     //-----------------------------------------------------------------------------
-                    void enqueue(std::shared_ptr<cpu::ICpuQueue> & iQueue, event::EventCpu & ev) final
+                    void enqueue(event::EventCpu & ev) final
                     {
-                        auto spQueueImpl = std::static_pointer_cast<QueueCpuOmp2CollectiveImpl>(iQueue);
-                        queue::enqueue(spQueueImpl, ev);
+                        queue::enqueue(*this, ev);
                     }
                     //-----------------------------------------------------------------------------
-                    void wait(std::shared_ptr<cpu::ICpuQueue> & iQueue, event::EventCpu const & ev) final
+                    void wait(event::EventCpu const & ev) final
                     {
-                        auto spQueueImpl = std::static_pointer_cast<QueueCpuOmp2CollectiveImpl>(iQueue);
-                        wait::wait(spQueueImpl, ev);
+                        wait::wait(*this, ev);
                     }
 
                 public:
@@ -244,12 +242,12 @@ namespace alpaka
             //! The CPU OpenMP2 collective device queue enqueue trait specialization.
             template<>
             struct Enqueue<
-                std::shared_ptr<queue::cpu::detail::QueueCpuOmp2CollectiveImpl>,
+                queue::cpu::detail::QueueCpuOmp2CollectiveImpl,
                 event::EventCpu>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto enqueue(
-                    std::shared_ptr<queue::cpu::detail::QueueCpuOmp2CollectiveImpl> &,
+                    queue::cpu::detail::QueueCpuOmp2CollectiveImpl &,
                     event::EventCpu &)
                 -> void
                 {
@@ -392,12 +390,12 @@ namespace alpaka
             //! The CPU OpenMP2 collective device queue event wait trait specialization.
             template<>
             struct WaiterWaitFor<
-                std::shared_ptr<queue::cpu::detail::QueueCpuOmp2CollectiveImpl>,
+                queue::cpu::detail::QueueCpuOmp2CollectiveImpl,
                 event::EventCpu>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto waiterWaitFor(
-                    std::shared_ptr<queue::cpu::detail::QueueCpuOmp2CollectiveImpl> &,
+                    queue::cpu::detail::QueueCpuOmp2CollectiveImpl &,
                     event::EventCpu const &)
                 -> void
                 {

--- a/test/common/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
+++ b/test/common/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
@@ -49,9 +49,18 @@ namespace alpaka
         {
             namespace detail
             {
+#if BOOST_COMP_CLANG
+    // avoid diagnostic warning: "has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit [-Werror,-Wweak-vtables]"
+    // https://stackoverflow.com/a/29288300
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
                 //#############################################################################
                 //! The CPU collective device queue implementation.
                 class QueueCpuOmp2CollectiveImpl final : public cpu::ICpuQueue
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic pop
+#endif
                 {
                 public:
                     //-----------------------------------------------------------------------------
@@ -68,8 +77,6 @@ namespace alpaka
                     auto operator=(QueueCpuOmp2CollectiveImpl const &) -> QueueCpuOmp2CollectiveImpl & = delete;
                     //-----------------------------------------------------------------------------
                     auto operator=(QueueCpuOmp2CollectiveImpl &&) -> QueueCpuOmp2CollectiveImpl & = delete;
-                    //-----------------------------------------------------------------------------
-                    ~QueueCpuOmp2CollectiveImpl() = default;
                     //-----------------------------------------------------------------------------
                     void enqueue(event::EventCpu & ev) final
                     {

--- a/test/common/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
+++ b/test/common/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
@@ -1,0 +1,457 @@
+/* Copyright 2019 Axel Huebl, Benjamin Worpitz, Matthias Werner
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+
+#if _OPENMP < 200203
+    #error If ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED is set, the compiler has to support OpenMP 2.0 or higher!
+#endif
+
+#include <alpaka/test/queue/Queue.hpp>
+
+#include <alpaka/core/Unused.hpp>
+#include <alpaka/dev/DevCpu.hpp>
+#include <alpaka/queue/cpu/ICpuQueue.hpp>
+#include <alpaka/queue/QueueCpuBlocking.hpp>
+#include <alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp>
+#include <alpaka/test/event/EventHostManualTrigger.hpp>
+
+#include <alpaka/dev/Traits.hpp>
+#include <alpaka/event/Traits.hpp>
+#include <alpaka/queue/Traits.hpp>
+#include <alpaka/wait/Traits.hpp>
+
+#include <atomic>
+#include <mutex>
+#include <omp.h>
+
+namespace alpaka
+{
+    namespace event
+    {
+        class EventCpu;
+    }
+}
+
+namespace alpaka
+{
+    namespace queue
+    {
+        namespace cpu
+        {
+            namespace detail
+            {
+                //#############################################################################
+                //! The CPU collective device queue implementation.
+                class QueueCpuOmp2CollectiveImpl final : public cpu::ICpuQueue
+                {
+                public:
+                    //-----------------------------------------------------------------------------
+                    QueueCpuOmp2CollectiveImpl(
+                        dev::DevCpu const & dev) noexcept :
+                            m_dev(dev),
+                            m_uCurrentlyExecutingTask(0u)
+                    {}
+                    //-----------------------------------------------------------------------------
+                    QueueCpuOmp2CollectiveImpl(QueueCpuOmp2CollectiveImpl const &) = delete;
+                    //-----------------------------------------------------------------------------
+                    QueueCpuOmp2CollectiveImpl(QueueCpuOmp2CollectiveImpl &&) = delete;
+                    //-----------------------------------------------------------------------------
+                    auto operator=(QueueCpuOmp2CollectiveImpl const &) -> QueueCpuOmp2CollectiveImpl & = delete;
+                    //-----------------------------------------------------------------------------
+                    auto operator=(QueueCpuOmp2CollectiveImpl &&) -> QueueCpuOmp2CollectiveImpl & = delete;
+                    //-----------------------------------------------------------------------------
+                    ~QueueCpuOmp2CollectiveImpl() = default;
+                    //-----------------------------------------------------------------------------
+                    void enqueue(std::shared_ptr<cpu::ICpuQueue> & iQueue, event::EventCpu & ev) final
+                    {
+                        auto spQueueImpl = std::static_pointer_cast<QueueCpuOmp2CollectiveImpl>(iQueue);
+                        queue::enqueue(spQueueImpl, ev);
+                    }
+                    //-----------------------------------------------------------------------------
+                    void wait(std::shared_ptr<cpu::ICpuQueue> & iQueue, event::EventCpu const & ev) final
+                    {
+                        auto spQueueImpl = std::static_pointer_cast<QueueCpuOmp2CollectiveImpl>(iQueue);
+                        wait::wait(spQueueImpl, ev);
+                    }
+
+                public:
+                    dev::DevCpu const m_dev;            //!< The device this queue is bound to.
+                    std::mutex mutable m_mutex;
+                    std::atomic<uint32_t> m_uCurrentlyExecutingTask;
+                };
+            }
+        }
+
+        //#############################################################################
+        //! The CPU collective device queue.
+        //
+        // @attention Queue can only be used together with the accelerator AccCpuOmp2Blocks.
+        //
+        // This queue is an example for a user provided queue and the behavior is strongly coupled
+        // to the user workflows.
+        //
+        // Within a OpenMP parallel region kernel will be performed collectively.
+        // All other operations will be performed from one thread (it is not defined which thread).
+        //
+        // Outside of a OpenMP parallel region the queue behaves like QueueCpuBlocking.
+        class QueueCpuOmp2Collective final
+        {
+        public:
+            //-----------------------------------------------------------------------------
+            QueueCpuOmp2Collective(
+                dev::DevCpu const & dev) :
+                    m_spQueueImpl(std::make_shared<cpu::detail::QueueCpuOmp2CollectiveImpl>(dev)),
+                    m_spBlockingQueue(std::make_shared<QueueCpuBlocking>(dev))
+            {
+                dev.m_spDevCpuImpl->RegisterQueue(m_spQueueImpl);
+            }
+            //-----------------------------------------------------------------------------
+            QueueCpuOmp2Collective(QueueCpuOmp2Collective const &) = default;
+            //-----------------------------------------------------------------------------
+            QueueCpuOmp2Collective(QueueCpuOmp2Collective &&) = default;
+            //-----------------------------------------------------------------------------
+            auto operator=(QueueCpuOmp2Collective const &) -> QueueCpuOmp2Collective & = default;
+            //-----------------------------------------------------------------------------
+            auto operator=(QueueCpuOmp2Collective &&) -> QueueCpuOmp2Collective & = default;
+            //-----------------------------------------------------------------------------
+            auto operator==(QueueCpuOmp2Collective const & rhs) const
+            -> bool
+            {
+                return m_spQueueImpl == rhs.m_spQueueImpl && m_spBlockingQueue == rhs.m_spBlockingQueue;
+            }
+            //-----------------------------------------------------------------------------
+            auto operator!=(QueueCpuOmp2Collective const & rhs) const
+            -> bool
+            {
+                return !((*this) == rhs);
+            }
+            //-----------------------------------------------------------------------------
+            ~QueueCpuOmp2Collective() = default;
+
+        public:
+            std::shared_ptr<cpu::detail::QueueCpuOmp2CollectiveImpl> m_spQueueImpl;
+            std::shared_ptr<QueueCpuBlocking> m_spBlockingQueue;
+        };
+    }
+
+    namespace dev
+    {
+        namespace traits
+        {
+            //#############################################################################
+            //! The CPU blocking device queue device type trait specialization.
+            template<>
+            struct DevType<
+                queue::QueueCpuOmp2Collective>
+            {
+                using type = dev::DevCpu;
+            };
+            //#############################################################################
+            //! The CPU blocking device queue device get trait specialization.
+            template<>
+            struct GetDev<
+                queue::QueueCpuOmp2Collective>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto getDev(
+                    queue::QueueCpuOmp2Collective const & queue)
+                -> dev::DevCpu
+                {
+                    return queue.m_spQueueImpl->m_dev;
+                }
+            };
+        }
+    }
+    namespace event
+    {
+        namespace traits
+        {
+            //#############################################################################
+            //! The CPU blocking device queue event type trait specialization.
+            template<>
+            struct EventType<
+                queue::QueueCpuOmp2Collective>
+            {
+                using type = event::EventCpu;
+            };
+        }
+    }
+    namespace queue
+    {
+        namespace traits
+        {
+
+            //#############################################################################
+            //! The CPU blocking device queue enqueue trait specialization.
+            //! This default implementation for all tasks directly invokes the function call operator of the task.
+            template<
+                typename TTask>
+            struct Enqueue<
+                queue::QueueCpuOmp2Collective,
+                TTask>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto enqueue(
+                    queue::QueueCpuOmp2Collective & queue,
+                    TTask const & task)
+                -> void
+                {
+                    if(::omp_in_parallel() != 0)
+                    {
+                        // wait for all tasks en-queued before the parallel region
+                        while(!queue::empty(*queue.m_spBlockingQueue)){}
+                        queue.m_spQueueImpl->m_uCurrentlyExecutingTask += 1u;
+
+                        #pragma omp single nowait
+                        task();
+
+                        queue.m_spQueueImpl->m_uCurrentlyExecutingTask -= 1u;
+                    }
+                    else
+                    {
+                        std::lock_guard<std::mutex> lk(queue.m_spQueueImpl->m_mutex);
+                        queue::enqueue(*queue.m_spBlockingQueue, task);
+                    }
+                }
+            };
+
+            //#############################################################################
+            //! The CPU blocking device queue test trait specialization.
+            template<>
+            struct Empty<
+                queue::QueueCpuOmp2Collective>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto empty(
+                    queue::QueueCpuOmp2Collective const & queue)
+                -> bool
+                {
+                    return queue.m_spQueueImpl->m_uCurrentlyExecutingTask == 0u &&
+                        queue::empty(*queue.m_spBlockingQueue);
+                }
+            };
+
+            //#############################################################################
+            //! The CPU OpenMP2 collective device queue enqueue trait specialization.
+            template<>
+            struct Enqueue<
+                std::shared_ptr<queue::cpu::detail::QueueCpuOmp2CollectiveImpl>,
+                event::EventCpu>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto enqueue(
+                    std::shared_ptr<queue::cpu::detail::QueueCpuOmp2CollectiveImpl> &,
+                    event::EventCpu &)
+                -> void
+                {
+                    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                    #pragma omp barrier
+                }
+            };
+            //#############################################################################
+            //! The CPU OpenMP2 collective device queue enqueue trait specialization.
+            template<>
+            struct Enqueue<
+                queue::QueueCpuOmp2Collective,
+                event::EventCpu>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto enqueue(
+                    queue::QueueCpuOmp2Collective & queue,
+                    event::EventCpu & event)
+                -> void
+                {
+                    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                    if(::omp_in_parallel() != 0)
+                    {
+                        // wait for all tasks en-queued before the parallel region
+                        while(!queue::empty(*queue.m_spBlockingQueue)){}
+                        #pragma omp barrier
+                    }
+                    else
+                    {
+                        queue::enqueue(*queue.m_spBlockingQueue, event);
+                    }
+
+                }
+            };
+
+            //#############################################################################
+            //! The CPU blocking device queue enqueue trait specialization.
+            //! This default implementation for all tasks directly invokes the function call operator of the task.
+            template<
+                typename TDim,
+                typename TIdx,
+                typename TKernelFnObj,
+                typename... TArgs>
+            struct Enqueue<
+                queue::QueueCpuOmp2Collective,
+                kernel::TaskKernelCpuOmp2Blocks<
+                    TDim,
+                    TIdx,
+                    TKernelFnObj,
+                    TArgs...>>
+            {
+            private:
+                using Task = kernel::TaskKernelCpuOmp2Blocks<
+                    TDim,
+                    TIdx,
+                    TKernelFnObj,
+                    TArgs ...>;
+            public:
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto enqueue(
+                    queue::QueueCpuOmp2Collective & queue,
+                    Task const & task)
+                -> void
+                {
+                    if(::omp_in_parallel() != 0)
+                    {
+                        while(!queue::empty(*queue.m_spBlockingQueue)){}
+                        // execute within an OpenMP parallel region
+                        queue.m_spQueueImpl->m_uCurrentlyExecutingTask += 1u;
+                        // execute task within an OpenMP parallel region
+                        task();
+                        queue.m_spQueueImpl->m_uCurrentlyExecutingTask -= 1u;
+                    }
+                    else
+                    {
+                        std::lock_guard<std::mutex> lk(queue.m_spQueueImpl->m_mutex);
+                        queue::enqueue(*queue.m_spBlockingQueue, task);
+                    }
+                }
+            };
+
+            //#############################################################################
+            //!
+            //#############################################################################
+            template<>
+            struct Enqueue<
+                queue::QueueCpuOmp2Collective,
+                test::event::EventHostManualTriggerCpu>
+            {
+                //-----------------------------------------------------------------------------
+                //
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto enqueue(
+                    queue::QueueCpuOmp2Collective & ,
+                    test::event::EventHostManualTriggerCpu & )
+                -> void
+                {
+                    // EventHostManualTriggerCpu are not supported for together with the queue QueueCpuOmp2Collective
+                    // but a specialization is needed to path the EventTests
+                }
+            };
+        }
+    }
+
+    namespace wait
+    {
+        namespace traits
+        {
+            //#############################################################################
+            //! The CPU blocking device queue thread wait trait specialization.
+            //!
+            //! Blocks execution of the calling thread until the queue has finished processing all previously requested tasks (kernels, data copies, ...)
+            template<>
+            struct CurrentThreadWaitFor<
+                queue::QueueCpuOmp2Collective>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto currentThreadWaitFor(
+                    queue::QueueCpuOmp2Collective const & queue)
+                -> void
+                {
+                    if(::omp_in_parallel() != 0)
+                    {
+                        // wait for all tasks en-queued before the parallel region
+                        while(!queue::empty(*queue.m_spBlockingQueue)){}
+                        #pragma omp barrier
+                    }
+                    else
+                    {
+                        std::lock_guard<std::mutex> lk(queue.m_spQueueImpl->m_mutex);
+                        wait::wait(*queue.m_spBlockingQueue);
+                    }
+                }
+            };
+
+
+            //#############################################################################
+            //! The CPU OpenMP2 collective device queue event wait trait specialization.
+            template<>
+            struct WaiterWaitFor<
+                std::shared_ptr<queue::cpu::detail::QueueCpuOmp2CollectiveImpl>,
+                event::EventCpu>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto waiterWaitFor(
+                    std::shared_ptr<queue::cpu::detail::QueueCpuOmp2CollectiveImpl> &,
+                    event::EventCpu const &)
+                -> void
+                {
+                    #pragma omp barrier
+                }
+            };
+            //#############################################################################
+            //! The CPU OpenMP2 collective queue event wait trait specialization.
+            template<>
+            struct WaiterWaitFor<
+                queue::QueueCpuOmp2Collective,
+                event::EventCpu>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto waiterWaitFor(
+                    queue::QueueCpuOmp2Collective & queue,
+                    event::EventCpu const & event)
+                -> void
+                {
+                    if(::omp_in_parallel() != 0)
+                    {
+                        // wait for all tasks en-queued before the parallel region
+                        while(!queue::empty(*queue.m_spBlockingQueue)){}
+                        wait::wait(queue);
+                    }
+                    else
+                        wait::wait(*queue.m_spBlockingQueue, event);
+                }
+            };
+        }
+    }
+    //-----------------------------------------------------------------------------
+    //! The test specifics.
+    namespace test
+    {
+        //-----------------------------------------------------------------------------
+        //! The test queue specifics.
+        namespace queue
+        {
+            namespace traits
+            {
+                //#############################################################################
+                //! The blocking queue trait specialization for a OpenMP2 collective CPU queue.
+                template<>
+                struct IsBlockingQueue<
+                    alpaka::queue::QueueCpuOmp2Collective>
+                {
+                    static constexpr bool value = true;
+                };
+            }
+        }
+    }
+}
+
+#include <alpaka/event/EventCpu.hpp>
+
+#endif

--- a/test/unit/event/src/EventTest.cpp
+++ b/test/unit/event/src/EventTest.cpp
@@ -12,6 +12,7 @@
 #include <alpaka/test/event/EventHostManualTrigger.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 #include <alpaka/test/queue/QueueTestFixture.hpp>
+#include <alpaka/test/queue/QueueCpuOmp2Collective.hpp>
 
 #include <catch2/catch.hpp>
 
@@ -285,7 +286,13 @@ void operator()()
 }
 };
 
-using TestQueues = alpaka::test::queue::TestQueues;
+using TestQueues = alpaka::meta::Concatenate<
+        alpaka::test::queue::TestQueues
+ #ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+        ,
+        std::tuple<std::tuple<alpaka::dev::DevCpu, alpaka::queue::QueueCpuOmp2Collective>>
+#endif
+    >;
 
 TEST_CASE( "eventTestShouldInitiallyBeTrue", "[event]")
 {

--- a/test/unit/queue/src/CollectiveQueue.cpp
+++ b/test/unit/queue/src/CollectiveQueue.cpp
@@ -1,0 +1,156 @@
+/* Copyright 2019 Axel Huebl, Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+
+#if _OPENMP < 200203
+    #error If ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED is set, the compiler has to support OpenMP 2.0 or higher!
+#endif
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/test/queue/Queue.hpp>
+#include <alpaka/test/queue/QueueTestFixture.hpp>
+#include <alpaka/test/queue/QueueCpuOmp2Collective.hpp>
+
+#include <vector>
+
+#include <catch2/catch.hpp>
+
+TEST_CASE( "queueCollective", "[queue]")
+{
+    // Define the index domain
+    using Dim = alpaka::dim::DimInt<1>;
+    using Idx = size_t;
+
+    // Define the accelerator
+    using Acc = alpaka::acc::AccCpuOmp2Blocks<Dim, Idx>;
+    using Dev = alpaka::dev::Dev<Acc>;
+
+    using Queue = alpaka::queue::QueueCpuOmp2Collective;
+    using Pltf = alpaka::pltf::Pltf<Dev>;
+
+    auto dev = alpaka::pltf::getDevByIdx<Pltf>(0u);
+    Queue queue(dev);
+
+    std::vector<int> results(4, -1);
+
+    using Vec = alpaka::vec::Vec<Dim, Idx>;
+    Vec const elementsPerThread(Vec::all(static_cast<Idx>(1)));
+    Vec const threadsPerBlock(Vec::all(static_cast<Idx>(1)));
+    Vec const blocksPerGrid(results.size());
+
+    using WorkDiv = alpaka::workdiv::WorkDivMembers<Dim, Idx>;
+    WorkDiv const workDiv(
+        blocksPerGrid,
+        threadsPerBlock,
+        elementsPerThread);
+
+    #pragma omp parallel num_threads(static_cast<int>(results.size()))
+    {
+        auto kernel =
+        [&] ALPAKA_FN_ACC (
+            Acc const & acc) noexcept
+        -> void
+        {
+            size_t threadId = alpaka::idx::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0];
+            // avoid that one thread is doing all the work
+            std::this_thread::sleep_for(std::chrono::milliseconds(200u * threadId));
+            results[threadId] = threadId;
+        };
+
+        // The kernel will be performed collectively.
+        // OpenMP will distribute the work between the threads from the parallel region
+        alpaka::kernel::exec<Acc>(
+               queue,
+               workDiv,
+               kernel);
+
+        alpaka::wait::wait(queue);
+    }
+
+    for(size_t i = 0; i < results.size(); ++i)
+    {
+        REQUIRE(static_cast<int>(i) == results.at(i));
+    }
+}
+
+TEST_CASE( "TestCollectiveMemcpy", "[queue]")
+{
+     // Define the index domain
+    using Dim = alpaka::dim::DimInt<1>;
+    using Idx = size_t;
+
+    // Define the accelerator
+    using Acc = alpaka::acc::AccCpuOmp2Blocks<Dim, Idx>;
+    using Dev = alpaka::dev::Dev<Acc>;
+
+    using Queue = alpaka::queue::QueueCpuOmp2Collective;
+    using Pltf = alpaka::pltf::Pltf<Dev>;
+
+    auto dev = alpaka::pltf::getDevByIdx<Pltf>(0u);
+    Queue queue(dev);
+
+    std::vector<int> results(4, -1);
+
+    // Define the work division
+    using Vec = alpaka::vec::Vec<Dim, Idx>;
+    Vec const elementsPerThread(Vec::all(static_cast<Idx>(1)));
+    Vec const threadsPerBlock(Vec::all(static_cast<Idx>(1)));
+    Vec const blocksPerGrid(results.size());
+
+    using WorkDiv = alpaka::workdiv::WorkDivMembers<Dim, Idx>;
+    WorkDiv const workDiv(
+        blocksPerGrid,
+        threadsPerBlock,
+        elementsPerThread);
+
+    #pragma omp parallel num_threads(static_cast<int>(results.size()))
+    {
+        int threadId = omp_get_thread_num();
+
+        using View = alpaka::mem::view::ViewPlainPtr<Dev, int, Dim, Idx>;
+
+        View dst(
+            results.data() + threadId,
+            dev,
+            Vec(1lu),
+            Vec(sizeof(int)));
+
+        View src(
+            &threadId,
+            dev,
+            Vec(1lu),
+            Vec(sizeof(int)));
+
+        // avoid that the first thread is executing the copy (can not be guaranteed)
+        size_t sleep_ms = (results.size() - static_cast<uint32_t>(threadId)) * 100u;
+        std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
+
+        // only one thread will perform this memcpy
+        alpaka::mem::view::copy(queue, dst, src, Vec(1lu));
+
+        alpaka::wait::wait(queue);
+    }
+
+    uint32_t numFlippedValues = 0u;
+    uint32_t numNonIntitialValues = 0u;
+    for(size_t i = 0; i < results.size(); ++i)
+    {
+        if(static_cast<int>(i) == results.at(i))
+            numFlippedValues++;
+        if(results.at(i) != -1)
+            numNonIntitialValues++;
+    }
+    // only one thread is allowed to flip the value
+    REQUIRE(numFlippedValues == 1u);
+    // only one value is allowed to differ from the initial value
+    REQUIRE(numNonIntitialValues == 1u);
+}
+
+#endif

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -8,6 +8,9 @@
  */
 
 #include <alpaka/queue/Traits.hpp>
+#include <alpaka/meta/Concatenate.hpp>
+
+#include <alpaka/test/queue/QueueCpuOmp2Collective.hpp>
 
 #include <alpaka/test/queue/Queue.hpp>
 #include <alpaka/test/queue/QueueTestFixture.hpp>
@@ -159,7 +162,13 @@ void operator()()
 }
 };
 
-using TestQueues = alpaka::test::queue::TestQueues;
+using TestQueues = alpaka::meta::Concatenate<
+        alpaka::test::queue::TestQueues
+ #ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+        ,
+        std::tuple<std::tuple<alpaka::dev::DevCpu, alpaka::queue::QueueCpuOmp2Collective>>
+#endif
+    >;
 
 TEST_CASE( "queueIsInitiallyEmpty", "[queue]")
 {


### PR DESCRIPTION
solves #820

By providing a queue interface class it is possible to handle user defines queues within alpaka.

- add queue interface `ICpuQueue`
- remove usage of hardcoded register function for each queue type within the device

The second commit provides a OpenMP collective queue as test case for an externally defined queue which is designed with the requirements of #820 in mind.