### PR TITLE
fix memory alignment

### DIFF
--- a/include/alpaka/mem/alloc/AllocCpuBoostAligned.hpp
+++ b/include/alpaka/mem/alloc/AllocCpuBoostAligned.hpp
@@ -16,6 +16,8 @@
 
 #include <boost/align.hpp>
 
+#include <algorithm>
+
 namespace alpaka
 {
     namespace mem
@@ -51,10 +53,24 @@ namespace alpaka
                         std::size_t const & sizeElems)
                     -> T *
                     {
+#if (defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+                        // For CUDA host memory must be aligned to 4 kib to pin it with `cudaHostRegister`,
+                        // this was described in older programming guides but was removed later.
+                        // From testing with PIConGPU and cuda-memcheck we found out that the alignment is still required.
+                        //
+                        // For HIP the required alignment is the size of a cache line.
+                        // https://rocm-developer-tools.github.io/HIP/group__Memory.html#gab8258f051e1a1f7385f794a15300e674
+                        // To avoid issues with HIP(cuda) the alignment will be set also for HIP(clang/hcc)
+                        // to 4kib.
+                        // @todo evaluate requirements when the HIP ecosystem is more stable
+                        constexpr size_t minAlignement = 4096;
+#else
+                        constexpr size_t minAlignement = TAlignment::value;
+#endif
                         alpaka::ignore_unused(alloc);
                         return
                             reinterpret_cast<T *>(
-                                boost::alignment::aligned_alloc(TAlignment::value, sizeElems * sizeof(T)));
+                                boost::alignment::aligned_alloc(std::max(TAlignment::value, minAlignement), sizeElems * sizeof(T)));
                     }
                 };
 


### PR DESCRIPTION
fix #873

Align host memory for alapka host buffer always to 4kib to avoid data
races when a GPU updates host memory.

I do not set the memory alignment for HIP to the minimum value (documentation says that memory must be aligned to a cache line). I can currently not clearly verify the needed alignment because the AMD tools are not working on the system where I have access. So I decided to stay conservative and added an alignment that works for HIP(cuda) and fulfills the requirements from the documentation.