### PR TITLE
alpaka/math Overloaded float specialization

### DIFF
--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -58,6 +58,21 @@ namespace alpaka
                     return ::abs(arg);
                 }
             };
+
+            template<>
+            struct Abs<
+                AbsHipBuiltIn,
+                float>
+            {
+                __device__ static auto abs(
+                    AbsHipBuiltIn const & abs_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(abs_ctx);
+                    return ::fabsf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library abs.
+        //! The CUDA built in abs.
         class AbsCudaBuiltIn
         {
         public:
@@ -58,7 +58,7 @@ namespace alpaka
                     return ::abs(arg);
                 }
             };
-
+            //! The CUDA built in abs float specialization.
             template<>
             struct Abs<
                 AbsHipBuiltIn,

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -61,11 +61,11 @@ namespace alpaka
             //! The CUDA built in abs float specialization.
             template<>
             struct Abs<
-                AbsHipBuiltIn,
+                AbsCudaBuiltIn,
                 float>
             {
                 __device__ static auto abs(
-                    AbsHipBuiltIn const & abs_ctx,
+                    AbsCudaBuiltIn const & abs_ctx,
                     float const & arg)
                 -> float
                 {

--- a/include/alpaka/math/abs/AbsHipBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library abs.
+        //! The HIP built in abs.
         class AbsHipBuiltIn
         {
         public:
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::abs(arg);
                 }
             };
-
+            //! The HIP built in abs float specialization.
             template<>
             struct Abs<
                 AbsHipBuiltIn,

--- a/include/alpaka/math/abs/AbsHipBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::abs(arg);
                 }
             };
+
+            template<>
+            struct Abs<
+                AbsHipBuiltIn,
+                float>
+            {
+                __device__ static auto abs(
+                    AbsHipBuiltIn const & abs_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(abs_ctx);
+                    return ::fabsf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
@@ -58,6 +58,21 @@ namespace alpaka
                     return ::acos(arg);
                 }
             };
+
+            template<>
+            struct Acos<
+                AcosCudaBuiltIn,
+                float>
+            {
+                __device__ static auto acos(
+                    AcosCudaBuiltIn const & acos_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(acos_ctx);
+                    return ::acosf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library acos.
+        //! The CUDA built in acos.
         class AcosCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library acos trait specialization.
+            //! The CUDA acos trait specialization.
             template<
                 typename TArg>
             struct Acos<

--- a/include/alpaka/math/acos/AcosHipBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosHipBuiltIn.hpp
@@ -67,6 +67,22 @@ namespace alpaka
                     return ::acos(arg);
                 }
             };
+
+            template<>
+            struct Acos<
+                AcosHipBuiltIn,
+                float>
+            {
+                ALPAKA_NO_HOST_ACC_WARNING
+                __device__ static auto acos(
+                    AcosHipBuiltIn const & acos_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(acos_ctx);
+                    return ::acosf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/acos/AcosHipBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library acos.
+        //! The HIP acos.
         class AcosHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library acos trait specialization.
+            //! The HIP acos trait specialization.
             template<
                 typename TArg>
             struct Acos<
@@ -67,7 +67,7 @@ namespace alpaka
                     return ::acos(arg);
                 }
             };
-
+            //! The HIP acos float specialization.
             template<>
             struct Acos<
                 AcosHipBuiltIn,

--- a/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library asin.
+        //! The CUDA built in asin.
         class AsinCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library asin trait specialization.
+            //! The CUDA asin trait specialization.
             template<
                 typename TArg>
             struct Asin<

--- a/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
@@ -58,6 +58,21 @@ namespace alpaka
                     return ::asin(arg);
                 }
             };
+
+            template<>
+            struct Asin<
+                AsinCudaBuiltIn,
+                float>
+            {
+                __device__ static auto asin(
+                    AsinCudaBuiltIn const & asin_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(asin_ctx);
+                    return ::asinf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/asin/AsinHipBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::asin(arg);
                 }
             };
+
+            template<>
+            struct Asin<
+                AsinHipBuiltIn,
+                float>
+            {
+                __device__ static auto asin(
+                    AsinHipBuiltIn const & asin_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(asin_ctx);
+                    return ::asinf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/asin/AsinHipBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library asin.
+        //! The HIP asin.
         class AsinHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library asin trait specialization.
+            //! The HIP asin trait specialization.
             template<
                 typename TArg>
             struct Asin<
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::asin(arg);
                 }
             };
-
+            //! The HIP asin float specialization.
             template<>
             struct Asin<
                 AsinHipBuiltIn,

--- a/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
@@ -58,6 +58,21 @@ namespace alpaka
                     return ::atan(arg);
                 }
             };
+
+            template<>
+            struct Atan<
+                AtanCudaBuiltIn,
+                float>
+            {
+                __device__ static auto atan(
+                    AtanCudaBuiltIn const & atan_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(atan_ctx);
+                    return ::atanf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library atan.
+        //! The CUDA built in atan.
         class AtanCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library atan trait specialization.
+            //! The CUDA atan trait specialization.
             template<
                 typename TArg>
             struct Atan<

--- a/include/alpaka/math/atan/AtanHipBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::atan(arg);
                 }
             };
