### PR TITLE
implement queue properties

### DIFF
--- a/example/helloWorldLambda/src/helloWorldLambda.cpp
+++ b/example/helloWorldLambda/src/helloWorldLambda.cpp
@@ -22,7 +22,7 @@
 //-----------------------------------------------------------------------------
 //! This functions says hi to the world and
 //! can be encapsulated into a std::function
-//! and used as a kernel function. It is 
+//! and used as a kernel function. It is
 //! just another way to define alpaka kernels
 //! and might be useful when it is necessary
 //! to lift an existing function into a kernel
@@ -52,24 +52,40 @@ void ALPAKA_FN_ACC hiWorldFunction(
     for(size_t i = 0; i < nExclamationMarks; ++i){
         printf("!");
     }
-                                                          
-    printf("\n");  
+
+    printf("\n");
 }
 
 auto main()
 -> int
 {
-// This example is hard-coded to use the sequential backend.
 // It requires support for extended lambdas when using nvcc as CUDA compiler.
-#if defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED) && (!defined(__NVCC__) || (defined(__NVCC__) && defined(__CUDACC_EXTENDED_LAMBDA__) ))
+// Requires sequential backend if CI is used
+#if (!defined(__NVCC__) || (defined(__NVCC__) && defined(__CUDACC_EXTENDED_LAMBDA__) )) && \
+    (!defined(ALPAKA_CI) || defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED))
 
     // Define the index domain
     using Dim = alpaka::dim::DimInt<3>;
     using Idx = std::size_t;
 
     // Define the accelerator
+    //
+    // It is possible to choose from a set of accelerators
+    // that are defined in the alpaka::acc namespace e.g.:
+    // - AccGpuCudaRt
+    // - AccCpuThreads
+    // - AccCpuFibers
+    // - AccCpuOmp2Threads
+    // - AccCpuOmp2Blocks
+    // - AccCpuOmp4
+    // - AccCpuSerial
     using Acc = alpaka::acc::AccCpuSerial<Dim, Idx>;
-    using Queue = alpaka::queue::QueueCpuBlocking;
+
+    // Defines the synchronization behavior of a queue
+    //
+    // choose between Blocking and NonBlocking
+    using QueueProperty = alpaka::queue::Blocking;
+    using Queue = alpaka::queue::Queue<Acc, QueueProperty>;
     using Dev = alpaka::dev::Dev<Acc>;
     using Pltf = alpaka::pltf::Pltf<Dev>;
 
@@ -101,12 +117,12 @@ auto main()
     // Alpaka is able to execute lambda functions (anonymous functions) which
     // are available since the C++11 standard.
     // Alpaka forces the lambda function to accept
-    // the utilized accelerator as first argument. 
+    // the utilized accelerator as first argument.
     // All following arguments can be provided after
-    // the lambda function declaration or be captured. 
+    // the lambda function declaration or be captured.
     //
     // This example passes the number exclamation marks, that should
-    // be written after we greet the world, to the 
+    // be written after we greet the world, to the
     // lambda function.
     alpaka::kernel::exec<Acc>(
         queue,
@@ -131,6 +147,7 @@ auto main()
         },
         nExclamationMarks
     );
+    alpaka::wait::wait(queue);
 
     return EXIT_SUCCESS;
 

--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -34,6 +34,7 @@
 
 // Implementation details.
 #include <alpaka/core/ClipCast.hpp>
+#include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Fibers.hpp>
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/dev/DevCpu.hpp>
@@ -79,7 +80,8 @@ namespace alpaka
             public block::shared::st::BlockSharedMemStMasterSync,
             public block::sync::BlockSyncBarrierFiber<TIdx>,
             public rand::RandStdLib,
