### PR TITLE
backport to 0.3.6

### DIFF
--- a/include/alpaka/core/Cuda.hpp
+++ b/include/alpaka/core/Cuda.hpp
@@ -85,6 +85,8 @@ namespace alpaka
                     std::cerr << sError << std::endl;
 #endif
                     ALPAKA_DEBUG_BREAK;
+                    // reset the last error to allow user side error handling
+                    cudaGetLastError();
                     throw std::runtime_error(sError);
                 }
             }

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -69,6 +69,21 @@ namespace alpaka
                     //boost::ignore_unused(abs);
                     return ::abs(arg);
                 }
+            }
+            //! The CUDA built in abs double specialization.
+            template<>
+            struct Abs<
+                AbsCudaBuiltIn,
+                double>
+            {
+                __device__ static auto abs(
+                    AbsCudaBuiltIn const & abs_ctx,
+                    TArg const & arg)
+                -> decltype(::fabs(arg))
+                {
+                    alpaka::ignore_unused(abs_ctx);
+                    return ::fabs(arg);
+                }
             };
             //! The CUDA built in abs float specialization.
             template<>

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -69,7 +69,7 @@ namespace alpaka
                     //boost::ignore_unused(abs);
                     return ::abs(arg);
                 }
-            }
+            };
             //! The CUDA built in abs double specialization.
             template<>
             struct Abs<

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -73,11 +73,11 @@ namespace alpaka
             //! The CUDA built in abs float specialization.
             template<>
             struct Abs<
-                AbsHipBuiltIn,
+                AbsCudaBuiltIn,
                 float>
             {
                 __device__ static auto abs(
-                    AbsHipBuiltIn const & abs_ctx,
+                    AbsCudaBuiltIn const & abs_ctx,
                     float const & arg)
                 -> float
                 {

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -70,6 +70,21 @@ namespace alpaka
                     return ::abs(arg);
                 }
             };
+
+            template<>
+            struct Abs<
+                AbsHipBuiltIn,
+                float>
+            {
+                __device__ static auto abs(
+                    AbsHipBuiltIn const & abs_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(abs_ctx);
+                    return ::fabsf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -78,7 +78,7 @@ namespace alpaka
             {
                 __device__ static auto abs(
                     AbsCudaBuiltIn const & abs_ctx,
-                    TArg const & arg)
+                    double const & arg)
                 -> decltype(::fabs(arg))
                 {
                     alpaka::ignore_unused(abs_ctx);

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/abs/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto abs(
-                    AbsCudaBuiltIn const & /*abs*/,
+                    AbsCudaBuiltIn const & abs_ctx,
                     TArg const & arg)
                 -> decltype(::abs(arg))
                 {
-                    //boost::ignore_unused(abs);
+                    alpaka::ignore_unused(abs_ctx);
                     return ::abs(arg);
                 }
             };

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library abs.
+        //! The CUDA built in abs.
         class AbsCudaBuiltIn
         {
         public:
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::abs(arg);
                 }
             };
-
+            //! The CUDA built in abs float specialization.
             template<>
             struct Abs<
                 AbsHipBuiltIn,

--- a/include/alpaka/math/abs/Traits.hpp
+++ b/include/alpaka/math/abs/Traits.hpp
@@ -51,14 +51,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Abs.
         //! \tparam TArg The arg type.
-        //! \param abs The object specializing Abs.
+        //! \param abs_ctx The object specializing Abs.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto abs(
-            T const & abs,
+            T const & abs_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -66,7 +66,7 @@ namespace alpaka
                 T,
                 TArg>
             ::abs(
-                abs,
+                abs_ctx,
                 arg))
 #endif
         {
@@ -75,7 +75,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::abs(
-                    abs,
+                    abs_ctx,
                     arg);
         }
 
