### PR TITLE
[WIP] Find hiprand/rocrand by ROCm provided config files.

### DIFF
--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -801,72 +801,28 @@ IF(ALPAKA_ACC_GPU_HIP_ENABLE)
                     LIST(APPEND HIP_HIPCC_FLAGS "-Xcudafe --diag_suppress=esa_on_defaulted_function_ignored")
                 ENDIF()
 
-                # random numbers library ( HIP(NVCC) ) /hiprand
-                # HIP_ROOT_DIR is set by FindHIP.cmake
-                FIND_PATH(HIP_RAND_INC
-                    NAMES "hiprand_kernel.h"
-                    PATHS "${HIP_ROOT_DIR}/hiprand" "${HIP_ROOT_DIR}/include" "hiprand"
-                    PATHS "/opt/rocm/rocrand/hiprand"
-                    PATH_SUFFIXES "include" "hiprand")
-                FIND_LIBRARY(HIP_RAND_LIBRARY
-                    NAMES "hiprand-d" "hiprand"
-                    PATHS "${HIP_ROOT_DIR}/hiprand" "${HIP_ROOT_DIR}" "hiprand"
-                    PATHS "/opt/rocm/rocrand/hiprand"
-                    ENV HIP_PATH
-                    PATH_SUFFIXES "lib" "lib64")
-                IF(NOT HIP_RAND_INC)
-                    MESSAGE(FATAL_ERROR "Could not find hipRAND include (also searched in: HIP_ROOT_DIR=${HIP_ROOT_DIR}).")
-                ENDIF()
-                IF(NOT HIP_RAND_LIBRARY)
-                    MESSAGE(FATAL_ERROR "Could not find hipRAND library (also searched in: HIP_ROOT_DIR=${HIP_ROOT_DIR}).")
-                ENDIF()
-                LIST(APPEND _ALPAKA_INCLUDE_DIRECTORIES_PUBLIC "${HIP_RAND_INC}")
-                LIST(APPEND _ALPAKA_LINK_LIBRARIES_PUBLIC "${HIP_RAND_LIBRARY}")
+
             ENDIF() # nvcc
+
+            # # HIP random numbers
+            FIND_PACKAGE(hiprand REQUIRED CONFIG PATHS "${HIP_ROOT_DIR}/hiprand")
+            IF(hiprand_FOUND)
+                LIST(APPEND _ALPAKA_INCLUDE_DIRECTORIES_PUBLIC "${hiprand_INCLUDE_DIRS}")
+                LIST(APPEND _ALPAKA_LINK_LIBRARIES_PUBLIC "${hiprand_LIBRARIES}")
+            ELSE()
+                MESSAGE(FATAL_ERROR "Could not find hipRAND (also searched in: HIP_ROOT_DIR=${HIP_ROOT_DIR}/hiprand).")
+            ENDIF()
 
             IF(ALPAKA_HIP_PLATFORM MATCHES "hcc")
 
-                # random numbers library ( HIP(HCC) ) /rocrand
-                FIND_PATH(ROC_RAND_INC
-                    rocrand_kernel.h
-                    PATHS "${HIP_ROOT_DIR}/rocrand" "${HIP_ROOT_DIR}" "rocrand"
-                    PATHS "/opt/rocm/rocrand"
-                    ENV HIP_PATH
-                    PATH_SUFFIXES "include")
-                FIND_LIBRARY(ROC_RAND_LIBRARY
-                    rocrand-d
-                    rocrand
-                    PATHS "${HIP_ROOT_DIR}/rocrand" "${HIP_ROOT_DIR}" "rocrand"
-                    PATHS "/opt/rocm/rocrand"
-                    ENV HIP_PATH
-                    PATH_SUFFIXES "lib" "lib64")
-
-                # random numbers library ( HIP(HCC) ) rocrand/hiprand
-                FIND_PATH(HIP_RAND_INC
-                    hiprand_kernel.h
-                    PATHS "${HIP_ROOT_DIR}/hiprand" "${HIP_ROOT_DIR}" "hiprand"
-                    PATHS "/opt/rocm/hiprand"
-                    ENV HIP_PATH
-                    PATH_SUFFIXES "include")
-                FIND_LIBRARY(HIP_RAND_LIBRARY
-                    hiprand-d
-                    hiprand
-                    PATHS "${HIP_ROOT_DIR}/hiprand" "${HIP_ROOT_DIR}" "hiprand"
-                    PATHS "/opt/rocm/hiprand"
-                    ENV HIP_PATH
-                    PATH_SUFFIXES "lib" "lib64")
-                IF(NOT HIP_RAND_INC OR NOT HIP_RAND_LIBRARY)
-                    MESSAGE(FATAL_ERROR "Could not find hipRAND library")
+                # # hiprand requires ROCm implementation of random numbers by rocrand
+                FIND_PACKAGE(rocrand REQUIRED CONFIG PATHS "${HIP_ROOT_DIR}/rocrand")
+                IF(rocrand_FOUND)
+                    LIST(APPEND _ALPAKA_INCLUDE_DIRECTORIES_PUBLIC "${rocrand_INCLUDE_DIRS}")
+                    LIST(APPEND _ALPAKA_LINK_LIBRARIES_PUBLIC "${rocrand_LIBRARIES}")
+                ELSE()
+                    MESSAGE(FATAL_ERROR "Could not find rocRAND (also searched in: HIP_ROOT_DIR=${HIP_ROOT_DIR}/rocrand).")
                 ENDIF()
