### PR TITLE
Use C++14 helper types for traits

### DIFF
--- a/doc/markdown/user/implementation/library/Details.md
+++ b/doc/markdown/user/implementation/library/Details.md
@@ -216,10 +216,10 @@ namespace queue
 	struct Enqueue<
 		TQueue
 		TTask,
-		typename std::enable_if<
+		std::enable_if_t<
 			std::is_base_of<UserQueue, TQueue>::value
 			&& (TTask::TaskId == 1u)
-		>::type>
+		>>
 	{
 		ALPAKA_FN_HOST static auto enqueue(
 			TQueue & queue,

--- a/include/alpaka/acc/Traits.hpp
+++ b/include/alpaka/acc/Traits.hpp
@@ -112,9 +112,9 @@ namespace alpaka
             struct QueueType<
                 TAcc,
                 TProperty,
-                typename std::enable_if<
+                std::enable_if_t<
                     concepts::ImplementsConcept<acc::ConceptAcc, TAcc>::value
-                >::type
+                >
             >
             {
                 using type = typename QueueType<

--- a/include/alpaka/core/Align.hpp
+++ b/include/alpaka/core/Align.hpp
@@ -100,8 +100,8 @@ namespace alpaka
             ((__VA_ARGS__)<=64?64:128\
             )))))))
     #define ALPAKA_OPTIMAL_ALIGNMENT(...)\
-            ALPAKA_OPTIMAL_ALIGNMENT_SIZE(sizeof(typename std::remove_cv<__VA_ARGS__>::type))
+            ALPAKA_OPTIMAL_ALIGNMENT_SIZE(sizeof(std::remove_cv_t<__VA_ARGS__>))
 #else
     #define ALPAKA_OPTIMAL_ALIGNMENT(...)\
-            ::alpaka::core::align::OptimalAlignment<sizeof(typename std::remove_cv<__VA_ARGS__>::type)>::value
+            ::alpaka::core::align::OptimalAlignment<sizeof(std::remove_cv_t<__VA_ARGS__>)>::value
 #endif

--- a/include/alpaka/core/Assert.hpp
+++ b/include/alpaka/core/Assert.hpp
@@ -66,7 +66,7 @@ namespace alpaka
                 typename TArg>
             struct AssertValueUnsigned<
                 TArg,
