### PR TITLE
Add concept for CurrentThreadWaitFor

### DIFF
--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -12,6 +12,7 @@
 #include <alpaka/dev/Traits.hpp>
 #include <alpaka/mem/buf/Traits.hpp>
 #include <alpaka/pltf/Traits.hpp>
+#include <alpaka/wait/Traits.hpp>
 
 #include <alpaka/queue/cpu/ICpuQueue.hpp>
 #include <alpaka/core/Unused.hpp>
@@ -130,7 +131,7 @@ namespace alpaka
 
         //#############################################################################
         //! The CPU device handle.
-        class DevCpu
+        class DevCpu : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, DevCpu>
         {
             friend struct pltf::traits::GetDevByIdx<pltf::PltfCpu>;
         protected:

--- a/include/alpaka/dev/DevCudaRt.hpp
+++ b/include/alpaka/dev/DevCudaRt.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     {
         //#############################################################################
         //! The CUDA RT device handle.
-        class DevCudaRt
+        class DevCudaRt : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, DevCudaRt>
         {
             friend struct pltf::traits::GetDevByIdx<pltf::PltfCudaRt>;
 

--- a/include/alpaka/dev/DevHipRt.hpp
+++ b/include/alpaka/dev/DevHipRt.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     {
         //#############################################################################
         //! The HIP RT device handle.
-        class DevHipRt
+        class DevHipRt : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, DevHipRt>
         {
             friend struct pltf::traits::GetDevByIdx<pltf::PltfHipRt>;
 

--- a/include/alpaka/event/EventCpu.hpp
+++ b/include/alpaka/event/EventCpu.hpp
@@ -37,7 +37,7 @@ namespace alpaka
             {
                 //#############################################################################
                 //! The CPU device event implementation.
-                class EventCpuImpl final
+                class EventCpuImpl final : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, EventCpuImpl>
                 {
                 public:
                     //-----------------------------------------------------------------------------
@@ -94,7 +94,7 @@ namespace alpaka
 
         //#############################################################################
         //! The CPU device event.
-        class EventCpu final
+        class EventCpu final : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, EventCpu>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/event/EventCudaRt.hpp
+++ b/include/alpaka/event/EventCudaRt.hpp
@@ -99,7 +99,7 @@ namespace alpaka
 
         //#############################################################################
         //! The CUDA RT device event.
-        class EventCudaRt final
+        class EventCudaRt final : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, EventCudaRt>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/event/EventHipRt.hpp
+++ b/include/alpaka/event/EventHipRt.hpp
@@ -99,7 +99,7 @@ namespace alpaka
 
         //#############################################################################
         //! The HIP RT device event.
-        class EventHipRt final
+        class EventHipRt final : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, EventHipRt>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/queue/QueueCpuBlocking.hpp
+++ b/include/alpaka/queue/QueueCpuBlocking.hpp
@@ -88,7 +88,7 @@ namespace alpaka
 
         //#############################################################################
         //! The CPU device queue.
-        class QueueCpuBlocking final
+        class QueueCpuBlocking final : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, QueueCpuBlocking>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/queue/QueueCpuNonBlocking.hpp
+++ b/include/alpaka/queue/QueueCpuNonBlocking.hpp
@@ -102,7 +102,7 @@ namespace alpaka
 
         //#############################################################################
         //! The CPU device queue.
-        class QueueCpuNonBlocking final
+        class QueueCpuNonBlocking final : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, QueueCpuNonBlocking>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/queue/QueueCudaRtBlocking.hpp
+++ b/include/alpaka/queue/QueueCudaRtBlocking.hpp
@@ -111,7 +111,7 @@ namespace alpaka
 
         //#############################################################################
         //! The CUDA RT blocking queue.
-        class QueueCudaRtBlocking final
+        class QueueCudaRtBlocking final : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, QueueCudaRtBlocking>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/queue/QueueCudaRtNonBlocking.hpp
+++ b/include/alpaka/queue/QueueCudaRtNonBlocking.hpp
@@ -111,7 +111,7 @@ namespace alpaka
 
         //#############################################################################
         //! The CUDA RT non-blocking queue.
-        class QueueCudaRtNonBlocking final
+        class QueueCudaRtNonBlocking final : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, QueueCudaRtNonBlocking>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/queue/QueueHipRtBlocking.hpp
+++ b/include/alpaka/queue/QueueHipRtBlocking.hpp
@@ -116,7 +116,7 @@ namespace alpaka
 
         //#############################################################################
         //! The HIP RT blocking queue.
-        class QueueHipRtBlocking final
+        class QueueHipRtBlocking final : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, QueueHipRtBlocking>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/queue/QueueHipRtNonBlocking.hpp
+++ b/include/alpaka/queue/QueueHipRtNonBlocking.hpp
@@ -116,7 +116,7 @@ namespace alpaka
 
         //#############################################################################
         //! The HIP RT non-blocking queue.
-        class QueueHipRtNonBlocking final
+        class QueueHipRtNonBlocking final : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, QueueHipRtNonBlocking>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/wait/Traits.hpp
+++ b/include/alpaka/wait/Traits.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Concepts.hpp>
 
 namespace alpaka
 {
@@ -17,6 +18,8 @@ namespace alpaka
     //! The wait specifics.
     namespace wait
     {
+        struct ConceptCurrentThreadWaitFor;
+
         //-----------------------------------------------------------------------------
         //! The wait traits.
         namespace traits
@@ -45,8 +48,9 @@ namespace alpaka
             TAwaited const & awaited)
         -> void
         {
+            using ImplementationBase = concepts::ImplementationBase<ConceptCurrentThreadWaitFor, TAwaited>;
             traits::CurrentThreadWaitFor<
-                TAwaited>
+                ImplementationBase>
             ::currentThreadWaitFor(
                 awaited);
         }

--- a/test/common/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
+++ b/test/common/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
@@ -108,7 +108,7 @@ namespace alpaka
         // All other operations will be performed from one thread (it is not defined which thread).
         //
         // Outside of a OpenMP parallel region the queue behaves like QueueCpuBlocking.
-        class QueueCpuOmp2Collective final
+        class QueueCpuOmp2Collective final : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, QueueCpuOmp2Collective>
         {
         public:
             //-----------------------------------------------------------------------------


### PR DESCRIPTION
* add a concept for the `CurrentThreadWaitFor` trait
* tag all classes that currently implement this trait. This is not strictly necessary because those classes do not inherit the trait implementation. However it makes it possible to see at the class definition which concepts it implements.
* This prepares for some classes to share their implementation of this trait. My goal is to have a base class for the `QueueCudaRtBlocking` and `QueueCudaRtNonBlocking` classes because they are mostly identical.