### PR TITLE
CMake: Honor _ROOT Env Hints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,16 @@ cmake_minimum_required(VERSION 3.7.0)
 project("alpakaAll")
 
 ################################################################################
+# CMake policies
+#
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
+################################################################################
 # Options and Variants
 
 option(alpaka_BUILD_EXAMPLES "Build the examples" ON)

--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -24,6 +24,16 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 ################################################################################
+# CMake policies
+#
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
+################################################################################
 # alpaka.
 
 # Return values.

--- a/example/bufferCopy/CMakeLists.txt
+++ b/example/bufferCopy/CMakeLists.txt
@@ -32,6 +32,16 @@ SET(_TARGET_NAME "bufferCopy")
 
 PROJECT(${_TARGET_NAME})
 
+################################################################################
+# CMake policies
+#
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 #-------------------------------------------------------------------------------
 # Find alpaka.
 

--- a/example/helloWorld/CMakeLists.txt
+++ b/example/helloWorld/CMakeLists.txt
@@ -32,6 +32,16 @@ SET(_TARGET_NAME "helloWorld")
 
 PROJECT(${_TARGET_NAME})
 
+################################################################################
+# CMake policies
+#
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 #-------------------------------------------------------------------------------
 # Find alpaka.
 

--- a/example/helloWorldLambda/CMakeLists.txt
+++ b/example/helloWorldLambda/CMakeLists.txt
@@ -32,6 +32,16 @@ SET(_TARGET_NAME "helloWorldLambda")
 
 PROJECT(${_TARGET_NAME})
 
+################################################################################
+# CMake policies
+#
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 #-------------------------------------------------------------------------------
 # Find alpaka.
 

--- a/example/vectorAdd/CMakeLists.txt
+++ b/example/vectorAdd/CMakeLists.txt
@@ -32,6 +32,16 @@ SET(_TARGET_NAME "vectorAdd")
 
 PROJECT(${_TARGET_NAME})
 
+################################################################################
+# CMake policies
+#
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 #-------------------------------------------------------------------------------
 # Find alpaka.
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,12 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
+# Search in <PackageName>_ROOT:
+# https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 PROJECT("alpakaTest")
 
 ################################################################################

--- a/test/unit/stream/CMakeLists.txt
+++ b/test/unit/stream/CMakeLists.txt
@@ -32,6 +32,16 @@ SET(_TARGET_NAME "stream")
 
 PROJECT(${_TARGET_NAME})
 
+################################################################################
+# CMake policies
+#
+# Search in <PackageName>_ROOT:
+#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+
+if(POLICY CMP0074)
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 #-------------------------------------------------------------------------------
 # Find alpaka test common.
 


### PR DESCRIPTION
backport of #751

CMake 3.12.0+ honor `<Package>_ROOT` environment hints which are
often set on HPC systems. Previously, it was only looking for
`<Package>_DIR` paths in `find_package` calls.

This new policy is useful since HPC systems usually set `_DIR`,
`_ROOT` or expand the `CMAKE_PREFIX_PATH`. Therefore we want to
use it as soon as it is available.

On systems where those env vars are set, e.g. Hypnos, this also
throws a warning if the default (OLD) policy is used with CMake
3.12.4 or newer.

References:

- https://cmake.org/cmake/help/v3.12/policy/CMP0074.html