@@ -99,19 +99,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto abs(
-                    T const & abs,
+                    T const & abs_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::abs(
-                        static_cast<typename T::AbsBase const &>(abs),
+                        static_cast<typename T::AbsBase const &>(abs_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::abs(
-                            static_cast<typename T::AbsBase const &>(abs),
+                            static_cast<typename T::AbsBase const &>(abs_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/acos/Traits.hpp>
-
-#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -63,11 +62,11 @@ namespace alpaka
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_ACC_CUDA_ONLY static auto acos(
-                    AcosCudaBuiltIn const & /*acos*/,
+                    AcosCudaBuiltIn const & acos_ctx,
                     TArg const & arg)
                 -> decltype(::acos(arg))
                 {
-                    //boost::ignore_unused(acos);
+                    alpaka::ignore_unused(acos_ctx);
                     return ::acos(arg);
                 }
             };

--- a/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library acos.
+        //! The CUDA built in acos.
         class AcosCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library acos trait specialization.
+            //! The CUDA acos trait specialization.
             template<
                 typename TArg>
             struct Acos<

--- a/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
@@ -71,6 +71,21 @@ namespace alpaka
                     return ::acos(arg);
                 }
             };
+
+            template<>
+            struct Acos<
+                AcosCudaBuiltIn,
+                float>
+            {
+                __device__ static auto acos(
+                    AcosCudaBuiltIn const & acos_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(acos_ctx);
+                    return ::acosf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/acos/Traits.hpp
+++ b/include/alpaka/math/acos/Traits.hpp
@@ -48,14 +48,14 @@ namespace alpaka
         //! Computes the principal value of the arc cosine.
         //!
         //! \tparam TArg The arg type.
-        //! \param acos The object specializing Acos.
+        //! \param acos_ctx The object specializing Acos.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto acos(
-            T const & acos,
+            T const & acos_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -63,7 +63,7 @@ namespace alpaka
                 T,
                 TArg>
             ::acos(
-                acos,
+                acos_ctx,
                 arg))
 #endif
         {
@@ -72,7 +72,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::acos(
-                    acos,
+                    acos_ctx,
                     arg);
         }
 
@@ -96,19 +96,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto acos(
-                    T const & acos,
+                    T const & acos_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::acos(
-                        static_cast<typename T::AcosBase const &>(acos),
+                        static_cast<typename T::AcosBase const &>(acos_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::acos(
-                            static_cast<typename T::AcosBase const &>(acos),
+                            static_cast<typename T::AcosBase const &>(acos_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library asin.
+        //! The CUDA built in asin.
         class AsinCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library asin trait specialization.
+            //! The CUDA asin trait specialization.
             template<
                 typename TArg>
             struct Asin<

--- a/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
@@ -24,6 +24,7 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
@@ -62,11 +63,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto asin(
-                    AsinCudaBuiltIn const & /*asin*/,
+                    AsinCudaBuiltIn const & asin_ctx,
                     TArg const & arg)
                 -> decltype(::asin(arg))
                 {
-                    //boost::ignore_unused(asin);
+                    alpaka::ignore_unused(asin_ctx);
                     return ::asin(arg);
                 }
             };

--- a/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
@@ -70,6 +70,21 @@ namespace alpaka
                     return ::asin(arg);
                 }
             };
+
+            template<>
+            struct Asin<
+                AsinCudaBuiltIn,
+                float>
+            {
+                __device__ static auto asin(
+                    AsinCudaBuiltIn const & asin_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(asin_ctx);
+                    return ::asinf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/asin/Traits.hpp
+++ b/include/alpaka/math/asin/Traits.hpp
@@ -48,14 +48,14 @@ namespace alpaka
         //! Computes the principal value of the arc sine.
         //!
         //! \tparam TArg The arg type.
-        //! \param asin The object specializing Asin.
+        //! \param asin_ctx The object specializing Asin.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto asin(
-            T const & asin,
+            T const & asin_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -63,7 +63,7 @@ namespace alpaka
                 T,
                 TArg>
             ::asin(
-                asin,
+                asin_ctx,
                 arg))
 #endif
         {
@@ -72,7 +72,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::asin(
-                    asin,
+                    asin_ctx,
                     arg);
         }
 
@@ -96,19 +96,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto asin(
-                    T const & asin,
+                    T const & asin_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::asin(
-                        static_cast<typename T::AsinBase const &>(asin),
+                        static_cast<typename T::AsinBase const &>(asin_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::asin(
-                            static_cast<typename T::AsinBase const &>(asin),
+                            static_cast<typename T::AsinBase const &>(asin_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
@@ -70,6 +70,21 @@ namespace alpaka
                     return ::atan(arg);
                 }
             };
+
+            template<>
+            struct Atan<
+                AtanCudaBuiltIn,
+                float>
+            {
+                __device__ static auto atan(
+                    AtanCudaBuiltIn const & atan_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(atan_ctx);
+                    return ::atanf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/atan/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto atan(
-                    AtanCudaBuiltIn const & /*atan*/,
+                    AtanCudaBuiltIn const & atan_ctx,
                     TArg const & arg)
                 -> decltype(::atan(arg))
                 {
-                    //boost::ignore_unused(atan);
+                    alpaka::ignore_unused(atan_ctx);
                     return ::atan(arg);
                 }
             };

--- a/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library atan.
+        //! The CUDA built in atan.
         class AtanCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library atan trait specialization.
+            //! The CUDA atan trait specialization.
             template<
                 typename TArg>
             struct Atan<

--- a/include/alpaka/math/atan/Traits.hpp
+++ b/include/alpaka/math/atan/Traits.hpp
@@ -48,14 +48,14 @@ namespace alpaka
         //! Computes the principal value of the arc tangent.
         //!
         //! \tparam TArg The arg type.
-        //! \param atan The object specializing Atan.
+        //! \param atan_ctx The object specializing Atan.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto atan(
-            T const & atan,
+            T const & atan_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -63,7 +63,7 @@ namespace alpaka
                 T,
                 TArg>
             ::atan(
-                atan,
+                atan_ctx,
                 arg))
 #endif
         {
@@ -72,7 +72,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::atan(
-                    atan,
+                    atan_ctx,
                     arg);
         }
 
@@ -96,19 +96,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto atan(
-                    T const & atan,
+                    T const & atan_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::atan(
-                        static_cast<typename T::AtanBase const &>(atan),
+                        static_cast<typename T::AtanBase const &>(atan_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::atan(
-                            static_cast<typename T::AtanBase const &>(atan),
+                            static_cast<typename T::AtanBase const &>(atan_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
@@ -74,6 +74,23 @@ namespace alpaka
                     return ::atan2(y, x);
                 }
             };
+
+            template<>
+            struct Atan2<
+                Atan2CudaBuiltIn,
+                float,
+                float>
+            {
+                __device__ static auto atan2(
+                    Atan2CudaBuiltIn const & atan2_ctx,
+                    float const & y,
+                    float const & x)
+                -> float
+                {
+                    alpaka::ignore_unused(atan2_ctx);
+                    return ::atan2f(y, x);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library atan2.
+        //! The CUDA built in atan2.
         class Atan2CudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library atan2 trait specialization.
+            //! The CUDA atan2 trait specialization.
             template<
                 typename Ty,
                 typename Tx>

--- a/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/atan2/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -65,12 +64,12 @@ namespace alpaka
                     && std::is_floating_point<Tx>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto atan2(
-                    Atan2CudaBuiltIn const & /*abs*/,
+                    Atan2CudaBuiltIn const & abs_ctx,
                     Ty const & y,
                     Tx const & x)
                 -> decltype(::atan2(y, x))
                 {
-                    //boost::ignore_unused(abs);
+                    alpaka::ignore_unused(abs_ctx);
                     return ::atan2(y, x);
                 }
             };

--- a/include/alpaka/math/atan2/Traits.hpp
+++ b/include/alpaka/math/atan2/Traits.hpp
@@ -51,7 +51,7 @@ namespace alpaka
         //! \tparam T The type of the object specializing Atan2.
         //! \tparam Ty The y arg type.
         //! \tparam Tx The x arg type.
-        //! \param atan2 The object specializing Atan2.
+        //! \param atan2_ctx The object specializing Atan2.
         //! \param y The y arg.
         //! \param x The x arg.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -60,7 +60,7 @@ namespace alpaka
             typename Ty,
             typename Tx>
         ALPAKA_FN_HOST_ACC auto atan2(
-            T const & atan2,
+            T const & atan2_ctx,
             Ty const & y,
             Tx const & x)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
@@ -70,7 +70,7 @@ namespace alpaka
                 Ty,
                 Tx>
             ::atan2(
-                atan2,
+                atan2_ctx,
                 y,
                 x))
 #endif
@@ -81,7 +81,7 @@ namespace alpaka
                     Ty,
                     Tx>
                 ::atan2(
-                    atan2,
+                    atan2_ctx,
                     y,
                     x);
         }
@@ -108,13 +108,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto atan2(
-                    T const & atan2,
+                    T const & atan2_ctx,
                     Ty const & y,
                     Tx const & x)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::atan2(
-                        static_cast<typename T::Atan2Base const &>(atan2),
+                        static_cast<typename T::Atan2Base const &>(atan2_ctx),
                         y,
                         x))
 #endif
@@ -122,7 +122,7 @@ namespace alpaka
                     // Delegate the call to the base class.
                     return
                         math::atan2(
-                            static_cast<typename T::Atan2Base const &>(atan2),
+                            static_cast<typename T::Atan2Base const &>(atan2_ctx),
                             y,
                             x);
                 }

--- a/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
@@ -63,10 +63,10 @@ namespace alpaka
                 ALPAKA_FN_ACC_CUDA_ONLY static auto cbrt(
                     CbrtCudaBuiltIn const & /*cbrt*/,
                     TArg const & arg)
-                -> decltype(std::cbrt(arg))
+                -> decltype(::cbrt(arg))
                 {
                     //boost::ignore_unused(cbrt);
-                    return std::cbrt(arg);
+                    return ::cbrt(arg);
                 }
             };
 

--- a/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/cbrt/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -61,11 +60,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto cbrt(
-                    CbrtCudaBuiltIn const & /*cbrt*/,
+                    CbrtCudaBuiltIn const & cbrt_ctx,
                     TArg const & arg)
                 -> decltype(::cbrt(arg))
                 {
-                    //boost::ignore_unused(cbrt);
+                    alpaka::ignore_unused(cbrt_ctx);
                     return ::cbrt(arg);
                 }
             };

--- a/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
@@ -41,7 +41,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library cbrt.
+        //! The CUDA built in cbrt.
         class CbrtCudaBuiltIn
         {
         public:
@@ -51,7 +51,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library cbrt trait specialization.
+            //! The CUDA cbrt trait specialization.
             template<
                 typename TArg>
             struct Cbrt<

--- a/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
@@ -69,6 +69,21 @@ namespace alpaka
                     return std::cbrt(arg);
                 }
             };
+
+            template<>
+            struct Cbrt<
+                CbrtCudaBuiltIn,
+                float>
+            {
+                __device__ static auto cbrt(
+                    CbrtCudaBuiltIn const & cbrt_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(cbrt_ctx);
+                    return ::cbrtf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/cbrt/Traits.hpp
+++ b/include/alpaka/math/cbrt/Traits.hpp
@@ -49,14 +49,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Cbrt.
         //! \tparam TArg The arg type.
-        //! \param cbrt The object specializing Cbrt.
+        //! \param cbrt_ctx The object specializing Cbrt.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto cbrt(
-            T const & cbrt,
+            T const & cbrt_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -64,7 +64,7 @@ namespace alpaka
                 T,
                 TArg>
             ::cbrt(
-                cbrt,
+                cbrt_ctx,
                 arg))
 #endif
         {
@@ -73,7 +73,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::cbrt(
-                    cbrt,
+                    cbrt_ctx,
                     arg);
         }
 
@@ -97,19 +97,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto cbrt(
-                    T const & cbrt,
+                    T const & cbrt_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::cbrt(
-                        static_cast<typename T::CbrtBase const &>(cbrt),
+                        static_cast<typename T::CbrtBase const &>(cbrt_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::cbrt(
-                            static_cast<typename T::CbrtBase const &>(cbrt),
+                            static_cast<typename T::CbrtBase const &>(cbrt_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
@@ -70,6 +70,21 @@ namespace alpaka
                     return ::ceil(arg);
                 }
             };
+
+            template<>
+            struct Ceil<
+                CeilCudaBuiltIn,
+                float>
+            {
+                __device__ static auto ceil(
+                    CeilCudaBuiltIn const & ceil_ctx,
+                    float const & arg)
+                ->float
+                {
+                    alpaka::ignore_unused(ceil_ctx);
+                    return ::ceilf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/ceil/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto ceil(
-                    CeilCudaBuiltIn const & /*ceil*/,
+                    CeilCudaBuiltIn const & ceil_ctx,
                     TArg const & arg)
                 -> decltype(::ceil(arg))
                 {
-                    //boost::ignore_unused(ceil);
+                    alpaka::ignore_unused(ceil_ctx);
                     return ::ceil(arg);
                 }
             };

--- a/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library ceil.
+        //! The CUDA built in ceil.
         class CeilCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library ceil trait specialization.
+            //! The CUDA ceil trait specialization.
             template<
                 typename TArg>
             struct Ceil<
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::ceil(arg);
                 }
             };
-
+            //
             template<>
             struct Ceil<
                 CeilCudaBuiltIn,

--- a/include/alpaka/math/ceil/Traits.hpp
+++ b/include/alpaka/math/ceil/Traits.hpp
@@ -49,14 +49,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Ceil.
         //! \tparam TArg The arg type.
-        //! \param ceil The object specializing Ceil.
+        //! \param ceil_ctx The object specializing Ceil.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto ceil(
-            T const & ceil,
+            T const & ceil_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -64,7 +64,7 @@ namespace alpaka
                 T,
                 TArg>
             ::ceil(
-                ceil,
+                ceil_ctx,
                 arg))
 #endif
         {
@@ -73,7 +73,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::ceil(
-                    ceil,
+                    ceil_ctx,
                     arg);
         }
 
@@ -97,19 +97,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto ceil(
-                    T const & ceil,
+                    T const & ceil_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::ceil(
-                        static_cast<typename T::CeilBase const &>(ceil),
+                        static_cast<typename T::CeilBase const &>(ceil_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::ceil(
-                            static_cast<typename T::CeilBase const &>(ceil),
+                            static_cast<typename T::CeilBase const &>(ceil_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/cos/CosCudaBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/cos/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto cos(
-                    CosCudaBuiltIn const & /*cos*/,
+                    CosCudaBuiltIn const & cos_ctx,
                     TArg const & arg)
                 -> decltype(::cos(arg))
                 {
-                    //boost::ignore_unused(cos);
+                    alpaka::ignore_unused(cos_ctx);
                     return ::cos(arg);
                 }
             };

--- a/include/alpaka/math/cos/CosCudaBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library cos.
+        //! The CUDA built in cos.
         class CosCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library cos trait specialization.
+            //! The CUDA cos trait specialization.
             template<
                 typename TArg>
             struct Cos<

--- a/include/alpaka/math/cos/CosCudaBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosCudaBuiltIn.hpp
@@ -70,6 +70,21 @@ namespace alpaka
                     return ::cos(arg);
                 }
             };
+
+            template<>
+            struct Cos<
+                CosCudaBuiltIn,
+                float>
+            {
+                __device__ static auto cos(
+                    CosCudaBuiltIn const & cos_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(cos_ctx);
+                    return ::cosf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/cos/Traits.hpp
+++ b/include/alpaka/math/cos/Traits.hpp
@@ -49,14 +49,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Cos.
         //! \tparam TArg The arg type.
-        //! \param cos The object specializing Cos.
+        //! \param cos_ctx The object specializing Cos.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto cos(
-            T const & cos,
+            T const & cos_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -64,7 +64,7 @@ namespace alpaka
                 T,
                 TArg>
             ::cos(
-                cos,
+                cos_ctx,
                 arg))
 #endif
         {
@@ -73,7 +73,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::cos(
-                    cos,
+                    cos_ctx,
                     arg);
         }
 
@@ -97,19 +97,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto cos(
-                    T const & cos,
+                    T const & cos_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::cos(
-                        static_cast<typename T::CosBase const &>(cos),
+                        static_cast<typename T::CosBase const &>(cos_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::cos(
-                            static_cast<typename T::CosBase const &>(cos),
+                            static_cast<typename T::CosBase const &>(cos_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
@@ -70,6 +70,21 @@ namespace alpaka
                     return ::erf(arg);
                 }
             };
+
+            template<>
+            struct Erf<
+                ErfCudaBuiltIn,
+                float>
+            {
+                __device__ static auto erf(
+                    ErfCudaBuiltIn const & erf_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(erf_ctx);
+                    return ::erff(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/erf/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto erf(
-                    ErfCudaBuiltIn const & /*erf*/,
+                    ErfCudaBuiltIn const & erf_ctx,
                     TArg const & arg)
                 -> decltype(::erf(arg))
                 {
-                    //boost::ignore_unused(erf);
+                    alpaka::ignore_unused(erf_ctx);
                     return ::erf(arg);
                 }
             };

--- a/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library erf.
+        //! The CUDA built in erf.
         class ErfCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library erf trait specialization.
+            //! The CUDA erf trait specialization.
             template<
                 typename TArg>
             struct Erf<

--- a/include/alpaka/math/erf/Traits.hpp
+++ b/include/alpaka/math/erf/Traits.hpp
@@ -49,14 +49,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Erf.
         //! \tparam TArg The arg type.
-        //! \param erf The object specializing Erf.
+        //! \param erf_ctx The object specializing Erf.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto erf(
-            T const & erf,
+            T const & erf_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -64,7 +64,7 @@ namespace alpaka
                 T,
                 TArg>
             ::erf(
-                erf,
+                erf_ctx,
                 arg))
 #endif
         {
@@ -73,7 +73,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::erf(
-                    erf,
+                    erf_ctx,
                     arg);
         }
 
@@ -97,19 +97,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto erf(
-                    T const & erf,
+                    T const & erf_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::erf(
-                        static_cast<typename T::ErfBase const &>(erf),
+                        static_cast<typename T::ErfBase const &>(erf_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::erf(
-                            static_cast<typename T::ErfBase const &>(erf),
+                            static_cast<typename T::ErfBase const &>(erf_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/exp/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto exp(
-                    ExpCudaBuiltIn const & /*exp*/,
+                    ExpCudaBuiltIn const & exp_ctx,
                     TArg const & arg)
                 -> decltype(::exp(arg))
                 {
-                    //boost::ignore_unused(exp);
+                    alpaka::ignore_unused(exp_ctx);
                     return ::exp(arg);
                 }
             };

--- a/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
@@ -70,6 +70,21 @@ namespace alpaka
                     return ::exp(arg);
                 }
             };
+
+            template<>
+            struct Exp<
+                ExpCudaBuiltIn,
+                float>
+            {
+                __device__ static auto exp(
+                    ExpCudaBuiltIn const & exp_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(exp_ctx);
+                    return ::expf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library exp.
+        //! The CUDA built in exp.
         class ExpCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library exp trait specialization.
+            //! The CUDA exp trait specialization.
             template<
                 typename TArg>
             struct Exp<
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::exp(arg);
                 }
             };
-
+            //! The CUDA exp float specialization.
             template<>
             struct Exp<
                 ExpCudaBuiltIn,

--- a/include/alpaka/math/exp/Traits.hpp
+++ b/include/alpaka/math/exp/Traits.hpp
@@ -49,13 +49,13 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Exp.
         //! \tparam TArg The arg type.
-        //! \param exp The object specializing Exp.
+        //! \param exp_ctx The object specializing Exp.
         //! \param arg The arg.
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto exp(
-            T const & exp,
+            T const & exp_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -63,7 +63,7 @@ namespace alpaka
                 T,
                 TArg>
             ::exp(
-                exp,
+                exp_ctx,
                 arg))
 #endif
         {
@@ -72,7 +72,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::exp(
-                    exp,
+                    exp_ctx,
                     arg);
         }
 
@@ -96,19 +96,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto exp(
-                    T const & exp,
+                    T const & exp_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::exp(
-                        static_cast<typename T::ExpBase const &>(exp),
+                        static_cast<typename T::ExpBase const &>(exp_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::exp(
-                            static_cast<typename T::ExpBase const &>(exp),
+                            static_cast<typename T::ExpBase const &>(exp_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/floor/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto floor(
-                    FloorCudaBuiltIn const & /*floor*/,
+                    FloorCudaBuiltIn const & floor_ctx,
                     TArg const & arg)
                 -> decltype(::floor(arg))
                 {
-                    //boost::ignore_unused(floor);
+                    alpaka::ignore_unused(floor_ctx);
                     return ::floor(arg);
                 }
             };

--- a/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
@@ -70,6 +70,21 @@ namespace alpaka
                     return ::floor(arg);
                 }
             };
+
+            template<>
+            struct Floor<
+                FloorCudaBuiltIn,
+                float>
+            {
+                __device__ static auto floor(
+                    FloorCudaBuiltIn const & floor_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(floor_ctx);
+                    return ::floorf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library floor.
+        //! The CUDA built in floor.
         class FloorCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library floor trait specialization.
+            //! The CUDA floor trait specialization.
             template<
                 typename TArg>
             struct Floor<
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::floor(arg);
                 }
             };
-
+            //! The CUDA floor float specialization.
             template<>
             struct Floor<
                 FloorCudaBuiltIn,

--- a/include/alpaka/math/floor/Traits.hpp
+++ b/include/alpaka/math/floor/Traits.hpp
@@ -49,14 +49,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Floor.
         //! \tparam TArg The arg type.
-        //! \param floor The object specializing Floor.
+        //! \param floor_ctx The object specializing Floor.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto floor(
-            T const & floor,
+            T const & floor_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -64,7 +64,7 @@ namespace alpaka
                 T,
                 TArg>
             ::floor(
-                floor,
+                floor_ctx,
                 arg))
 #endif
         {
@@ -73,7 +73,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::floor(
-                    floor,
+                    floor_ctx,
                     arg);
         }
 
@@ -97,19 +97,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto floor(
-                    T const & floor,
+                    T const & floor_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::floor(
-                        static_cast<typename T::FloorBase const &>(floor),
+                        static_cast<typename T::FloorBase const &>(floor_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::floor(
-                            static_cast<typename T::FloorBase const &>(floor),
+                            static_cast<typename T::FloorBase const &>(floor_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/fmod/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -65,12 +64,12 @@ namespace alpaka
                     && std::is_floating_point<Ty>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto fmod(
-                    FmodCudaBuiltIn const & /*fmod*/,
+                    FmodCudaBuiltIn const & fmod_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::fmod(x, y))
                 {
-                    //boost::ignore_unused(fmod);
+                    alpaka::ignore_unused(fmod_ctx);
                     return ::fmod(
                         x,
                         y);

--- a/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
@@ -71,7 +71,28 @@ namespace alpaka
                 -> decltype(::fmod(x, y))
                 {
                     //boost::ignore_unused(fmod);
-                    return ::fmod(x, y);
+                    return ::fmod(
+                        x,
+                        y);
+                }
+            };
+
+            template<>
+            struct Fmod<
+                FmodCudaBuiltIn,
+                float,
+                float>
+            {
+                __device__ static auto fmod(
+                    FmodCudaBuiltIn const & fmod_ctx,
+                    float const & x,
+                    float const & y)
+                -> float
+                {
+                    alpaka::ignore_unused(fmod_ctx);
+                    return ::fmodf(
+                        x,
+                        y);
                 }
             };
         }

--- a/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library fmod.
+        //! The CUDA built in fmod.
         class FmodCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library fmod trait specialization.
+            //! The CUDA fmod trait specialization.
             template<
                 typename Tx,
                 typename Ty>
@@ -76,7 +76,7 @@ namespace alpaka
                         y);
                 }
             };
-
+            //! The CUDA fmod float specialization.
             template<>
             struct Fmod<
                 FmodCudaBuiltIn,

--- a/include/alpaka/math/fmod/Traits.hpp
+++ b/include/alpaka/math/fmod/Traits.hpp
@@ -51,7 +51,7 @@ namespace alpaka
         //! \tparam T The type of the object specializing Fmod.
         //! \tparam Tx The type of the first argument.
         //! \tparam Ty The type of the second argument.
-        //! \param fmod The object specializing Fmod.
+        //! \param fmod_ctx The object specializing Fmod.
         //! \param x The first argument.
         //! \param y The second argument.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -60,7 +60,7 @@ namespace alpaka
             typename Tx,
             typename Ty>
         ALPAKA_FN_HOST_ACC auto fmod(
-            T const & fmod,
+            T const & fmod_ctx,
             Tx const & x,
             Ty const & y)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
@@ -70,7 +70,7 @@ namespace alpaka
                 Tx,
                 Ty>
             ::fmod(
-                fmod,
+                fmod_ctx,
                 x,
                 y))
 #endif
@@ -81,7 +81,7 @@ namespace alpaka
                     Tx,
                     Ty>
                 ::fmod(
-                    fmod,
+                    fmod_ctx,
                     x,
                     y);
         }
@@ -106,19 +106,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto fmod(
-                    T const & fmod,
+                    T const & fmod_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::fmod(
-                        static_cast<typename T::FmodBase const &>(fmod),
+                        static_cast<typename T::FmodBase const &>(fmod_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::fmod(
-                            static_cast<typename T::FmodBase const &>(fmod),
+                            static_cast<typename T::FmodBase const &>(fmod_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/log/LogCudaBuiltIn.hpp
+++ b/include/alpaka/math/log/LogCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/log/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto log(
-                    LogCudaBuiltIn const & /*log*/,
+                    LogCudaBuiltIn const & log_ctx,
                     TArg const & arg)
                 -> decltype(::log(arg))
                 {
-                    //boost::ignore_unused(log);
+                    alpaka::ignore_unused(log_ctx);
                     return ::log(arg);
                 }
             };

--- a/include/alpaka/math/log/LogCudaBuiltIn.hpp
+++ b/include/alpaka/math/log/LogCudaBuiltIn.hpp
@@ -70,6 +70,22 @@ namespace alpaka
                     return ::log(arg);
                 }
             };
+
+            template<>
+            struct Log<
+                LogCudaBuiltIn,
+                float>
+            {
+                __device__ static auto log(
+                    LogCudaBuiltIn const & log_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(log_ctx);
+                    return ::logf(arg);
+                }
+            };
+
         }
     }
 }

--- a/include/alpaka/math/log/LogCudaBuiltIn.hpp
+++ b/include/alpaka/math/log/LogCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library log.
+        // ! The CUDA built in log.
         class LogCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library log trait specialization.
+            //! The CUDA log trait specialization.
             template<
                 typename TArg>
             struct Log<
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::log(arg);
                 }
             };
-
+            //! The CUDA log float specialization.
             template<>
             struct Log<
                 LogCudaBuiltIn,

--- a/include/alpaka/math/log/Traits.hpp
+++ b/include/alpaka/math/log/Traits.hpp
@@ -49,14 +49,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Log.
         //! \tparam TArg The arg type.
-        //! \param log The object specializing Log.
+        //! \param log_ctx The object specializing Log.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto log(
-            T const & log,
+            T const & log_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -64,7 +64,7 @@ namespace alpaka
                 T,
                 TArg>
             ::log(
-                log,
+                log_ctx,
                 arg))
 #endif
         {
@@ -73,7 +73,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::log(
-                    log,
+                    log_ctx,
                     arg);
         }
 
@@ -97,19 +97,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto log(
-                    T const & log,
+                    T const & log_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::log(
-                        static_cast<typename T::LogBase const &>(log),
+                        static_cast<typename T::LogBase const &>(log_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::log(
-                            static_cast<typename T::LogBase const &>(log),
+                            static_cast<typename T::LogBase const &>(log_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/max/MaxCudaBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library max.
+        //! The CUDA built in max.
         class MaxCudaBuiltIn
         {
         public:
@@ -75,7 +75,7 @@ namespace alpaka
                 }
             };
             //#############################################################################
-            //! The standard library mixed integral floating point max trait specialization.
+            //! The CUDA mixed integral floating point max trait specialization.
             template<
                 typename Tx,
                 typename Ty>

--- a/include/alpaka/math/max/MaxCudaBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/max/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -65,12 +64,12 @@ namespace alpaka
                     && std::is_integral<Ty>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto max(
-                    MaxCudaBuiltIn const & /*max*/,
+                    MaxCudaBuiltIn const & max_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::max(x, y))
                 {
-                    //boost::ignore_unused(max);
+                    alpaka::ignore_unused(max_ctx);
                     return ::max(x, y);
                 }
             };
@@ -90,12 +89,12 @@ namespace alpaka
                         && std::is_integral<Ty>::value)>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto max(
-                    MaxCudaBuiltIn const & /*max*/,
+                    MaxCudaBuiltIn const & max_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::fmax(x, y))
                 {
-                    //boost::ignore_unused(max);
+                    alpaka::ignore_unused(max_ctx);
                     return ::fmax(x, y);
                 }
             };

--- a/include/alpaka/math/max/Traits.hpp
+++ b/include/alpaka/math/max/Traits.hpp
@@ -52,7 +52,7 @@ namespace alpaka
         //! \tparam T The type of the object specializing Max.
         //! \tparam Tx The type of the first argument.
         //! \tparam Ty The type of the second argument.
-        //! \param max The object specializing Max.
+        //! \param max_ctx The object specializing Max.
         //! \param x The first argument.
         //! \param y The second argument.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -61,7 +61,7 @@ namespace alpaka
             typename Tx,
             typename Ty>
         ALPAKA_FN_HOST_ACC auto max(
-            T const & max,
+            T const & max_ctx,
             Tx const & x,
             Ty const & y)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
@@ -71,7 +71,7 @@ namespace alpaka
                 Tx,
                 Ty>
             ::max(
-                max,
+                max_ctx,
                 x,
                 y))
 #endif
@@ -82,7 +82,7 @@ namespace alpaka
                     Tx,
                     Ty>
                 ::max(
-                    max,
+                    max_ctx,
                     x,
                     y);
         }
@@ -109,13 +109,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto max(
-                    T const & max,
+                    T const & max_ctx,
                     Tx const & x,
                     Ty const & y)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::max(
-                        static_cast<typename T::MaxBase const &>(max),
+                        static_cast<typename T::MaxBase const &>(max_ctx),
                         x,
                         y))
 #endif
@@ -123,7 +123,7 @@ namespace alpaka
                     // Delegate the call to the base class.
                     return
                         math::max(
-                            static_cast<typename T::MaxBase const &>(max),
+                            static_cast<typename T::MaxBase const &>(max_ctx),
                             x,
                             y);
                 }

--- a/include/alpaka/math/min/MinCudaBuiltIn.hpp
+++ b/include/alpaka/math/min/MinCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/min/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -65,12 +64,12 @@ namespace alpaka
                     && std::is_integral<Ty>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto min(
-                    MinCudaBuiltIn const & /*min*/,
+                    MinCudaBuiltIn const & min_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::min(x, y))
                 {
-                    //boost::ignore_unused(min);
+                    alpaka::ignore_unused(min_ctx);
                     return ::min(x, y);
                 }
             };
@@ -90,12 +89,12 @@ namespace alpaka
                         && std::is_integral<Ty>::value)>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto min(
-                    MinCudaBuiltIn const & /*min*/,
+                    MinCudaBuiltIn const & min_ctx,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::fmin(x, y))
                 {
-                    //boost::ignore_unused(min);
+                    alpaka::ignore_unused(min_ctx);
                     return ::fmin(x, y);
                 }
             };

--- a/include/alpaka/math/min/MinCudaBuiltIn.hpp
+++ b/include/alpaka/math/min/MinCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library min.
+        //! The CUDA built in min.
         class MinCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library integral min trait specialization.
+            //! The CUDA integral min trait specialization.
             template<
                 typename Tx,
                 typename Ty>

--- a/include/alpaka/math/min/Traits.hpp
+++ b/include/alpaka/math/min/Traits.hpp
@@ -52,7 +52,7 @@ namespace alpaka
         //! \tparam T The type of the object specializing Min.
         //! \tparam Tx The type of the first argument.
         //! \tparam Ty The type of the second argument.
-        //! \param min The object specializing Min.
+        //! \param min_ctx The object specializing Min.
         //! \param x The first argument.
         //! \param y The second argument.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -61,7 +61,7 @@ namespace alpaka
             typename Tx,
             typename Ty>
         ALPAKA_FN_HOST_ACC auto min(
-            T const & min,
+            T const & min_ctx,
             Tx const & x,
             Ty const & y)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
@@ -71,7 +71,7 @@ namespace alpaka
                 Tx,
                 Ty>
             ::min(
-                min,
+                min_ctx,
                 x,
                 y))
 #endif
@@ -82,7 +82,7 @@ namespace alpaka
                     Tx,
                     Ty>
                 ::min(
-                    min,
+                    min_ctx,
                     x,
                     y);
         }
@@ -109,13 +109,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto min(
-                    T const & min,
+                    T const & min_ctx,
                     Tx const & x,
                     Ty const & y)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::min(
-                        static_cast<typename T::MinBase const &>(min),
+                        static_cast<typename T::MinBase const &>(min_ctx),
                         x,
                         y))
 #endif
@@ -123,7 +123,7 @@ namespace alpaka
                     // Delegate the call to the base class.
                     return
                         math::min(
-                            static_cast<typename T::MinBase const &>(min),
+                            static_cast<typename T::MinBase const &>(min_ctx),
                             x,
                             y);
                 }

--- a/include/alpaka/math/pow/PowCudaBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/pow/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -65,12 +64,12 @@ namespace alpaka
                     && std::is_floating_point<TExp>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto pow(
-                    PowCudaBuiltIn const & /*pow*/,
+                    PowCudaBuiltIn const & pow_ctx,
                     TBase const & base,
                     TExp const & exp)
                 -> decltype(::pow(base, exp))
                 {
-                    //boost::ignore_unused(pow);
+                    alpaka::ignore_unused(pow_ctx);
                     return ::pow(base, exp);
                 }
             };

--- a/include/alpaka/math/pow/PowCudaBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowCudaBuiltIn.hpp
@@ -74,6 +74,23 @@ namespace alpaka
                     return ::pow(base, exp);
                 }
             };