-            public time::TimeStdLib
+            public time::TimeStdLib,
+            public concepts::Implements<ConceptAcc, AccCpuFibers<TDim, TIdx>>
         {
         public:
             // Partial specialization with the correct TDim and TIdx is not allowed.

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -38,6 +38,7 @@
 #include <alpaka/idx/Traits.hpp>
 
 // Implementation details.
+#include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 
@@ -80,7 +81,8 @@ namespace alpaka
             public block::shared::st::BlockSharedMemStNoSync,
             public block::sync::BlockSyncNoOp,
             public rand::RandStdLib,
-            public time::TimeOmp
+            public time::TimeOmp,
+            public concepts::Implements<ConceptAcc, AccCpuOmp2Blocks<TDim, TIdx>>
         {
         public:
             // Partial specialization with the correct TDim and TIdx is not allowed.

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -38,6 +38,7 @@
 
 // Implementation details.
 #include <alpaka/core/ClipCast.hpp>
+#include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 
@@ -81,7 +82,8 @@ namespace alpaka
             public block::shared::st::BlockSharedMemStMasterSync,
             public block::sync::BlockSyncBarrierOmp,
             public rand::RandStdLib,
-            public time::TimeOmp
+            public time::TimeOmp,
+            public concepts::Implements<ConceptAcc, AccCpuOmp2Threads<TDim, TIdx>>
         {
         public:
             // Partial specialization with the correct TDim and TIdx is not allowed.

--- a/include/alpaka/acc/AccCpuOmp4.hpp
+++ b/include/alpaka/acc/AccCpuOmp4.hpp
@@ -38,6 +38,7 @@
 
 // Implementation details.
 #include <alpaka/core/ClipCast.hpp>
+#include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 
@@ -81,7 +82,8 @@ namespace alpaka
             public block::shared::st::BlockSharedMemStMasterSync,
             public block::sync::BlockSyncBarrierOmp,
             public rand::RandStdLib,
-            public time::TimeOmp
+            public time::TimeOmp,
+            public concepts::Implements<ConceptAcc, AccCpuOmp4<TDim, TIdx>>
         {
         public:
             // Partial specialization with the correct TDim and TIdx is not allowed.

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -33,6 +33,7 @@
 #include <alpaka/idx/Traits.hpp>
 
 // Implementation details.
+#include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 
@@ -74,7 +75,8 @@ namespace alpaka
             public block::shared::st::BlockSharedMemStNoSync,
             public block::sync::BlockSyncNoOp,
             public rand::RandStdLib,
-            public time::TimeStdLib
+            public time::TimeStdLib,
+            public concepts::Implements<ConceptAcc, AccCpuSerial<TDim, TIdx>>
         {
         public:
             // Partial specialization with the correct TDim and TIdx is not allowed.

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -33,6 +33,7 @@
 #include <alpaka/idx/Traits.hpp>
 
 // Implementation details.
+#include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 
@@ -72,7 +73,8 @@ namespace alpaka
             public block::shared::st::BlockSharedMemStNoSync,
             public block::sync::BlockSyncNoOp,
             public rand::RandStdLib,
-            public time::TimeStdLib
+            public time::TimeStdLib,
+            public concepts::Implements<ConceptAcc, AccCpuTbbBlocks<TDim, TIdx>>
         {
         public:
             // Partial specialization with the correct TDim and TIdx is not allowed.

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -34,6 +34,7 @@
 // Implementation details.
 #include <alpaka/core/BoostPredef.hpp>
 #include <alpaka/core/ClipCast.hpp>
+#include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 
@@ -76,7 +77,8 @@ namespace alpaka
             public block::shared::st::BlockSharedMemStMasterSync,
             public block::sync::BlockSyncBarrierThread<TIdx>,
             public rand::RandStdLib,
-            public time::TimeStdLib
+            public time::TimeStdLib,
+            public concepts::Implements<ConceptAcc, AccCpuThreads<TDim, TIdx>>
         {
         public:
             // Partial specialization with the correct TDim and TIdx is not allowed.

--- a/include/alpaka/acc/AccGpuCudaRt.hpp
+++ b/include/alpaka/acc/AccGpuCudaRt.hpp
@@ -39,6 +39,7 @@
 
 // Implementation details.
 #include <alpaka/core/ClipCast.hpp>
+#include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Cuda.hpp>
 #include <alpaka/dev/DevCudaRt.hpp>
 
@@ -78,7 +79,8 @@ namespace alpaka
             public block::shared::st::BlockSharedMemStCudaBuiltIn,
             public block::sync::BlockSyncCudaBuiltIn,
             public rand::RandCuRand,
-            public time::TimeCudaBuiltIn
+            public time::TimeCudaBuiltIn,
+            public concepts::Implements<ConceptAcc, AccGpuCudaRt<TDim, TIdx>>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/acc/AccGpuHipRt.hpp
+++ b/include/alpaka/acc/AccGpuHipRt.hpp
@@ -39,6 +39,7 @@
 
 // Implementation details.
 #include <alpaka/core/ClipCast.hpp>
+#include <alpaka/core/Concepts.hpp>
 #include <alpaka/dev/DevHipRt.hpp>
 #include <alpaka/core/Hip.hpp>
 
@@ -78,7 +79,8 @@ namespace alpaka
             public block::shared::st::BlockSharedMemStHipBuiltIn,
             public block::sync::BlockSyncHipBuiltIn,
             public rand::RandHipRand,
-            public time::TimeHipBuiltIn
+            public time::TimeHipBuiltIn,
+            public concepts::Implements<ConceptAcc, AccGpuHipRt<TDim, TIdx>>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/acc/Traits.hpp
+++ b/include/alpaka/acc/Traits.hpp
@@ -12,8 +12,13 @@
 #include <alpaka/acc/AccDevProps.hpp>
 #include <alpaka/core/Common.hpp>
 
+#include <alpaka/core/Concepts.hpp>
+#include <alpaka/queue/Traits.hpp>
+#include <alpaka/pltf/Traits.hpp>
+
 #include <string>
 #include <typeinfo>
+#include <type_traits>
 
 namespace alpaka
 {
@@ -21,6 +26,8 @@ namespace alpaka
     //! The accelerator specifics.
     namespace acc
     {
+        struct ConceptAcc;
+
         //-----------------------------------------------------------------------------
         //! The accelerator traits.
         namespace traits
@@ -92,6 +99,29 @@ namespace alpaka
                 traits::GetAccName<
                     TAcc>
                 ::getAccName();
+        }
+    }
+
+    namespace queue
+    {
+        namespace traits
+        {
+            template<
+                typename TAcc,
+                typename TProperty>
+            struct QueueType<
+                TAcc,
+                TProperty,
+                typename std::enable_if<
+                    concepts::ImplementsConcept<acc::ConceptAcc, TAcc>::value
+                >::type
+            >
+            {
+                using type = typename QueueType<
+                    typename pltf::traits::PltfType<TAcc>::type,
+                    TProperty
+                >::type;
+            };
         }
     }
 }

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -193,6 +193,7 @@
 #include <alpaka/queue/QueueCpuNonBlocking.hpp>
 #include <alpaka/queue/QueueCpuBlocking.hpp>
 #include <alpaka/queue/Traits.hpp>
+#include <alpaka/queue/Properties.hpp>
 //-----------------------------------------------------------------------------
 // time
 #include <alpaka/time/Traits.hpp>

--- a/include/alpaka/core/Concepts.hpp
+++ b/include/alpaka/core/Concepts.hpp
@@ -25,20 +25,22 @@ namespace alpaka
         {
         };
 
+        //#############################################################################
+        //! Checks whether the concept is implemented by the given class
+        template<
+            typename TConcept,
+            typename TDerived>
+        struct ImplementsConcept {
+            template<
+                typename TBase>
+            static auto implements(Implements<TConcept, TBase>&) -> std::true_type;
+            static auto implements(...) -> std::false_type;
+
+            static constexpr auto value = decltype(implements(std::declval<TDerived&>()))::value;
+        };
+
         namespace detail
         {
-            template<
-                typename TConcept,
-                typename TDerived>
-            struct ImplementsConcept {
-                template<
-                    typename TBase>
-                static auto implements(Implements<TConcept, TBase>&) -> std::true_type;
-                static auto implements(...) -> std::false_type;
-
-                static constexpr auto value = decltype(implements(std::declval<TDerived&>()))::value;
-            };
-
             //#############################################################################
             //! Returns the type that implements the given concept in the inheritance hierarchy.
             template<

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -18,6 +18,9 @@
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/dev/cpu/SysInfo.hpp>
 
+#include <alpaka/queue/Traits.hpp>
+#include <alpaka/queue/Properties.hpp>
+
 #include <map>
 #include <mutex>
 #include <memory>
@@ -283,6 +286,29 @@ namespace alpaka
                 dev::DevCpu>
             {
                 using type = pltf::PltfCpu;
+            };
+        }
+    }
+    namespace queue
+    {
+        namespace traits
+        {
+            template<>
+            struct QueueType<
+                dev::DevCpu,
+                queue::Blocking
+            >
+            {
+                using type = queue::QueueCpuBlocking;
+            };
+
+            template<>
+            struct QueueType<
+                dev::DevCpu,
+                queue::NonBlocking
+            >
+            {
+                using type = queue::QueueCpuNonBlocking;
             };
         }
     }

--- a/include/alpaka/dev/DevCudaRt.hpp
+++ b/include/alpaka/dev/DevCudaRt.hpp
@@ -22,6 +22,9 @@
 #include <alpaka/pltf/Traits.hpp>
 #include <alpaka/wait/Traits.hpp>
 
+#include <alpaka/queue/Traits.hpp>
+#include <alpaka/queue/Properties.hpp>
+
 #include <alpaka/core/Cuda.hpp>
 
 namespace alpaka
@@ -36,6 +39,12 @@ namespace alpaka
             struct GetDevByIdx;
         }
         class PltfCudaRt;
+    }
+
+    namespace queue
+    {
+        class QueueCudaRtBlocking;
+        class QueueCudaRtNonBlocking;
     }
 
     namespace dev
@@ -251,6 +260,29 @@ namespace alpaka
                         dev.m_iDevice));
                     ALPAKA_CUDA_RT_CHECK(cudaDeviceSynchronize());
                 }
