### PR TITLE
/math/exp/Traits muted cuda-warning

### DIFF
--- a/include/alpaka/math/exp/Traits.hpp
+++ b/include/alpaka/math/exp/Traits.hpp
@@ -39,6 +39,7 @@ namespace alpaka
         //! \tparam TArg The arg type.
         //! \param exp_ctx The object specializing Exp.
         //! \param arg The arg.
+        ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>


### PR DESCRIPTION
Following warning has to be suppressed:
/alpaka/include/alpaka/math/exp/Traits.hpp(58): warning: calling a __host__ function from a __host__ __device__ function is not allowed
