### PR TITLE
gitignore: more IntelliJ/KDevelop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,10 @@
 # VIM project files
 .vimrc
 
+# IDE & tmp build
 .idea/
+cmake-build-*/
+.kdev?/
+*.kdev?
+spack-build*
+build/


### PR DESCRIPTION
Add more typical files/dirs created by IntelliJ IDEs (CLion) and Kdevelop.

Related to #921 