### PR TITLE
Fixes GCC/Address Sanitizer false-positive issue.

### DIFF
--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -200,14 +200,14 @@ namespace alpaka
                 for(TIdx i = 0; i < numBlocksInGrid; ++i)
 #endif
                 {
-                    acc.m_gridBlockIdx =
-                        idx::mapIdx<TDim::value>(
 #if _OPENMP < 200805
-                            vec::Vec<dim::DimInt<1u>, TIdx>(static_cast<TIdx>(i)),
+                    auto const i_tidx  = static_cast<TIdx>(i); // for issue #840
+                    auto const index   = vec::Vec<dim::DimInt<1u>, TIdx>( i_tidx ); // for issue #840
 #else
-                            vec::Vec<dim::DimInt<1u>, TIdx>(i),
+                    auto const index   = vec::Vec<dim::DimInt<1u>, TIdx>( i ); // for issue #840
 #endif
-                            gridBlockExtent);
+                    acc.m_gridBlockIdx = idx::mapIdx<TDim::value>(index,
+                                                                  gridBlockExtent);
 
                     boundKernelFnObj(
                         acc);


### PR DESCRIPTION
- mainly contributed by DLR Braunschweig/A.Rempke

fixes #840 

Note, the `#if-#else` section on OpenMP version could be removed, because a trivial static_cast (same type) is supposed to be a no-op. Just kept it there so you better see for which case the type is maybe different from TIdx' type.
And both lines are required (cast of `i` and definition of index).