### PR TITLE
Simplify AtomicHierarchy

### DIFF
--- a/include/alpaka/atomic/AtomicHierarchy.hpp
+++ b/include/alpaka/atomic/AtomicHierarchy.hpp
@@ -9,21 +9,18 @@
 
 #pragma once
 
-#include <alpaka/core/Positioning.hpp>
 #include <alpaka/atomic/Traits.hpp>
 
-#include <type_traits>
+#include <alpaka/meta/InheritFromList.hpp>
+#include <alpaka/meta/Unique.hpp>
+
+#include <tuple>
 
 namespace alpaka
 {
     namespace atomic
     {
-        namespace atomicHierarchy
-        {
-            class Empty0{};
-            class Empty1{};
-            class Empty2{};
-        }
+
         //#############################################################################
         //! build a single class to inherit from different atomic implementations
         //
@@ -41,83 +38,18 @@ namespace alpaka
             typename TBlockAtomic,
             typename TThreadAtomic
         >
-        class AtomicHierarchy :
-            public TGridAtomic,
-            public std::conditional<
-                std::is_same<TGridAtomic,TBlockAtomic>::value,
-                atomicHierarchy::Empty1,
-                TBlockAtomic
-            >::type,
-            public std::conditional<
-                std::is_same<TGridAtomic,TThreadAtomic>::value ||
-                    std::is_same<TBlockAtomic,TThreadAtomic>::value,
-                atomicHierarchy::Empty2,
-                TThreadAtomic
-            >::type
-            , public concepts::Implements<ConceptAtomic, AtomicHierarchy<
-                TGridAtomic,
-                TBlockAtomic,
-                TThreadAtomic
-            >>
-        {
-            public:
-            using UsedAtomicHierarchies = AtomicHierarchy<
-                TGridAtomic,
-                TBlockAtomic,
-                TThreadAtomic
+        using AtomicHierarchy
+            = alpaka::meta::InheritFromList<
+                alpaka::meta::Unique<
+                    std::tuple<
+                        TGridAtomic,
+                        TBlockAtomic,
+                        TThreadAtomic,
+                        concepts::Implements<ConceptAtomicGrids, TGridAtomic>,
+                        concepts::Implements<ConceptAtomicBlocks, TBlockAtomic>,
+                        concepts::Implements<ConceptAtomicThreads, TThreadAtomic>
+                    >
+                >
             >;
-        };
-
-        namespace traits
-        {
-            template<
-                typename TGridAtomic,
-                typename TBlockAtomic,
-                typename TThreadAtomic
-            >
-            struct AtomicBase<
-                AtomicHierarchy<
-                    TGridAtomic,
-                    TBlockAtomic,
-                    TThreadAtomic
-                >,
-                hierarchy::Threads>
-            {
-                using type = TThreadAtomic;
-            };
-
-            template<
-                typename TGridAtomic,
-                typename TBlockAtomic,
-                typename TThreadAtomic
-            >
-            struct AtomicBase<
-                AtomicHierarchy<
-                    TGridAtomic,
-                    TBlockAtomic,
-                    TThreadAtomic
-                >,
-                hierarchy::Blocks>
-            {
-                using type = TBlockAtomic;
-            };
-
-            template<
-                typename TGridAtomic,
-                typename TBlockAtomic,
-                typename TThreadAtomic
-            >
-            struct AtomicBase<
-                AtomicHierarchy<
-                    TGridAtomic,
-                    TBlockAtomic,
-                    TThreadAtomic
-                >,
-                hierarchy::Grids>
-            {
-                using type = TGridAtomic;
-            };
-
-        }
     }
 }

--- a/include/alpaka/atomic/Traits.hpp
+++ b/include/alpaka/atomic/Traits.hpp
@@ -21,7 +21,43 @@ namespace alpaka
     //! The atomic operation traits specifics.
     namespace atomic
     {
-        struct ConceptAtomic;
+        struct ConceptAtomicGrids;
+        struct ConceptAtomicBlocks;
+        struct ConceptAtomicThreads;
+
+        namespace detail
+        {
+            template<
+                typename THierarchy
+            >
+            struct AtomicHierarchyConceptType;
+
+            template<>
+            struct AtomicHierarchyConceptType<
+                hierarchy::Threads>
+            {
+                using type = ConceptAtomicThreads;
+            };
+
+            template<>
+            struct AtomicHierarchyConceptType<
+                hierarchy::Blocks>
+            {
+                using type = ConceptAtomicBlocks;
+            };
+
+            template<>
+            struct AtomicHierarchyConceptType<
+                hierarchy::Grids>
+            {
+                using type = ConceptAtomicGrids;
+            };
+        }
+
+        template<
+            typename THierarchy
+        >
+        using AtomicHierarchyConcept = typename detail::AtomicHierarchyConceptType<THierarchy>::type;
 
         //-----------------------------------------------------------------------------
         //! The atomic operation traits.
@@ -36,14 +72,6 @@ namespace alpaka
                 typename THierarchy,
                 typename TSfinae = void>
             struct AtomicOp;
-
-            //#############################################################################
-            //! Get the atomic implementation for a hierarchy level
-            template<
-                typename TAtomic,
-                typename THierarchy
-            >
-            struct AtomicBase;
         }
 
         //-----------------------------------------------------------------------------
