### PR TITLE
math/abs: Added trait specialisation for double.

### DIFF
--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -66,7 +66,7 @@ namespace alpaka
             {
                 __device__ static auto abs(
                     AbsCudaBuiltIn const & abs_ctx,
-                    TArg const & arg)
+                    double const & arg)
                 -> decltype(::fabs(arg))
                 {
                     alpaka::ignore_unused(abs_ctx);

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -57,6 +57,21 @@ namespace alpaka
                     alpaka::ignore_unused(abs_ctx);
                     return ::abs(arg);
                 }
+            }
+            //! The CUDA built in abs double specialization.
+            template<>
+            struct Abs<
+                AbsCudaBuiltIn,
+                double>
+            {
+                __device__ static auto abs(
+                    AbsCudaBuiltIn const & abs_ctx,
+                    TArg const & arg)
+                -> decltype(::fabs(arg))
+                {
+                    alpaka::ignore_unused(abs_ctx);
+                    return ::fabs(arg);
+                }
             };
             //! The CUDA built in abs float specialization.
             template<>

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -57,7 +57,7 @@ namespace alpaka
                     alpaka::ignore_unused(abs_ctx);
                     return ::abs(arg);
                 }
-            }
+            };
             //! The CUDA built in abs double specialization.
             template<>
             struct Abs<

--- a/include/alpaka/math/abs/AbsHipBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsHipBuiltIn.hpp
@@ -66,6 +66,21 @@ namespace alpaka
                     return ::abs(arg);
                 }
             };
+            //! The HIP built in abs double specialization.
+            template<>
+            struct Abs<
+                AbsHipBuiltIn,
+                double>
+            {
+                __device__ static auto abs(
+                    AbsHipBuiltIn const & abs_ctx,
+                    TArg const & arg)
+                -> decltype(::fabs(arg))
+                {
+                    alpaka::ignore_unused(abs_ctx);
+                    return ::fabs(arg);
+                }
+            };
             //! The HIP built in abs float specialization.
             template<>
             struct Abs<

--- a/include/alpaka/math/abs/AbsHipBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsHipBuiltIn.hpp
@@ -74,7 +74,7 @@ namespace alpaka
             {
                 __device__ static auto abs(
                     AbsHipBuiltIn const & abs_ctx,
-                    TArg const & arg)
+                    double const & arg)
                 -> decltype(::fabs(arg))
                 {
                     alpaka::ignore_unused(abs_ctx);


### PR DESCRIPTION
In include/alpaka/math/abs:
Int is also supported in cuda/hip, so fabs is used for double type.
abs for int
fabs for double <-- was missing
fabsf for float