-                typename std::enable_if<!std::is_unsigned<TArg>::value>::type>
+                std::enable_if_t<!std::is_unsigned<TArg>::value>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto assertValueUnsigned(
@@ -85,7 +85,7 @@ namespace alpaka
                 typename TArg>
             struct AssertValueUnsigned<
                 TArg,
-                typename std::enable_if<std::is_unsigned<TArg>::value>::type>
+                std::enable_if_t<std::is_unsigned<TArg>::value>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto assertValueUnsigned(
@@ -128,7 +128,7 @@ namespace alpaka
             struct AssertGreaterThan<
                 TLhs,
                 TRhs,
-                typename std::enable_if<!std::is_unsigned<TRhs>::value || (TLhs::value != 0u)>::type>
+                std::enable_if_t<!std::is_unsigned<TRhs>::value || (TLhs::value != 0u)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto assertGreaterThan(
@@ -149,7 +149,7 @@ namespace alpaka
             struct AssertGreaterThan<
                 TLhs,
                 TRhs,
-                typename std::enable_if<std::is_unsigned<TRhs>::value && (TLhs::value == 0u)>::type>
+                std::enable_if_t<std::is_unsigned<TRhs>::value && (TLhs::value == 0u)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto assertGreaterThan(

--- a/include/alpaka/core/Concepts.hpp
+++ b/include/alpaka/core/Concepts.hpp
@@ -57,7 +57,7 @@ namespace alpaka
             struct ImplementationBaseType<
                 TConcept,
                 TDerived,
-                typename std::enable_if<!ImplementsConcept<TConcept, TDerived>::value>::type>
+                std::enable_if_t<!ImplementsConcept<TConcept, TDerived>::value>>
             {
                 using type = TDerived;
             };
@@ -70,7 +70,7 @@ namespace alpaka
             struct ImplementationBaseType<
                 TConcept,
                 TDerived,
-                typename std::enable_if<ImplementsConcept<TConcept, TDerived>::value>::type>
+                std::enable_if_t<ImplementsConcept<TConcept, TDerived>::value>>
             {
                 template<
                     typename TBase>

--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -28,6 +28,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <type_traits>
 
 namespace alpaka
 {
@@ -189,7 +190,7 @@ namespace alpaka
             private:
                 // NOTE: To avoid invalid memory accesses to memory of a different thread
                 // `std::remove_reference` enforces the function object to be copied.
-                typename std::remove_reference<TFnObj>::type m_FnObj;
+                std::remove_reference_t<TFnObj> m_FnObj;
             };
 
             //#############################################################################
@@ -239,14 +240,14 @@ namespace alpaka
             private:
                 // NOTE: To avoid invalid memory accesses to memory of a different thread
                 // `std::remove_reference` enforces the function object to be copied.
-                typename std::remove_reference<TFnObj>::type m_FnObj;
+                std::remove_reference_t<TFnObj> m_FnObj;
             };
 
             //-----------------------------------------------------------------------------
             template<
                 typename TFnObj0,
                 typename TFnObj1,
-                typename = typename std::enable_if<!std::is_same<void, decltype(std::declval<TFnObj0>()())>::value>::type>
+                typename = std::enable_if_t<!std::is_same<void, decltype(std::declval<TFnObj0>()())>::value>>
             auto invokeBothReturnFirst(
                     TFnObj0 && fn0,
                     TFnObj1 && fn1)
@@ -260,7 +261,7 @@ namespace alpaka
             template<
                 typename TFnObj0,
                 typename TFnObj1,
-                typename = typename std::enable_if<std::is_same<void, decltype(std::declval<TFnObj0>()())>::value>::type>
+                typename = std::enable_if_t<std::is_same<void, decltype(std::declval<TFnObj0>()())>::value>>
             auto invokeBothReturnFirst(
                     TFnObj0 && fn0,
                     TFnObj1 && fn1)

--- a/include/alpaka/core/Cuda.hpp
+++ b/include/alpaka/core/Cuda.hpp
@@ -82,14 +82,14 @@ namespace alpaka
             // NOTE: All ignored errors have to be convertible to cudaError_t.
             template<
                 typename... TErrors/*,
-                typename = typename std::enable_if<
+                typename = std::enable_if_t<
                     meta::Conjunction<
                         std::true_type,
                         std::is_convertible<
                             TErrors,
                             cudaError_t
                         >...
-                    >::value>::type*/>
+                    >::value> */>
             ALPAKA_FN_HOST auto cudaRtCheckIgnore(
                 cudaError_t const & error,
                 char const * cmd,
@@ -292,7 +292,7 @@ namespace alpaka
                 typename T>
             struct DimType<
                 T,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_same<T, char1>::value
                     || std::is_same<T, double1>::value
                     || std::is_same<T, float1>::value
@@ -305,7 +305,7 @@ namespace alpaka
                     || std::is_same<T, ulong1>::value
                     || std::is_same<T, ulonglong1>::value
                     || std::is_same<T, ushort1>::value
-                >::type>
+                >>
             {
                 using type = dim::DimInt<1u>;
             };
@@ -315,7 +315,7 @@ namespace alpaka
                 typename T>
             struct DimType<
                 T,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_same<T, char2>::value
                     || std::is_same<T, double2>::value
                     || std::is_same<T, float2>::value
@@ -328,7 +328,7 @@ namespace alpaka
                     || std::is_same<T, ulong2>::value
                     || std::is_same<T, ulonglong2>::value
                     || std::is_same<T, ushort2>::value
-                >::type>
+                >>
             {
                 using type = dim::DimInt<2u>;
             };
@@ -338,7 +338,7 @@ namespace alpaka
                 typename T>
             struct DimType<
                 T,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_same<T, char3>::value
                     || std::is_same<T, dim3>::value
                     || std::is_same<T, double3>::value
@@ -358,7 +358,7 @@ namespace alpaka
                     || std::is_same<T, __cuda_builtin_blockDim_t>::value
                     || std::is_same<T, __cuda_builtin_gridDim_t>::value
 #endif
-                >::type>
+                >>
             {
                 using type = dim::DimInt<3u>;
             };
@@ -368,7 +368,7 @@ namespace alpaka
                 typename T>
             struct DimType<
                 T,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_same<T, char4>::value
                     || std::is_same<T, double4>::value
                     || std::is_same<T, float4>::value
@@ -381,7 +381,7 @@ namespace alpaka
                     || std::is_same<T, ulong4>::value
                     || std::is_same<T, ulonglong4>::value
                     || std::is_same<T, ushort4>::value
-                >::type>
+                >>
             {
                 using type = dim::DimInt<4u>;
             };
@@ -397,8 +397,8 @@ namespace alpaka
                 typename T>
             struct ElemType<
                 T,
-                typename std::enable_if<
-                    cuda::traits::IsCudaBuiltInType<T>::value>::type>
+                std::enable_if_t<
+                    cuda::traits::IsCudaBuiltInType<T>::value>>
             {
                 using type = decltype(std::declval<T>().x);
             };
@@ -415,9 +415,9 @@ namespace alpaka
             struct GetExtent<
                 dim::DimInt<dim::Dim<TExtent>::value - 1u>,
                 TExtent,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 1)>::type>
+                    && (dim::Dim<TExtent>::value >= 1)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getExtent(
@@ -433,9 +433,9 @@ namespace alpaka
             struct GetExtent<
                 dim::DimInt<dim::Dim<TExtent>::value - 2u>,
                 TExtent,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 2)>::type>
+                    && (dim::Dim<TExtent>::value >= 2)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getExtent(
@@ -451,9 +451,9 @@ namespace alpaka
             struct GetExtent<
                 dim::DimInt<dim::Dim<TExtent>::value - 3u>,
                 TExtent,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 3)>::type>
+                    && (dim::Dim<TExtent>::value >= 3)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getExtent(
@@ -469,9 +469,9 @@ namespace alpaka
             struct GetExtent<
                 dim::DimInt<dim::Dim<TExtent>::value - 4u>,
                 TExtent,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 4)>::type>
+                    && (dim::Dim<TExtent>::value >= 4)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getExtent(
@@ -489,9 +489,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TExtent>::value - 1u>,
                 TExtent,
                 TExtentVal,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 1)>::type>
+                    && (dim::Dim<TExtent>::value >= 1)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setExtent(
@@ -511,9 +511,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TExtent>::value - 2u>,
                 TExtent,
                 TExtentVal,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 2)>::type>
+                    && (dim::Dim<TExtent>::value >= 2)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setExtent(
@@ -533,9 +533,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TExtent>::value - 3u>,
                 TExtent,
                 TExtentVal,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 3)>::type>
+                    && (dim::Dim<TExtent>::value >= 3)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setExtent(
@@ -555,9 +555,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TExtent>::value - 4u>,
                 TExtent,
                 TExtentVal,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 4)>::type>
+                    && (dim::Dim<TExtent>::value >= 4)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setExtent(
@@ -581,9 +581,9 @@ namespace alpaka
             struct GetOffset<
                 dim::DimInt<dim::Dim<TOffsets>::value - 1u>,
                 TOffsets,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 1)>::type>
+                    && (dim::Dim<TOffsets>::value >= 1)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getOffset(
@@ -599,9 +599,9 @@ namespace alpaka
             struct GetOffset<
                 dim::DimInt<dim::Dim<TOffsets>::value - 2u>,
                 TOffsets,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 2)>::type>
+                    && (dim::Dim<TOffsets>::value >= 2)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getOffset(
@@ -617,9 +617,9 @@ namespace alpaka
             struct GetOffset<
                 dim::DimInt<dim::Dim<TOffsets>::value - 3u>,
                 TOffsets,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 3)>::type>
+                    && (dim::Dim<TOffsets>::value >= 3)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getOffset(
@@ -635,9 +635,9 @@ namespace alpaka
             struct GetOffset<
                 dim::DimInt<dim::Dim<TOffsets>::value - 4u>,
                 TOffsets,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 4)>::type>
+                    && (dim::Dim<TOffsets>::value >= 4)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getOffset(
@@ -655,9 +655,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TOffsets>::value - 1u>,
                 TOffsets,
                 TOffset,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 1)>::type>
+                    && (dim::Dim<TOffsets>::value >= 1)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setOffset(
@@ -677,9 +677,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TOffsets>::value - 2u>,
                 TOffsets,
                 TOffset,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 2)>::type>
+                    && (dim::Dim<TOffsets>::value >= 2)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setOffset(
@@ -699,9 +699,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TOffsets>::value - 3u>,
                 TOffsets,
                 TOffset,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 3)>::type>
+                    && (dim::Dim<TOffsets>::value >= 3)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setOffset(
@@ -721,9 +721,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TOffsets>::value - 4u>,
                 TOffsets,
                 TOffset,
-                typename std::enable_if<
+                std::enable_if_t<
                     cuda::traits::IsCudaBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 4)>::type>
+                    && (dim::Dim<TOffsets>::value >= 4)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setOffset(
@@ -746,8 +746,8 @@ namespace alpaka
                 typename TIdx>
             struct IdxType<
                 TIdx,
-                typename std::enable_if<
-                    cuda::traits::IsCudaBuiltInType<TIdx>::value>::type>
+                std::enable_if_t<
+                    cuda::traits::IsCudaBuiltInType<TIdx>::value>>
             {
                 using type = std::size_t;
             };

--- a/include/alpaka/core/Hip.hpp
+++ b/include/alpaka/core/Hip.hpp
@@ -69,14 +69,14 @@ namespace alpaka
             // NOTE: All ignored errors have to be convertible to hipError_t.
             template<
                 typename... TErrors/*,
-                typename = typename std::enable_if<
+                typename = std::enable_if_t<
                     meta::Conjunction<
                         std::true_type,
                         std::is_convertible<
                             TErrors,
                             hipError_t
                         >...
-                    >::value>::type*/>
+                    >::value>*/>
             ALPAKA_FN_HOST auto hipRtCheckIgnore(
                 hipError_t const & error,
                 char const * cmd,
@@ -219,7 +219,7 @@ namespace alpaka
                 typename T>
             struct DimType<
                 T,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_same<T, char1>::value
                     || std::is_same<T, double1>::value
                     || std::is_same<T, float1>::value
@@ -227,7 +227,7 @@ namespace alpaka
                     || std::is_same<T, long1>::value
                     || std::is_same<T, longlong1>::value
                     || std::is_same<T, short1>::value
-                >::type>
+                >>
             {
                 using type = dim::DimInt<1u>;
             };
@@ -235,13 +235,13 @@ namespace alpaka
                 typename T>
             struct DimType<
                 T,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_same<T, uchar1>::value
                     || std::is_same<T, uint1>::value
                     || std::is_same<T, ulong1>::value
                     || std::is_same<T, ulonglong1>::value
                     || std::is_same<T, ushort1>::value
-                >::type>
+                >>
             {
                 using type = dim::DimInt<1u>;
             };
@@ -251,7 +251,7 @@ namespace alpaka
                 typename T>
             struct DimType<
                 T,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_same<T, char2>::value
                     || std::is_same<T, double2>::value
                     || std::is_same<T, float2>::value
@@ -259,7 +259,7 @@ namespace alpaka
                     || std::is_same<T, long2>::value
                     || std::is_same<T, longlong2>::value
                     || std::is_same<T, short2>::value
-                >::type>
+                >>
             {
                 using type = dim::DimInt<2u>;
             };
@@ -267,13 +267,13 @@ namespace alpaka
                 typename T>
             struct DimType<
                 T,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_same<T, uchar2>::value
                     || std::is_same<T, uint2>::value
                     || std::is_same<T, ulong2>::value
                     || std::is_same<T, ulonglong2>::value
                     || std::is_same<T, ushort2>::value
-                >::type>
+                >>
             {
                 using type = dim::DimInt<2u>;
             };
@@ -283,7 +283,7 @@ namespace alpaka
                 typename T>
             struct DimType<
                 T,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_same<T, char3>::value
                     || std::is_same<T, dim3>::value
                     || std::is_same<T, double3>::value
@@ -292,7 +292,7 @@ namespace alpaka
                     || std::is_same<T, long3>::value
                     || std::is_same<T, longlong3>::value
                     || std::is_same<T, short3>::value
-                >::type>
+                >>
             {
                 using type = dim::DimInt<3u>;
             };
@@ -300,13 +300,13 @@ namespace alpaka
                 typename T>
             struct DimType<
                 T,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_same<T, uchar3>::value
                     || std::is_same<T, uint3>::value
                     || std::is_same<T, ulong3>::value
                     || std::is_same<T, ulonglong3>::value
                     || std::is_same<T, ushort3>::value
-                >::type>
+                >>
             {
                 using type = dim::DimInt<3u>;
             };
@@ -316,7 +316,7 @@ namespace alpaka
                 typename T>
             struct DimType<
                 T,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_same<T, char4>::value
                     || std::is_same<T, double4>::value
                     || std::is_same<T, float4>::value
@@ -324,7 +324,7 @@ namespace alpaka
                     || std::is_same<T, long4>::value
                     || std::is_same<T, longlong4>::value
                     || std::is_same<T, short4>::value
-                >::type>
+                >>
             {
                 using type = dim::DimInt<4u>;
             };
@@ -332,13 +332,13 @@ namespace alpaka
                 typename T>
             struct DimType<
                 T,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_same<T, uchar4>::value
                     || std::is_same<T, uint4>::value
                     || std::is_same<T, ulong4>::value
                     || std::is_same<T, ulonglong4>::value
                     || std::is_same<T, ushort4>::value
-                >::type>
+                >>
             {
                 using type = dim::DimInt<4u>;
             };
@@ -354,8 +354,8 @@ namespace alpaka
                 typename T>
             struct ElemType<
                 T,
-                typename std::enable_if<
-                    hip::traits::IsHipBuiltInType<T>::value>::type>
+                std::enable_if_t<
+                    hip::traits::IsHipBuiltInType<T>::value>>
             {
                 using type = decltype(std::declval<T>().x);
             };
@@ -372,9 +372,9 @@ namespace alpaka
             struct GetExtent<
                 dim::DimInt<dim::Dim<TExtent>::value - 1u>,
                 TExtent,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 1)>::type>
+                    && (dim::Dim<TExtent>::value >= 1)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getExtent(
@@ -390,9 +390,9 @@ namespace alpaka
             struct GetExtent<
                 dim::DimInt<dim::Dim<TExtent>::value - 2u>,
                 TExtent,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 2)>::type>
+                    && (dim::Dim<TExtent>::value >= 2)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getExtent(
@@ -408,9 +408,9 @@ namespace alpaka
             struct GetExtent<
                 dim::DimInt<dim::Dim<TExtent>::value - 3u>,
                 TExtent,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 3)>::type>
+                    && (dim::Dim<TExtent>::value >= 3)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getExtent(
@@ -426,9 +426,9 @@ namespace alpaka
             struct GetExtent<
                 dim::DimInt<dim::Dim<TExtent>::value - 4u>,
                 TExtent,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 4)>::type>
+                    && (dim::Dim<TExtent>::value >= 4)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getExtent(
@@ -446,9 +446,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TExtent>::value - 1u>,
                 TExtent,
                 TExtentVal,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 1)>::type>
+                    && (dim::Dim<TExtent>::value >= 1)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setExtent(
@@ -468,9 +468,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TExtent>::value - 2u>,
                 TExtent,
                 TExtentVal,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 2)>::type>
+                    && (dim::Dim<TExtent>::value >= 2)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setExtent(
@@ -490,9 +490,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TExtent>::value - 3u>,
                 TExtent,
                 TExtentVal,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 3)>::type>
+                    && (dim::Dim<TExtent>::value >= 3)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setExtent(
@@ -512,9 +512,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TExtent>::value - 4u>,
                 TExtent,
                 TExtentVal,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TExtent>::value
-                    && (dim::Dim<TExtent>::value >= 4)>::type>
+                    && (dim::Dim<TExtent>::value >= 4)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setExtent(
@@ -538,9 +538,9 @@ namespace alpaka
             struct GetOffset<
                 dim::DimInt<dim::Dim<TOffsets>::value - 1u>,
                 TOffsets,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 1)>::type>
+                    && (dim::Dim<TOffsets>::value >= 1)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getOffset(
@@ -556,9 +556,9 @@ namespace alpaka
             struct GetOffset<
                 dim::DimInt<dim::Dim<TOffsets>::value - 2u>,
                 TOffsets,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 2)>::type>
+                    && (dim::Dim<TOffsets>::value >= 2)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getOffset(
@@ -574,9 +574,9 @@ namespace alpaka
             struct GetOffset<
                 dim::DimInt<dim::Dim<TOffsets>::value - 3u>,
                 TOffsets,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 3)>::type>
+                    && (dim::Dim<TOffsets>::value >= 3)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getOffset(
@@ -592,9 +592,9 @@ namespace alpaka
             struct GetOffset<
                 dim::DimInt<dim::Dim<TOffsets>::value - 4u>,
                 TOffsets,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 4)>::type>
+                    && (dim::Dim<TOffsets>::value >= 4)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getOffset(
@@ -612,9 +612,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TOffsets>::value - 1u>,
                 TOffsets,
                 TOffset,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 1)>::type>
+                    && (dim::Dim<TOffsets>::value >= 1)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setOffset(
@@ -634,9 +634,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TOffsets>::value - 2u>,
                 TOffsets,
                 TOffset,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 2)>::type>
+                    && (dim::Dim<TOffsets>::value >= 2)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setOffset(
@@ -656,9 +656,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TOffsets>::value - 3u>,
                 TOffsets,
                 TOffset,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 3)>::type>
+                    && (dim::Dim<TOffsets>::value >= 3)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setOffset(
@@ -678,9 +678,9 @@ namespace alpaka
                 dim::DimInt<dim::Dim<TOffsets>::value - 4u>,
                 TOffsets,
                 TOffset,
-                typename std::enable_if<
+                std::enable_if_t<
                     hip::traits::IsHipBuiltInType<TOffsets>::value
-                    && (dim::Dim<TOffsets>::value >= 4)>::type>
+                    && (dim::Dim<TOffsets>::value >= 4)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setOffset(
@@ -703,8 +703,8 @@ namespace alpaka
                 typename TIdx>
             struct IdxType<
                 TIdx,
-                typename std::enable_if<
-                    hip::traits::IsHipBuiltInType<TIdx>::value>::type>
+                std::enable_if_t<
+                    hip::traits::IsHipBuiltInType<TIdx>::value>>
             {
                 using type = std::size_t;
             };

--- a/include/alpaka/core/Utility.hpp
+++ b/include/alpaka/core/Utility.hpp
@@ -30,7 +30,7 @@ namespace alpaka
 #if BOOST_LANG_CUDA && BOOST_COMP_CLANG_CUDA || BOOST_COMP_HIP
         template< class T >
         ALPAKA_FN_HOST_ACC
-        typename std::add_rvalue_reference<T>::type
+        std::add_rvalue_reference_t<T>
         declval();
 #else
         using std::declval;

--- a/include/alpaka/dim/DimArithmetic.hpp
+++ b/include/alpaka/dim/DimArithmetic.hpp
@@ -27,7 +27,7 @@ namespace alpaka
                 typename T>
             struct DimType<
                 T,
-                typename std::enable_if<std::is_arithmetic<T>::value>::type>
+                std::enable_if_t<std::is_arithmetic<T>::value>>
             {
                 using type = dim::DimInt<1u>;
             };

--- a/include/alpaka/elem/Traits.hpp
+++ b/include/alpaka/elem/Traits.hpp
@@ -33,7 +33,7 @@ namespace alpaka
         //! The element type trait alias template to remove the ::type.
         template<
             typename TView>
-        using Elem = typename std::remove_volatile<typename traits::ElemType<TView>::type>::type;
+        using Elem = std::remove_volatile_t<typename traits::ElemType<TView>::type>;
 
         //-----------------------------------------------------------------------------
         // Trait specializations for unsigned integral types.
@@ -45,7 +45,7 @@ namespace alpaka
                 typename T>
             struct ElemType<
                 T,
-                typename std::enable_if<std::is_fundamental<T>::value>::type>
+                std::enable_if_t<std::is_fundamental<T>::value>>
             {
                 using type = T;
             };

--- a/include/alpaka/extent/Traits.hpp
+++ b/include/alpaka/extent/Traits.hpp
@@ -217,8 +217,8 @@ namespace alpaka
             struct GetExtent<
                 dim::DimInt<0u>,
                 TExtent,
-                typename std::enable_if<
-                    std::is_integral<TExtent>::value>::type>
+                std::enable_if_t<
+                    std::is_integral<TExtent>::value>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getExtent(
@@ -237,8 +237,8 @@ namespace alpaka
                 dim::DimInt<0u>,
                 TExtent,
                 TExtentVal,
-                typename std::enable_if<
-                    std::is_integral<TExtent>::value>::type>
+                std::enable_if_t<
+                    std::is_integral<TExtent>::value>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setExtent(

--- a/include/alpaka/idx/MapIdx.hpp
+++ b/include/alpaka/idx/MapIdx.hpp
@@ -13,6 +13,8 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Unused.hpp>
 
+#include <type_traits>
+
 namespace alpaka
 {
     namespace idx
@@ -59,7 +61,7 @@ namespace alpaka
             struct MapIdx<
                 TidxDimOut,
                 1u,
-                typename std::enable_if<TidxDimOut != 1u>::type>
+                std::enable_if_t<TidxDimOut != 1u>>
             {
                 //-----------------------------------------------------------------------------
                 // \tparam TElem Type of the index values.
@@ -103,7 +105,7 @@ namespace alpaka
             struct MapIdx<
                 1u,
                 TidxDimIn,
-                typename std::enable_if<TidxDimIn != 1u>::type>
+                std::enable_if_t<TidxDimIn != 1u>>
             {
                 //-----------------------------------------------------------------------------
                 // \tparam TElem Type of the index values.

--- a/include/alpaka/idx/Traits.hpp
+++ b/include/alpaka/idx/Traits.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <utility>
+#include <type_traits>
 
 namespace alpaka
 {
@@ -46,9 +47,9 @@ namespace alpaka
                 typename T>
             struct IdxType<
                 T,
-                typename std::enable_if<std::is_arithmetic<T>::value>::type>
+                std::enable_if_t<std::is_arithmetic<T>::value>>
             {
-                using type = typename std::decay<T>::type;
+                using type = std::decay_t<T>;
             };
         }
 

--- a/include/alpaka/kernel/TaskKernelCpuFibers.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuFibers.hpp
@@ -91,7 +91,7 @@ namespace alpaka
                     m_args(std::forward<TArgs>(args)...)
             {
                 static_assert(
-                    dim::Dim<typename std::decay<TWorkDiv>::type>::value == TDim::value,
+                    dim::Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                     "The work division and the execution task have to be of the same dimensionality!");
             }
             //-----------------------------------------------------------------------------
@@ -122,7 +122,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](typename std::decay<TArgs>::type const & ... args)
+                        [&](std::decay_t<TArgs> const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -152,7 +152,7 @@ namespace alpaka
 
                 auto const boundGridBlockExecHost(
                     meta::apply(
-                        [this, &acc, &blockThreadExtent, &fiberPool](typename std::decay<TArgs>::type const & ... args)
+                        [this, &acc, &blockThreadExtent, &fiberPool](std::decay_t<TArgs> const & ... args)
                         {
                             // Bind the kernel and its arguments to the grid block function.
                             return
@@ -182,7 +182,7 @@ namespace alpaka
                 vec::Vec<TDim, TIdx> const & blockThreadExtent,
                 FiberPool & fiberPool,
                 TKernelFnObj const & kernelFnObj,
-                typename std::decay<TArgs>::type const & ... args)
+                std::decay_t<TArgs> const & ... args)
             -> void
             {
                     // The futures of the threads in the current block.
@@ -236,7 +236,7 @@ namespace alpaka
                 FiberPool &,
 #endif
                 TKernelFnObj const & kernelFnObj,
-                typename std::decay<TArgs>::type const & ... args)
+                std::decay_t<TArgs> const & ... args)
             -> void
             {
                 // Bind the arguments to the accelerator block thread execution function.
@@ -266,7 +266,7 @@ namespace alpaka
                 acc::AccCpuFibers<TDim, TIdx> & acc,
                 vec::Vec<TDim, TIdx> const & blockThreadIdx,
                 TKernelFnObj const & kernelFnObj,
-                typename std::decay<TArgs>::type const & ... args)
+                std::decay_t<TArgs> const & ... args)
             -> void
             {
                 // We have to store the fiber data before the kernel is calling any of the methods of this class depending on them.
@@ -294,7 +294,7 @@ namespace alpaka
             }
 
             TKernelFnObj m_kernelFnObj;
-            std::tuple<typename std::decay<TArgs>::type...> m_args;
+            std::tuple<std::decay_t<TArgs>...> m_args;
         };
     }
 

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -69,7 +69,7 @@ namespace alpaka
             {
 
                 static_assert(
-                    dim::Dim<typename std::decay<TWorkDiv>::type>::value == TDim::value,
+                    dim::Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                     "The work division and the execution task have to be of the same dimensionality!");
             }
             //-----------------------------------------------------------------------------
@@ -100,7 +100,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](typename std::decay<TArgs>::type const & ... args)
+                        [&](std::decay_t<TArgs> const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -120,7 +120,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](typename std::decay<TArgs>::type const & ... args)
+                        [this](std::decay_t<TArgs> const & ... args)
                         {
                             return
                                 std::bind(
@@ -219,7 +219,7 @@ namespace alpaka
             }
 
             TKernelFnObj m_kernelFnObj;
-            std::tuple<typename std::decay<TArgs>::type...> m_args;
+            std::tuple<std::decay_t<TArgs>...> m_args;
         };
     }
 

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -68,7 +68,7 @@ namespace alpaka
                     m_args(std::forward<TArgs>(args)...)
             {
                 static_assert(
-                    dim::Dim<typename std::decay<TWorkDiv>::type>::value == TDim::value,
+                    dim::Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                     "The work division and the execution task have to be of the same dimensionality!");
             }
             //-----------------------------------------------------------------------------
@@ -99,7 +99,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](typename std::decay<TArgs>::type const & ... args)
+                        [&](std::decay_t<TArgs> const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -119,7 +119,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](typename std::decay<TArgs>::type const & ... args)
+                        [this](std::decay_t<TArgs> const & ... args)
                         {
                             return
                                 std::bind(
@@ -204,7 +204,7 @@ namespace alpaka
 
         private:
             TKernelFnObj m_kernelFnObj;
-            std::tuple<typename std::decay<TArgs>::type...> m_args;
+            std::tuple<std::decay_t<TArgs>...> m_args;
         };
     }
 

--- a/include/alpaka/kernel/TaskKernelCpuOmp4.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp4.hpp
@@ -68,7 +68,7 @@ namespace alpaka
                     m_args(std::forward<TArgs>(args)...)
             {
                 static_assert(
-                    dim::Dim<typename std::decay<TWorkDiv>::type>::value == TDim::value,
+                    dim::Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                     "The work division and the execution task have to be of the same dimensionality!");
             }
             //-----------------------------------------------------------------------------
@@ -99,7 +99,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](typename std::decay<TArgs>::type const & ... args)
+                        [&](std::decay_t<TArgs> const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -119,7 +119,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](typename std::decay<TArgs>::type const & ... args)
+                        [this](std::decay_t<TArgs> const & ... args)
                         {
                             return
                                 std::bind(
@@ -217,7 +217,7 @@ namespace alpaka
 
         private:
             TKernelFnObj m_kernelFnObj;
-            std::tuple<typename std::decay<TArgs>::type...> m_args;
+            std::tuple<std::decay_t<TArgs>...> m_args;
         };
     }
 

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -61,7 +61,7 @@ namespace alpaka
                     m_args(std::forward<TArgs>(args)...)
             {
                 static_assert(
-                    dim::Dim<typename std::decay<TWorkDiv>::type>::value == TDim::value,
+                    dim::Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                     "The work division and the execution task have to be of the same dimensionality!");
             }
             //-----------------------------------------------------------------------------
@@ -92,7 +92,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](typename std::decay<TArgs>::type const & ... args)
+                        [&](std::decay_t<TArgs> const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -112,7 +112,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](typename std::decay<TArgs>::type const & ... args)
+                        [this](std::decay_t<TArgs> const & ... args)
                         {
                             return
                                 std::bind(
@@ -148,7 +148,7 @@ namespace alpaka
 
         private:
             TKernelFnObj m_kernelFnObj;
-            std::tuple<typename std::decay<TArgs>::type...> m_args;
+            std::tuple<std::decay_t<TArgs>...> m_args;
         };
     }
 

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -67,7 +67,7 @@ namespace alpaka
                     m_args(std::forward<TArgs>(args)...)
             {
                 static_assert(
-                    dim::Dim<typename std::decay<TWorkDiv>::type>::value == TDim::value,
+                    dim::Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                     "The work division and the execution task have to be of the same dimensionality!");
             }
             //-----------------------------------------------------------------------------
@@ -98,7 +98,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](typename std::decay<TArgs>::type const & ... args)
+                        [&](std::decay_t<TArgs> const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -118,7 +118,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](typename std::decay<TArgs>::type const & ... args)
+                        [this](std::decay_t<TArgs> const & ... args)
                         {
                             return
                                 std::bind(
@@ -161,7 +161,7 @@ namespace alpaka
 
         private:
             TKernelFnObj m_kernelFnObj;
-            std::tuple<typename std::decay<TArgs>::type...> m_args;
+            std::tuple<std::decay_t<TArgs>...> m_args;
         };
     }
 

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -90,7 +90,7 @@ namespace alpaka
                     m_args(std::forward<TArgs>(args)...)
             {
                 static_assert(
-                    dim::Dim<typename std::decay<TWorkDiv>::type>::value == TDim::value,
+                    dim::Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                     "The work division and the execution task have to be of the same dimensionality!");
             }
             //-----------------------------------------------------------------------------
@@ -121,7 +121,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](typename std::decay<TArgs>::type const & ... args)
+                        [&](std::decay_t<TArgs> const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -147,7 +147,7 @@ namespace alpaka
                 // Bind the kernel and its arguments to the grid block function.
                 auto const boundGridBlockExecHost(
                     meta::apply(
-                        [this, &acc, &blockThreadExtent, &threadPool](typename std::decay<TArgs>::type const & ... args)
+                        [this, &acc, &blockThreadExtent, &threadPool](std::decay_t<TArgs> const & ... args)
                         {
                             return
                                 std::bind(
@@ -176,7 +176,7 @@ namespace alpaka
                 vec::Vec<TDim, TIdx> const & blockThreadExtent,
                 ThreadPool & threadPool,
                 TKernelFnObj const & kernelFnObj,
-                typename std::decay<TArgs>::type const & ... args)
+                std::decay_t<TArgs> const & ... args)
             -> void
             {
                     // The futures of the threads in the current block.
@@ -232,7 +232,7 @@ namespace alpaka
                 ThreadPool &,
 #endif
                 TKernelFnObj const & kernelFnObj,
-                typename std::decay<TArgs>::type const & ... args)
+                std::decay_t<TArgs> const & ... args)
             -> void
             {
                 // Bind the arguments to the accelerator block thread execution function.
@@ -262,7 +262,7 @@ namespace alpaka
                 acc::AccCpuThreads<TDim, TIdx> & acc,
                 vec::Vec<TDim, TIdx> const & blockThreadIdx,
                 TKernelFnObj const & kernelFnObj,
-                typename std::decay<TArgs>::type const & ... args)
+                std::decay_t<TArgs> const & ... args)
             -> void
             {
                 // We have to store the thread data before the kernel is calling any of the methods of this class depending on them.
@@ -296,7 +296,7 @@ namespace alpaka
             }
 
             TKernelFnObj m_kernelFnObj;
-            std::tuple<typename std::decay<TArgs>::type...> m_args;
+            std::tuple<std::decay_t<TArgs>...> m_args;
         };
     }
 

--- a/include/alpaka/kernel/TaskKernelGpuCudaRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuCudaRt.hpp
@@ -79,8 +79,8 @@ namespace alpaka
 // with clang it is not possible to query std::result_of for a pure device lambda created on the host side
 #if !(BOOST_COMP_CLANG_CUDA && BOOST_COMP_CLANG)
                     static_assert(
-                        std::is_same<typename std::result_of<
-                            TKernelFnObj(acc::AccGpuCudaRt<TDim, TIdx> const &, TArgs const & ...)>::type, void>::value,
+                        std::is_same<std::result_of_t<
+                            TKernelFnObj(acc::AccGpuCudaRt<TDim, TIdx> const &, TArgs const & ...)>, void>::value,
                         "The TKernelFnObj is required to return void!");
 #endif
                     acc::AccGpuCudaRt<TDim, TIdx> acc(threadElemExtent);
@@ -165,7 +165,7 @@ namespace alpaka
                     m_args(std::forward<TArgs>(args)...)
             {
                 static_assert(
-                    dim::Dim<typename std::decay<TWorkDiv>::type>::value == TDim::value,
+                    dim::Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                     "The work division and the execution task have to be of the same dimensionality!");
             }
             //-----------------------------------------------------------------------------
@@ -180,7 +180,7 @@ namespace alpaka
             ~TaskKernelGpuCudaRt() = default;
 
             TKernelFnObj m_kernelFnObj;
-            std::tuple<typename std::decay<TArgs>::type...> m_args;
+            std::tuple<std::decay_t<TArgs>...> m_args;
         };
     }
 