+
+            template<>
+            struct Pow<
+                PowCudaBuiltIn,
+                float,
+                float>
+            {
+                __device__ static auto pow(
+                    PowCudaBuiltIn const & pow_ctx,
+                    float const & base,
+                    float const & exp)
+                -> float
+                {
+                    alpaka::ignore_unused(pow_ctx);
+                    return ::powf(base, exp);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/pow/PowCudaBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library pow.
+        //! The CUDA built in pow.
         class PowCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library pow trait specialization.
+            //! The CUDA pow trait specialization.
             template<
                 typename TBase,
                 typename TExp>
@@ -74,7 +74,7 @@ namespace alpaka
                     return ::pow(base, exp);
                 }
             };
-
+            //! The CUDA pow float specialization.
             template<>
             struct Pow<
                 PowCudaBuiltIn,

--- a/include/alpaka/math/pow/Traits.hpp
+++ b/include/alpaka/math/pow/Traits.hpp
@@ -51,7 +51,7 @@ namespace alpaka
         //! \tparam T The type of the object specializing Pow.
         //! \tparam TBase The base type.
         //! \tparam TExp The exponent type.
-        //! \param pow The object specializing Pow.
+        //! \param pow_ctx The object specializing Pow.
         //! \param base The base.
         //! \param exp The exponent.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -60,7 +60,7 @@ namespace alpaka
             typename TBase,
             typename TExp>
         ALPAKA_FN_HOST_ACC auto pow(
-            T const & pow,
+            T const & pow_ctx,
             TBase const & base,
             TExp const & exp)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
