### PR TITLE
Fix TBB installation in CI

### DIFF
--- a/script/travis/install_tbb.sh
+++ b/script/travis/install_tbb.sh
@@ -20,15 +20,17 @@ then
     travis_retry sudo apt-get -y --quiet --allow-unauthenticated --no-install-recommends install libtbb-dev
 elif [ "$TRAVIS_OS_NAME" = "osx" ]
 then
+    brew unlink python@2
     brew install tbb
 elif [ "$TRAVIS_OS_NAME" = "windows" ]
 then
     TBB_ARCHIVE_VER="tbb44_20160526oss"
-    TBB_DOWNLOAD_URL="https://www.threadingbuildingblocks.org/sites/default/files/software_releases/windows/${TBB_ARCHIVE_VER}_win_0.zip"
-    TBB_DST_PATH="${TBB_ROOT_DIR}/tbb.zip"
+    TBB_DOWNLOAD_URL="https://github.com/intel/tbb/releases/download/4.4.5/${TBB_ARCHIVE_VER}_win.zip"
+    TBB_DST_PATH="tbb.zip"
+    powershell.exe -Command '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; Invoke-WebRequest "'${TBB_DOWNLOAD_URL}'" -OutFile "'${TBB_DST_PATH}'"'
     mkdir "${TBB_ROOT_DIR}"
-    powershell.exe Invoke-WebRequest "${TBB_DOWNLOAD_URL}" -OutFile "${TBB_DST_PATH}"
     unzip -q "${TBB_DST_PATH}" -d "${TBB_ROOT_DIR}"
+    rm "${TBB_DST_PATH}"
     TBB_UNZIP_DIR="${TBB_ROOT_DIR}/${TBB_ARCHIVE_VER}"
     mv ${TBB_UNZIP_DIR}/* "${TBB_ROOT_DIR}/"
     rmdir "${TBB_UNZIP_DIR}"


### PR DESCRIPTION
TBB downloads and installation on both Windows and Mac fails since a few days in all builds.
On Mac the default python3 conflicts with the python2 verision that the current tbb receipt depends on.
The Windows download now requires some extra settings because the default TLS version of powershell is too low.
@ComputationalRadiationPhysics/alpaka-developers Please approve! This issue blocks all PRs.