+
+            template<>
+            struct Atan<
+                AtanHipBuiltIn,
+                float>
+            {
+                __device__ static auto atan(
+                    AtanHipBuiltIn const & atan_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(atan_ctx);
+                    return ::atanf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/atan/AtanHipBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library atan.
+        //! The HIP atan.
         class AtanHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library atan trait specialization.
+            //! The HIP atan trait specialization.
             template<
                 typename TArg>
             struct Atan<
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::atan(arg);
                 }
             };
-
+            //! The HIP atan float specialization.
             template<>
             struct Atan<
                 AtanHipBuiltIn,

--- a/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library atan2.
+        //! The CUDA built in atan2.
         class Atan2CudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library atan2 trait specialization.
+            //! The CUDA atan2 trait specialization.
             template<
                 typename Ty,
                 typename Tx>

--- a/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
@@ -62,6 +62,23 @@ namespace alpaka
                     return ::atan2(y, x);
                 }
             };
+
+            template<>
+            struct Atan2<
+                Atan2CudaBuiltIn,
+                float,
+                float>
+            {
+                __device__ static auto atan2(
+                    Atan2CudaBuiltIn const & atan2_ctx,
+                    float const & y,
+                    float const & x)
+                -> float
+                {
+                    alpaka::ignore_unused(atan2_ctx);
+                    return ::atan2f(y, x);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/atan2/Atan2HipBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2HipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library atan2.
+        //! The HIP atan2.
         class Atan2HipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library atan2 trait specialization.
+            //! The HIP atan2 trait specialization.
             template<
                 typename Ty,
                 typename Tx>
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::atan2(y, x);
                 }
             };
-
+            //! The HIP sin float specialization.
             template<>
             struct Atan2<
                 Atan2HipBuiltIn,

--- a/include/alpaka/math/atan2/Atan2HipBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2HipBuiltIn.hpp
@@ -70,6 +70,23 @@ namespace alpaka
                     return ::atan2(y, x);
                 }
             };
+
+            template<>
+            struct Atan2<
+                Atan2HipBuiltIn,
+                float,
+                float>
+            {
+                __device__ static auto atan2(
+                    Atan2HipBuiltIn const & atan2_ctx,
+                    float const & y,
+                    float const & x)
+                -> float
+                {
+                    alpaka::ignore_unused(atan2_ctx);
+                    return ::atan2f(y, x);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
@@ -58,6 +58,21 @@ namespace alpaka
                     return ::cbrt(arg);
                 }
             };
+
+            template<>
+            struct Cbrt<
+                CbrtCudaBuiltIn,
+                float>
+            {
+                __device__ static auto cbrt(
+                    CbrtCudaBuiltIn const & cbrt_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(cbrt_ctx);
+                    return ::cbrtf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library cbrt.
+        //! The CUDA built in cbrt.
         class CbrtCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library cbrt trait specialization.
+            //! The CUDA cbrt trait specialization.
             template<
                 typename TArg>
             struct Cbrt<

--- a/include/alpaka/math/cbrt/CbrtHipBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::cbrt(arg);
                 }
             };
+
+            template<>
+            struct Cbrt<
+                CbrtHipBuiltIn,
+                float>
+            {
+                __device__ static auto cbrt(
+                    CbrtHipBuiltIn const & cbrt_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(cbrt_ctx);
+                    return ::cbrtf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/cbrt/CbrtHipBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library cbrt.
+        //! The HIP cbrt.
         class CbrtHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library cbrt trait specialization.
+            //! The HIP cbrt trait specialization.
             template<
                 typename TArg>
             struct Cbrt<
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::cbrt(arg);
                 }
             };
-
+            //! The HIP cbrt float specialization.
             template<>
             struct Cbrt<
                 CbrtHipBuiltIn,

--- a/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library ceil.
+        //! The CUDA built in ceil.
         class CeilCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library ceil trait specialization.
+            //! The CUDA ceil trait specialization.
             template<
                 typename TArg>
             struct Ceil<
@@ -58,7 +58,7 @@ namespace alpaka
                     return ::ceil(arg);
                 }
             };
-
+            //
             template<>
             struct Ceil<
                 CeilCudaBuiltIn,

--- a/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
@@ -58,6 +58,21 @@ namespace alpaka
                     return ::ceil(arg);
                 }
             };
+
+            template<>
+            struct Ceil<
+                CeilCudaBuiltIn,
+                float>
+            {
+                __device__ static auto ceil(
+                    CeilCudaBuiltIn const & ceil_ctx,
+                    float const & arg)
+                ->float
+                {
+                    alpaka::ignore_unused(ceil_ctx);
+                    return ::ceilf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/ceil/CeilHipBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::ceil(arg);
                 }
             };
