### PR TITLE
Remove setting cmake policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,16 +18,6 @@ project("alpakaAll")
 SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
 
 ################################################################################
-# CMake policies
-#
-# Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
-
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
-
-################################################################################
 # Options and Variants
 
 option(alpaka_BUILD_EXAMPLES "Build the examples" ON)

--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -14,16 +14,6 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.15)
 
 ################################################################################
-# CMake policies
-#
-# Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
-
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
-
-################################################################################
 # alpaka.
 
 # Return values.

--- a/cmake/addExecutable.cmake
+++ b/cmake/addExecutable.cmake
@@ -31,11 +31,9 @@ MACRO(ALPAKA_ADD_EXECUTABLE In_Name)
                     SET_SOURCE_FILES_PROPERTIES(${_file} PROPERTIES CUDA_SOURCE_PROPERTY_FORMAT OBJ)
                 ENDIF()
             ENDFOREACH()
-            IF (CMAKE_VERSION VERSION_LESS 3.9.0)
-                CMAKE_POLICY(SET CMP0023 OLD)   # CUDA_ADD_EXECUTABLE calls TARGET_LINK_LIBRARIES without keywords.
-            ELSE()
-                SET(CUDA_LINK_LIBRARIES_KEYWORD "PUBLIC")
-            ENDIF()
+
+            SET(CUDA_LINK_LIBRARIES_KEYWORD "PUBLIC")
+
             CUDA_ADD_EXECUTABLE(
                 ${In_Name}
                 ${ARGN})
@@ -46,11 +44,6 @@ MACRO(ALPAKA_ADD_EXECUTABLE In_Name)
 		            SET_SOURCE_FILES_PROPERTIES(${_file} PROPERTIES HIP_SOURCE_PROPERTY_FORMAT OBJ)
 		        ENDIF()
 	      ENDFOREACH()
-        IF (CMAKE_VERSION VERSION_LESS 3.9.0)
-            CMAKE_POLICY(SET CMP0023 OLD)   # CUDA_ADD_EXECUTABLE calls TARGET_LINK_LIBRARIES without keywords.
-        ELSE()
-            SET(HIP_LINK_LIBRARIES_KEYWORD "PUBLIC")
-        ENDIF()
 
 	      HIP_ADD_EXECUTABLE(
 		        ${In_Name}

--- a/cmake/addLibrary.cmake
+++ b/cmake/addLibrary.cmake
@@ -107,11 +107,7 @@ MACRO(ALPAKA_ADD_LIBRARY libraryName)
                     SET_SOURCE_FILES_PROPERTIES( ${_file} PROPERTIES CUDA_SOURCE_PROPERTY_FORMAT OBJ )
                 ENDIF()
             ENDFOREACH()
-            IF (CMAKE_VERSION VERSION_LESS 3.9.0)
-                CMAKE_POLICY(SET CMP0023 OLD)   # CUDA_ADD_EXECUTABLE calls TARGET_LINK_LIBRARIES without keywords.
-            ELSE()
-                SET(CUDA_LINK_LIBRARIES_KEYWORD "PUBLIC")
-            ENDIF()
+            SET(CUDA_LINK_LIBRARIES_KEYWORD "PUBLIC")
             CUDA_ADD_LIBRARY(
                 ${libraryName}
                 ${sourceFileNames}
@@ -128,7 +124,6 @@ MACRO(ALPAKA_ADD_LIBRARY libraryName)
                     SET_SOURCE_FILES_PROPERTIES( ${_file} PROPERTIES HIP_SOURCE_PROPERTY_FORMAT OBJ )
                 ENDIF()
             ENDFOREACH()
-            CMAKE_POLICY(SET CMP0023 OLD)   # CUDA_ADD_LIBRARY calls TARGET_LINK_LIBRARIES without keywords.
             HIP_ADD_LIBRARY(
                 ${libraryName}
                 ${sourceFileNames}

--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -194,9 +194,6 @@ FUNCTION(list_add_prefix In_Prefix In_ListVariableName)
     FOREACH(
         item
         IN LISTS ${In_ListVariableName})
-        IF(POLICY CMP0054)
-            CMAKE_POLICY(SET CMP0054 NEW)   # Only interpret if() arguments as variables or keywords when unquoted.
-        ENDIF()
         IF(NOT "${item}" STREQUAL "")
             LIST(
                 APPEND

--- a/example/bufferCopy/CMakeLists.txt
+++ b/example/bufferCopy/CMakeLists.txt
@@ -30,16 +30,6 @@ SET(_TARGET_NAME bufferCopy)
 
 PROJECT(${_TARGET_NAME})
 
-################################################################################
-# CMake policies
-#
-# Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
-
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
-
 #-------------------------------------------------------------------------------
 # Find alpaka.
 

--- a/example/helloWorld/CMakeLists.txt
+++ b/example/helloWorld/CMakeLists.txt
@@ -30,16 +30,6 @@ SET(_TARGET_NAME helloWorld)
 
 PROJECT(${_TARGET_NAME})
 
-################################################################################
-# CMake policies
-#
-# Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
-
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
-
 #-------------------------------------------------------------------------------
 # Find alpaka.
 

--- a/example/helloWorldLambda/CMakeLists.txt
+++ b/example/helloWorldLambda/CMakeLists.txt
@@ -30,16 +30,6 @@ SET(_TARGET_NAME helloWorldLambda)
 
 PROJECT(${_TARGET_NAME})
 
-################################################################################
-# CMake policies
-#
-# Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
-
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
-
 #-------------------------------------------------------------------------------
 # Find alpaka.
 

--- a/example/reduce/CMakeLists.txt
+++ b/example/reduce/CMakeLists.txt
@@ -30,16 +30,6 @@ SET(_TARGET_NAME reduce)
 
 PROJECT(${_TARGET_NAME})
 
-################################################################################
-# CMake policies
-#
-# Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
-
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
-
 #-------------------------------------------------------------------------------
 # Find alpaka.
 

--- a/example/vectorAdd/CMakeLists.txt
+++ b/example/vectorAdd/CMakeLists.txt
@@ -30,15 +30,6 @@ SET(_TARGET_NAME vectorAdd)
 
 PROJECT(${_TARGET_NAME})
 
-################################################################################
-# CMake policies
-#
-# Search in <PackageName>_ROOT:
-#   https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
-
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
 
 #-------------------------------------------------------------------------------
 # Find alpaka.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,12 +10,6 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.15)
 
-# Search in <PackageName>_ROOT:
-# https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
-if(POLICY CMP0074)
-    cmake_policy(SET CMP0074 NEW)
-endif()
-
 LIST(APPEND CMAKE_MODULE_PATH "${ALPAKA_ROOT}")
 FIND_PACKAGE(alpaka REQUIRED)
 


### PR DESCRIPTION
After we increased the CMAKE_MINIMUM_REQUIRED version we can now remove
setting older policies because all of them are now implicitly set to new.