### PR TITLE
/test/.../KernelExecutionFixture.hpp missing pragma once

### DIFF
--- a/test/common/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/test/common/include/alpaka/test/KernelExecutionFixture.hpp
@@ -7,6 +7,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#pragma once
+
 #include <alpaka/alpaka.hpp>
 
 #include <alpaka/test/Check.hpp>


### PR DESCRIPTION
Bug fix:  When included multiple times missing pragma once threw compiling error.