+            };
+        }
+    }
+    namespace queue
+    {
+        namespace traits
+        {
+            template<>
+            struct QueueType<
+                dev::DevCudaRt,
+                queue::Blocking
+            >
+            {
+                using type = queue::QueueCudaRtBlocking;
+            };
+
+            template<>
+            struct QueueType<
+                dev::DevCudaRt,
+                queue::NonBlocking
+            >
+            {
+                using type = queue::QueueCudaRtNonBlocking;
             };
         }
     }

--- a/include/alpaka/dev/DevHipRt.hpp
+++ b/include/alpaka/dev/DevHipRt.hpp
@@ -22,6 +22,9 @@
 #include <alpaka/pltf/Traits.hpp>
 #include <alpaka/wait/Traits.hpp>
 
+#include <alpaka/queue/Traits.hpp>
+#include <alpaka/queue/Properties.hpp>
+
 #include <alpaka/core/Hip.hpp>
 
 namespace alpaka
@@ -36,6 +39,12 @@ namespace alpaka
             struct GetDevByIdx;
         }
         class PltfHipRt;
+    }
+
+    namespace queue
+    {
+        class QueueHipRtBlocking;
+        class QueueHipRtNonBlocking;
     }
 
     namespace dev
@@ -251,6 +260,29 @@ namespace alpaka
                         dev.m_iDevice));
                     ALPAKA_HIP_RT_CHECK(hipDeviceSynchronize());
                 }