@@ -70,7 +70,7 @@ namespace alpaka
                 TBase,
                 TExp>
             ::pow(
-                pow,
+                pow_ctx,
                 base,
                 exp))
 #endif
@@ -81,7 +81,7 @@ namespace alpaka
                     TBase,
                     TExp>
                 ::pow(
-                    pow,
+                    pow_ctx,
                     base,
                     exp);
         }
@@ -108,13 +108,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto pow(
-                    T const & pow,
+                    T const & pow_ctx,
                     TBase const & base,
                     TExp const & exp)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::pow(
-                        static_cast<typename T::PowBase const &>(pow),
+                        static_cast<typename T::PowBase const &>(pow_ctx),
                         base,
                         exp))
 #endif
@@ -122,7 +122,7 @@ namespace alpaka
                     // Delegate the call to the base class.
                     return
                         math::pow(
-                            static_cast<typename T::PowBase const &>(pow),
+                            static_cast<typename T::PowBase const &>(pow_ctx),
                             base,
                             exp);
                 }

--- a/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/remainder/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto remainder(
-                    RemainderCudaBuiltIn const & /*remainder*/,
+                    RemainderCudaBuiltIn const & remainder_ctx,
                     TArg const & arg)
                 -> decltype(::remainder(arg))
                 {
-                    //boost::ignore_unused(remainder);
+                    alpaka::ignore_unused(remainder_ctx);
                     return ::remainder(arg);
                 }
             };