@@ -335,7 +335,7 @@ namespace alpaka
                     // Get the size of the block shared dynamic memory.
                     auto const blockSharedMemDynSizeBytes(
                         meta::apply(
-                            [&](typename std::decay<TArgs>::type const & ... args)
+                            [&](std::decay_t<TArgs> const & ... args)
                             {
                                 return
                                     kernel::getBlockSharedMemDynSizeBytes<
@@ -377,9 +377,9 @@ namespace alpaka
                     // This forces the type of a float argument given with std::forward to this function to be of type float instead of e.g. "float const & __ptr64" (MSVC).
                     // If not given by value, the kernel launch code does not copy the value but the pointer to the value location.
                     meta::apply(
-                        [&](typename std::decay<TArgs>::type const & ... args)
+                        [&](std::decay_t<TArgs> const & ... args)
                         {
-                            kernel::cuda::detail::cudaKernel<TDim, TIdx, TKernelFnObj, typename std::decay<TArgs>::type...><<<
+                            kernel::cuda::detail::cudaKernel<TDim, TIdx, TKernelFnObj, std::decay_t<TArgs>...><<<
                                 gridDim,
                                 blockDim,
                                 static_cast<std::size_t>(blockSharedMemDynSizeBytes),
@@ -455,7 +455,7 @@ namespace alpaka
                     // Get the size of the block shared dynamic memory.
                     auto const blockSharedMemDynSizeBytes(
                         meta::apply(
-                            [&](typename std::decay<TArgs>::type const & ... args)
+                            [&](std::decay_t<TArgs> const & ... args)
                             {
                                 return
                                     kernel::getBlockSharedMemDynSizeBytes<
@@ -476,7 +476,7 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     // Log the function attributes.
                     cudaFuncAttributes funcAttrs;
-                    cudaFuncGetAttributes(&funcAttrs, kernel::cuda::detail::cudaKernel<TDim, TIdx, TKernelFnObj, typename std::decay<TArgs>::type...>);
+                    cudaFuncGetAttributes(&funcAttrs, kernel::cuda::detail::cudaKernel<TDim, TIdx, TKernelFnObj, std::decay_t<TArgs>...>);
                     std::cout << __func__
                         << " binaryVersion: " << funcAttrs.binaryVersion
                         << " constSizeBytes: " << funcAttrs.constSizeBytes << " B"
@@ -494,9 +494,9 @@ namespace alpaka
                             queue.m_spQueueImpl->m_dev.m_iDevice));
                     // Enqueue the kernel execution.
                     meta::apply(
-                        [&](typename std::decay<TArgs>::type const & ... args)
+                        [&](std::decay_t<TArgs> const & ... args)
                         {
-                            kernel::cuda::detail::cudaKernel<TDim, TIdx, TKernelFnObj, typename std::decay<TArgs>::type...><<<
+                            kernel::cuda::detail::cudaKernel<TDim, TIdx, TKernelFnObj, std::decay_t<TArgs>...><<<
                                 gridDim,
                                 blockDim,
                                 static_cast<std::size_t>(blockSharedMemDynSizeBytes),

--- a/include/alpaka/kernel/TaskKernelGpuHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuHipRt.hpp
@@ -171,7 +171,7 @@ namespace alpaka
                     m_args(std::forward<TArgs>(args)...)
             {
                 static_assert(
-                    dim::Dim<typename std::decay<TWorkDiv>::type>::value == TDim::value,
+                    dim::Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                     "The work division and the execution task have to be of the same dimensionality!");
             }
             //-----------------------------------------------------------------------------
@@ -191,7 +191,7 @@ namespace alpaka
             ALPAKA_FN_HOST_ACC ~TaskKernelGpuHipRt() = default;
 
             TKernelFnObj m_kernelFnObj;
-            std::tuple<typename std::decay<TArgs>::type...> m_args;
+            std::tuple<std::decay_t<TArgs>...> m_args;
         };
     }
 
@@ -353,7 +353,7 @@ namespace alpaka
                             #if defined(BOOST_COMP_HCC) && BOOST_COMP_HCC
                             ALPAKA_FN_HOST_ACC
                             #endif
-                            [&](typename std::decay<TArgs>::type const & ... args)
+                            [&](std::decay_t<TArgs> const & ... args)
                             {
                                 return
                                     kernel::getBlockSharedMemDynSizeBytes<
@@ -374,7 +374,7 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     // Log the function attributes.
                     /*hipFuncAttributes funcAttrs;
-                    hipFuncGetAttributes(&funcAttrs, kernel::hip::detail::hipKernel<TDim, TIdx, TKernelFnObj, typename std::decay<TArgs>::type...>);
+                    hipFuncGetAttributes(&funcAttrs, kernel::hip::detail::hipKernel<TDim, TIdx, TKernelFnObj, std::decay_t<TArgs>...>);
                     std::cout << __func__
                         << " binaryVersion: " << funcAttrs.binaryVersion
                         << " constSizeBytes: " << funcAttrs.constSizeBytes << " B"
@@ -392,10 +392,10 @@ namespace alpaka
                             queue.m_spQueueImpl->m_dev.m_iDevice));
 
                     meta::apply(
-                        [&](typename std::decay<TArgs>::type const & ... args)
+                        [&](std::decay_t<TArgs> const & ... args)
                         {
                             hipLaunchKernelGGL(
-                                HIP_KERNEL_NAME(kernel::hip::detail::hipKernel< TDim, TIdx, TKernelFnObj, typename std::decay<TArgs>::type... >),
+                                HIP_KERNEL_NAME(kernel::hip::detail::hipKernel< TDim, TIdx, TKernelFnObj, std::decay_t<TArgs>... >),
                                 gridDim,
                                 blockDim,
                                 static_cast<std::uint32_t>(blockSharedMemDynSizeBytes),
@@ -475,7 +475,7 @@ namespace alpaka
                     // Get the size of the block shared dynamic memory.
                     auto const blockSharedMemDynSizeBytes(
                         meta::apply(
-                            [&](typename std::decay<TArgs>::type const & ... args)
+                            [&](std::decay_t<TArgs> const & ... args)
                             {
                                 return
                                     kernel::getBlockSharedMemDynSizeBytes<
@@ -497,7 +497,7 @@ namespace alpaka
                     // hipFuncAttributes not ported from HIP to HIP.
                     // Log the function attributes.
                     /*hipFuncAttributes funcAttrs;
-                    hipFuncGetAttributes(&funcAttrs, kernel::hip::detail::hipKernel<TDim, TIdx, TKernelFnObj, typename std::decay<TArgs>::type....>);
+                    hipFuncGetAttributes(&funcAttrs, kernel::hip::detail::hipKernel<TDim, TIdx, TKernelFnObj, std::decay_t<TArgs>....>);
                     std::cout << __func__
                         << " binaryVersion: " << funcAttrs.binaryVersion
                         << " constSizeBytes: " << funcAttrs.constSizeBytes << " B"
@@ -515,10 +515,10 @@ namespace alpaka
                             queue.m_spQueueImpl->m_dev.m_iDevice));
 
                     meta::apply(
-                        [&](typename std::decay<TArgs>::type const & ... args)
+                        [&](std::decay_t<TArgs> const & ... args)
                         {
                             hipLaunchKernelGGL(
-                                HIP_KERNEL_NAME(kernel::hip::detail::hipKernel< TDim, TIdx, TKernelFnObj, typename std::decay<TArgs>::type... >),
+                                HIP_KERNEL_NAME(kernel::hip::detail::hipKernel< TDim, TIdx, TKernelFnObj, std::decay_t<TArgs>... >),
                                 gridDim,
                                 blockDim,
                                 static_cast<std::uint32_t>(blockSharedMemDynSizeBytes),

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -155,7 +155,7 @@ namespace alpaka
                     TArgs const & ...)
                 {
                     static_assert(
-                        std::is_same<typename std::result_of<TKernelFnObj(TAcc const &, TArgs const & ...)>::type, void>::value,
+                        std::is_same<std::result_of_t<TKernelFnObj(TAcc const &, TArgs const & ...)>, void>::value,
                         "The TKernelFnObj is required to return void!");
                 }
             };
@@ -185,10 +185,10 @@ namespace alpaka
             detail::CheckFnReturnType<TAcc>{}(kernelFnObj, args...);
 
             static_assert(
-                dim::Dim<typename std::decay<TWorkDiv>::type>::value == dim::Dim<TAcc>::value,
+                dim::Dim<std::decay_t<TWorkDiv>>::value == dim::Dim<TAcc>::value,
                 "The dimensions of TAcc and TWorkDiv have to be identical!");
             static_assert(
-                std::is_same<idx::Idx<typename std::decay<TWorkDiv>::type>, idx::Idx<TAcc>>::value,
+                std::is_same<idx::Idx<std::decay_t<TWorkDiv>>, idx::Idx<TAcc>>::value,
                 "The idx type of TAcc and the idx type of TWorkDiv have to be identical!");
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Abs<
                 AbsCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto abs(
                     AbsCudaBuiltIn const & abs_ctx,

--- a/include/alpaka/math/abs/AbsHipBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Abs<
                 AbsHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto abs(
                     AbsHipBuiltIn const & abs_ctx,

--- a/include/alpaka/math/abs/AbsStdLib.hpp
+++ b/include/alpaka/math/abs/AbsStdLib.hpp
@@ -36,9 +36,9 @@ namespace alpaka
             struct Abs<
                 AbsStdLib,
                 TArg,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_arithmetic<TArg>::value
-                    && std::is_signed<TArg>::value>::type>
+                    && std::is_signed<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto abs(
                     AbsStdLib const & abs_ctx,

--- a/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Acos<
                 AcosCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto acos(
                     AcosCudaBuiltIn const & acos_ctx,

--- a/include/alpaka/math/acos/AcosHipBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Acos<
                 AcosHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 __device__ static auto acos(

--- a/include/alpaka/math/acos/AcosStdLib.hpp
+++ b/include/alpaka/math/acos/AcosStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Acos<
                 AcosStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto acos(
                     AcosStdLib const & acos_ctx,

--- a/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Asin<
                 AsinCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto asin(
                     AsinCudaBuiltIn const & asin_ctx,

--- a/include/alpaka/math/asin/AsinHipBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Asin<
                 AsinHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto asin(
                     AsinHipBuiltIn const & asin_ctx,

--- a/include/alpaka/math/asin/AsinStdLib.hpp
+++ b/include/alpaka/math/asin/AsinStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Asin<
                 AsinStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto asin(
                     AsinStdLib const & asin_ctx,

--- a/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Atan<
                 AtanCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto atan(
                     AtanCudaBuiltIn const & atan_ctx,

--- a/include/alpaka/math/atan/AtanHipBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Atan<
                 AtanHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto atan(
                     AtanHipBuiltIn const & atan_ctx,

--- a/include/alpaka/math/atan/AtanStdLib.hpp
+++ b/include/alpaka/math/atan/AtanStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Atan<
                 AtanStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto atan(
                     AtanStdLib const & atan_ctx,

--- a/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
@@ -46,9 +46,9 @@ namespace alpaka
                 Atan2CudaBuiltIn,
                 Ty,
                 Tx,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_floating_point<Ty>::value
-                    && std::is_floating_point<Tx>::value>::type>
+                    && std::is_floating_point<Tx>::value>>
             {
                 __device__ static auto atan2(
                     Atan2CudaBuiltIn const & atan2_ctx,

--- a/include/alpaka/math/atan2/Atan2HipBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2HipBuiltIn.hpp
@@ -54,9 +54,9 @@ namespace alpaka
                 Atan2HipBuiltIn,
                 Ty,
                 Tx,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_floating_point<Ty>::value
-                    && std::is_floating_point<Tx>::value>::type>
+                    && std::is_floating_point<Tx>::value>>
             {
                 __device__ static auto atan2(
                     Atan2HipBuiltIn const & atan2_ctx,

--- a/include/alpaka/math/atan2/Atan2StdLib.hpp
+++ b/include/alpaka/math/atan2/Atan2StdLib.hpp
@@ -37,9 +37,9 @@ namespace alpaka
                 Atan2StdLib,
                 Ty,
                 Tx,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_arithmetic<Ty>::value
-                    && std::is_arithmetic<Tx>::value>::type>
+                    && std::is_arithmetic<Tx>::value>>
             {
                 ALPAKA_FN_HOST static auto atan2(
                     Atan2StdLib const & abs,

--- a/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Cbrt<
                 CbrtCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 __device__ static auto cbrt(
                     CbrtCudaBuiltIn const & cbrt_ctx,

--- a/include/alpaka/math/cbrt/CbrtHipBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Cbrt<
                 CbrtHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 __device__ static auto cbrt(
                     CbrtHipBuiltIn const & cbrt_ctx,

--- a/include/alpaka/math/cbrt/CbrtStdLib.hpp
+++ b/include/alpaka/math/cbrt/CbrtStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Cbrt<
                 CbrtStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto cbrt(
                     CbrtStdLib const & cbrt_ctx,

--- a/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Ceil<
                 CeilCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto ceil(
                     CeilCudaBuiltIn const & ceil_ctx,

--- a/include/alpaka/math/ceil/CeilHipBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Ceil<
                 CeilHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto ceil(
                     CeilHipBuiltIn const & ceil_ctx,

--- a/include/alpaka/math/ceil/CeilStdLib.hpp
+++ b/include/alpaka/math/ceil/CeilStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Ceil<
                 CeilStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto ceil(
                     CeilStdLib const & ceil_ctx,

--- a/include/alpaka/math/cos/CosCudaBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Cos<
                 CosCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto cos(
                     CosCudaBuiltIn const & cos_ctx,

--- a/include/alpaka/math/cos/CosHipBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Cos<
                 CosHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto cos(
                     CosHipBuiltIn const & cos_ctx,

--- a/include/alpaka/math/cos/CosStdLib.hpp
+++ b/include/alpaka/math/cos/CosStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Cos<
                 CosStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto cos(
                     CosStdLib const & cos_ctx,

--- a/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Erf<
                 ErfCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto erf(
                     ErfCudaBuiltIn const & erf_ctx,

--- a/include/alpaka/math/erf/ErfHipBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Erf<
                 ErfHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto erf(
                     ErfHipBuiltIn const & erf_ctx,

--- a/include/alpaka/math/erf/ErfStdLib.hpp
+++ b/include/alpaka/math/erf/ErfStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Erf<
                 ErfStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto erf(
                     ErfStdLib const & erf_ctx,

--- a/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Exp<
                 ExpCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto exp(
                     ExpCudaBuiltIn const & exp_ctx,

--- a/include/alpaka/math/exp/ExpHipBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Exp<
                 ExpHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto exp(
                     ExpHipBuiltIn const & exp_ctx,

--- a/include/alpaka/math/exp/ExpStdLib.hpp
+++ b/include/alpaka/math/exp/ExpStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Exp<
                 ExpStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto exp(
                     ExpStdLib const & exp_ctx,

--- a/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Floor<
                 FloorCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto floor(
                     FloorCudaBuiltIn const & floor_ctx,

--- a/include/alpaka/math/floor/FloorHipBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Floor<
                 FloorHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto floor(
                     FloorHipBuiltIn const & floor_ctx,

--- a/include/alpaka/math/floor/FloorStdLib.hpp
+++ b/include/alpaka/math/floor/FloorStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Floor<
                 FloorStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto floor(
                     FloorStdLib const & floor_ctx,

--- a/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
@@ -46,9 +46,9 @@ namespace alpaka
                 FmodCudaBuiltIn,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_floating_point<Tx>::value
-                    && std::is_floating_point<Ty>::value>::type>
+                    && std::is_floating_point<Ty>::value>>
             {
                 __device__ static auto fmod(
                     FmodCudaBuiltIn const & fmod_ctx,

--- a/include/alpaka/math/fmod/FmodHipBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodHipBuiltIn.hpp
@@ -54,9 +54,9 @@ namespace alpaka
                 FmodHipBuiltIn,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_floating_point<Tx>::value
-                    && std::is_floating_point<Ty>::value>::type>
+                    && std::is_floating_point<Ty>::value>>
             {
                 __device__ static auto fmod(
                     FmodHipBuiltIn const & fmod_ctx,

--- a/include/alpaka/math/fmod/FmodStdLib.hpp
+++ b/include/alpaka/math/fmod/FmodStdLib.hpp
@@ -37,9 +37,9 @@ namespace alpaka
                 FmodStdLib,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_arithmetic<Tx>::value
-                    && std::is_arithmetic<Ty>::value>::type>
+                    && std::is_arithmetic<Ty>::value>>
             {
                 ALPAKA_FN_HOST static auto fmod(
                     FmodStdLib const & fmod_ctx,

--- a/include/alpaka/math/log/LogCudaBuiltIn.hpp
+++ b/include/alpaka/math/log/LogCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Log<
                 LogCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto log(
                     LogCudaBuiltIn const & log_ctx,

--- a/include/alpaka/math/log/LogHipBuiltIn.hpp
+++ b/include/alpaka/math/log/LogHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Log<
                 LogHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto log(
                     LogHipBuiltIn const & log_ctx,

--- a/include/alpaka/math/log/LogStdLib.hpp
+++ b/include/alpaka/math/log/LogStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Log<
                 LogStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto log(
                     LogStdLib const & log_ctx,

--- a/include/alpaka/math/max/MaxCudaBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxCudaBuiltIn.hpp
@@ -45,9 +45,9 @@ namespace alpaka
                 MaxCudaBuiltIn,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_integral<Tx>::value
-                    && std::is_integral<Ty>::value>::type>
+                    && std::is_integral<Ty>::value>>
             {
                 __device__ static auto max(
                     MaxCudaBuiltIn const & max_ctx,
@@ -67,11 +67,11 @@ namespace alpaka
                 MaxCudaBuiltIn,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_arithmetic<Tx>::value
                     && std::is_arithmetic<Ty>::value
                     && !(std::is_integral<Tx>::value
-                        && std::is_integral<Ty>::value)>::type>
+                        && std::is_integral<Ty>::value)>>
             {
                 __device__ static auto max(
                     MaxCudaBuiltIn const & max_ctx,

--- a/include/alpaka/math/max/MaxHipBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxHipBuiltIn.hpp
@@ -54,9 +54,9 @@ namespace alpaka
                 MaxHipBuiltIn,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_integral<Tx>::value
-                    && std::is_integral<Ty>::value>::type>
+                    && std::is_integral<Ty>::value>>
             {
                 __device__ static auto max(
                     MaxHipBuiltIn const & max_ctx,
@@ -76,11 +76,11 @@ namespace alpaka
                 MaxHipBuiltIn,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_arithmetic<Tx>::value
                     && std::is_arithmetic<Ty>::value
                     && !(std::is_integral<Tx>::value
-                        && std::is_integral<Ty>::value)>::type>
+                        && std::is_integral<Ty>::value)>>
             {
                 __device__ static auto max(
                     MaxHipBuiltIn const & max_ctx,

--- a/include/alpaka/math/max/MaxStdLib.hpp
+++ b/include/alpaka/math/max/MaxStdLib.hpp
@@ -38,9 +38,9 @@ namespace alpaka
                 MaxStdLib,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_integral<Tx>::value
-                    && std::is_integral<Ty>::value>::type>
+                    && std::is_integral<Ty>::value>>
             {
                 ALPAKA_FN_HOST static auto max(
                     MaxStdLib const & max_ctx,
@@ -60,11 +60,11 @@ namespace alpaka
                 MaxStdLib,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_arithmetic<Tx>::value
                     && std::is_arithmetic<Ty>::value
                     && !(std::is_integral<Tx>::value
-                        && std::is_integral<Ty>::value)>::type>
+                        && std::is_integral<Ty>::value)>>
             {
                 ALPAKA_FN_HOST static auto max(
                     MaxStdLib const & max_ctx,

--- a/include/alpaka/math/min/MinCudaBuiltIn.hpp
+++ b/include/alpaka/math/min/MinCudaBuiltIn.hpp
@@ -46,9 +46,9 @@ namespace alpaka
                 MinCudaBuiltIn,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_integral<Tx>::value
-                    && std::is_integral<Ty>::value>::type>
+                    && std::is_integral<Ty>::value>>
             {
                 __device__ static auto min(
                     MinCudaBuiltIn const & min_ctx,
@@ -68,11 +68,11 @@ namespace alpaka
                 MinCudaBuiltIn,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_arithmetic<Tx>::value
                     && std::is_arithmetic<Ty>::value
                     && !(std::is_integral<Tx>::value
-                        && std::is_integral<Ty>::value)>::type>
+                        && std::is_integral<Ty>::value)>>
             {
                 __device__ static auto min(
                     MinCudaBuiltIn const & min_ctx,

--- a/include/alpaka/math/min/MinHipBuiltIn.hpp
+++ b/include/alpaka/math/min/MinHipBuiltIn.hpp
@@ -56,9 +56,9 @@ namespace alpaka
                 MinHipBuiltIn,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_integral<Tx>::value
-                    && std::is_integral<Ty>::value>::type>
+                    && std::is_integral<Ty>::value>>
             {
                 __device__ static auto min(
                     MinHipBuiltIn const & min_ctx,
@@ -78,11 +78,11 @@ namespace alpaka
                 MinHipBuiltIn,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_arithmetic<Tx>::value
                     && std::is_arithmetic<Ty>::value
                     && !(std::is_integral<Tx>::value
-                        && std::is_integral<Ty>::value)>::type>
+                        && std::is_integral<Ty>::value)>>
             {
                 __device__ static auto min(
                     MinHipBuiltIn const & min_ctx,

--- a/include/alpaka/math/min/MinStdLib.hpp
+++ b/include/alpaka/math/min/MinStdLib.hpp
@@ -38,9 +38,9 @@ namespace alpaka
                 MinStdLib,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_integral<Tx>::value
-                    && std::is_integral<Ty>::value>::type>
+                    && std::is_integral<Ty>::value>>
             {
                 ALPAKA_FN_HOST static auto min(
                     MinStdLib const & min_ctx,
@@ -60,11 +60,11 @@ namespace alpaka
                 MinStdLib,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_arithmetic<Tx>::value
                     && std::is_arithmetic<Ty>::value
                     && !(std::is_integral<Tx>::value
-                        && std::is_integral<Ty>::value)>::type>
+                        && std::is_integral<Ty>::value)>>
             {
                 ALPAKA_FN_HOST static auto min(
                     MinStdLib const & min_ctx,

--- a/include/alpaka/math/pow/PowCudaBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowCudaBuiltIn.hpp
@@ -46,9 +46,9 @@ namespace alpaka
                 PowCudaBuiltIn,
                 TBase,
                 TExp,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_floating_point<TBase>::value
-                    && std::is_floating_point<TExp>::value>::type>
+                    && std::is_floating_point<TExp>::value>>
             {
                 __device__ static auto pow(
                     PowCudaBuiltIn const & pow_ctx,

--- a/include/alpaka/math/pow/PowHipBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowHipBuiltIn.hpp
@@ -54,9 +54,9 @@ namespace alpaka
                 PowHipBuiltIn,
                 TBase,
                 TExp,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_floating_point<TBase>::value
-                    && std::is_floating_point<TExp>::value>::type>
+                    && std::is_floating_point<TExp>::value>>
             {
                 __device__ static auto pow(
                     PowHipBuiltIn const & pow_ctx,

--- a/include/alpaka/math/pow/PowStdLib.hpp
+++ b/include/alpaka/math/pow/PowStdLib.hpp
@@ -37,9 +37,9 @@ namespace alpaka
                 PowStdLib,
                 TBase,
                 TExp,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_arithmetic<TBase>::value
-                    && std::is_arithmetic<TExp>::value>::type>
+                    && std::is_arithmetic<TExp>::value>>
             {
                 ALPAKA_FN_HOST static auto pow(
                     PowStdLib const & pow_ctx,

--- a/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
@@ -46,9 +46,9 @@ namespace alpaka
                 RemainderCudaBuiltIn,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_floating_point<Tx>::value
-                    && std::is_floating_point<Ty>::value>::type>
+                    && std::is_floating_point<Ty>::value>>
             {
                 __device__ static auto remainder(
                     RemainderCudaBuiltIn const & remainder_ctx,

--- a/include/alpaka/math/remainder/RemainderHipBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderHipBuiltIn.hpp
@@ -54,9 +54,9 @@ namespace alpaka
                 RemainderHipBuiltIn,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_floating_point<Tx>::value
-                    && std::is_floating_point<Ty>::value>::type>
+                    && std::is_floating_point<Ty>::value>>
             {
                 __device__ static auto remainder(
                     RemainderHipBuiltIn const & remainder_ctx,

--- a/include/alpaka/math/remainder/RemainderStdLib.hpp
+++ b/include/alpaka/math/remainder/RemainderStdLib.hpp
@@ -37,9 +37,9 @@ namespace alpaka
                 RemainderStdLib,
                 Tx,
                 Ty,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_floating_point<Tx>::value
-                    && std::is_floating_point<Ty>::value>::type>
+                    && std::is_floating_point<Ty>::value>>
             {
                 ALPAKA_FN_HOST static auto remainder(
                     RemainderStdLib const & remainder_ctx,

--- a/include/alpaka/math/round/RoundCudaBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Round<
                 RoundCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto round(
                     RoundCudaBuiltIn const & round_ctx,
@@ -62,8 +62,8 @@ namespace alpaka
             struct Lround<
                 RoundCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto lround(
                     RoundCudaBuiltIn const & lround_ctx,
@@ -81,8 +81,8 @@ namespace alpaka
             struct Llround<
                 RoundCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto llround(
                     RoundCudaBuiltIn const & llround_ctx,

--- a/include/alpaka/math/round/RoundHipBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Round<
                 RoundHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto round(
                     RoundHipBuiltIn const & round_ctx,
@@ -70,8 +70,8 @@ namespace alpaka
             struct Lround<
                 RoundHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto lround(
                     RoundHipBuiltIn const & lround_ctx,
@@ -89,8 +89,8 @@ namespace alpaka
             struct Llround<
                 RoundHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto llround(
                     RoundHipBuiltIn const & llround_ctx,

--- a/include/alpaka/math/round/RoundStdLib.hpp
+++ b/include/alpaka/math/round/RoundStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Round<
                 RoundStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto round(
                     RoundStdLib const & round_ctx,
@@ -53,8 +53,8 @@ namespace alpaka
             struct Lround<
                 RoundStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto lround(
                     RoundStdLib const & lround_ctx,
@@ -72,8 +72,8 @@ namespace alpaka
             struct Llround<
                 RoundStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto llround(
                     RoundStdLib const & llround_ctx,

--- a/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Rsqrt<
                 RsqrtCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 __device__ static auto rsqrt(
                     RsqrtCudaBuiltIn const & rsqrt_ctx,

--- a/include/alpaka/math/rsqrt/RsqrtHipBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Rsqrt<
                 RsqrtHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 __device__ static auto rsqrt(
                     RsqrtHipBuiltIn const & rsqrt_ctx,

--- a/include/alpaka/math/rsqrt/RsqrtStdLib.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Rsqrt<
                 RsqrtStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto rsqrt(
                     RsqrtStdLib const & rsqrt_ctx,

--- a/include/alpaka/math/sin/SinCudaBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Sin<
                 SinCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto sin(
                     SinCudaBuiltIn const & sin_ctx,

--- a/include/alpaka/math/sin/SinHipBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Sin<
                 SinHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto sin(
                     SinHipBuiltIn const & sin_ctx,

--- a/include/alpaka/math/sin/SinStdLib.hpp
+++ b/include/alpaka/math/sin/SinStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Sin<
                 SinStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto sin(
                     SinStdLib const & sin_ctx,

--- a/include/alpaka/math/sincos/SinCosStdLib.hpp
+++ b/include/alpaka/math/sincos/SinCosStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct SinCos<
                 SinCosStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto sincos(
                     SinCosStdLib const & sincos_ctx,

--- a/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Sqrt<
                 SqrtCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto sqrt(
                     SqrtCudaBuiltIn const & sqrt_ctx,

--- a/include/alpaka/math/sqrt/SqrtHipBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Sqrt<
                 SqrtHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto sqrt(
                     SqrtHipBuiltIn const & sqrt_ctx,

--- a/include/alpaka/math/sqrt/SqrtStdLib.hpp
+++ b/include/alpaka/math/sqrt/SqrtStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Sqrt<
                 SqrtStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto sqrt(
                     SqrtStdLib const & sqrt_ctx,

--- a/include/alpaka/math/tan/TanCudaBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Tan<
                 TanCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto tan(
                     TanCudaBuiltIn const & tan_ctx,

--- a/include/alpaka/math/tan/TanHipBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Tan<
                 TanHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto tan(
                     TanHipBuiltIn const & tan_ctx,

--- a/include/alpaka/math/tan/TanStdLib.hpp
+++ b/include/alpaka/math/tan/TanStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Tan<
                 TanStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto tan(
                     TanStdLib const & tan_ctx,

--- a/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             struct Trunc<
                 TruncCudaBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto trunc(
                     TruncCudaBuiltIn const & trunc_ctx,

--- a/include/alpaka/math/trunc/TruncHipBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncHipBuiltIn.hpp
@@ -52,8 +52,8 @@ namespace alpaka
             struct Trunc<
                 TruncHipBuiltIn,
                 TArg,
-                typename std::enable_if<
-                    std::is_floating_point<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_floating_point<TArg>::value>>
             {
                 __device__ static auto trunc(
                     TruncHipBuiltIn const & trunc_ctx,

--- a/include/alpaka/math/trunc/TruncStdLib.hpp
+++ b/include/alpaka/math/trunc/TruncStdLib.hpp
@@ -35,8 +35,8 @@ namespace alpaka
             struct Trunc<
                 TruncStdLib,
                 TArg,
-                typename std::enable_if<
-                    std::is_arithmetic<TArg>::value>::type>
+                std::enable_if_t<
+                    std::is_arithmetic<TArg>::value>>
             {
                 ALPAKA_FN_HOST static auto trunc(
                     TruncStdLib const & trunc_ctx,

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -28,6 +28,7 @@
 #include <alpaka/meta/DependentFalseType.hpp>
 
 #include <memory>
+#include <type_traits>
 
 namespace alpaka
 {
@@ -248,7 +249,7 @@ namespace alpaka
             struct GetExtent<
                 TIdxIntegralConst,
                 mem::buf::BufCpu<TElem, TDim, TIdx>,
-                typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
+                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getExtent(

--- a/include/alpaka/mem/buf/BufCudaRt.hpp
+++ b/include/alpaka/mem/buf/BufCudaRt.hpp
@@ -28,6 +28,7 @@
 
 #include <functional>
 #include <memory>
+#include <type_traits>
 
 namespace alpaka
 {
@@ -206,7 +207,7 @@ namespace alpaka
             struct GetExtent<
                 TIdxIntegralConst,
                 mem::buf::BufCudaRt<TElem, TDim, TIdx>,
-                typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
+                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getExtent(

--- a/include/alpaka/mem/buf/BufHipRt.hpp
+++ b/include/alpaka/mem/buf/BufHipRt.hpp
@@ -28,6 +28,7 @@
 
 #include <functional>
 #include <memory>
+#include <type_traits>
 
 namespace alpaka
 {
@@ -206,7 +207,7 @@ namespace alpaka
             struct GetExtent<
                 TIdxIntegralConst,
                 mem::buf::BufHipRt<TElem, TDim, TIdx>,
-                typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
+                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getExtent(

--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -74,7 +74,7 @@ namespace alpaka
                             "The source view and the extent are required to have compatible idx type!");
 
                         static_assert(
-                            std::is_same<elem::Elem<TViewDst>, typename std::remove_const<elem::Elem<TViewSrc>>::type>::value,
+                            std::is_same<elem::Elem<TViewDst>, std::remove_const_t<elem::Elem<TViewSrc>>>::value,
                             "The source and the destination view are required to have the same element type!");
 
                         //-----------------------------------------------------------------------------

--- a/include/alpaka/mem/buf/cuda/Copy.hpp
+++ b/include/alpaka/mem/buf/cuda/Copy.hpp
@@ -31,6 +31,7 @@
 
 #include <set>
 #include <tuple>
+#include <type_traits>
 
 
 namespace alpaka
@@ -76,7 +77,7 @@ namespace alpaka
                             "The views and the extent are required to have the same dimensionality!");
                         // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
                         static_assert(
-                            std::is_same<elem::Elem<TViewDst>, typename std::remove_const<elem::Elem<TViewSrc>>::type>::value,
+                            std::is_same<elem::Elem<TViewDst>, std::remove_const_t<elem::Elem<TViewSrc>>>::value,
                             "The source and the destination view are required to have the same element type!");
 
                         using Idx = idx::Idx<TExtent>;
@@ -160,7 +161,7 @@ namespace alpaka
                             "The views and the extent are required to have the same dimensionality!");
                         // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
                         static_assert(
-                            std::is_same<elem::Elem<TViewDst>, typename std::remove_const<elem::Elem<TViewSrc>>::type>::value,
+                            std::is_same<elem::Elem<TViewDst>, std::remove_const_t<elem::Elem<TViewSrc>>>::value,
                             "The source and the destination view are required to have the same element type!");
 
                         using Idx = idx::Idx<TExtent>;
@@ -275,7 +276,7 @@ namespace alpaka
                             "The views and the extent are required to have the same dimensionality!");
                         // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
                         static_assert(
-                            std::is_same<elem::Elem<TViewDst>, typename std::remove_const<elem::Elem<TViewSrc>>::type>::value,
+                            std::is_same<elem::Elem<TViewDst>, std::remove_const_t<elem::Elem<TViewSrc>>>::value,
                             "The source and the destination view are required to have the same element type!");
 
                         using Idx = idx::Idx<TExtent>;

--- a/include/alpaka/mem/buf/hip/Copy.hpp
+++ b/include/alpaka/mem/buf/hip/Copy.hpp
@@ -31,6 +31,7 @@
 
 #include <set>
 #include <tuple>
+#include <type_traits>
 
 
 namespace alpaka
@@ -75,7 +76,7 @@ namespace alpaka
                             "The views and the extent are required to have the same dimensionality!");
                         // TODO: Maybe check for Size of TViewDst and TViewSrc to have greater or equal range than TExtent.
                         static_assert(
-                            std::is_same<elem::Elem<TViewDst>, typename std::remove_const<elem::Elem<TViewSrc>>::type>::value,
+                            std::is_same<elem::Elem<TViewDst>, std::remove_const_t<elem::Elem<TViewSrc>>>::value,
                             "The source and the destination view are required to have the same element type!");
 
                         using Idx = idx::Idx<TExtent>;
@@ -158,7 +159,7 @@ namespace alpaka
                             "The views and the extent are required to have the same dimensionality!");
                         // TODO: Maybe check for Size of TViewDst and TViewSrc to have greater or equal range than TExtent.
                         static_assert(
-                            std::is_same<elem::Elem<TViewDst>, typename std::remove_const<elem::Elem<TViewSrc>>::type>::value,
+                            std::is_same<elem::Elem<TViewDst>, std::remove_const_t<elem::Elem<TViewSrc>>>::value,
                             "The source and the destination view are required to have the same element type!");
 
                         using Idx = idx::Idx<TExtent>;
@@ -274,7 +275,7 @@ namespace alpaka
                             "The views and the extent are required to have the same dimensionality!");
                         // TODO: Maybe check for Size of TViewDst and TViewSrc to have greater or equal range than TExtent.
                         static_assert(
-                            std::is_same<elem::Elem<TViewDst>, typename std::remove_const<elem::Elem<TViewSrc>>::type>::value,
+                            std::is_same<elem::Elem<TViewDst>, std::remove_const_t<elem::Elem<TViewSrc>>>::value,
                             "The source and the destination view are required to have the same element type!");
 
                         using Idx = idx::Idx<TExtent>;

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -24,6 +24,7 @@
 #include <boost/config.hpp>
 
 #include <iosfwd>
+#include <type_traits>
 
 namespace alpaka
 {
@@ -91,7 +92,7 @@ namespace alpaka
                     struct GetPitchBytesDefault<
                         TIdx,
                         TView,
-                        typename std::enable_if<TIdx::value < (dim::Dim<TView>::value - 1)>::type>
+                        std::enable_if_t<TIdx::value < (dim::Dim<TView>::value - 1)>>
                     {
                         //-----------------------------------------------------------------------------
                         ALPAKA_FN_HOST static auto getPitchBytesDefault(
@@ -342,7 +343,7 @@ namespace alpaka
                     dim::Dim<TViewDst>::value == dim::Dim<TExtent>::value,
                     "The destination view and the extent are required to have the same dimensionality!");
                 static_assert(
-                    std::is_same<elem::Elem<TViewDst>, typename std::remove_const<elem::Elem<TViewSrc>>::type>::value,
+                    std::is_same<elem::Elem<TViewDst>, std::remove_const_t<elem::Elem<TViewSrc>>>::value,
                     "The source and the destination view are required to have the same element type!");
 
                 return

--- a/include/alpaka/mem/view/ViewCompileTimeArray.hpp
+++ b/include/alpaka/mem/view/ViewCompileTimeArray.hpp
@@ -33,7 +33,7 @@ namespace alpaka
                 typename TFixedSizeArray>
             struct DevType<
                 TFixedSizeArray,
-                typename std::enable_if<std::is_array<TFixedSizeArray>::value>::type>
+                std::enable_if_t<std::is_array<TFixedSizeArray>::value>>
             {
                 using type = dev::DevCpu;
             };
@@ -44,7 +44,7 @@ namespace alpaka
                 typename TFixedSizeArray>
             struct GetDev<
                 TFixedSizeArray,
-                typename std::enable_if<std::is_array<TFixedSizeArray>::value>::type>
+                std::enable_if_t<std::is_array<TFixedSizeArray>::value>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getDev(
@@ -67,7 +67,7 @@ namespace alpaka
                 typename TFixedSizeArray>
             struct DimType<
                 TFixedSizeArray,
-                typename std::enable_if<std::is_array<TFixedSizeArray>::value>::type>
+                std::enable_if_t<std::is_array<TFixedSizeArray>::value>>
             {
                 using type = dim::DimInt<std::rank<TFixedSizeArray>::value>;
             };
@@ -83,10 +83,10 @@ namespace alpaka
                 typename TFixedSizeArray>
             struct ElemType<
                 TFixedSizeArray,
-                typename std::enable_if<
-                    std::is_array<TFixedSizeArray>::value>::type>
+                std::enable_if_t<
+                    std::is_array<TFixedSizeArray>::value>>
             {
-                using type = typename std::remove_all_extent<TFixedSizeArray>::type;
+                using type = std::remove_all_extent_t<TFixedSizeArray>;
             };
         }
     }
@@ -102,10 +102,10 @@ namespace alpaka
             struct GetExtent<
                 TIdxIntegralConst,
                 TFixedSizeArray,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_array<TFixedSizeArray>::value
                     && (std::rank<TFixedSizeArray>::value > TIdxIntegralConst::value)
-                    && (std::extent<TFixedSizeArray, TIdxIntegralConst::value>::value > 0u)>::type>
+                    && (std::extent<TFixedSizeArray, TIdxIntegralConst::value>::value > 0u)>>
             {
                 //-----------------------------------------------------------------------------
                 static constexpr auto getExtent(
@@ -131,10 +131,10 @@ namespace alpaka
                     typename TFixedSizeArray>
                 struct GetPtrNative<
                     TFixedSizeArray,
-                    typename std::enable_if<
-                        std::is_array<TFixedSizeArray>::value>::type>
+                    std::enable_if_t<
+                        std::is_array<TFixedSizeArray>::value>>
                 {
-                    using TElem = typename std::remove_all_extent<TFixedSizeArray>::type;
+                    using TElem = std::remove_all_extent_t<TFixedSizeArray>;
 
                     //-----------------------------------------------------------------------------
                     static auto getPtrNative(
@@ -159,11 +159,11 @@ namespace alpaka
                 struct GetPitchBytes<
                     dim::DimInt<std::rank<TFixedSizeArray>::value - 1u>,
                     TFixedSizeArray,
-                    typename std::enable_if<
+                    std::enable_if_t<
                         std::is_array<TFixedSizeArray>::value
-                        && (std::extent<TFixedSizeArray, std::rank<TFixedSizeArray>::value - 1u>::value > 0u)>::type>
+                        && (std::extent<TFixedSizeArray, std::rank<TFixedSizeArray>::value - 1u>::value > 0u)>>
                 {
-                    using TElem = typename std::remove_all_extent<TFixedSizeArray>::type;
+                    using TElem = std::remove_all_extent_t<TFixedSizeArray>;
 
                     //-----------------------------------------------------------------------------
                     static constexpr auto getPitchBytes(
@@ -188,7 +188,7 @@ namespace alpaka
             struct GetOffset<
                 TIdx,
                 TFixedSizeArray,
-                typename std::enable_if<std::is_array<TFixedSizeArray>::value>::type>
+                std::enable_if_t<std::is_array<TFixedSizeArray>::value>>
             {
                 //-----------------------------------------------------------------------------
                 static auto getOffset(
@@ -210,7 +210,7 @@ namespace alpaka
                 typename TFixedSizeArray>
             struct IdxType<
                 TFixedSizeArray,
-                typename std::enable_if<std::is_array<TFixedSizeArray>::value>::type>
+                std::enable_if_t<std::is_array<TFixedSizeArray>::value>>
             {
                 using type = std::size_t;
             };

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -16,6 +16,8 @@
 #include <alpaka/dev/DevCudaRt.hpp>
 #include <alpaka/dev/DevHipRt.hpp>
 
+#include <type_traits>
+
 namespace alpaka
 {
     namespace mem
@@ -205,7 +207,7 @@ namespace alpaka
             struct GetExtent<
                 TIdxIntegralConst,
                 mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx>,
-                typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
+                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC
@@ -259,7 +261,7 @@ namespace alpaka
                 struct GetPitchBytes<
                     TIdxIntegralConst,
                     mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx>,
-                    typename std::enable_if<TIdxIntegralConst::value < TDim::value>::type>
+                    std::enable_if_t<TIdxIntegralConst::value < TDim::value>>
                 {
                     ALPAKA_FN_HOST static auto getPitchBytes(
                         mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx> const & view)

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -271,7 +271,7 @@ namespace alpaka
             struct GetExtent<
                 TIdxIntegralConst,
                 mem::view::ViewSubView<TDev, TElem, TDim, TIdx>,
-                typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
+                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getExtent(
@@ -407,7 +407,7 @@ namespace alpaka
             struct GetOffset<
                 TIdxIntegralConst,
                 mem::view::ViewSubView<TDev, TElem, TDim, TIdx>,
-                typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
+                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getOffset(

--- a/include/alpaka/meta/ApplyTuple.hpp
+++ b/include/alpaka/meta/ApplyTuple.hpp
@@ -92,7 +92,7 @@ namespace alpaka
                 detail::apply_impl(
                     std::forward<F>(f),
                     std::forward<Tuple>(t),
-                    std::make_index_sequence<std::tuple_size<typename std::decay<Tuple>::type>::value>{});
+                    std::make_index_sequence<std::tuple_size<std::decay_t<Tuple>>::value>{});
         }
     }
 }

--- a/include/alpaka/meta/Filter.hpp
+++ b/include/alpaka/meta/Filter.hpp
@@ -48,10 +48,10 @@ namespace alpaka
                 Ts...>
             {
                 using type =
-                    typename std::conditional<
+                    std::conditional_t<
                         TPred<T>::value,
                         Concatenate<TList<T>, typename FilterImplHelper<TList, TPred, Ts...>::type>,
-                        typename FilterImplHelper<TList, TPred, Ts...>::type >::type;
+                        typename FilterImplHelper<TList, TPred, Ts...>::type >;
             };
 
             //#############################################################################

--- a/include/alpaka/meta/Integral.hpp
+++ b/include/alpaka/meta/Integral.hpp
@@ -37,13 +37,13 @@ namespace alpaka
             typename T0,
             typename T1>
         using HigherMax =
-            typename std::conditional<
+            std::conditional_t<
                 (sizeof(T0) > sizeof(T1)),
                 T0,
-                typename std::conditional<
+                std::conditional_t<
                     ((sizeof(T0) == sizeof(T1)) && std::is_unsigned<T0>::value && std::is_signed<T1>::value),
                         T0,
-                        T1>::type>::type;
+                        T1>>;
 
         //#############################################################################
         //! The type that has the lower max value.
@@ -51,13 +51,13 @@ namespace alpaka
             typename T0,
             typename T1>
         using LowerMax =
-            typename std::conditional<
+            std::conditional_t<
                 (sizeof(T0) < sizeof(T1)),
                 T0,
-                typename std::conditional<
+                std::conditional_t<
                     ((sizeof(T0) == sizeof(T1)) && std::is_signed<T0>::value && std::is_unsigned<T1>::value),
                         T0,
-                        T1>::type>::type;
+                        T1>>;
 
         //#############################################################################
         //! The type that has the higher min value. If both types have the same min value, the type with the wider range is chosen.
@@ -65,22 +65,22 @@ namespace alpaka
             typename T0,
             typename T1>
         using HigherMin =
-            typename std::conditional<
+            std::conditional_t<
                 (std::is_unsigned<T0>::value == std::is_unsigned<T1>::value),
-                typename std::conditional<
+                std::conditional_t<
                     std::is_unsigned<T0>::value,
-                        typename std::conditional<
+                        std::conditional_t<
                         (sizeof(T0) < sizeof(T1)),
                             T1,
-                            T0>::type,
-                        typename std::conditional<
+                            T0>,
+                        std::conditional_t<
                         (sizeof(T0) < sizeof(T1)),
                             T0,
-                            T1>::type>::type,
-                typename std::conditional<
+                            T1>>,
+                std::conditional_t<
                     std::is_unsigned<T0>::value,
                         T0,
-                        T1>::type>::type;
+                        T1>>;
 
         //#############################################################################
         //! The type that has the lower min value. If both types have the same min value, the type with the wider range is chosen.
@@ -88,15 +88,15 @@ namespace alpaka
             typename T0,
             typename T1>
         using LowerMin =
-            typename std::conditional<
+            std::conditional_t<
                 (std::is_unsigned<T0>::value == std::is_unsigned<T1>::value),
-                typename std::conditional<
+                std::conditional_t<
                     (sizeof(T0) > sizeof(T1)),
                         T0,
-                        T1>::type,
-                typename std::conditional<
+                        T1>,
+                std::conditional_t<
                     std::is_signed<T0>::value,
                         T0,
-                        T1>::type>::type;
+                        T1>>;
     }
 }

--- a/include/alpaka/meta/IsStrictBase.hpp
+++ b/include/alpaka/meta/IsStrictBase.hpp
@@ -24,6 +24,6 @@ namespace alpaka
             std::integral_constant<
                 bool,
                 std::is_base_of<TBase, TDerived>::value
-                && !std::is_same<TBase, typename std::decay<TDerived>::type>::value>;
+                && !std::is_same<TBase, std::decay_t<TDerived>>::value>;
     }
 }

--- a/include/alpaka/offset/Traits.hpp
+++ b/include/alpaka/offset/Traits.hpp
@@ -176,8 +176,8 @@ namespace alpaka
             struct GetOffset<
                 dim::DimInt<0u>,
                 TOffsets,
-                typename std::enable_if<
-                    std::is_integral<TOffsets>::value>::type>
+                std::enable_if_t<
+                    std::is_integral<TOffsets>::value>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getOffset(
@@ -196,8 +196,8 @@ namespace alpaka
                 dim::DimInt<0u>,
                 TOffsets,
                 TOffset,
-                typename std::enable_if<
-                    std::is_integral<TOffsets>::value>::type>
+                std::enable_if_t<
+                    std::is_integral<TOffsets>::value>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setOffset(

--- a/include/alpaka/pltf/Traits.hpp
+++ b/include/alpaka/pltf/Traits.hpp
@@ -115,7 +115,7 @@ namespace alpaka
             struct QueueType<
                 TPltf,
                 TProperty,
-                typename std::enable_if<concepts::ImplementsConcept<pltf::ConceptPltf, TPltf>::value>::type
+                std::enable_if_t<concepts::ImplementsConcept<pltf::ConceptPltf, TPltf>::value>
             >
             {
                 using type = typename QueueType<

--- a/include/alpaka/queue/Traits.hpp
+++ b/include/alpaka/queue/Traits.hpp
@@ -66,7 +66,7 @@ namespace alpaka
         {
             traits::Enqueue<
                 TQueue,
-                typename std::decay<TTask>::type>
+                std::decay_t<TTask>>
             ::enqueue(
                 queue,
                 std::forward<TTask>(task));

--- a/include/alpaka/rand/RandCuRand.hpp
+++ b/include/alpaka/rand/RandCuRand.hpp
@@ -219,8 +219,8 @@ namespace alpaka
                 struct CreateNormalReal<
                     RandCuRand,
                     T,
-                    typename std::enable_if<
-                        std::is_floating_point<T>::value>::type>
+                    std::enable_if_t<
+                        std::is_floating_point<T>::value>>
                 {
                     //-----------------------------------------------------------------------------
                     __device__ static auto createNormalReal(
@@ -237,8 +237,8 @@ namespace alpaka
                 struct CreateUniformReal<
                     RandCuRand,
                     T,
-                    typename std::enable_if<
-                        std::is_floating_point<T>::value>::type>
+                    std::enable_if_t<
+                        std::is_floating_point<T>::value>>
                 {
                     //-----------------------------------------------------------------------------
                     __device__ static auto createUniformReal(
@@ -255,8 +255,8 @@ namespace alpaka
                 struct CreateUniformUint<
                     RandCuRand,
                     T,
-                    typename std::enable_if<
-                        std::is_integral<T>::value>::type>
+                    std::enable_if_t<
+                        std::is_integral<T>::value>>
                 {
                     //-----------------------------------------------------------------------------
                     __device__ static auto createUniformUint(

--- a/include/alpaka/rand/RandHipRand.hpp
+++ b/include/alpaka/rand/RandHipRand.hpp
@@ -235,8 +235,8 @@ namespace alpaka
                 struct CreateNormalReal<
                     RandHipRand,
                     T,
-                    typename std::enable_if<
-                        std::is_floating_point<T>::value>::type>
+                    std::enable_if_t<
+                        std::is_floating_point<T>::value>>
                 {
                     //-----------------------------------------------------------------------------
 
@@ -254,8 +254,8 @@ namespace alpaka
                 struct CreateUniformReal<
                     RandHipRand,
                     T,
-                    typename std::enable_if<
-                        std::is_floating_point<T>::value>::type>
+                    std::enable_if_t<
+                        std::is_floating_point<T>::value>>
                 {
                     //-----------------------------------------------------------------------------
 
@@ -273,8 +273,8 @@ namespace alpaka
                 struct CreateUniformUint<
                     RandHipRand,
                     T,
-                    typename std::enable_if<
-                        std::is_integral<T>::value>::type>
+                    std::enable_if_t<
+                        std::is_integral<T>::value>>
                 {
                     //-----------------------------------------------------------------------------
 

--- a/include/alpaka/rand/RandStdLib.hpp
+++ b/include/alpaka/rand/RandStdLib.hpp
@@ -221,8 +221,8 @@ namespace alpaka
                 struct CreateNormalReal<
                     RandStdLib,
                     T,
-                    typename std::enable_if<
-                        std::is_floating_point<T>::value>::type>
+                    std::enable_if_t<
+                        std::is_floating_point<T>::value>>
                 {
                     //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST static auto createNormalReal(
@@ -240,8 +240,8 @@ namespace alpaka
                 struct CreateUniformReal<
                     RandStdLib,
                     T,
-                    typename std::enable_if<
-                        std::is_floating_point<T>::value>::type>
+                    std::enable_if_t<
+                        std::is_floating_point<T>::value>>
                 {
                     //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST static auto createUniformReal(
@@ -259,8 +259,8 @@ namespace alpaka
                 struct CreateUniformUint<
                     RandStdLib,
                     T,
-                    typename std::enable_if<
-                        std::is_integral<T>::value>::type>
+                    std::enable_if_t<
+                        std::is_integral<T>::value>>
                 {
                     //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST static auto createUniformUint(

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -135,7 +135,7 @@ namespace alpaka
             ALPAKA_NO_HOST_ACC_WARNING
             template<
                 bool B = (TDim::value == 0u),
-                typename = typename std::enable_if<B>::type>
+                typename = std::enable_if_t<B>>
             ALPAKA_FN_HOST_ACC Vec() :
                 m_data{static_cast<TVal>(0u)}
             {}
@@ -148,12 +148,12 @@ namespace alpaka
             template<
                 typename TArg0,
                 typename... TArgs,
-                typename = typename std::enable_if<
+                typename = std::enable_if_t<
                     // There have to be dim arguments.
                     (sizeof...(TArgs)+1 == TDim::value)
                     &&
-                    (std::is_same<TVal, typename std::decay<TArg0>::type>::value)
-                    >::type>
+                    (std::is_same<TVal, std::decay_t<TArg0>>::value)
+                    >>
             ALPAKA_FN_HOST_ACC Vec(
                 TArg0 && arg0,
                 TArgs && ... args) :
@@ -296,8 +296,8 @@ namespace alpaka
             ALPAKA_NO_HOST_ACC_WARNING
             template<
                 typename TIdx,
-                typename = typename std::enable_if<
-                    std::is_integral<TIdx>::value>::type>
+                typename = std::enable_if_t<
+                    std::is_integral<TIdx>::value>>
             ALPAKA_FN_HOST_ACC auto operator[](
                 TIdx const iIdx)
             -> TVal &
@@ -314,8 +314,8 @@ namespace alpaka
             ALPAKA_NO_HOST_ACC_WARNING
             template<
                 typename TIdx,
-                typename = typename std::enable_if<
-                    std::is_integral<TIdx>::value>::type>
+                typename = std::enable_if_t<
+                    std::is_integral<TIdx>::value>>
             ALPAKA_FN_HOST_ACC auto operator[](
                 TIdx const iIdx) const
             -> TVal
@@ -873,12 +873,12 @@ namespace alpaka
             struct SubVecFromIndices<
                 Vec<TDim, TVal>,
                 std::integer_sequence<std::size_t, TIndices...>,
-                typename std::enable_if<
+                std::enable_if_t<
                     !std::is_same<
                         std::integer_sequence<std::size_t, TIndices...>,
                         std::make_integer_sequence<std::size_t, TDim::value>
                     >::value
-                >::type>
+                >>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto subVecFromIndices(
@@ -902,12 +902,12 @@ namespace alpaka
             struct SubVecFromIndices<
                 Vec<TDim, TVal>,
                 std::integer_sequence<std::size_t, TIndices...>,
-                typename std::enable_if<
+                std::enable_if_t<
                     std::is_same<
                         std::integer_sequence<std::size_t, TIndices...>,
                         std::make_integer_sequence<std::size_t, TDim::value>
                     >::value
-                >::type>
+                >>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto subVecFromIndices(
@@ -1242,7 +1242,7 @@ namespace alpaka
             struct GetExtent<
                 TIdxIntegralConst,
                 vec::Vec<TDim, TVal>,
-                typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
+                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getExtent(
@@ -1263,7 +1263,7 @@ namespace alpaka
                 TIdxIntegralConst,
                 vec::Vec<TDim, TVal>,
                 TExtentVal,
-                typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
+                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setExtent(
@@ -1289,7 +1289,7 @@ namespace alpaka
             struct GetOffset<
                 TIdxIntegralConst,
                 vec::Vec<TDim, TVal>,
-                typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
+                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getOffset(
@@ -1310,7 +1310,7 @@ namespace alpaka
                 TIdxIntegralConst,
                 vec::Vec<TDim, TVal>,
                 TOffset,
-                typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
+                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto setOffset(

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -24,6 +24,7 @@
 #include <functional>
 #include <set>
 #include <array>
+#include <type_traits>
 
 //-----------------------------------------------------------------------------
 //! The alpaka library.
@@ -50,7 +51,7 @@ namespace alpaka
             //!     2) ret<=maxDivisor
             template<
                 typename T,
-                typename = typename std::enable_if<std::is_integral<T>::value>::type>
+                typename = std::enable_if_t<std::is_integral<T>::value>>
             ALPAKA_FN_HOST auto nextDivisorLowerOrEqual(
                 T const & maxDivisor,
                 T const & dividend)
@@ -75,7 +76,7 @@ namespace alpaka
             //! \return A list of all divisors less then or equal to the given maximum.
             template<
                 typename T,
-                typename = typename std::enable_if<std::is_integral<T>::value>::type>
+                typename = std::enable_if_t<std::is_integral<T>::value>>
             ALPAKA_FN_HOST auto allDivisorsLessOrEqual(
                 T const & val,
                 T const & maxDivisor)

--- a/test/common/include/alpaka/test/MeasureKernelRunTime.hpp
+++ b/test/common/include/alpaka/test/MeasureKernelRunTime.hpp
@@ -34,7 +34,7 @@ namespace alpaka
                 std::cout
                     << "measureKernelRunTime("
                     << " queue: " << typeid(TQueue).name()
-                    << " task: " << typeid(typename std::decay<TTask>::type).name()
+                    << " task: " << typeid(std::decay_t<TTask>).name()
                     << ")" << std::endl;
 #endif
                 // Wait for the queue to finish all tasks enqueued prior to the giventask.

--- a/test/common/include/alpaka/test/acc/TestAccs.hpp
+++ b/test/common/include/alpaka/test/acc/TestAccs.hpp
@@ -241,8 +241,8 @@ namespace alpaka
                 {
                     using type =
                         EnabledAccs<
-                            typename std::tuple_element<0, TTestAccParamSet>::type,
-                            typename std::tuple_element<1, TTestAccParamSet>::type
+                            std::tuple_element_t<0, TTestAccParamSet>,
+                            std::tuple_element_t<1, TTestAccParamSet>
                         >;
                 };
 

--- a/test/common/include/alpaka/test/mem/view/Iterator.hpp
+++ b/test/common/include/alpaka/test/mem/view/Iterator.hpp
@@ -11,6 +11,8 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include <type_traits>
+
 namespace alpaka
 {
     //-----------------------------------------------------------------------------
@@ -35,10 +37,10 @@ namespace alpaka
                     template<
                         typename T,
                         typename TSource>
-                    using MimicConst = typename std::conditional<
+                    using MimicConst = std::conditional_t<
                         std::is_const<TSource>::value,
-                        typename std::add_const<T>::type,
-                        typename std::remove_const<T>::type>;
+                        std::add_const_t<T>,
+                        std::remove_const_t<T>>;
 
 #if BOOST_COMP_GNUC
     #pragma GCC diagnostic push
@@ -50,10 +52,10 @@ namespace alpaka
                         typename TSfinae = void>
                     class IteratorView
                     {
-                        using TViewDecayed = typename std::decay<TView>::type;
+                        using TViewDecayed = std::decay_t<TView>;
                         using Dim = alpaka::dim::Dim<TViewDecayed>;
                         using Idx = alpaka::idx::Idx<TViewDecayed>;
-                        using Elem = typename MimicConst<alpaka::elem::Elem<TViewDecayed>, TView>::type;
+                        using Elem = MimicConst<alpaka::elem::Elem<TViewDecayed>, TView>;
 
                     public:
                         //-----------------------------------------------------------------------------
@@ -147,7 +149,7 @@ namespace alpaka
                             // sum{[py*z, px*y, ElemSize*x]} -> offset in byte
                             auto const offsetInByte(dimensionalOffsetsInByte.foldrAll(std::plus<Idx>()));
 
-                            using Byte = typename MimicConst<std::uint8_t, Elem>::type;
+                            using Byte = MimicConst<std::uint8_t, Elem>;
                             Byte* ptr(reinterpret_cast<Byte*>(m_nativePtr) + offsetInByte);
 
 #if 0

--- a/test/common/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/test/common/include/alpaka/test/mem/view/ViewTest.hpp
@@ -17,6 +17,7 @@
 #include <catch2/catch.hpp>
 
 #include <numeric>
+#include <type_traits>
 
 
 namespace alpaka
@@ -117,7 +118,7 @@ namespace alpaka
                             std::is_pointer<NativePtr>::value,
                             "The value returned by getPtrNative has to be a pointer.");
                         static_assert(
-                            std::is_const<typename std::remove_pointer<NativePtr>::type>::value,
+                            std::is_const<std::remove_pointer_t<NativePtr>>::value,
                             "The value returned by getPtrNative has to be const when the view is const.");
 
                         if(alpaka::extent::getExtentProduct(view) != static_cast<TIdx>(0u))
@@ -329,7 +330,7 @@ namespace alpaka
                             std::is_pointer<NativePtr>::value,
                             "The value returned by getPtrNative has to be a pointer.");
                         static_assert(
-                            !std::is_const<typename std::remove_pointer<NativePtr>::type>::value,
+                            !std::is_const<std::remove_pointer_t<NativePtr>>::value,
                             "The value returned by getPtrNative has to be non-const when the view is non-const.");
                     }
 

--- a/test/common/include/alpaka/test/queue/QueueTestFixture.hpp
+++ b/test/common/include/alpaka/test/queue/QueueTestFixture.hpp
@@ -9,6 +9,8 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include <tuple>
+
 namespace alpaka
 {
     namespace test
@@ -20,8 +22,8 @@ namespace alpaka
                 typename TDevQueue>
             struct QueueTestFixture
             {
-                using Dev = typename std::tuple_element<0, TDevQueue>::type;
-                using Queue = typename std::tuple_element<1, TDevQueue>::type;
+                using Dev = std::tuple_element_t<0, TDevQueue>;
+                using Queue = std::tuple_element_t<1, TDevQueue>;
 
                 using Pltf = alpaka::pltf::Pltf<Dev>;
 

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -15,6 +15,7 @@
 #include <catch2/catch.hpp>
 
 #include <climits>
+#include <type_traits>
 
 //-----------------------------------------------------------------------------
 ALPAKA_NO_HOST_ACC_WARNING
@@ -609,14 +610,14 @@ template<
 class AtomicTestKernel<
     alpaka::acc::AccGpuCudaRt<TDim, TIdx>,
     T,
-    typename std::enable_if<
+    std::enable_if_t<
         !std::is_same<int, T>::value
         && !std::is_same<unsigned int, T>::value
         && !std::is_same<unsigned long int, T>::value
         && !std::is_same<unsigned long long int, T>::value
         && !std::is_same<float, T>::value
         && !std::is_same<double, T>::value
-    >::type>
+    >>
 {
 public:
     //-----------------------------------------------------------------------------
@@ -892,14 +893,14 @@ template<
 class AtomicTestKernel<
     alpaka::acc::AccGpuHipRt<TDim, TIdx>,
     T,
-    typename std::enable_if<
+    std::enable_if_t<
         !std::is_same<int, T>::value
         && !std::is_same<unsigned int, T>::value
         && !std::is_same<unsigned long int, T>::value
         && !std::is_same<unsigned long long int, T>::value
         && !std::is_same<float, T>::value
         && !std::is_same<double, T>::value
-    >::type>
+    >>
 {
 public:
     //-----------------------------------------------------------------------------

--- a/test/unit/math/sincos/src/sincos.cpp
+++ b/test/unit/math/sincos/src/sincos.cpp
@@ -15,10 +15,12 @@
 
 #include <catch2/catch.hpp>
 
+#include <type_traits>
+
 // https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
 template <typename TAcc, typename FP>
 ALPAKA_FN_ACC
-typename std::enable_if< !std::numeric_limits<FP>::is_integer, bool >::type
+std::enable_if_t< !std::numeric_limits<FP>::is_integer, bool >
 almost_equal(TAcc const & acc, FP x, FP y, int ulp)
 {
     // the machine epsilon has to be scaled to the magnitude of the values used

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -98,7 +98,7 @@ TEST_CASE("basicVecTraits", "[vec]")
                     vec));
 
         /*using VecCastConst = decltype(vecCast);
-        using VecCast = typename std::decay<VecCastConst>::type;
+        using VecCast = std::decay_t<VecCastConst>;
         static_assert(
             std::is_same<
                 alpaka::idx::Idx<VecCast>,


### PR DESCRIPTION
Replace the old `typename std::[trait]<...>::type` with C++14 `std::[trait]_t<...>`.
Add occasionally missing `#include <type_traits>`.

There is a similar helper for values, but this is C++17, so not changed.

TODO: test properly, since  I could have introduced typos.