@@ -68,7 +96,7 @@ namespace alpaka
             THierarchy const & = THierarchy())
         -> T
         {
-            using ImplementationBase = typename traits::AtomicBase<concepts::ImplementationBase<ConceptAtomic, TAtomic>, THierarchy>::type;
+            using ImplementationBase = typename concepts::ImplementationBase<AtomicHierarchyConcept<THierarchy>, TAtomic>;
             return
                 traits::AtomicOp<
                     TOp,
@@ -105,7 +133,7 @@ namespace alpaka
             THierarchy const & = THierarchy())
         -> T
         {
-            using ImplementationBase = typename traits::AtomicBase<concepts::ImplementationBase<ConceptAtomic, TAtomic>, THierarchy>::type;
+            using ImplementationBase = typename concepts::ImplementationBase<AtomicHierarchyConcept<THierarchy>, TAtomic>;
             return
                 traits::AtomicOp<
                     TOp,

--- a/include/alpaka/meta/InheritFromList.hpp
+++ b/include/alpaka/meta/InheritFromList.hpp
@@ -1,0 +1,32 @@
+/* Copyright 2019 Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+namespace alpaka
+{
+    namespace meta
+    {
+        template<
+            typename TBaseList
+        >
+        class InheritFromList;
+
+        template<
+            template<typename...> class TList,
+            typename... TBases
+        >
+        class InheritFromList<
+            TList<TBases...>
+        >
+            : public TBases...
+        {
+        };
+    }
+}

--- a/include/alpaka/meta/Unique.hpp
+++ b/include/alpaka/meta/Unique.hpp
@@ -1,0 +1,60 @@
+/* Copyright 2019 Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+#include <alpaka/meta/Metafunctions.hpp>
+
+namespace alpaka
+{
+    namespace meta
+    {
+        namespace detail
+        {
+            template<
+                typename T,
+                typename... Ts>
+            struct UniqueHelper
+            {
+                using type = T;
+            };
+
+            template<
+                template<typename...> class TList,
+                typename... Ts,
+                typename U,
+                typename... Us>
+            struct UniqueHelper<TList<Ts...>, U, Us...>
+                : std::conditional<(Disjunction<std::is_same<U, Ts>...>::value)
+                    , UniqueHelper<TList<Ts...>, Us...>
+                    , UniqueHelper<TList<Ts..., U>, Us...>>::type
+            {};
+
+            template<
+                typename T>
+            struct UniqueImpl;
+
+            template<
+                template<typename...> class TList,
+                typename... Ts>
+            struct UniqueImpl<TList<Ts...>>
+            {
+                using type = typename UniqueHelper<TList<>, Ts...>::type;
+            };
+        }
+
+        //#############################################################################
+        //! Trait that returns a list with only unique (no equal) types (a set). Duplicates will be filtered out.
+        template<
+            typename TList>
+        using Unique = typename detail::UniqueImpl<TList>::type;
+    }
+}

--- a/test/unit/meta/src/UniqueTest.cpp
+++ b/test/unit/meta/src/UniqueTest.cpp
@@ -1,0 +1,70 @@
+/* Copyright 2019 Axel Huebl, Benjamin Worpitz
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <alpaka/meta/Unique.hpp>
+
+#include <catch2/catch.hpp>
+
+#include <tuple>
+#include <type_traits>
+
+//-----------------------------------------------------------------------------
+TEST_CASE("uniqueWithDuplicate", "[meta]")
+{
+    using UniqueInput =
+        std::tuple<
+            int,
+            float,
+            int,
+            float,
+            float,
+            int>;
+
+    using UniqueResult =
+        alpaka::meta::Unique<
+            UniqueInput
+        >;
+
+    using UniqueReference =
+        std::tuple<
+            int,
+            float>;
+
+    static_assert(
+        std::is_same<
+            UniqueReference,
+            UniqueResult
+        >::value,
+        "alpaka::meta::Unique failed!");
+}
+
+//-----------------------------------------------------------------------------
+TEST_CASE("uniqueWithoutDuplicate", "[meta]")
+{
+    using UniqueInput =
+        std::tuple<
+            int,
+            float,
+            double>;
+
+    using UniqueResult =
+        alpaka::meta::Unique<
+            UniqueInput
+        >;
+
+    using UniqueReference =
+        UniqueInput;
+
+    static_assert(
+        std::is_same<
+            UniqueReference,
+            UniqueResult
+        >::value,
+        "alpaka::meta::Unique failed!");
+}


### PR DESCRIPTION
This ads some metaprogramming constructs:
* `Unique`: removes duplicates from a type list
* `InheritFromList`: object that inherits from a list of types

Given those two generic constructs it is possible to replace the complicated inheritance logic as well as the AtomicBase trait.