--- a/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
@@ -70,6 +70,25 @@ namespace alpaka
                     return ::remainder(arg);
                 }
             };
+
+            template<>
+            struct Remainder<
+                RemainderCudaBuiltIn,
+                float,
+                float>
+            {
+                __device__ static auto remainder(
+                    RemainderCudaBuiltIn const & remainder_ctx,
+                    float const & x,
+                    float const & y)
+                -> float
+                {
+                    alpaka::ignore_unused(remainder_ctx);
+                    return ::remainderf(
+                        x,
+                        y);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library remainder.
+        //! The CUDA built in remainder.
         class RemainderCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library remainder trait specialization.
+            //! The CUDA remainder trait specialization.
             template<
                 typename TArg>
             struct Remainder<
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::remainder(arg);
                 }
             };
-
+            //! The CUDA remainder float specialization.
             template<>
             struct Remainder<
                 RemainderCudaBuiltIn,

--- a/include/alpaka/math/remainder/Traits.hpp
+++ b/include/alpaka/math/remainder/Traits.hpp
@@ -51,7 +51,7 @@ namespace alpaka
         //! \tparam T The type of the object specializing Remainder.
         //! \tparam Tx The type of the first argument.
         //! \tparam Ty The type of the second argument.
-        //! \param remainder The object specializing Max.
+        //! \param remainder_ctx The object specializing Max.
         //! \param x The first argument.
         //! \param y The second argument.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -60,7 +60,7 @@ namespace alpaka
             typename Tx,
             typename Ty>
         ALPAKA_FN_HOST_ACC auto remainder(
-            T const & remainder,
+            T const & remainder_ctx,
             Tx const & x,
             Ty const & y)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