+
+            template<>
+            struct Ceil<
+                CeilHipBuiltIn,
+                float>
+            {
+                __device__ static auto ceil(
+                    CeilHipBuiltIn const & ceil_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(ceil_ctx);
+                    return ::ceilf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/ceil/CeilHipBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library ceil.
+        //! The HIP ceil.
         class CeilHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library ceil trait specialization.
+            //! The HIP ceil trait specialization.
             template<
                 typename TArg>
             struct Ceil<
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::ceil(arg);
                 }
             };
-
+            //! The HIP cos float specialization.
             template<>
             struct Ceil<
                 CeilHipBuiltIn,

--- a/include/alpaka/math/cos/CosCudaBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library cos.
+        //! The CUDA built in cos.
         class CosCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library cos trait specialization.
+            //! The CUDA cos trait specialization.
             template<
                 typename TArg>
             struct Cos<

--- a/include/alpaka/math/cos/CosCudaBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosCudaBuiltIn.hpp
@@ -58,6 +58,21 @@ namespace alpaka
                     return ::cos(arg);
                 }
             };
+
+            template<>
+            struct Cos<
+                CosCudaBuiltIn,
+                float>
+            {
+                __device__ static auto cos(
+                    CosCudaBuiltIn const & cos_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(cos_ctx);
+                    return ::cosf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/cos/CosHipBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::cos(arg);
                 }
             };
+
+            template<>
+            struct Cos<
+                CosHipBuiltIn,
+                float>
+            {
+                __device__ static auto cos(
+                    CosHipBuiltIn const & cos_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(cos_ctx);
+                    return ::cosf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/cos/CosHipBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library cos.
+        //! The HIP cos.
         class CosHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library cos trait specialization.
+            //! The HIP cos trait specialization.
             template<
                 typename TArg>
             struct Cos<
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::cos(arg);
                 }
             };
-
+            //! The HIP cos float specialization.
             template<>
             struct Cos<
                 CosHipBuiltIn,

--- a/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library erf.
+        //! The CUDA built in erf.
         class ErfCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library erf trait specialization.
+            //! The CUDA erf trait specialization.
             template<
                 typename TArg>
             struct Erf<

--- a/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
@@ -58,6 +58,21 @@ namespace alpaka
                     return ::erf(arg);
                 }
             };
+
+            template<>
+            struct Erf<
+                ErfCudaBuiltIn,
+                float>
+            {
+                __device__ static auto erf(
+                    ErfCudaBuiltIn const & erf_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(erf_ctx);
+                    return ::erff(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/erf/ErfHipBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::erf(arg);
                 }
             };
+
+            template<>
+            struct Erf<
+                ErfHipBuiltIn,
+                float>
+            {
+                __device__ static auto erf(
+                    ErfHipBuiltIn const & erf_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(erf_ctx);
+                    return ::erff(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/erf/ErfHipBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library erf.
+        //! The HIP erf.
         class ErfHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library erf trait specialization.
+            //! The HIP erf trait specialization.
             template<
                 typename TArg>
             struct Erf<
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::erf(arg);
                 }
             };
-
+            //! The HIP erf float specialization.
             template<>
             struct Erf<
                 ErfHipBuiltIn,

--- a/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library exp.
+        //! The CUDA built in exp.
         class ExpCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library exp trait specialization.
+            //! The CUDA exp trait specialization.
             template<
                 typename TArg>
             struct Exp<
@@ -58,7 +58,7 @@ namespace alpaka
                     return ::exp(arg);
                 }
             };
-
+            //! The CUDA exp float specialization.
             template<>
             struct Exp<
                 ExpCudaBuiltIn,

--- a/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
@@ -58,6 +58,21 @@ namespace alpaka
                     return ::exp(arg);
                 }
             };
+
+            template<>
+            struct Exp<
+                ExpCudaBuiltIn,
+                float>
+            {
+                __device__ static auto exp(
+                    ExpCudaBuiltIn const & exp_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(exp_ctx);
+                    return ::expf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/exp/ExpHipBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library exp.
+        //! The HIP exp.
         class ExpHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library exp trait specialization.
+            //! The HIP exp trait specialization.
             template<
                 typename TArg>
             struct Exp<
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::exp(arg);
                 }
             };
-
+            //! The HIP exp float specialization.
             template<>
             struct Exp<
                 ExpHipBuiltIn,

--- a/include/alpaka/math/exp/ExpHipBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::exp(arg);
                 }
             };
+
+            template<>
+            struct Exp<
+                ExpHipBuiltIn,
+                float>
+            {
+                __device__ static auto exp(
+                    ExpHipBuiltIn const & exp_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(exp_ctx);
+                    return ::expf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
@@ -58,6 +58,21 @@ namespace alpaka
                     return ::floor(arg);
                 }
             };
