### PR TITLE
HIP-clang support

### DIFF
--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -93,14 +93,14 @@ OPTION(ALPAKA_ACC_GPU_HIP_ONLY_MODE "Only back-ends using HIP can be enabled in 
 
 # Drop-down combo box in cmake-gui for HIP platforms.
 SET(ALPAKA_HIP_PLATFORM "nvcc" CACHE STRING "Specify HIP platform")
-SET_PROPERTY(CACHE ALPAKA_HIP_PLATFORM PROPERTY STRINGS "nvcc;hcc")
+SET_PROPERTY(CACHE ALPAKA_HIP_PLATFORM PROPERTY STRINGS "nvcc;hcc;clang")
 
 IF(ALPAKA_ACC_GPU_HIP_ENABLE AND NOT ALPAKA_ACC_GPU_HIP_ONLY_MODE)
     MESSAGE(WARNING "HIP back-end must be used together with ALPAKA_ACC_GPU_HIP_ONLY_MODE")
     SET(ALPAKA_ACC_GPU_HIP_ENABLE OFF CACHE BOOL "" FORCE)
 ENDIF()
 
-IF(ALPAKA_ACC_GPU_HIP_ENABLE AND ALPAKA_HIP_PLATFORM MATCHES "hcc")
+IF(ALPAKA_ACC_GPU_HIP_ENABLE AND (ALPAKA_HIP_PLATFORM MATCHES "hcc" OR ALPAKA_HIP_PLATFORM MATCHES "clang"))
     MESSAGE(WARNING
         "The HIP back-end is currently experimental, especially for HCC. "
         "In alpaka HIP(HCC) has a few workarounds and does not support 3D memory and constant memory. "

--- a/include/alpaka/block/sync/BlockSyncHipBuiltIn.hpp
+++ b/include/alpaka/block/sync/BlockSyncHipBuiltIn.hpp
@@ -82,7 +82,7 @@ namespace alpaka
                         int predicate)
                     -> int
                     {
-#if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && BOOST_COMP_HCC
+#if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && (BOOST_COMP_HCC || BOOST_COMP_HIP)
                         // workaround for unsupported syncthreads_* operation on HIP(HCC)
                         __shared__ int tmp;
                         __syncthreads();
@@ -114,7 +114,7 @@ namespace alpaka
                         int predicate)
                     -> int
                     {
-#if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && BOOST_COMP_HCC
+#if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && (BOOST_COMP_HCC || BOOST_COMP_HIP)
                         // workaround for unsupported syncthreads_* operation on HIP(HCC)
                         __shared__ int tmp;
                         __syncthreads();
@@ -146,7 +146,7 @@ namespace alpaka
                         int predicate)
                     -> int
                     {
-#if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && BOOST_COMP_HCC
+#if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && (BOOST_COMP_HCC || BOOST_COMP_HIP)
                         // workaround for unsupported syncthreads_* operation on HIP(HCC)
                         __shared__ int tmp;
                         __syncthreads();

--- a/include/alpaka/core/BoostPredef.hpp
+++ b/include/alpaka/core/BoostPredef.hpp
@@ -21,7 +21,7 @@
 //---------------------------------------HIP-----------------------------------
 // __HIPCC__ is defined by hipcc (if either __HCC__ or __CUDACC__ is defined)
 #if !defined(BOOST_LANG_HIP)
-  #if defined(__HIPCC__) && ( defined(__CUDACC__) || defined(__HCC__) )
+  #if defined(__HIPCC__) && ( defined(__CUDACC__) || defined(__HCC__) || defined(__HIP__))
     #include <hip/hip_runtime.h>
     //HIP defines "abort()" as "{asm("trap;");}", which breaks some kernels
     #undef abort
@@ -56,6 +56,16 @@
         #define BOOST_COMP_HCC BOOST_VERSION_NUMBER_AVAILABLE
     #else
         #define BOOST_COMP_HCC BOOST_VERSION_NUMBER_NOT_AVAILABLE
+    #endif
+#endif
+
+//-----------------------------------------------------------------------------
+// hip compiler detection
+#if !defined(BOOST_COMP_HIP)
+    #if defined(__HIP__)
+        #define BOOST_COMP_HIP BOOST_VERSION_NUMBER_AVAILABLE
+    #else
+        #define BOOST_COMP_HIP BOOST_VERSION_NUMBER_NOT_AVAILABLE
     #endif
 #endif
 

--- a/include/alpaka/core/Utility.hpp
+++ b/include/alpaka/core/Utility.hpp
@@ -27,7 +27,7 @@ namespace alpaka
         // within an alpaka accelerator kernel too.
         // This function can be used only within std::decltype().
         //-----------------------------------------------------------------------------
-#if BOOST_LANG_CUDA && BOOST_COMP_CLANG_CUDA
+#if BOOST_LANG_CUDA && BOOST_COMP_CLANG_CUDA || BOOST_COMP_HIP
         template< class T >
         ALPAKA_FN_HOST_ACC
         typename std::add_rvalue_reference<T>::type

--- a/include/alpaka/kernel/TaskKernelGpuHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuHipRt.hpp
@@ -41,6 +41,7 @@
 
 #include <alpaka/core/BoostPredef.hpp>
 #include <alpaka/core/Hip.hpp>
+#include <alpaka/core/Utility.hpp>
 #include <alpaka/meta/ApplyTuple.hpp>
 #include <alpaka/meta/Metafunctions.hpp>
 
@@ -76,11 +77,15 @@ namespace alpaka
 #if BOOST_ARCH_PTX && (BOOST_ARCH_PTX < BOOST_VERSION_NUMBER(2, 0, 0))
     #error "Cuda device capability >= 2.0 is required!"
 #endif
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wignored-attributes"
                     static_assert(
-                        std::is_same<typename std::result_of<
-                            TKernelFnObj(acc::AccGpuHipRt<TDim, TIdx> const &, TArgs const & ...)>::type, void>::value,
+                        std::is_same<
+                            decltype(kernelFnObj(
+                                alpaka::core::declval<acc::AccGpuHipRt<TDim, TIdx> const>(),
+                                args...)),
+                        void>::value,
                         "The TKernelFnObj is required to return void!");
 #pragma clang diagnostic pop
 

--- a/include/alpaka/math/abs/AbsHipBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/acos/AcosHipBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/asin/AsinHipBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/atan/AtanHipBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/atan2/Atan2HipBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2HipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/cbrt/CbrtHipBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/ceil/CeilHipBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/cos/CosHipBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/erf/ErfHipBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/exp/ExpHipBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/floor/FloorHipBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/fmod/FmodHipBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/log/LogHipBuiltIn.hpp
+++ b/include/alpaka/math/log/LogHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/max/MaxHipBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/min/MinHipBuiltIn.hpp
+++ b/include/alpaka/math/min/MinHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/pow/PowHipBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/remainder/RemainderHipBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/round/RoundHipBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/rsqrt/RsqrtHipBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/sin/SinHipBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/sincos/SinCosHipBuiltIn.hpp
+++ b/include/alpaka/math/sincos/SinCosHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/sqrt/SqrtHipBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/tan/TanHipBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/math/trunc/TruncHipBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncHipBuiltIn.hpp
@@ -24,7 +24,7 @@
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
     #include <cuda_runtime_api.h>
 #else
-    #if BOOST_COMP_HCC
+    #if BOOST_COMP_HCC || BOOST_COMP_HIP
         #include <math_functions.h>
     #else
         #include <math_functions.hpp>

--- a/include/alpaka/queue/QueueHipRtNonBlocking.hpp
+++ b/include/alpaka/queue/QueueHipRtNonBlocking.hpp
@@ -23,6 +23,7 @@
 #include <alpaka/event/Traits.hpp>
 #include <alpaka/queue/Traits.hpp>
 #include <alpaka/wait/Traits.hpp>
+#include <alpaka/meta/DependentFalseType.hpp>
 
 #include <alpaka/core/Hip.hpp>
 
@@ -259,6 +260,15 @@ namespace alpaka
                     TTask const & task)
                 -> void
                 {
+#if BOOST_COMP_HIP
+                    // NOTE: hip callbacks are not blocking the stream.
+                    // The workaround used for HIP(hcc) would avoid the usage in a workflow with
+                    // many stream/event synchronizations (e.g. PIConGPU).
+                    // @todo remove this assert when hipStreamAddCallback is fixed
+                    static_assert(
+                                meta::DependentFalseType<TTask>::value,
+                                "Callbacks are not supported for HIP-clang");
+#endif
 
 #if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
                     {

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -34,7 +34,7 @@
 // Some compilers do not support the out of class versions:
 // - the nvcc CUDA compiler (at least 8.0)
 // - the intel compiler
-#if BOOST_COMP_HCC || BOOST_COMP_NVCC || BOOST_COMP_INTEL || (BOOST_COMP_CLANG_CUDA >= BOOST_VERSION_NUMBER(4, 0, 0)) || (BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(8, 0, 0))
+#if BOOST_COMP_HCC || BOOST_COMP_HIP || BOOST_COMP_NVCC || BOOST_COMP_INTEL || (BOOST_COMP_CLANG_CUDA >= BOOST_VERSION_NUMBER(4, 0, 0)) || (BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(8, 0, 0))
     #define ALPAKA_CREATE_VEC_IN_CLASS
 #endif
 

--- a/test/unit/core/src/BoostPredefTest.cpp
+++ b/test/unit/core/src/BoostPredefTest.cpp
@@ -34,6 +34,9 @@ TEST_CASE("printDefines", "[core]")
 #if BOOST_COMP_HCC
     std::cout << "BOOST_COMP_HCC:" << BOOST_COMP_HCC << std::endl;
 #endif
+#if BOOST_COMP_HIP
+    std::cout << "BOOST_COMP_HIP:" << BOOST_COMP_HIP << std::endl;
+#endif
 #if BOOST_COMP_CLANG
     std::cout << "BOOST_COMP_CLANG:" << BOOST_COMP_CLANG << std::endl;
 #endif

--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -82,7 +82,7 @@ void operator()()
 
     //-----------------------------------------------------------------------------
     // FIXME: constant memory in HIP(HCC) is still not working
-#if !defined(BOOST_COMP_HCC) || !BOOST_COMP_HCC
+#if !BOOST_COMP_HCC && !BOOST_COMP_HIP
     // initialized static constant device memory
     {
         auto const viewConstantMemInitialized(
@@ -158,7 +158,7 @@ void operator()()
 
     //-----------------------------------------------------------------------------
     // FIXME: static device memory in HIP(HCC) is still not working
-#if !defined(BOOST_COMP_HCC) || !BOOST_COMP_HCC
+#if !BOOST_COMP_HCC && !BOOST_COMP_HIP
     // initialized static global device memory
     {
         auto const viewGlobalMemInitialized(

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -33,6 +33,8 @@ void operator()()
 }
 };
 
+#if !BOOST_COMP_HIP // HIP-clang is currently not supporting callbacks
+
 //-----------------------------------------------------------------------------
 struct TestTemplateCallback
 {
@@ -161,6 +163,8 @@ void operator()()
 }
 };
 
+#endif
+
 using TestQueues = alpaka::meta::Concatenate<
         alpaka::test::queue::TestQueues
  #ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
@@ -173,6 +177,8 @@ TEST_CASE( "queueIsInitiallyEmpty", "[queue]")
 {
     alpaka::meta::forEachType< TestQueues >( TestTemplateEmpty() );
 }
+
+#if !BOOST_COMP_HIP // HIP-clang is currently not supporting callbacks
 
 TEST_CASE( "queueCallbackIsWorking", "[queue]")
 {
@@ -193,3 +199,5 @@ TEST_CASE( "queueShouldNotExecuteTasksInParallel", "[queue]")
 {
     alpaka::meta::forEachType< TestQueues >( TestQueueDoesNotExecuteTasksInParallel() );
 }
+
+#endif


### PR DESCRIPTION
Add support for the compiler HIP-clang.

- extent CMake `ALPAKA_HIP_PLATFORM` with the option `clang`
- add define `BOOST_COMP_HIP` if hip-clang is used

I know that we currently not cover hip-clang in the CI. The reason is that hip-clang is currently not final released and the installation is not as easy. Never the less we need these changes to work more closely together with AMD and Cray. At all HIP-clang is nearly equal to HIP-hcc but is more relaxed with the function attributes `__host__` and `__device__` so that #802 is not needed.
If someone breaks HIP-clang support somehow with a follow up PR it is not dramatic I will keep an eye on it and fix it if needed.