### PR TITLE
fix hip-hcc compile

### DIFF
--- a/include/alpaka/kernel/TaskKernelGpuHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuHipRt.hpp
@@ -512,12 +512,13 @@ namespace alpaka
                     meta::apply(
                         [&](typename std::decay<TArgs>::type const & ... args)
                         {
-                            hipLaunchKernel(
+                            hipLaunchKernelGGL(
                                 HIP_KERNEL_NAME(kernel::hip::detail::hipKernel< TDim, TIdx, TKernelFnObj, typename std::decay<TArgs>::type... >),
                                 gridDim,
                                 blockDim,
-                                static_cast<std::size_t>(blockSharedMemDynSizeBytes),
+                                static_cast<std::uint32_t>(blockSharedMemDynSizeBytes),
                                 queue.m_spQueueImpl->m_HipQueue,
+                                hipLaunchParm{},
                                 threadElemExtent,
                                 task.m_kernelFnObj,
                                 args...

--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, Erik Zenker, Matthias Werner
+/* Copyright 2019 Benjamin Worpitz, Erik Zenker, Matthias Werner, Rene Widera
  *
  * This file is part of Alpaka.
  *
@@ -154,6 +154,7 @@ namespace alpaka
                         ALPAKA_FN_HOST auto operator()() const
                         -> void
                         {
+#if defined(BOOST_COMP_HCC) && !defined(__HIP_DEVICE_COMPILE__)
                             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
@@ -177,6 +178,7 @@ namespace alpaka
                                             static_cast<std::size_t>(this->m_extentWidthBytes));
                                     });
                             }
+#endif
                         }
                     };
 


### PR DESCRIPTION
- fix wrong kernel call method for blocking queues
- fix compiler error (see #736): pure host function is interpreted for device 
  - this fix disable the method content for the device path

This PR replaces #736