+
+            template<>
+            struct Floor<
+                FloorCudaBuiltIn,
+                float>
+            {
+                __device__ static auto floor(
+                    FloorCudaBuiltIn const & floor_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(floor_ctx);
+                    return ::floorf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library floor.
+        //! The CUDA built in floor.
         class FloorCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library floor trait specialization.
+            //! The CUDA floor trait specialization.
             template<
                 typename TArg>
             struct Floor<
@@ -58,7 +58,7 @@ namespace alpaka
                     return ::floor(arg);
                 }
             };
-
+            //! The CUDA floor float specialization.
             template<>
             struct Floor<
                 FloorCudaBuiltIn,

--- a/include/alpaka/math/floor/FloorHipBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library floor.
+        //! The HIP floor.
         class FloorHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library floor trait specialization.
+            //! The HIP floor trait specialization.
             template<
                 typename TArg>
             struct Floor<
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::floor(arg);
                 }
             };
-
+            //! The HIP floor float specialization.
             template<>
             struct Floor<
                 FloorHipBuiltIn,

--- a/include/alpaka/math/floor/FloorHipBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::floor(arg);
                 }
             };
+
+            template<>
+            struct Floor<
+                FloorHipBuiltIn,
+                float>
+            {
+                __device__ static auto floor(
+                    FloorHipBuiltIn const & floor_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(floor_ctx);
+                    return ::floorf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library fmod.
+        //! The CUDA built in fmod.
         class FmodCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library fmod trait specialization.
+            //! The CUDA fmod trait specialization.
             template<
                 typename Tx,
                 typename Ty>
@@ -64,7 +64,7 @@ namespace alpaka
                         y);
                 }
             };
-
+            //! The CUDA fmod float specialization.
             template<>
             struct Fmod<
                 FmodCudaBuiltIn,

--- a/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
@@ -59,7 +59,28 @@ namespace alpaka
                 -> decltype(::fmod(x, y))
                 {
                     alpaka::ignore_unused(fmod_ctx);
-                    return ::fmod(x, y);
+                    return ::fmod(
+                        x,
+                        y);
+                }
+            };
+
+            template<>
+            struct Fmod<
+                FmodCudaBuiltIn,
+                float,
+                float>
+            {
+                __device__ static auto fmod(
+                    FmodCudaBuiltIn const & fmod_ctx,
+                    float const & x,
+                    float const & y)
+                -> float
+                {
+                    alpaka::ignore_unused(fmod_ctx);
+                    return ::fmodf(
+                        x,
+                        y);
                 }
             };
         }

--- a/include/alpaka/math/fmod/FmodHipBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library fmod.
+        //! The HIP fmod.
         class FmodHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library fmod trait specialization.
+            //! The HIP fmod trait specialization.
             template<
                 typename Tx,
                 typename Ty>
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::fmod(x, y);
                 }
             };
-
+            //! The HIP fmod float specialization.
             template<>
             struct Fmod<
                 FmodHipBuiltIn,

--- a/include/alpaka/math/fmod/FmodHipBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodHipBuiltIn.hpp
@@ -70,6 +70,23 @@ namespace alpaka
                     return ::fmod(x, y);
                 }
             };
+
+            template<>
+            struct Fmod<
+                FmodHipBuiltIn,
+                float,
+                float>
+            {
+                __device__ static auto fmod(
+                    FmodHipBuiltIn const & fmod_ctx,
+                    float const & x,
+                    float const & y)
+                -> float
+                {
+                    alpaka::ignore_unused(fmod_ctx);
+                    return ::fmodf(x, y);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/log/LogCudaBuiltIn.hpp
+++ b/include/alpaka/math/log/LogCudaBuiltIn.hpp
@@ -58,6 +58,22 @@ namespace alpaka
                     return ::log(arg);
                 }
             };
+
+            template<>
+            struct Log<
+                LogCudaBuiltIn,
+                float>
+            {
+                __device__ static auto log(
+                    LogCudaBuiltIn const & log_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(log_ctx);
+                    return ::logf(arg);
+                }
+            };
+
         }
     }
 }

--- a/include/alpaka/math/log/LogCudaBuiltIn.hpp
+++ b/include/alpaka/math/log/LogCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library log.
+        // ! The CUDA built in log.
         class LogCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library log trait specialization.
+            //! The CUDA log trait specialization.
             template<
                 typename TArg>
             struct Log<
@@ -58,7 +58,7 @@ namespace alpaka
                     return ::log(arg);
                 }
             };
-
+            //! The CUDA log float specialization.
             template<>
             struct Log<
                 LogCudaBuiltIn,

--- a/include/alpaka/math/log/LogHipBuiltIn.hpp
+++ b/include/alpaka/math/log/LogHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::log(arg);
                 }
             };
+
+            template<>
+            struct Log<
+                LogHipBuiltIn,
+                float>
+            {
+                __device__ static auto log(
+                    LogHipBuiltIn const & log_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(log_ctx);
+                    return ::logf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/log/LogHipBuiltIn.hpp
+++ b/include/alpaka/math/log/LogHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library log.
+        //! The HIP log.
         class LogHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library log trait specialization.
+            //! The HIP log trait specialization.
             template<
                 typename TArg>
             struct Log<
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::log(arg);
                 }
             };
