### PR TITLE
fix warning: implicit deleted constructor

### DIFF
--- a/include/alpaka/rand/RandCuRand.hpp
+++ b/include/alpaka/rand/RandCuRand.hpp
@@ -48,9 +48,12 @@ namespace alpaka
                 public:
 
                     //-----------------------------------------------------------------------------
-                    //! After calling this constructor the instance is not valid initialized and
-                    //! need to be overwritten with a valid object
-                    Xor() = default;
+                    // After calling this constructor the instance is not valid initialized and
+                    // need to be overwritten with a valid object
+                    //-----------------------------------------------------------------------------
+                    ALPAKA_FN_HOST_ACC Xor() : m_State(curandStateXORWOW_t{})
+                    {
+                    }
 
                     //-----------------------------------------------------------------------------
                     __device__ Xor(

--- a/include/alpaka/rand/RandHipRand.hpp
+++ b/include/alpaka/rand/RandHipRand.hpp
@@ -53,12 +53,12 @@ namespace alpaka
                 public:
 
                     //-----------------------------------------------------------------------------
-                    //! Constructor.
-                    //
                     // After calling this constructor the instance is not valid initialized and
                     // need to be overwritten with a valid object
                     //-----------------------------------------------------------------------------
-                    Xor() = default;
+                    ALPAKA_FN_HOST_ACC Xor() : m_State(hiprandStateXORWOW_t{})
+                    {
+                    }
 
                     //-----------------------------------------------------------------------------
                     //! Constructor.


### PR DESCRIPTION
fix warning for`RandHipRand` and `RandCuRand`

- the default constructor can be called from the device or host side.

```
In file included from alpaka/test/unit/kernel/src//KernelLambda.cpp:15:
In file included from alpaka/test/common/include/alpaka/test/acc/TestAccs.hpp:12:
In file included from alpaka/include/alpaka/alpaka.hpp:29:
In file included from alpaka/include/alpaka/acc/AccGpuHipRt.hpp:30:
alpaka/include/alpaka/rand/RandHipRand.hpp:61:21: warning: explicitly defaulted default constructor is implicitly deleted [-Wdefaulted-function-deleted]
                    Xor() = default;
                    ^
alpaka/include/alpaka/rand/RandHipRand.hpp:78:42: note: default constructor of 'Xor' is implicitly deleted because field 'm_State' has no default constructor
                    hiprandStateXORWOW_t m_State;
```