### PR TITLE
fix warning for `std::__shared_counter`

### DIFF
--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -675,6 +675,21 @@ IF(ALPAKA_ACC_GPU_CUDA_ENABLE)
                     LIST(APPEND CUDA_NVCC_FLAGS -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored)
                 ENDIF()
 
+                # avoids warnings on host-device signature of 'std::__shared_count<>'
+                IF(CUDA_VERSION EQUAL 10.0)
+                    LIST(APPEND CUDA_NVCC_FLAGS -Xcudafe --diag_suppress=2905)
+                ENDIF()
+
+                # avoids warnings on host-device signature of 'std::__shared_count<>'
+                IF(CUDA_VERSION EQUAL 10.1)
+                    LIST(APPEND CUDA_NVCC_FLAGS -Xcudafe --diag_suppress=2912)
+                ENDIF()
+
+                # avoids warnings on host-device signature of 'std::__shared_count<>'
+                IF(CUDA_VERSION EQUAL 10.2)
+                    LIST(APPEND CUDA_NVCC_FLAGS -Xcudafe --diag_suppress=2976)
+                ENDIF()
+
                 IF(ALPAKA_CUDA_KEEP_FILES)
                     MAKE_DIRECTORY("${PROJECT_BINARY_DIR}/nvcc_tmp")
                     LIST(APPEND CUDA_NVCC_FLAGS "--keep" "--keep-dir" "${PROJECT_BINARY_DIR}/nvcc_tmp")


### PR DESCRIPTION
supress warning for CUDA 10.1 - 10.2:

```
alpaka/vec/Vec.hpp(1040): warning ComputationalRadiationPhysics#2912-D: calling a __host__ function("std::__shared_count<( ::__gnu_cxx::_Lock_policy)2> ::__shared_count") from a __host__ __device__ function("alpaka::dev::DevCpu::DevCpu") is not allowed
```

Note that the suppression number is CUDA version-specific and must be fixed for each version independently. 

issue and solution mentioned in #838