-
+            //! The HIP log float specialization.
             template<>
             struct Log<
                 LogHipBuiltIn,

--- a/include/alpaka/math/max/MaxCudaBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxCudaBuiltIn.hpp
@@ -29,7 +29,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library max.
+        //! The CUDA built in max.
         class MaxCudaBuiltIn
         {
         public:
@@ -62,7 +62,7 @@ namespace alpaka
                 }
             };
             //#############################################################################
-            //! The standard library mixed integral floating point max trait specialization.
+            //! The CUDA mixed integral floating point max trait specialization.
             template<
                 typename Tx,
                 typename Ty>

--- a/include/alpaka/math/max/MaxHipBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library max.
+        //! The HIP max.
         class MaxHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library integral max trait specialization.
+            //! The HIP integral max trait specialization.
             template<
                 typename Tx,
                 typename Ty>
@@ -71,7 +71,7 @@ namespace alpaka
                 }
             };
             //#############################################################################
-            //! The standard library mixed integral floating point max trait specialization.
+            //! The HIP mixed integral floating point max trait specialization.
             template<
                 typename Tx,
                 typename Ty>

--- a/include/alpaka/math/min/MinCudaBuiltIn.hpp
+++ b/include/alpaka/math/min/MinCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library min.
+        //! The CUDA built in min.
         class MinCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library integral min trait specialization.
+            //! The CUDA integral min trait specialization.
             template<
                 typename Tx,
                 typename Ty>

--- a/include/alpaka/math/min/MinHipBuiltIn.hpp
+++ b/include/alpaka/math/min/MinHipBuiltIn.hpp
@@ -40,7 +40,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library min.
+        //! The HIP min.
         class MinHipBuiltIn
         {
         public:
@@ -50,7 +50,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library integral min trait specialization.
+            //! The HIP integral min trait specialization.
             template<
                 typename Tx,
                 typename Ty>
@@ -73,7 +73,7 @@ namespace alpaka
                 }
             };
             //#############################################################################
-            //! The standard library mixed integral floating point min trait specialization.
+            //! The HIP mixed integral floating point min trait specialization.
             template<
                 typename Tx,
                 typename Ty>

--- a/include/alpaka/math/pow/PowCudaBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library pow.
+        //! The CUDA built in pow.
         class PowCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library pow trait specialization.
+            //! The CUDA pow trait specialization.
             template<
                 typename TBase,
                 typename TExp>
@@ -62,7 +62,7 @@ namespace alpaka
                     return ::pow(base, exp);
                 }
             };
-
+            //! The CUDA pow float specialization.
             template<>
             struct Pow<
                 PowCudaBuiltIn,

--- a/include/alpaka/math/pow/PowCudaBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowCudaBuiltIn.hpp
@@ -62,6 +62,23 @@ namespace alpaka
                     return ::pow(base, exp);
                 }
             };
+
+            template<>
+            struct Pow<
+                PowCudaBuiltIn,
+                float,
+                float>
+            {
+                __device__ static auto pow(
+                    PowCudaBuiltIn const & pow_ctx,
+                    float const & base,
+                    float const & exp)
+                -> float
+                {
+                    alpaka::ignore_unused(pow_ctx);
+                    return ::powf(base, exp);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/pow/PowHipBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library pow.
+        //! The HIP pow.
         class PowHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library pow trait specialization.
+            //! The HIP pow trait specialization.
             template<
                 typename TBase,
                 typename TExp>
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::pow(base, exp);
                 }
             };
-
+            //! The HIP pow float specialization.
             template<>
             struct Pow<
                 PowCudaBuiltIn,

--- a/include/alpaka/math/pow/PowHipBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowHipBuiltIn.hpp
@@ -70,6 +70,23 @@ namespace alpaka
                     return ::pow(base, exp);
                 }
             };
+
+            template<>
+            struct Pow<
+                PowCudaBuiltIn,
+                float,
+                float>
+            {
+                __device__ static auto pow(
+                    PowCudaBuiltIn const & pow_ctx,
+                    float const & base,
+                    float const & exp)
+                -> float
+                {
+                    alpaka::ignore_unused(pow_ctx);
+                    return ::powf(base, exp);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/pow/PowHipBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowHipBuiltIn.hpp
@@ -73,12 +73,12 @@ namespace alpaka
             //! The HIP pow float specialization.
             template<>
             struct Pow<
-                PowCudaBuiltIn,
+                PowHipBuiltIn,
                 float,
                 float>
             {
                 __device__ static auto pow(
-                    PowCudaBuiltIn const & pow_ctx,
+                    PowHipBuiltIn const & pow_ctx,
                     float const & base,
                     float const & exp)
                 -> float

--- a/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library remainder.
+        //! The CUDA built in remainder.
         class RemainderCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library remainder trait specialization.
+            //! The CUDA remainder trait specialization.
             template<
                 typename Tx,
                 typename Ty>
@@ -66,7 +66,7 @@ namespace alpaka
                         y);
                 }
             };