@@ -70,7 +70,7 @@ namespace alpaka
                 Tx,
                 Ty>
             ::remainder(
-                remainder,
+                remainder_ctx,
                 x,
                 y))
 #endif
@@ -81,7 +81,7 @@ namespace alpaka
                     Tx,
                     Ty>
                 ::remainder(
-                    remainder,
+                    remainder_ctx,
                     x,
                     y);
         }
@@ -108,13 +108,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto remainder(
-                    T const & remainder,
+                    T const & remainder_ctx,
                     Tx const & x,
                     Ty const & y)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::remainder(
-                        static_cast<typename T::RemainderBase const &>(remainder),
+                        static_cast<typename T::RemainderBase const &>(remainder_ctx),
                         x,
                         y))
 #endif
@@ -122,7 +122,7 @@ namespace alpaka
                     // Delegate the call to the base class.
                     return
                         math::remainder(
-                            static_cast<typename T::RemainderBase const &>(remainder),
+                            static_cast<typename T::RemainderBase const &>(remainder_ctx),
                             x,
                             y);
                 }

--- a/include/alpaka/math/round/RoundCudaBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/round/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto round(
-                    RoundCudaBuiltIn const & /*round*/,
+                    RoundCudaBuiltIn const & round_ctx,
                     TArg const & arg)
                 -> decltype(::round(arg))
                 {
-                    //boost::ignore_unused(round);
+                    alpaka::ignore_unused(round_ctx);
                     return ::round(arg);
                 }
             };
@@ -81,11 +80,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto lround(
-                    RoundCudaBuiltIn const & /*lround*/,
+                    RoundCudaBuiltIn const & lround_ctx,
                     TArg const & arg)
                 -> long int
                 {
-                    //boost::ignore_unused(lround);
+                    alpaka::ignore_unused(lround_ctx);
                     return ::lround(arg);
                 }
             };
@@ -100,11 +99,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto llround(
-                    RoundCudaBuiltIn const & /*llround*/,
+                    RoundCudaBuiltIn const & llround_ctx,
                     TArg const & arg)
                 -> long int
                 {
-                    //boost::ignore_unused(llround);
+                    alpaka::ignore_unused(llround_ctx);
                     return ::llround(arg);
                 }
             };

--- a/include/alpaka/math/round/RoundCudaBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundCudaBuiltIn.hpp
@@ -111,11 +111,11 @@ namespace alpaka
             //! The CUDA round float specialization.
             template<>
             struct Round<
-                RoundHipBuiltIn,
+                RoundCudaBuiltIn,
                 float>
             {
                 __device__ static auto round(
-                    RoundHipBuiltIn const & round_ctx,
+                    RoundCudaBuiltIn const & round_ctx,
                     float const & arg)
                 -> float
                 {

--- a/include/alpaka/math/round/RoundCudaBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library round.
+        //! The CUDA round.
         class RoundCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library round trait specialization.
+            //! The CUDA round trait specialization.
             template<
                 typename TArg>
             struct Round<
@@ -71,7 +71,7 @@ namespace alpaka
                 }
             };
             //#############################################################################
-            //! The standard library round trait specialization.
+            //! The CUDA lround trait specialization.
             template<
                 typename TArg>
             struct Lround<
@@ -90,7 +90,7 @@ namespace alpaka
                 }
             };
             //#############################################################################
-            //! The standard library round trait specialization.
+            //! The CUDA llround trait specialization.
             template<
                 typename TArg>
             struct Llround<
@@ -108,7 +108,7 @@ namespace alpaka
                     return ::llround(arg);
                 }
             };
-
+            //! The CUDA round float specialization.
             template<>
             struct Round<
                 RoundHipBuiltIn,

--- a/include/alpaka/math/round/RoundCudaBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundCudaBuiltIn.hpp
@@ -108,6 +108,21 @@ namespace alpaka
                     return ::llround(arg);
                 }
             };