+            };
+        }
+    }
+    namespace queue
+    {
+        namespace traits
+        {
+            template<>
+            struct QueueType<
+                dev::DevHipRt,
+                queue::Blocking
+            >
+            {
+                using type = queue::QueueHipRtBlocking;
+            };
+
+            template<>
+            struct QueueType<
+                dev::DevHipRt,
+                queue::NonBlocking
+            >
+            {
+                using type = queue::QueueHipRtNonBlocking;
             };
         }
     }

--- a/include/alpaka/pltf/PltfCpu.hpp
+++ b/include/alpaka/pltf/PltfCpu.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/pltf/Traits.hpp>
 #include <alpaka/dev/DevCpu.hpp>
+#include <alpaka/core/Concepts.hpp>
 
 #include <sstream>
 #include <vector>
@@ -21,7 +22,8 @@ namespace alpaka
     {
         //#############################################################################
         //! The CPU device platform.
-        class PltfCpu
+        class PltfCpu :
+            public concepts::Implements<ConceptPltf, PltfCpu>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/pltf/PltfCudaRt.hpp
+++ b/include/alpaka/pltf/PltfCudaRt.hpp
@@ -12,6 +12,7 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/BoostPredef.hpp>
+#include <alpaka/core/Concepts.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
@@ -32,7 +33,8 @@ namespace alpaka
     {
         //#############################################################################
         //! The CUDA RT device manager.
-        class PltfCudaRt
+        class PltfCudaRt :
+            public concepts::Implements<ConceptPltf, PltfCudaRt>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/pltf/PltfHipRt.hpp
+++ b/include/alpaka/pltf/PltfHipRt.hpp
@@ -12,6 +12,7 @@
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
 
 #include <alpaka/core/BoostPredef.hpp>
+#include <alpaka/core/Concepts.hpp>
 
 #if !BOOST_LANG_HIP
     #error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
@@ -32,7 +33,8 @@ namespace alpaka
     {
         //#############################################################################
         //! The HIP RT device manager.
-        class PltfHipRt
+        class PltfHipRt :
+            public concepts::Implements<ConceptPltf, PltfHipRt>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/pltf/Traits.hpp
+++ b/include/alpaka/pltf/Traits.hpp
@@ -12,9 +12,14 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/dev/Traits.hpp>
 
+#include <alpaka/core/Concepts.hpp>
+#include <alpaka/queue/Traits.hpp>
+#include <alpaka/dev/Traits.hpp>
+
 #include <boost/config.hpp>
 
 #include <vector>
+#include <type_traits>
 
 namespace alpaka
 {
@@ -22,6 +27,8 @@ namespace alpaka
     //! The platform specifics.
     namespace pltf
     {
+        struct ConceptPltf;
+
         //-----------------------------------------------------------------------------
         //! The platform traits.
         namespace traits
@@ -102,6 +109,25 @@ namespace alpaka
             }
 
             return devs;
+        }
+    }
+    namespace queue
+    {
+        namespace traits
+        {
+            template<
+                typename TPltf,
+                typename TProperty>
+            struct QueueType<
+                TPltf,
+                TProperty,
+                typename std::enable_if<concepts::ImplementsConcept<pltf::ConceptPltf, TPltf>::value>::type
+            >
+            {
+                using type = typename QueueType<
+                    typename dev::traits::DevType<TPltf>::type,
+                    TProperty>::type;
+            };
         }
     }
 }

--- a/include/alpaka/queue/Properties.hpp
+++ b/include/alpaka/queue/Properties.hpp
@@ -1,0 +1,31 @@
+/* Copyright 2019 Rene Widera
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+namespace alpaka
+{
+    namespace queue
+    {
+        //-----------------------------------------------------------------------------
+        //! Properties to define queue behavior
+        namespace property
+        {
+            //#############################################################################
+            //! The caller is waiting until the enqueued task is finished
+            struct Blocking{};
+
+            //#############################################################################
+            //! The caller is NOT waiting until the enqueued task is finished
+            struct NonBlocking{};
+        }
+
+        using namespace property;
+    }
+}

--- a/include/alpaka/queue/Traits.hpp
+++ b/include/alpaka/queue/Traits.hpp
@@ -40,6 +40,14 @@ namespace alpaka
                 typename TQueue,
                 typename TSfinae = void>
             struct Empty;
+
+            //#############################################################################
+            //! Queue for an accelerator
+            template<
+                typename TAcc,
+                typename TProperty,
+                typename TSfinae = void>
+            struct QueueType;
         }
 
         //-----------------------------------------------------------------------------
@@ -78,5 +86,14 @@ namespace alpaka
                 ::empty(
                     queue);
         }
+
+        //-----------------------------------------------------------------------------
+        //! Queue based on the environment and a property
+        //
+        // Environment type can be a accelerator, device or a platform.
+        template<
+            typename TEnv,
+            typename TProperty>
+        using Queue = typename traits::QueueType<TEnv, TProperty>::type;
     }
 }

--- a/include/alpaka/queue/Traits.hpp
+++ b/include/alpaka/queue/Traits.hpp
@@ -90,7 +90,9 @@ namespace alpaka
         //-----------------------------------------------------------------------------
         //! Queue based on the environment and a property
         //
-        // Environment type can be a accelerator, device or a platform.
+        // \tparam TEnv Environment type, e.g.  accelerator, device or a platform.
+        //              queue::traits::QueueType must be specialized for TEnv
+        // \tparam TProperty Property to define the behavior of TEnv.
         template<
             typename TEnv,
             typename TProperty>


### PR DESCRIPTION
close #175

Implement a trait `queue::Queue` to derive the queue from the
accelerator/device or the platform based on a property.

- add concepts for
  - alpaka platforms
  - alpaka accelertors
- add queue trait `Queue`
- add queue properies e.g. `Blocking`, `NonBlocking`
- move declaration of `ImplementsConcept` from `detail` into the `concepts` namespace

Removes the precompiler guard that examples can only be useful executed
with the serial accelerator.

- add missing synchronization in the examples to support nonblocking
queues

The PR is split into two commits, it is easier to check them seperate.