### PR TITLE
Fix MacOS builds and add support for newer versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,9 @@ matrix:
       env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:16.04 CXX=clang++ CC=clang ALPAKA_CI_CLANG_VER=4.0.0 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_STDLIB=libc++    ALPAKA_CI_BOOST_BRANCH=boost-1.71.0 ALPAKA_CI_CMAKE_VER=3.15.2 ALPAKA_CI_ANALYSIS=ON  ALPAKA_DEBUG=1 ALPAKA_ACC_GPU_CUDA_ENABLE=ON  ALPAKA_CUDA_VERSION=8.0 ALPAKA_CUDA_COMPILER=clang
     - name: clang-6 Debug Analysis
       env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:18.04 CXX=clang++ CC=clang ALPAKA_CI_CLANG_VER=6.0.1 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_STDLIB=libc++    ALPAKA_CI_BOOST_BRANCH=boost-1.68.0 ALPAKA_CI_CMAKE_VER=3.13.5 ALPAKA_CI_ANALYSIS=ON  ALPAKA_DEBUG=2
-    - name: macOS 10.13 Xcode 10.1 Debug Analysis
+    - name: macOS 10.14 Xcode 11.2 Debug Analysis
       os: osx
-      osx_image: xcode10.1
+      osx_image: xcode11.2
       env:                                               CXX=g++     CC=gcc                             CMAKE_BUILD_TYPE=Debug                              ALPAKA_CI_BOOST_BRANCH=boost-1.65.1                            ALPAKA_CI_ANALYSIS=ON  ALPAKA_DEBUG=2 ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF
     - name: MSVC-2017 Debug Analysis
       os: windows
@@ -90,13 +90,49 @@ matrix:
       env:                                               CXX=cl.exe  CC=cl.exe                          CMAKE_BUILD_TYPE=Debug                              ALPAKA_CI_BOOST_BRANCH=boost-1.69.0 ALPAKA_CI_CMAKE_VER=3.13.5 ALPAKA_CI_ANALYSIS=ON  ALPAKA_DEBUG=2
 
     ### macOS
-    - name: macOS 10.13 Xcode 10.1 Debug
+    - name: macOS 10.14 Xcode 10.2.1 Debug
       os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
       env:                                               CXX=g++     CC=gcc                             CMAKE_BUILD_TYPE=Debug                              ALPAKA_CI_BOOST_BRANCH=boost-1.67.0                            ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF ALPAKA_CXX_STANDARD=14
-    - name: macOS 10.13 Xcode 10.1 Release
+    - name: macOS 10.14 Xcode 10.2.1 Release
       os: osx
-      osx_image: xcode10.1
+      osx_image: xcode10.2
+      env:                                               CXX=g++     CC=gcc                             CMAKE_BUILD_TYPE=Release                            ALPAKA_CI_BOOST_BRANCH=boost-1.71.0                            ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF
+
+    - name: macOS 10.14.4 Xcode 10.3 Debug
+      os: osx
+      osx_image: xcode10.3
+      env:                                               CXX=g++     CC=gcc                             CMAKE_BUILD_TYPE=Debug                              ALPAKA_CI_BOOST_BRANCH=boost-1.67.0                            ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF ALPAKA_CXX_STANDARD=14
+    - name: macOS 10.14.4 Xcode 10.3 Release
+      os: osx
+      osx_image: xcode10.3
+      env:                                               CXX=g++     CC=gcc                             CMAKE_BUILD_TYPE=Release                            ALPAKA_CI_BOOST_BRANCH=boost-1.71.0                            ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF
+
+    - name: macOS 10.14 Xcode 11.0 Debug
+      os: osx
+      osx_image: xcode11
+      env:                                               CXX=g++     CC=gcc                             CMAKE_BUILD_TYPE=Debug                              ALPAKA_CI_BOOST_BRANCH=boost-1.67.0                            ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF ALPAKA_CXX_STANDARD=14
+    - name: macOS 10.14 Xcode 11.0 Release
+      os: osx
+      osx_image: xcode11
+      env:                                               CXX=g++     CC=gcc                             CMAKE_BUILD_TYPE=Release                            ALPAKA_CI_BOOST_BRANCH=boost-1.71.0                            ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF
+
+    - name: macOS 10.14 Xcode 11.1 Debug
+      os: osx
+      osx_image: xcode11.1
+      env:                                               CXX=g++     CC=gcc                             CMAKE_BUILD_TYPE=Debug                              ALPAKA_CI_BOOST_BRANCH=boost-1.67.0                            ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF ALPAKA_CXX_STANDARD=14
+    - name: macOS 10.14 Xcode 11.1 Release
+      os: osx
+      osx_image: xcode11.1
+      env:                                               CXX=g++     CC=gcc                             CMAKE_BUILD_TYPE=Release                            ALPAKA_CI_BOOST_BRANCH=boost-1.71.0                            ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF
+
+    - name: macOS 10.14 Xcode 11.2 Debug
+      os: osx
+      osx_image: xcode11.2
+      env:                                               CXX=g++     CC=gcc                             CMAKE_BUILD_TYPE=Debug                              ALPAKA_CI_BOOST_BRANCH=boost-1.67.0                            ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF ALPAKA_CXX_STANDARD=14
+    - name: macOS 10.14 Xcode 11.2 Release
+      os: osx
+      osx_image: xcode11.2
       env:                                               CXX=g++     CC=gcc                             CMAKE_BUILD_TYPE=Release                            ALPAKA_CI_BOOST_BRANCH=boost-1.71.0                            ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF
 
     ### Windows

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Supported Compilers
 
 This library uses C++11 (or newer when available).
 
-|Accelerator Back-end|gcc 4.9.4 <br/> (Linux)|gcc 5.5 <br/> (Linux)|gcc 6.4/7.3 <br/> (Linux)|gcc 8.1/9.1 <br/> (Linux)|clang 4 <br/> (Linux)|clang 5 <br/> (Linux)|clang 6 <br/> (Linux)|clang 7 <br/> (Linux)|clang 8 <br/> (Linux)|Apple LLVM 10.0.0 <br/> (macOS)|MSVC 2017.9 <br/> (Windows)|
+|Accelerator Back-end|gcc 4.9.4 <br/> (Linux)|gcc 5.5 <br/> (Linux)|gcc 6.4/7.3 <br/> (Linux)|gcc 8.1/9.1 <br/> (Linux)|clang 4 <br/> (Linux)|clang 5 <br/> (Linux)|clang 6 <br/> (Linux)|clang 7 <br/> (Linux)|clang 8 <br/> (Linux)|Apple LLVM 10.2-11.2 <br/> (macOS)|MSVC 2017.9 <br/> (Windows)|
 |---|---|---|---|---|---|---|---|---|---|---|---|
 |Serial|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |OpenMP 2.0+ blocks|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|


### PR DESCRIPTION
The CI is currently broken because the macOS builds are failing with homebrew errors.
```
/usr/local/Homebrew/Library/Homebrew/brew.rb:23:in `require_relative': /usr/local/Homebrew/Library/Homebrew/global.rb:110: syntax error, unexpected keyword_rescue, expecting keyword_end (SyntaxError)
	from /usr/local/Homebrew/Library/Homebrew/brew.rb:23:in `<main>'
```
I do not know the exact reason but using newer macOS version (10.14 instead of 10.13) works.
This also removes support for XCode 10.1 but adds support for multiple newer verions (10.2-11.2).

Please approve so that CI works again.