-
+            //! The CUDA remainder float specialization.
             template<>
             struct Remainder<
                 RemainderCudaBuiltIn,

--- a/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
@@ -66,6 +66,25 @@ namespace alpaka
                         y);
                 }
             };
+
+            template<>
+            struct Remainder<
+                RemainderCudaBuiltIn,
+                float,
+                float>
+            {
+                __device__ static auto remainder(
+                    RemainderCudaBuiltIn const & remainder_ctx,
+                    float const & x,
+                    float const & y)
+                -> float
+                {
+                    alpaka::ignore_unused(remainder_ctx);
+                    return ::remainderf(
+                        x,
+                        y);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/remainder/RemainderHipBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderHipBuiltIn.hpp
@@ -70,6 +70,25 @@ namespace alpaka
                     return ::remainder(x, y);
                 }
             };
+
+            template<>
+            struct Remainder<
+                RemainderHipBuiltIn,
+                float,
+                float>
+            {
+                __device__ static auto remainder(
+                    RemainderHipBuiltIn const & remainder_ctx,
+                    float const & x,
+                    float const & y)
+                -> float
+                {
+                    alpaka::ignore_unused(remainder_ctx);
+                    return ::remainderf(
+                        x,
+                        y);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/remainder/RemainderHipBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library remainder.
+        //! The HIP remainder.
         class RemainderHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library remainder trait specialization.
+            //! The HIP remainder trait specialization.
             template<
                 typename Tx,
                 typename Ty>
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::remainder(x, y);
                 }
             };
-
+            //! The HIP remainder float specialization.
             template<>
             struct Remainder<
                 RemainderHipBuiltIn,

--- a/include/alpaka/math/round/RoundCudaBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library round.
+        //! The CUDA round.
         class RoundCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library round trait specialization.
+            //! The CUDA round trait specialization.
             template<
                 typename TArg>
             struct Round<
@@ -59,7 +59,7 @@ namespace alpaka
                 }
             };
             //#############################################################################
-            //! The standard library round trait specialization.
+            //! The CUDA lround trait specialization.
             template<
                 typename TArg>
             struct Lround<
@@ -78,7 +78,7 @@ namespace alpaka
                 }
             };
             //#############################################################################
-            //! The standard library round trait specialization.
+            //! The CUDA llround trait specialization.
             template<
                 typename TArg>
             struct Llround<
@@ -96,7 +96,7 @@ namespace alpaka
                     return ::llround(arg);
                 }
             };
-
+            //! The CUDA round float specialization.
             template<>
             struct Round<
                 RoundHipBuiltIn,

--- a/include/alpaka/math/round/RoundCudaBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundCudaBuiltIn.hpp
@@ -96,6 +96,21 @@ namespace alpaka
                     return ::llround(arg);
                 }
             };
+
+            template<>
+            struct Round<
+                RoundHipBuiltIn,
+                float>
+            {
+                __device__ static auto round(
+                    RoundHipBuiltIn const & round_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(round_ctx);
+                    return ::roundf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/round/RoundCudaBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundCudaBuiltIn.hpp
@@ -99,11 +99,11 @@ namespace alpaka
             //! The CUDA round float specialization.
             template<>
             struct Round<
-                RoundHipBuiltIn,
+                RoundCudaBuiltIn,
                 float>
             {
                 __device__ static auto round(
-                    RoundHipBuiltIn const & round_ctx,
+                    RoundCudaBuiltIn const & round_ctx,
                     float const & arg)
                 -> float
                 {

--- a/include/alpaka/math/round/RoundHipBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library round.
+        //! The HIP round.
         class RoundHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library round trait specialization.
+            //! The HIP round trait specialization.
             template<
                 typename TArg>
             struct Round<
@@ -67,7 +67,7 @@ namespace alpaka
                 }
             };
             //#############################################################################
-            //! The standard library round trait specialization.
+            //! The HIP round trait specialization.
             template<
                 typename TArg>
             struct Lround<

--- a/include/alpaka/math/round/RoundHipBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundHipBuiltIn.hpp
@@ -104,6 +104,21 @@ namespace alpaka
                     return ::llround(arg);
                 }
             };
+
+            template<>
+            struct Round<
+                RoundHipBuiltIn,
+                float>
+            {
+                __device__ static auto round(
+                    RoundHipBuiltIn const & round_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(round_ctx);
+                    return ::roundf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
@@ -58,6 +58,21 @@ namespace alpaka
                     return ::rsqrt(arg);
                 }
             };
+
+            template<>
+            struct Rsqrt<
+                RsqrtCudaBuiltIn,
+                float>
+            {
+                __device__ static auto rsqrt(
+                    RsqrtCudaBuiltIn const & rsqrt_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(rsqrt_ctx);
+                    return ::rsqrtf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library rsqrt.
+        //! The CUDA rsqrt.
         class RsqrtCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library rsqrt trait specialization.
+            //! The CUDA rsqrt trait specialization.
             template<
                 typename TArg>
             struct Rsqrt<
@@ -58,7 +58,7 @@ namespace alpaka
                     return ::rsqrt(arg);
                 }
             };