+
+            template<>
+            struct Round<
+                RoundHipBuiltIn,
+                float>
+            {
+                __device__ static auto round(
+                    RoundHipBuiltIn const & round_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(round_ctx);
+                    return ::roundf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/round/Traits.hpp
+++ b/include/alpaka/math/round/Traits.hpp
@@ -24,6 +24,7 @@
 #include <alpaka/meta/IsStrictBase.hpp>
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <boost/config.hpp>
 
@@ -65,14 +66,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Round.
         //! \tparam TArg The arg type.
-        //! \param round The object specializing Round.
+        //! \param round_ctx The object specializing Round.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto round(
-            T const & round,
+            T const & round_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -80,7 +81,7 @@ namespace alpaka
                 T,
                 TArg>
             ::round(
-                round,
+                round_ctx,
                 arg))
 #endif
         {
@@ -89,7 +90,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::round(
-                    round,
+                    round_ctx,
                     arg);
         }
         //-----------------------------------------------------------------------------
@@ -97,14 +98,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Round.
         //! \tparam TArg The arg type.
-        //! \param lround The object specializing Round.
+        //! \param lround_ctx The object specializing Round.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto lround(
-            T const & lround,
+            T const & lround_ctx,
             TArg const & arg)
         -> long int
         {
@@ -113,7 +114,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::lround(
-                    lround,
+                    lround_ctx,
                     arg);
         }
         //-----------------------------------------------------------------------------
@@ -121,14 +122,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Round.
         //! \tparam TArg The arg type.
-        //! \param llround The object specializing Round.
+        //! \param llround_ctx The object specializing Round.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto llround(
-            T const & llround,
+            T const & llround_ctx,
             TArg const & arg)
         -> long long int
         {
@@ -137,7 +138,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::llround(
-                    llround,
+                    llround_ctx,
                     arg);
         }
 
@@ -161,19 +162,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto round(
-                    T const & round,
+                    T const & round_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::round(
-                        static_cast<typename T::RoundBase const &>(round),
+                        static_cast<typename T::RoundBase const &>(round_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::round(
-                            static_cast<typename T::RoundBase const &>(round),
+                            static_cast<typename T::RoundBase const &>(round_ctx),
                             arg);
                 }
             };
@@ -195,19 +196,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto lround(
-                    T const & lround,
+                    T const & lround_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::lround(
-                        static_cast<typename T::RoundBase const &>(lround),
+                        static_cast<typename T::RoundBase const &>(lround_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::lround(
-                            static_cast<typename T::RoundBase const &>(lround),
+                            static_cast<typename T::RoundBase const &>(lround_ctx),
                             arg);
                 }
             };
@@ -229,19 +230,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto llround(
-                    T const & llround,
+                    T const & llround_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::llround(
-                        static_cast<typename T::RoundBase const &>(llround),
+                        static_cast<typename T::RoundBase const &>(llround_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::llround(
-                            static_cast<typename T::RoundBase const &>(llround),
+                            static_cast<typename T::RoundBase const &>(llround_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/rsqrt/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto rsqrt(
-                    RsqrtCudaBuiltIn const & /*rsqrt*/,
+                    RsqrtCudaBuiltIn const & rsqrt_ctx,
                     TArg const & arg)
                 -> decltype(::rsqrt(arg))
                 {
-                    //boost::ignore_unused(rsqrt);
+                    alpaka::ignore_unused(rsqrt_ctx);
                     return ::rsqrt(arg);
                 }
             };

--- a/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
@@ -70,6 +70,21 @@ namespace alpaka
                     return ::rsqrt(arg);
                 }
             };
+
+            template<>
+            struct Rsqrt<
+                RsqrtCudaBuiltIn,
+                float>
+            {
+                __device__ static auto rsqrt(
+                    RsqrtCudaBuiltIn const & rsqrt_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(rsqrt_ctx);
+                    return ::rsqrtf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library rsqrt.
+        //! The CUDA rsqrt.
         class RsqrtCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library rsqrt trait specialization.
+            //! The CUDA rsqrt trait specialization.
             template<
                 typename TArg>
             struct Rsqrt<
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::rsqrt(arg);
                 }
             };
-
+            //! The CUDA rsqrt float specialization.
             template<>
             struct Rsqrt<
                 RsqrtCudaBuiltIn,

--- a/include/alpaka/math/rsqrt/Traits.hpp
+++ b/include/alpaka/math/rsqrt/Traits.hpp
@@ -49,14 +49,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Rsqrt.
         //! \tparam TArg The arg type.
-        //! \param rsqrt The object specializing Rsqrt.
+        //! \param rsqrt_ctx The object specializing Rsqrt.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto rsqrt(
-            T const & rsqrt,
+            T const & rsqrt_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -64,7 +64,7 @@ namespace alpaka
                 T,
                 TArg>
             ::rsqrt(
-                rsqrt,
+                rsqrt_ctx,
                 arg))
 #endif
         {
@@ -73,7 +73,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::rsqrt(
-                    rsqrt,
+                    rsqrt_ctx,
                     arg);
         }
 
@@ -97,19 +97,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto rsqrt(
-                    T const & rsqrt,
+                    T const & rsqrt_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::rsqrt(
-                        static_cast<typename T::RsqrtBase const &>(rsqrt),
+                        static_cast<typename T::RsqrtBase const &>(rsqrt_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::rsqrt(
-                            static_cast<typename T::RsqrtBase const &>(rsqrt),
+                            static_cast<typename T::RsqrtBase const &>(rsqrt_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/sin/SinCudaBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library sin.
+        //! The CUDA sin.
         class SinCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library sin trait specialization.
+            //! The CUDA sin trait specialization.
             template<
                 typename TArg>
             struct Sin<
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::sin(arg);
                 }
             };
-
+            //! The CUDA sin float specialization.
             template<>
             struct Sin<
                 SinCudaBuiltIn,

--- a/include/alpaka/math/sin/SinCudaBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinCudaBuiltIn.hpp
@@ -70,6 +70,21 @@ namespace alpaka
                     return ::sin(arg);
                 }
             };
+
+            template<>
+            struct Sin<
+                SinCudaBuiltIn,
+                float>
+            {
+                __device__ static auto sin(
+                    SinCudaBuiltIn const & sin_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(sin_ctx);
+                    return ::sinf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/sin/SinCudaBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/sin/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto sin(
-                    SinCudaBuiltIn const & /*sin*/,
+                    SinCudaBuiltIn const & sin_ctx,
                     TArg const & arg)
                 -> decltype(::sin(arg))
                 {
-                    //boost::ignore_unused(sin);
+                    alpaka::ignore_unused(sin_ctx);
                     return ::sin(arg);
                 }
             };

--- a/include/alpaka/math/sin/Traits.hpp
+++ b/include/alpaka/math/sin/Traits.hpp
@@ -49,14 +49,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Sin.
         //! \tparam TArg The arg type.
-        //! \param sin The object specializing Sin.
+        //! \param sin_ctx The object specializing Sin.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto sin(
-            T const & sin,
+            T const & sin_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -64,7 +64,7 @@ namespace alpaka
                 T,
                 TArg>
             ::sin(
-                sin,
+                sin_ctx,
                 arg))
 #endif
         {
@@ -73,7 +73,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::sin(
-                    sin,
+                    sin_ctx,
                     arg);
         }
 
@@ -97,19 +97,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto sin(
-                    T const & sin,
+                    T const & sin_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::sin(
-                        static_cast<typename T::SinBase const &>(sin),
+                        static_cast<typename T::SinBase const &>(sin_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::sin(
-                            static_cast<typename T::SinBase const &>(sin),
+                            static_cast<typename T::SinBase const &>(sin_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/sqrt/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto sqrt(
-                    SqrtCudaBuiltIn const & /*sqrt*/,
+                    SqrtCudaBuiltIn const & sqrt_ctx,
                     TArg const & arg)
                 -> decltype(::sqrt(arg))
                 {
-                    //boost::ignore_unused(sqrt);
+                    alpaka::ignore_unused(sqrt_ctx);
                     return ::sqrt(arg);
                 }
             };

--- a/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
@@ -70,6 +70,22 @@ namespace alpaka
                     return ::sqrt(arg);
                 }
             };
+
+            template<>
+            struct Sqrt<
+                SqrtCudaBuiltIn,
+                float>
+            {
+                __device__ static auto sqrt(
+                    SqrtCudaBuiltIn const & sqrt_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(sqrt_ctx);
+                    return ::sqrtf(arg);
+                }
+            };
+
         }
     }
 }

--- a/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library sqrt.
+        //! The CUDA sqrt.
         class SqrtCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library sqrt trait specialization.
+            //! The CUDA sqrt trait specialization.
             template<
                 typename TArg>
             struct Sqrt<
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::sqrt(arg);
                 }
             };
-
+            //! The CUDA sqrt float specialization.
             template<>
             struct Sqrt<
                 SqrtCudaBuiltIn,

--- a/include/alpaka/math/sqrt/Traits.hpp
+++ b/include/alpaka/math/sqrt/Traits.hpp
@@ -49,14 +49,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Sqrt.
         //! \tparam TArg The arg type.
-        //! \param sqrt The object specializing Sqrt.
+        //! \param sqrt_ctx The object specializing Sqrt.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto sqrt(
-            T const & sqrt,
+            T const & sqrt_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -64,7 +64,7 @@ namespace alpaka
                 T,
                 TArg>
             ::sqrt(
-                sqrt,
+                sqrt_ctx,
                 arg))
 #endif
         {
@@ -73,7 +73,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::sqrt(
-                    sqrt,
+                    sqrt_ctx,
                     arg);
         }
 