-                LIST(APPEND _ALPAKA_INCLUDE_DIRECTORIES_PUBLIC "${HIP_RAND_INC}")
-                LIST(APPEND _ALPAKA_LINK_LIBRARIES_PUBLIC "${HIP_RAND_LIBRARY}")
-
-                IF(NOT ROC_RAND_INC OR NOT ROC_RAND_LIBRARY)
-                    MESSAGE(FATAL_ERROR "Could not find rocRAND library")
-                ENDIF()
-
-                LIST(APPEND _ALPAKA_INCLUDE_DIRECTORIES_PUBLIC "${ROC_RAND_INC}")
-                LIST(APPEND _ALPAKA_LINK_LIBRARIES_PUBLIC "${ROC_RAND_LIBRARY}")
 
             ENDIF()
 


### PR DESCRIPTION
WIP because: nvcc backend: linker complains about .so file that has version suffix (`/opt/rocm/rocrand/hiprand/lib/libhiprand.so.1.8.2`, gcc5.5.0, nvcc 10.1.168) (it works w/o suffix)
- there is also an .so link, either the finder could prefer this or there is a linker flag to deal with this?
- in the previous version the custom finder preferred the .so suffix, thus the error did not occur
- hip(hcc/clang) works (so should hip-clang), 

> /opt/rocm/hip/bin/hipcc_cmake_linker_helper /opt/rocm/hcc    CMakeFiles/rand.dir/src/rand_generated_RandTest.cpp.o -o rand  -L/opt/spack-modules/linux-ubuntu16.04-x86_64/gcc-5.4.0/cuda-10.1.168-l4n3hkb354k5lhxnqvik7wmv2zsgqljz/lib  -L/opt/spack-modules/linux-ubuntu16.04-x86_64/gcc-5.4.0/boost-1.65.1-5ovw2kdz2fh44at4z3bb2d7n5n3bs4u7/lib  -L/opt/spack-modules/linux-ubuntu16.04-x86_64/gcc-5.4.0/bzip2-1.0.6-ufczdvsqt6edesm36xiucyry7myhj7e7/lib  -L/opt/spack-modules/linux-ubuntu16.04-x86_64/gcc-5.4.0/openssl-1.0.2o-b4y3w3bsyvjla6eesv4vt6aplpfrpsha/lib  -L/opt/spack-modules/linux-ubuntu16.04-x86_64/gcc-5.4.0/zlib-1.2.11-5nus6knzumx4ik2yl44jxtgtsl7d54xb/lib  -L/opt/spack-modules/linux-ubuntu16.04-x86_64/gcc-5.4.0/ncurses-6.1-3o765ourmesfrji6yeclb4wb5w54aqbh/lib  -L/usr/lib/gcc/x86_64-linux-gnu/5  -L/opt/spack-modules/linux-ubuntu16.04-x86_64/gcc-5.4.0/cuda-10.1.168-l4n3hkb354k5lhxnqvik7wmv2zsgqljz/lib64 ../../common/libcommon.a -lpthread -lrt /opt/rocm/rocrand/hiprand/lib/libhiprand.so.1.8.2 -lcudart /usr/lib/x86_64-linux-gnu/libcuda.so ../../libCatchMain.a -lstdc++ -lm -lgcc_s -lgcc -lc -lgcc_s -lgcc
> nvcc fatal   : Don't know what to do with '/opt/rocm/rocrand/hiprand/lib/libhiprand.so.1.8.2'