-
+            //! The CUDA rsqrt float specialization.
             template<>
             struct Rsqrt<
                 RsqrtCudaBuiltIn,

--- a/include/alpaka/math/rsqrt/RsqrtHipBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::rsqrt(arg);
                 }
             };
+
+            template<>
+            struct Rsqrt<
+                RsqrtHipBuiltIn,
+                float>
+            {
+                __device__ static auto rsqrt(
+                    RsqrtHipBuiltIn const & rsqrt_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(rsqrt_ctx);
+                    return ::rsqrtf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/rsqrt/RsqrtHipBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library rsqrt.
+        //! The HIP rsqrt.
         class RsqrtHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library rsqrt trait specialization.
+            //! The HIP rsqrt trait specialization.
             template<
                 typename TArg>
             struct Rsqrt<
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::rsqrt(arg);
                 }
             };
-
+            //! The HIP rsqrt float specialization.
             template<>
             struct Rsqrt<
                 RsqrtHipBuiltIn,

--- a/include/alpaka/math/sin/SinCudaBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library sin.
+        //! The CUDA sin.
         class SinCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library sin trait specialization.
+            //! The CUDA sin trait specialization.
             template<
                 typename TArg>
             struct Sin<
@@ -58,7 +58,7 @@ namespace alpaka
                     return ::sin(arg);
                 }
             };
-
+            //! The CUDA sin float specialization.
             template<>
             struct Sin<
                 SinCudaBuiltIn,

--- a/include/alpaka/math/sin/SinCudaBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinCudaBuiltIn.hpp
@@ -58,6 +58,21 @@ namespace alpaka
                     return ::sin(arg);
                 }
             };
+
+            template<>
+            struct Sin<
+                SinCudaBuiltIn,
+                float>
+            {
+                __device__ static auto sin(
+                    SinCudaBuiltIn const & sin_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(sin_ctx);
+                    return ::sinf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/sin/SinHipBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::sin(arg);
                 }
             };
+
+            template<>
+            struct Sin<
+                SinCudaBuiltIn,
+                float>
+            {
+                __device__ static auto sin(
+                    SinCudaBuiltIn const & sin_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(sin_ctx);
+                    return ::sinf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/sin/SinHipBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library sin.
+        //! The HIP sin.
         class SinHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library sin trait specialization.
+            //! The HIP sin trait specialization.
             template<
                 typename TArg>
             struct Sin<
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::sin(arg);
                 }
             };
-
+            //! The HIP sin float specialization.
             template<>
             struct Sin<
                 SinCudaBuiltIn,

--- a/include/alpaka/math/sin/SinHipBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinHipBuiltIn.hpp
@@ -69,11 +69,11 @@ namespace alpaka
             //! The HIP sin float specialization.
             template<>
             struct Sin<
-                SinCudaBuiltIn,
+                SinHipBuiltIn,
                 float>
             {
                 __device__ static auto sin(
-                    SinCudaBuiltIn const & sin_ctx,
+                    SinHipBuiltIn const & sin_ctx,
                     float const & arg)
                 -> float
                 {

--- a/include/alpaka/math/sincos/SinCosCudaBuiltIn.hpp
+++ b/include/alpaka/math/sincos/SinCosCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! sincos.
+        //! The CUDA sincos.
         class SinCosCudaBuiltIn
         {
         public:
@@ -59,7 +59,7 @@ namespace alpaka
                 }
             };
 
-            //! sincos trait specialization.
+            //! The CUDA sin float specialization.
             template<>
             struct SinCos<
                 SinCosCudaBuiltIn,

--- a/include/alpaka/math/sincos/SinCosHipBuiltIn.hpp
+++ b/include/alpaka/math/sincos/SinCosHipBuiltIn.hpp
@@ -65,7 +65,7 @@ namespace alpaka
                 }
             };
 
-            //! sincos trait specialization.
+            //! The sincos float specialization.
             template<>
             struct SinCos<SinCosHipBuiltIn, float>
             {

--- a/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
@@ -58,6 +58,22 @@ namespace alpaka
                     return ::sqrt(arg);
                 }
             };
+
+            template<>
+            struct Sqrt<
+                SqrtCudaBuiltIn,
+                float>
+            {
+                __device__ static auto sqrt(
+                    SqrtCudaBuiltIn const & sqrt_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(sqrt_ctx);
+                    return ::sqrtf(arg);
+                }
+            };
+
         }
     }
 }

--- a/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library sqrt.
+        //! The CUDA sqrt.
         class SqrtCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library sqrt trait specialization.
+            //! The CUDA sqrt trait specialization.
             template<
                 typename TArg>
             struct Sqrt<