@@ -97,19 +97,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto sqrt(
-                    T const & sqrt,
+                    T const & sqrt_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::sqrt(
-                        static_cast<typename T::SqrtBase const &>(sqrt),
+                        static_cast<typename T::SqrtBase const &>(sqrt_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::sqrt(
-                            static_cast<typename T::SqrtBase const &>(sqrt),
+                            static_cast<typename T::SqrtBase const &>(sqrt_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/tan/TanCudaBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/tan/Traits.hpp>
-
-//#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto tan(
-                    TanCudaBuiltIn const & /*tan*/,
+                    TanCudaBuiltIn const & tan_ctx,
                     TArg const & arg)
                 -> decltype(::tan(arg))
                 {
-                    //boost::ignore_unused(tan);
+                    alpaka::ignore_unused(tan_ctx);
                     return ::tan(arg);
                 }
             };

--- a/include/alpaka/math/tan/TanCudaBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library tan.
+        //! The CUDA tan.
         class TanCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library tan trait specialization.
+            //! The CUDA tan trait specialization.
             template<
                 typename TArg>
             struct Tan<
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::tan(arg);
                 }
             };
-
+            //! The CUDA tan float specialization.
             template<>
             struct Tan<
                 TanCudaBuiltIn,

--- a/include/alpaka/math/tan/TanCudaBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanCudaBuiltIn.hpp
@@ -67,6 +67,21 @@ namespace alpaka
                 -> decltype(::tan(arg))
                 {
                     //boost::ignore_unused(tan);
+                    return ::tan(arg);
+                }
+            };
+
+            template<>
+            struct Tan<
+                TanCudaBuiltIn,
+                float>
+            {
+                __device__ static auto tan(
+                    TanCudaBuiltIn const & tan_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(tan_ctx);
                     return ::tanf(arg);
                 }
             };

--- a/include/alpaka/math/tan/Traits.hpp
+++ b/include/alpaka/math/tan/Traits.hpp
@@ -49,14 +49,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Tan.
         //! \tparam TArg The arg type.
-        //! \param tan The object specializing Tan.
+        //! \param tan_ctx The object specializing Tan.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto tan(
-            T const & tan,
+            T const & tan_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -64,7 +64,7 @@ namespace alpaka
                 T,
                 TArg>
             ::tan(
-                tan,
+                tan_ctx,
                 arg))
 #endif
         {
@@ -73,7 +73,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::tan(
-                    tan,
+                    tan_ctx,
                     arg);
         }
 
@@ -98,19 +98,19 @@ namespace alpaka
                 //
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto tan(
-                    T const & tan,
+                    T const & tan_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::tan(
-                        static_cast<typename T::TanBase const &>(tan),
+                        static_cast<typename T::TanBase const &>(tan_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::tan(
-                            static_cast<typename T::TanBase const &>(tan),
+                            static_cast<typename T::TanBase const &>(tan_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/trunc/Traits.hpp
+++ b/include/alpaka/math/trunc/Traits.hpp
@@ -49,14 +49,14 @@ namespace alpaka
         //!
         //! \tparam T The type of the object specializing Trunc.
         //! \tparam TArg The arg type.
-        //! \param trunc The object specializing Trunc.
+        //! \param trunc_ctx The object specializing Trunc.
         //! \param arg The arg.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename T,
             typename TArg>
         ALPAKA_FN_HOST_ACC auto trunc(
-            T const & trunc,
+            T const & trunc_ctx,
             TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
@@ -64,7 +64,7 @@ namespace alpaka
                 T,
                 TArg>
             ::trunc(
-                trunc,
+                trunc_ctx,
                 arg))
 #endif
         {
@@ -73,7 +73,7 @@ namespace alpaka
                     T,
                     TArg>
                 ::trunc(
-                    trunc,
+                    trunc_ctx,
                     arg);
         }
 
@@ -97,19 +97,19 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto trunc(
-                    T const & trunc,
+                    T const & trunc_ctx,
                     TArg const & arg)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::trunc(
-                        static_cast<typename T::TruncBase const &>(trunc),
+                        static_cast<typename T::TruncBase const &>(trunc_ctx),
                         arg))
 #endif
                 {
                     // Delegate the call to the base class.
                     return
                         math::trunc(
-                            static_cast<typename T::TruncBase const &>(trunc),
+                            static_cast<typename T::TruncBase const &>(trunc_ctx),
                             arg);
                 }
             };

--- a/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     namespace math
     {
         //#############################################################################
-        //! The standard library trunc.
+        //! The CUDA trunc.
         class TruncCudaBuiltIn
         {
         public:
@@ -52,7 +52,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The standard library trunc trait specialization.
+            //! The CUDA trunc trait specialization.
             template<
                 typename TArg>
             struct Trunc<
@@ -70,7 +70,7 @@ namespace alpaka
                     return ::trunc(arg);
                 }
             };
-
+            //! The CUDA trunc float specialization.
             template<>
             struct Trunc<
                 TruncCudaBuiltIn,

--- a/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
@@ -70,6 +70,21 @@ namespace alpaka
                     return ::trunc(arg);
                 }
             };
+
+            template<>
+            struct Trunc<
+                TruncCudaBuiltIn,
+                float>
+            {
+                __device__ static auto trunc(
+                    TruncCudaBuiltIn const & trunc_ctx,
+                    float const & arg)
+                -> float
+                {
+                    alpaka::ignore_unused(trunc_ctx);
+                    return ::truncf(arg);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/trunc/Traits.hpp>
-
-#include <boost/core/ignore_unused.hpp>
 
 #include <cuda_runtime.h>
 #include <type_traits>
@@ -62,11 +61,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto trunc(
-                    TruncCudaBuiltIn const & /*trunc*/,
+                    TruncCudaBuiltIn const & trunc_ctx,
                     TArg const & arg)
                 -> decltype(::trunc(arg))
                 {
-                    //boost::ignore_unused(trunc);
+                    alpaka::ignore_unused(trunc_ctx);
                     return ::trunc(arg);
                 }
             };


### PR DESCRIPTION
Backport last missing PR's

- fix: cuda exceptions #844
- math/abs: Added trait specialisation for double. #862
- alpaka/math Overloaded float specialization #837
- Fixes name conflicts in alpaka math functions. #784


# manual tests

- [x] use these changes together with PIConGPU 0.4.3