### PR TITLE
Always add nvcc warning/error numbers to output

### DIFF
--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -666,6 +666,10 @@ IF(ALPAKA_ACC_GPU_CUDA_ENABLE)
                 IF(ALPAKA_CUDA_SHOW_REGISTER)
                     LIST(APPEND CUDA_NVCC_FLAGS "-Xptxas=-v")
                 ENDIF()
+
+                # Always add warning/error numbers which can be used for suppressions
+                LIST(APPEND CUDA_NVCC_FLAGS -Xcudafe --display_error_number)
+
                 # avoids warnings on host-device signatured, default constructors/destructors
                 IF(CUDA_VERSION GREATER_EQUAL 9.0)
                     LIST(APPEND CUDA_NVCC_FLAGS -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored)


### PR DESCRIPTION
Thi enhances the errors and warning from the compiler in case there are any. 