### PR TITLE
fix cuda stream race condition

### DIFF
--- a/include/alpaka/stream/StreamCudaRtSync.hpp
+++ b/include/alpaka/stream/StreamCudaRtSync.hpp
@@ -87,7 +87,7 @@ namespace alpaka
                         ALPAKA_CUDA_RT_CHECK(
                             cudaStreamCreateWithFlags(
                                 &m_CudaStream,
-                                cudaStreamNonBlocking));
+                                cudaStreamDefault));
                     }
                     //-----------------------------------------------------------------------------
                     StreamCudaRtSyncImpl(StreamCudaRtSyncImpl const &) = delete;


### PR DESCRIPTION
**This is the fix to fix the current stable alpaka version** 
The solution for this issue will not be the same we will apply to the development branch.

fix #850

By using `cudaStreamCreateWithFlags(..., cudaStreamNonBlocking)` we
disabling the blocking behavior of `cudaMemcpy` and other blocking cuda
API calls.
By using `cudaStreamDefault` we can enforce the old `legacy` behavior.


- ~~[x] do not merge, I need to check if `StreamCudaRtAsync.hpp` must be updated too~~