@@ -58,7 +58,7 @@ namespace alpaka
                     return ::sqrt(arg);
                 }
             };
-
+            //! The CUDA sqrt float specialization.
             template<>
             struct Sqrt<
                 SqrtCudaBuiltIn,

--- a/include/alpaka/math/sqrt/SqrtHipBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library sqrt.
+        //! The HIP sqrt.
         class SqrtHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library sqrt trait specialization.
+            //! The HIP sqrt trait specialization.
             template<
                 typename TArg>
             struct Sqrt<
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::sqrt(arg);
                 }
             };
-
+            //! The HIP sqrt float specialization.
             template<>
             struct Sqrt<
                 SqrtHipBuiltIn,

--- a/include/alpaka/math/sqrt/SqrtHipBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::sqrt(arg);
                 }
             };
+
+            template<>
+            struct Sqrt<
+                SqrtHipBuiltIn,
+                float>
+            {
+                __device__ static auto sqrt(
+                    SqrtHipBuiltIn const & sqrt_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(sqrt_ctx);
+                    return ::sqrtf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/tan/TanCudaBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library tan.
+        //! The CUDA tan.
         class TanCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library tan trait specialization.
+            //! The CUDA tan trait specialization.
             template<
                 typename TArg>
             struct Tan<
@@ -58,7 +58,7 @@ namespace alpaka
                     return ::tan(arg);
                 }
             };
-
+            //! The CUDA tan float specialization.
             template<>
             struct Tan<
                 TanCudaBuiltIn,

--- a/include/alpaka/math/tan/TanCudaBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanCudaBuiltIn.hpp
@@ -55,6 +55,21 @@ namespace alpaka
                 -> decltype(::tan(arg))
                 {
                     alpaka::ignore_unused(tan_ctx);
+                    return ::tan(arg);
+                }
+            };
+
+            template<>
+            struct Tan<
+                TanCudaBuiltIn,
+                float>
+            {
+                __device__ static auto tan(
+                    TanCudaBuiltIn const & tan_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(tan_ctx);
                     return ::tanf(arg);
                 }
             };

--- a/include/alpaka/math/tan/TanHipBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanHipBuiltIn.hpp
@@ -63,6 +63,21 @@ namespace alpaka
                 -> decltype(::tan(arg))
                 {
                     alpaka::ignore_unused(tan_ctx);
+                    return ::tan(arg);
+                }
+            };
+
+            template<>
+            struct Tan<
+                TanHipBuiltIn,
+                float>
+            {
+                __device__ static auto tan(
+                    TanHipBuiltIn const & tan_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(tan_ctx);
                     return ::tanf(arg);
                 }
             };

--- a/include/alpaka/math/tan/TanHipBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library tan.
+        //! The HIP tan.
         class TanHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library tan trait specialization.
+            //! The HIP tan trait specialization.
             template<
                 typename TArg>
             struct Tan<
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::tan(arg);
                 }
             };
-
+            //! The HIP tan float specialization.
             template<>
             struct Tan<
                 TanHipBuiltIn,

--- a/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library trunc.
+        //! The CUDA trunc.
         class TruncCudaBuiltIn
         {
         public:
@@ -40,7 +40,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library trunc trait specialization.
+            //! The CUDA trunc trait specialization.
             template<
                 typename TArg>
             struct Trunc<
@@ -58,7 +58,7 @@ namespace alpaka
                     return ::trunc(arg);
                 }
             };
-
+            //! The CUDA trunc float specialization.
             template<>
             struct Trunc<
                 TruncCudaBuiltIn,

--- a/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
@@ -58,6 +58,21 @@ namespace alpaka
                     return ::trunc(arg);
                 }
             };
+
+            template<>
+            struct Trunc<
+                TruncCudaBuiltIn,
+                float>
+            {
+                __device__ static auto trunc(
+                    TruncCudaBuiltIn const & trunc_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(trunc_ctx);
+                    return ::truncf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/trunc/TruncHipBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library trunc.
+        //! The HIP trunc.
         class TruncHipBuiltIn
         {
         public:
@@ -48,7 +48,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library trunc trait specialization.
+            //! The HIP trunc trait specialization.
             template<
                 typename TArg>
             struct Trunc<
@@ -66,7 +66,7 @@ namespace alpaka
                     return ::trunc(arg);
                 }
             };
-
+            //! The HIP trunc float specialization.
             template<>
             struct Trunc<
                 TruncHipBuiltIn,

--- a/include/alpaka/math/trunc/TruncHipBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::trunc(arg);
                 }
             };
+
+            template<>
+            struct Trunc<
+                TruncHipBuiltIn,
+                float>
+            {
+                __device__ static auto trunc(
+                    TruncHipBuiltIn const & trunc_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(trunc_ctx);
+                    return ::truncf(arg);
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
Fixed all falsly copy-pasted "standard libary".
Regarding all, but the min and max functions:
Added a template specialization for floats, to explicitly use the float backends.

- [ ]  depends on #828 (math will be tested since then)

Edit: added dependency