### PR TITLE
fix: cuda exceptions

### DIFF
--- a/include/alpaka/core/Cuda.hpp
+++ b/include/alpaka/core/Cuda.hpp
@@ -73,6 +73,8 @@ namespace alpaka
                     std::cerr << sError << std::endl;
 #endif
                     ALPAKA_DEBUG_BREAK;
+                    // reset the last error to allow user side error handling
+                    cudaGetLastError();
                     throw std::runtime_error(sError);
                 }
             }


### PR DESCRIPTION
Exeptions those are triggered because of an error of a cuda api function
can mostly not be handled in alpaka. The reason is that cuda stores
always the last error and in that case the next api call after a catched
exception will crash.

This issue is fixed by resetting the cuda error before we throw.

Note: There is no driver api equivalent so handling exceptions triggered
by driver api calls is not possible. Those functions are currently only
used in the test `EventHostManualTrigger`.


I set the tabel `bug` for this PR because it is unexpected that it is not possible to handle exceptions.