### PR TITLE
unify CUDA/HIP function calls/types

### DIFF
--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -153,41 +153,41 @@ namespace alpaka
                     // Reading only the necessary attributes with cudaDeviceGetAttribute is faster than reading all with cuda
                     // https://devblogs.nvidia.com/cuda-pro-tip-the-fast-way-to-query-device-properties/
                     int multiProcessorCount = {};
-                    ALPAKA_CUDA_RT_CHECK(cudaDeviceGetAttribute(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
                         &multiProcessorCount,
                         cudaDevAttrMultiProcessorCount,
                         dev.m_iDevice));
 
                     int maxGridSize[3] = {};
-                    ALPAKA_CUDA_RT_CHECK(cudaDeviceGetAttribute(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
                         &maxGridSize[0],
                         cudaDevAttrMaxGridDimX,
                         dev.m_iDevice));
-                    ALPAKA_CUDA_RT_CHECK(cudaDeviceGetAttribute(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
                         &maxGridSize[1],
                         cudaDevAttrMaxGridDimY,
                         dev.m_iDevice));
-                    ALPAKA_CUDA_RT_CHECK(cudaDeviceGetAttribute(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
                         &maxGridSize[2],
                         cudaDevAttrMaxGridDimZ,
                         dev.m_iDevice));
 
                     int maxBlockDim[3] = {};
-                    ALPAKA_CUDA_RT_CHECK(cudaDeviceGetAttribute(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
                         &maxBlockDim[0],
                         cudaDevAttrMaxBlockDimX,
                         dev.m_iDevice));
-                    ALPAKA_CUDA_RT_CHECK(cudaDeviceGetAttribute(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
                         &maxBlockDim[1],
                         cudaDevAttrMaxBlockDimY,
                         dev.m_iDevice));
-                    ALPAKA_CUDA_RT_CHECK(cudaDeviceGetAttribute(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
                         &maxBlockDim[2],
                         cudaDevAttrMaxBlockDimZ,
                         dev.m_iDevice));
 
                     int maxThreadsPerBlock = {};
-                    ALPAKA_CUDA_RT_CHECK(cudaDeviceGetAttribute(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
                         &maxThreadsPerBlock,
                         cudaDevAttrMaxThreadsPerBlock,
                         dev.m_iDevice));
@@ -219,7 +219,7 @@ namespace alpaka
 
 #else
                     hipDeviceProp_t hipDevProp;
-                    ALPAKA_HIP_RT_CHECK(hipGetDeviceProperties(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipGetDeviceProperties(
                         &hipDevProp,
                         dev.m_iDevice));
 

--- a/include/alpaka/core/Cuda.hpp
+++ b/include/alpaka/core/Cuda.hpp
@@ -34,10 +34,8 @@
 #include <cuda_runtime.h>
 #include <cuda.h>
 
-#include <array>
 #include <type_traits>
 #include <utility>
-#include <iostream>
 #include <string>
 #include <stdexcept>
 #include <cstddef>
@@ -50,97 +48,10 @@
     #error "CUDA version 9.0 or greater required!"
 #endif
 
-namespace alpaka
-{
-    namespace cuda
-    {
-        namespace detail
-        {
-            //-----------------------------------------------------------------------------
-            //! CUDA runtime API error checking with log and exception, ignoring specific error values
-            ALPAKA_FN_HOST inline auto cudaRtCheck(
-                cudaError_t const & error,
-                char const * desc,
-                char const * file,
-                int const & line)
-            -> void
-            {
-                if(error != cudaSuccess)
-                {
-                    std::string const sError(std::string(file) + "(" + std::to_string(line) + ") " + std::string(desc) + " : '" + cudaGetErrorName(error) +  "': '" + std::string(cudaGetErrorString(error)) + "'!");
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
-                    std::cerr << sError << std::endl;
-#endif
-                    ALPAKA_DEBUG_BREAK;
-                    // reset the last error to allow user side error handling
-                    cudaGetLastError();
-                    throw std::runtime_error(sError);
-                }
-            }
-            //-----------------------------------------------------------------------------
-            //! CUDA runtime API error checking with log and exception, ignoring specific error values
-            // NOTE: All ignored errors have to be convertible to cudaError_t.
-            template<
-                typename... TErrors>
-            ALPAKA_FN_HOST auto cudaRtCheckIgnore(
-                cudaError_t const & error,
-                char const * cmd,
-                char const * file,
-                int const & line,
-                TErrors && ... ignoredErrorCodes)
-            -> void
-            {
-                if(error != cudaSuccess)
-                {
-                    std::array<cudaError_t, sizeof...(ignoredErrorCodes)> const aIgnoredErrorCodes{ignoredErrorCodes...};
-
-                    // If the error code is not one of the ignored ones.
-                    if(std::find(aIgnoredErrorCodes.cbegin(), aIgnoredErrorCodes.cend(), error) == aIgnoredErrorCodes.cend())
-                    {
-                        cudaRtCheck(error, ("'" + std::string(cmd) + "' returned error ").c_str(), file, line);
-                    }
-                }
-            }
-            //-----------------------------------------------------------------------------
-            //! CUDA runtime API last error checking with log and exception.
-            ALPAKA_FN_HOST inline auto cudaRtCheckLastError(
-                char const * desc,
-                char const * file,
-                int const & line)
-            -> void
-            {
-                cudaError_t const error(cudaGetLastError());
-                cudaRtCheck(error, desc, file, line);
-            }
-        }
-    }
-}
-
-#if BOOST_COMP_MSVC
-    //-----------------------------------------------------------------------------
-    //! CUDA runtime error checking with log and exception, ignoring specific error values
-    #define ALPAKA_CUDA_RT_CHECK_IGNORE(cmd, ...)\
-        ::alpaka::cuda::detail::cudaRtCheckLastError("'" #cmd "' A previous CUDA call (not this one) set the error ", __FILE__, __LINE__);\
-        ::alpaka::cuda::detail::cudaRtCheckIgnore(cmd, #cmd, __FILE__, __LINE__, __VA_ARGS__)
-#else
-    #if BOOST_COMP_CLANG
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-    #endif
-    //-----------------------------------------------------------------------------
-    //! CUDA runtime error checking with log and exception, ignoring specific error values
-    #define ALPAKA_CUDA_RT_CHECK_IGNORE(cmd, ...)\
-        ::alpaka::cuda::detail::cudaRtCheckLastError("'" #cmd "' A previous CUDA call (not this one) set the error ", __FILE__, __LINE__);\
-        ::alpaka::cuda::detail::cudaRtCheckIgnore(cmd, #cmd, __FILE__, __LINE__, ##__VA_ARGS__)
-    #if BOOST_COMP_CLANG
-        #pragma clang diagnostic pop
-    #endif
-#endif
-
-//-----------------------------------------------------------------------------
-//! CUDA runtime error checking with log and exception.
-#define ALPAKA_CUDA_RT_CHECK(cmd)\
-    ALPAKA_CUDA_RT_CHECK_IGNORE(cmd)
+#define ALPAKA_PP_CONCAT_DO(X,Y) X##Y
+#define ALPAKA_PP_CONCAT(X,Y) ALPAKA_PP_CONCAT_DO(X,Y)
+//! prefix a name with `cuda`
+#define ALPAKA_API_PREFIX(name) ALPAKA_PP_CONCAT_DO(cuda,name)
 
 namespace alpaka
 {
@@ -746,5 +657,7 @@ namespace alpaka
         }
     }
 }
+
+#include <alpaka/core/UniformCudaHip.hpp>
 
 #endif

--- a/include/alpaka/core/UniformCudaHip.hpp
+++ b/include/alpaka/core/UniformCudaHip.hpp
@@ -1,0 +1,136 @@
+/* Copyright 2019 Axel Huebl, Benjamin Worpitz, Matthias Werner, René Widera
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+
+#include <alpaka/core/BoostPredef.hpp>
+
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+    #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#endif
+
+#if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+    #error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#endif
+
+// Backend specific includes.
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+    #include <alpaka/core/Cuda.hpp>
+#else
+    #include <alpaka/core/Hip.hpp>
+#endif
+
+#include <string>
+#include <array>
+#include <type_traits>
+#include <string>
+#include <stdexcept>
+
+namespace alpaka
+{
+    namespace uniform_cuda_hip
+    {
+        namespace detail
+        {
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+            using Error_t = cudaError;
+#else
+            using Error_t = hipError_t;
+#endif
+            //-----------------------------------------------------------------------------
+            //! CUDA/HIP runtime API error checking with log and exception, ignoring specific error values
+            ALPAKA_FN_HOST inline auto rtCheck(
+                Error_t const & error,
+                char const * desc,
+                char const * file,
+                int const & line)
+            -> void
+            {
+                if(error != ALPAKA_API_PREFIX(Success))
+                {
+                    std::string const sError(std::string(file) + "(" + std::to_string(line) + ") " + std::string(desc) + " : '" + ALPAKA_API_PREFIX(GetErrorName)(error) +  "': '" + std::string(ALPAKA_API_PREFIX(GetErrorString)(error)) + "'!");
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
+                    std::cerr << sError << std::endl;
+#endif
+                    ALPAKA_DEBUG_BREAK;
+                    // reset the last error to allow user side error handling
+                    ALPAKA_API_PREFIX(GetLastError)();
+                    throw std::runtime_error(sError);
+                }
+            }
+            //-----------------------------------------------------------------------------
+            //! CUDA/Hip runtime API error checking with log and exception, ignoring specific error values
+            // NOTE: All ignored errors have to be convertible to Error_t.
+            template<
+                typename... TErrors>
+            ALPAKA_FN_HOST auto rtCheckIgnore(
+                Error_t const & error,
+                char const * cmd,
+                char const * file,
+                int const & line,
+                TErrors && ... ignoredErrorCodes)
+            -> void
+            {
+                if(error != ALPAKA_API_PREFIX(Success))
+                {
+                    std::array<Error_t, sizeof...(ignoredErrorCodes)> const aIgnoredErrorCodes{ignoredErrorCodes...};
+
+                    // If the error code is not one of the ignored ones.
+                    if(std::find(aIgnoredErrorCodes.cbegin(), aIgnoredErrorCodes.cend(), error) == aIgnoredErrorCodes.cend())
+                    {
+                        rtCheck(error, ("'" + std::string(cmd) + "' returned error ").c_str(), file, line);
+                    }
+                }
+            }
+            //-----------------------------------------------------------------------------
+            //! CUDA runtime API last error checking with log and exception.
+            ALPAKA_FN_HOST inline auto rtCheckLastError(
+                char const * desc,
+                char const * file,
+                int const & line)
+            -> void
+            {
+                Error_t const error(ALPAKA_API_PREFIX(GetLastError)());
+                rtCheck(error, desc, file, line);
+            }
+        }
+    }
+}
+
+#if BOOST_COMP_MSVC
+    //-----------------------------------------------------------------------------
+    //! CUDA runtime error checking with log and exception, ignoring specific error values
+    #define ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(cmd, ...)\
+        ::alpaka::uniform_cuda_hip::detail::rtCheckLastError("'" #cmd "' A previous API call (not this one) set the error ", __FILE__, __LINE__);\
+        ::alpaka::uniform_cuda_hip::detail::rtCheckIgnore(cmd, #cmd, __FILE__, __LINE__, __VA_ARGS__)
+#else
+    #if BOOST_COMP_CLANG
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+    #endif
+    //-----------------------------------------------------------------------------
+    //! CUDA runtime error checking with log and exception, ignoring specific error values
+    #define ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(cmd, ...)\
+        ::alpaka::uniform_cuda_hip::detail::rtCheckLastError("'" #cmd "' A previous API call (not this one) set the error ", __FILE__, __LINE__);\
+        ::alpaka::uniform_cuda_hip::detail::rtCheckIgnore(cmd, #cmd, __FILE__, __LINE__, ##__VA_ARGS__)
+    #if BOOST_COMP_CLANG
+        #pragma clang diagnostic pop
+    #endif
+#endif
+
+//-----------------------------------------------------------------------------
+//! CUDA runtime error checking with log and exception.
+#define ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cmd)\
+    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(cmd)
+
+#endif

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -116,24 +116,18 @@ namespace alpaka
                     dev::DevUniformCudaHipRt const & dev)
                 -> std::string
                 {
+                    // There is cuda/hip-DeviceGetAttribute as faster alternative to cuda/hip-GetDeviceProperties to get a single device property but it has no option to get the name
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                    // There is cudaDeviceGetAttribute as faster alternative to cudaGetDeviceProperties to get a single device property but it has no option to get the name
-                    cudaDeviceProp cudaDevProp;
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaGetDeviceProperties(
-                            &cudaDevProp,
-                            dev.m_iDevice));
-
-                    return std::string(cudaDevProp.name);
+                    cudaDeviceProp devProp;
 #else
-                    hipDeviceProp_t hipDevProp;
-                    ALPAKA_HIP_RT_CHECK(
-                        hipGetDeviceProperties(
-                            &hipDevProp,
+                    hipDeviceProp_t devProp;
+#endif
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(GetDeviceProperties)(
+                            &devProp,
                             dev.m_iDevice));
 
-                    return std::string(hipDevProp.name);
-#endif
+                    return std::string(devProp.name);
                 }
             };
 
@@ -148,37 +142,20 @@ namespace alpaka
                     dev::DevUniformCudaHipRt const & dev)
                 -> std::size_t
                 {
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                     // Set the current device to wait for.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaSetDevice(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(SetDevice)(
                             dev.m_iDevice));
 
                     std::size_t freeInternal(0u);
                     std::size_t totalInternal(0u);
 
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaMemGetInfo(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(MemGetInfo)(
                             &freeInternal,
                             &totalInternal));
 
                     return totalInternal;
-#else
-                  // Set the current device to wait for.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipSetDevice(
-                            dev.m_iDevice));
-
-                    std::size_t freeInternal(0u);
-                    std::size_t totalInternal(0u);
-
-                    ALPAKA_HIP_RT_CHECK(
-                        hipMemGetInfo(
-                            &freeInternal,
-                            &totalInternal));
-
-                    return totalInternal;
-#endif
                 }
             };
 
@@ -193,37 +170,20 @@ namespace alpaka
                     dev::DevUniformCudaHipRt const & dev)
                 -> std::size_t
                 {
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                     // Set the current device to wait for.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaSetDevice(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(SetDevice)(
                             dev.m_iDevice));
 
                     std::size_t freeInternal(0u);
                     std::size_t totalInternal(0u);
 
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaMemGetInfo(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(MemGetInfo)(
                             &freeInternal,
                             &totalInternal));
 
                     return freeInternal;
-#else
-                    // Set the current device to wait for.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipSetDevice(
-                            dev.m_iDevice));
-
-                    std::size_t freeInternal(0u);
-                    std::size_t totalInternal(0u);
-
-                    ALPAKA_HIP_RT_CHECK(
-                        hipMemGetInfo(
-                            &freeInternal,
-                            &totalInternal));
-
-                    return freeInternal;
-#endif
                 }
             };
 
@@ -240,21 +200,12 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                     // Set the current device to wait for.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaSetDevice(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(SetDevice)(
                             dev.m_iDevice));
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaDeviceReset());
-#else
-                    // Set the current device to wait for.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipSetDevice(
-                            dev.m_iDevice));
-                    ALPAKA_HIP_RT_CHECK(
-                        hipDeviceReset());
-#endif
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(DeviceReset)());
                 }
             };
         }
@@ -321,17 +272,11 @@ namespace alpaka
                 -> void
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+
                     // Set the current device to wait for.
-                    ALPAKA_CUDA_RT_CHECK(cudaSetDevice(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(
                         dev.m_iDevice));
-                    ALPAKA_CUDA_RT_CHECK(cudaDeviceSynchronize());
-#else
-                    // Set the current device to wait for.
-                    ALPAKA_HIP_RT_CHECK(hipSetDevice(
-                        dev.m_iDevice));
-                    ALPAKA_HIP_RT_CHECK(hipDeviceSynchronize());
-#endif
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(DeviceSynchronize)());
                 }
             };
         }

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -456,31 +456,19 @@ namespace alpaka
 
                         if(!mem::buf::isPinned(buf))
                         {
-#if (defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA)
+#if (defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
                             if(buf.m_spBufCpuImpl->m_extentElements.prod() != 0)
                             {
                                 // - cudaHostRegisterDefault:
                                 //   See http://cgi.cs.indiana.edu/~nhusted/dokuwiki/doku.php?id=programming:cudaperformance1
                                 // - cudaHostRegisterPortable:
                                 //   The memory returned by this call will be considered as pinned memory by all CUDA contexts, not just the one that performed the allocation.
-                                ALPAKA_CUDA_RT_CHECK_IGNORE(
-                                    cudaHostRegister(
+                                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
+                                    ALPAKA_API_PREFIX(HostRegister)(
                                         const_cast<void *>(reinterpret_cast<void const *>(mem::view::getPtrNative(buf))),
                                         extent::getExtentProduct(buf) * sizeof(elem::Elem<buf::BufCpu<TElem, TDim, TIdx>>),
-                                        cudaHostRegisterDefault),
-                                    cudaErrorHostMemoryAlreadyRegistered);
-
-                                buf.m_spBufCpuImpl->m_bPinned = true;
-                            }
-#elif (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
-                            if(buf.m_spBufCpuImpl->m_extentElements.prod() != 0)
-                            {
-                                ALPAKA_HIP_RT_CHECK_IGNORE(
-                                    hipHostRegister(
-                                        const_cast<void *>(reinterpret_cast<void const *>(mem::view::getPtrNative(buf))),
-                                        extent::getExtentProduct(buf) * sizeof(elem::Elem<buf::BufCpu<TElem, TDim, TIdx>>),
-                                        hipHostRegisterDefault),
-                                    hipErrorHostMemoryAlreadyRegistered);
+                                        ALPAKA_API_PREFIX(HostRegisterDefault)),
+                                    ALPAKA_API_PREFIX(ErrorHostMemoryAlreadyRegistered));
 
                                 buf.m_spBufCpuImpl->m_bPinned = true;
                             }
@@ -527,18 +515,11 @@ namespace alpaka
 
                         if(mem::buf::isPinned(bufImpl))
                         {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA
-                            ALPAKA_CUDA_RT_CHECK_IGNORE(
-                                cudaHostUnregister(
+#if (defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
+                                ALPAKA_API_PREFIX(HostUnregister)(
                                     const_cast<void *>(reinterpret_cast<void const *>(bufImpl.m_pMem))),
-                                cudaErrorHostMemoryNotRegistered);
-
-                            bufImpl.m_bPinned = false;
-#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP
-                            ALPAKA_HIP_RT_CHECK_IGNORE(
-                                hipHostUnregister(
-                                    const_cast<void *>(reinterpret_cast<void const *>(bufImpl.m_pMem))),
-                                hipErrorHostMemoryNotRegistered);
+                                ALPAKA_API_PREFIX(ErrorHostMemoryNotRegistered));
 
                             bufImpl.m_bPinned = false;
 #else

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -174,31 +174,17 @@ namespace alpaka
                     auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(view)));
                     ALPAKA_ASSERT(extentWidth <= dstWidth);
 
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                     // Set the current device.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaSetDevice(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(SetDevice)(
                             iDevice));
                     // Initiate the memory set.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaMemsetAsync(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(MemsetAsync)(
                             dstNativePtr,
                             static_cast<int>(byte),
                             static_cast<size_t>(extentWidthBytes),
                             queue.m_spQueueImpl->m_UniformCudaHipQueue));
-#else
-                    // Set the current device.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipSetDevice(
-                            iDevice));
-                    // Initiate the memory set.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipMemsetAsync(
-                            dstNativePtr,
-                            static_cast<int>(byte),
-                            static_cast<size_t>(extentWidthBytes),
-                            queue.m_spQueueImpl->m_UniformCudaHipQueue));
-#endif
                 }
             };
             //#############################################################################
@@ -246,31 +232,17 @@ namespace alpaka
                     auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(view)));
                     ALPAKA_ASSERT(extentWidth <= dstWidth);
 
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                     // Set the current device.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaSetDevice(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(SetDevice)(
                             iDevice));
                     // Initiate the memory set.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaMemsetAsync(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(MemsetAsync)(
                             dstNativePtr,
                             static_cast<int>(byte),
                             static_cast<size_t>(extentWidthBytes),
                             queue.m_spQueueImpl->m_UniformCudaHipQueue));
-#else
-                    // Set the current device.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipSetDevice(
-                            iDevice));
-                    // Initiate the memory set.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipMemsetAsync(
-                            dstNativePtr,
-                            static_cast<int>(byte),
-                            static_cast<size_t>(extentWidthBytes),
-                            queue.m_spQueueImpl->m_UniformCudaHipQueue));
-#endif
                     wait::wait(queue);
                 }
             };
@@ -324,35 +296,19 @@ namespace alpaka
                     ALPAKA_ASSERT(extentWidth <= dstWidth);
                     ALPAKA_ASSERT(extentHeight <= dstHeight);
 
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                     // Set the current device.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaSetDevice(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(SetDevice)(
                             iDevice));
                     // Initiate the memory set.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaMemset2DAsync(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(Memset2DAsync)(
                             dstNativePtr,
                             static_cast<size_t>(dstPitchBytesX),
                             static_cast<int>(byte),
                             static_cast<size_t>(extentWidthBytes),
                             static_cast<size_t>(extentHeight),
                             queue.m_spQueueImpl->m_UniformCudaHipQueue));
-#else
-                    // Set the current device.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipSetDevice(
-                            iDevice));
-                    // Initiate the memory set.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipMemset2DAsync(
-                            dstNativePtr,
-                            static_cast<size_t>(dstPitchBytesX),
-                            static_cast<int>(byte),
-                            static_cast<size_t>(extentWidthBytes),
-                            static_cast<size_t>(extentHeight),
-                            queue.m_spQueueImpl->m_UniformCudaHipQueue));
-#endif
                 }
             };
             //#############################################################################
@@ -405,15 +361,14 @@ namespace alpaka
                     ALPAKA_ASSERT(extentWidth <= dstWidth);
                     ALPAKA_ASSERT(extentHeight <= dstHeight);
 
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                     // Set the current device.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaSetDevice(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(SetDevice)(
                             iDevice));
 
                     // Initiate the memory set.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaMemset2DAsync(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(Memset2DAsync)(
                             dstNativePtr,
                             static_cast<size_t>(dstPitchBytesX),
                             static_cast<int>(byte),
@@ -421,22 +376,6 @@ namespace alpaka
                             static_cast<size_t>(extentHeight),
                             queue.m_spQueueImpl->m_UniformCudaHipQueue));
 
-#else
-                    // Set the current device.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipSetDevice(
-                            iDevice));
-
-                    // Initiate the memory set.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipMemset2DAsync(
-                            dstNativePtr,
-                            static_cast<size_t>(dstPitchBytesX),
-                            static_cast<int>(byte),
-                            static_cast<size_t>(extentWidthBytes),
-                            static_cast<size_t>(extentHeight),
-                            queue.m_spQueueImpl->m_UniformCudaHipQueue));
-#endif
                     wait::wait(queue);
                 }
             };
@@ -494,59 +433,31 @@ namespace alpaka
                     ALPAKA_ASSERT(extentHeight <= dstHeight);
                     ALPAKA_ASSERT(extentDepth <= dstDepth);
 
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                     // Fill CUDA parameter structures.
-                    cudaPitchedPtr const cudaPitchedPtrVal(
-                        make_cudaPitchedPtr(
+                    ALPAKA_API_PREFIX(PitchedPtr) const pitchedPtrVal(
+                        ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(PitchedPtr))(
                             dstNativePtr,
                             static_cast<size_t>(dstPitchBytesX),
                             static_cast<size_t>(dstWidth * static_cast<Idx>(sizeof(Elem))),
                             static_cast<size_t>(dstPitchBytesY / dstPitchBytesX)));
 
-                    cudaExtent const cudaExtentVal(
-                        make_cudaExtent(
+                    ALPAKA_API_PREFIX(Extent) const extentVal(
+                        ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(Extent))(
                             static_cast<size_t>(extentWidth * static_cast<Idx>(sizeof(Elem))),
                             static_cast<size_t>(extentHeight),
                             static_cast<size_t>(extentDepth)));
 
                     // Set the current device.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaSetDevice(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(SetDevice)(
                             iDevice));
                     // Initiate the memory set.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaMemset3DAsync(
-                            cudaPitchedPtrVal,
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(Memset3DAsync)(
+                            pitchedPtrVal,
                             static_cast<int>(byte),
-                            cudaExtentVal,
+                            extentVal,
                             queue.m_spQueueImpl->m_UniformCudaHipQueue));
-#else
-                    // Fill CUDA parameter structures.
-                    hipPitchedPtr const hipPitchedPtrVal(
-                        make_hipPitchedPtr(
-                            dstNativePtr,
-                            static_cast<size_t>(dstPitchBytesX),
-                            static_cast<size_t>(dstWidth * static_cast<Idx>(sizeof(Elem))),
-                            static_cast<size_t>(dstPitchBytesY / dstPitchBytesX)));
-
-                    hipExtent const hipExtentVal(
-                        make_hipExtent(
-                            static_cast<size_t>(extentWidth * static_cast<Idx>(sizeof(Elem))),
-                            static_cast<size_t>(extentHeight),
-                            static_cast<size_t>(extentDepth)));
-
-                    // Set the current device.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipSetDevice(
-                            iDevice));
-                    // Initiate the memory set.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipMemset3DAsync(
-                            hipPitchedPtrVal,
-                            static_cast<int>(byte),
-                            hipExtentVal,
-                            queue.m_spQueueImpl->m_UniformCudaHipQueue));
-#endif
                 }
             };
             //#############################################################################
@@ -603,59 +514,32 @@ namespace alpaka
                     ALPAKA_ASSERT(extentHeight <= dstHeight);
                     ALPAKA_ASSERT(extentDepth <= dstDepth);
 
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                     // Fill CUDA parameter structures.
-                    cudaPitchedPtr const cudaPitchedPtrVal(
-                        make_cudaPitchedPtr(
+                    ALPAKA_API_PREFIX(PitchedPtr) const pitchedPtrVal(
+                        ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(PitchedPtr))(
                             dstNativePtr,
                             static_cast<size_t>(dstPitchBytesX),
                             static_cast<size_t>(dstWidth * static_cast<Idx>(sizeof(Elem))),
                             static_cast<size_t>(dstPitchBytesY / dstPitchBytesX)));
 
-                    cudaExtent const cudaExtentVal(
-                        make_cudaExtent(
+                    ALPAKA_API_PREFIX(Extent) const extentVal(
+                        ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(Extent))(
                             static_cast<size_t>(extentWidth * static_cast<Idx>(sizeof(Elem))),
                             static_cast<size_t>(extentHeight),
                             static_cast<size_t>(extentDepth)));
 
                     // Set the current device.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaSetDevice(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(SetDevice)(
                             iDevice));
                     // Initiate the memory set.
-                    ALPAKA_CUDA_RT_CHECK(
-                        cudaMemset3DAsync(
-                            cudaPitchedPtrVal,
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(Memset3DAsync)(
+                            pitchedPtrVal,
                             static_cast<int>(byte),
-                            cudaExtentVal,
+                            extentVal,
                             queue.m_spQueueImpl->m_UniformCudaHipQueue));
-#else
-                    // Fill CUDA parameter structures.
-                    hipPitchedPtr const hipPitchedPtrVal(
-                        make_hipPitchedPtr(
-                            dstNativePtr,
-                            static_cast<size_t>(dstPitchBytesX),
-                            static_cast<size_t>(dstWidth * static_cast<Idx>(sizeof(Elem))),
-                            static_cast<size_t>(dstPitchBytesY / dstPitchBytesX)));
 
-                    hipExtent const hipExtentVal(
-                        make_hipExtent(
-                            static_cast<size_t>(extentWidth * static_cast<Idx>(sizeof(Elem))),
-                            static_cast<size_t>(extentHeight),
-                            static_cast<size_t>(extentDepth)));
-
-                    // Set the current device.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipSetDevice(
-                            iDevice));
-                    // Initiate the memory set.
-                    ALPAKA_HIP_RT_CHECK(
-                        hipMemset3DAsync(
-                            hipPitchedPtrVal,
-                            static_cast<int>(byte),
-                            hipExtentVal,
-                            queue.m_spQueueImpl->m_UniformCudaHipQueue));
-#endif
                     wait::wait(queue);
                 }
             };

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -314,21 +314,22 @@ namespace alpaka
                         TExtent const & extent)
                     {
                         TElem* pMemAcc(nullptr);
+
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                        ALPAKA_CUDA_RT_CHECK(
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             cudaGetSymbolAddress(
                                 reinterpret_cast<void **>(&pMemAcc),
                                 *pMem));
 #else
     #ifdef __HIP_PLATFORM_NVCC__
-                        ALPAKA_HIP_RT_CHECK(hipCUDAErrorTohipError(
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipCUDAErrorTohipError(
                             cudaGetSymbolAddress(
                                 reinterpret_cast<void **>(&pMemAcc),
                                 *pMem)));
     #else
                         // FIXME: still does not work in HIP(HCC) (results in hipErrorNotFound)
                         // HIP_SYMBOL(X) not useful because it only does #X on HIP(HCC), while &X on HIP(NVCC)
-                        ALPAKA_HIP_RT_CHECK(
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             hipGetSymbolAddress(
                                 reinterpret_cast<void **>(&pMemAcc),
                                 pMem));

--- a/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
@@ -72,33 +72,21 @@ namespace alpaka
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                         // Set the current device.
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                            ALPAKA_CUDA_RT_CHECK(
-                            cudaStreamCreateWithFlags(
-                                &m_UniformCudaHipQueue,
-                                cudaStreamNonBlocking));
-#else
-                            ALPAKA_HIP_RT_CHECK(
-                            hipSetDevice(
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                            ALPAKA_API_PREFIX(SetDevice)(
                                 m_dev.m_iDevice));
-#endif
+
                         // - [cuda/hip]StreamDefault: Default queue creation flag.
                         // - [cuda/hip]StreamNonBlocking: Specifies that work running in the created queue may run concurrently with work in queue 0 (the NULL queue),
                         //   and that the created queue should perform no implicit synchronization with queue 0.
                         // Create the queue on the current device.
                         // NOTE: [cuda/hip]StreamNonBlocking is required to match the semantic implemented in the alpaka CPU queue.
                         // It would be too much work to implement implicit default queue synchronization on CPU.
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                            ALPAKA_CUDA_RT_CHECK(
-                            cudaStreamCreateWithFlags(
+
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                            ALPAKA_API_PREFIX(StreamCreateWithFlags)(
                                 &m_UniformCudaHipQueue,
-                                cudaStreamNonBlocking));
-#else
-                            ALPAKA_HIP_RT_CHECK(
-                            hipStreamCreateWithFlags(
-                                &m_UniformCudaHipQueue,
-                                hipStreamNonBlocking));
-#endif
+                                ALPAKA_API_PREFIX(StreamNonBlocking)));
 
                     }
                     //-----------------------------------------------------------------------------
@@ -119,34 +107,23 @@ namespace alpaka
                         // In case the device is still doing work in the queue when [cuda/hip]StreamDestroy() is called, the function will return immediately
                         // and the resources associated with queue will be released automatically once the device has completed all work in queue.
                         // -> No need to synchronize here.
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
 
-                        ALPAKA_CUDA_RT_CHECK(
-                            cudaSetDevice(
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                            ALPAKA_API_PREFIX(SetDevice)(
                                 m_dev.m_iDevice));
-                        // In case the device is still doing work in the queue when cudaStreamDestroy() is called, the function will return immediately
+                        // In case the device is still doing work in the queue when cuda/hip-StreamDestroy() is called, the function will return immediately
                         // and the resources associated with queue will be released automatically once the device has completed all work in queue.
                         // -> No need to synchronize here.
-                        ALPAKA_CUDA_RT_CHECK(
-                            cudaStreamDestroy(
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                            ALPAKA_API_PREFIX(StreamDestroy)(
                                 m_UniformCudaHipQueue));
-#else
-                        ALPAKA_HIP_RT_CHECK(
-                            hipSetDevice(
-                                m_dev.m_iDevice));
-                        ALPAKA_HIP_RT_CHECK(
-                            hipStreamDestroy(
-                                m_UniformCudaHipQueue));
-#endif
+
                     }
 
                 public:
                     dev::DevUniformCudaHipRt const m_dev;   //!< The device this queue is bound to.
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                    cudaStream_t m_UniformCudaHipQueue;
-#else
-                    hipStream_t m_UniformCudaHipQueue;
-#endif
+                    ALPAKA_API_PREFIX(Stream_t) m_UniformCudaHipQueue;
+
 #if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
                     int m_callees = 0;
                     std::mutex m_mutex;
@@ -271,10 +248,11 @@ namespace alpaka
 
                 //-----------------------------------------------------------------------------
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                static void CUDART_CB uniformCudaHipRtCallback(cudaStream_t /*queue*/, cudaError_t /*status*/, void *arg)
+                static void CUDART_CB
 #else
-                static void HIPRT_CB uniformCudaHipRtCallback(hipStream_t /*queue*/, hipError_t /*status*/, void *arg)
+                static void HIPRT_CB
 #endif
+                uniformCudaHipRtCallback(ALPAKA_API_PREFIX(Stream_t) /*queue*/, ALPAKA_API_PREFIX(Error_t) /*status*/, void *arg)
                 {
                     // explicitly copy the shared_ptr so that this method holds the state even when the executing thread has already finished.
                     const auto pCallbackSynchronizationData = reinterpret_cast<CallbackSynchronizationData*>(arg)->shared_from_this();
@@ -314,19 +292,12 @@ namespace alpaka
 #endif
                     auto pCallbackSynchronizationData = std::make_shared<CallbackSynchronizationData>();
 
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                    ALPAKA_CUDA_RT_CHECK(cudaStreamAddCallback(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamAddCallback)(
                         queue.m_spQueueImpl->m_UniformCudaHipQueue,
                         uniformCudaHipRtCallback,
                         pCallbackSynchronizationData.get(),
                         0u));
-#else
-                    ALPAKA_HIP_RT_CHECK(hipStreamAddCallback(
-                        queue.m_spQueueImpl->m_UniformCudaHipQueue,
-                        uniformCudaHipRtCallback,
-                        pCallbackSynchronizationData.get(),
-                        0u));
-#endif
+
                     // We start a new std::thread which stores the task to be executed.
                     // This circumvents the limitation that it is not possible to call CUDA/HIP methods within the CUDA/HIP callback thread.
                     // The CUDA/HIP thread signals the std::thread when it is ready to execute the task.
@@ -386,22 +357,16 @@ namespace alpaka
                 -> bool
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                    // Query is allowed even for queues on non current device.
-                    cudaError_t ret = cudaSuccess;
-                    ALPAKA_CUDA_RT_CHECK_IGNORE(
-                        ret = cudaStreamQuery(queue.m_spQueueImpl->m_UniformCudaHipQueue),
-                        cudaErrorNotReady);
-                    return (ret == cudaSuccess);
-#elif BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
+
+#if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
                     return (queue.m_spQueueImpl->m_callees==0);
 #else
-                    hipError_t ret = hipSuccess;
-                    ALPAKA_HIP_RT_CHECK_IGNORE(
-                        ret = hipStreamQuery(
-                            queue.m_spQueueImpl->m_UniformCudaHipQueue),
-                        hipErrorNotReady);
-                    return (ret == hipSuccess);
+                    // Query is allowed even for queues on non current device.
+                    ALPAKA_API_PREFIX(Error_t) ret = ALPAKA_API_PREFIX(Success);
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
+                        ret = ALPAKA_API_PREFIX(StreamQuery)(queue.m_spQueueImpl->m_UniformCudaHipQueue),
+                        ALPAKA_API_PREFIX(ErrorNotReady));
+                    return (ret == ALPAKA_API_PREFIX(Success));
 #endif
                 }
             };
@@ -426,18 +391,13 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                    // Sync is allowed even for queues on non current device.
-                    ALPAKA_CUDA_RT_CHECK(cudaStreamSynchronize(
-                        queue.m_spQueueImpl->m_UniformCudaHipQueue));
-
-#elif BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
+#if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
                     while(queue.m_spQueueImpl->m_callees>0) {
                         std::this_thread::sleep_for(std::chrono::milliseconds(10u));
                     }
 #else
                     // Sync is allowed even for queues on non current device.
-                    ALPAKA_HIP_RT_CHECK( hipStreamSynchronize(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK( ALPAKA_API_PREFIX(StreamSynchronize)(
                         queue.m_spQueueImpl->m_UniformCudaHipQueue));
 #endif
                 }

--- a/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -402,16 +402,16 @@ namespace alpaka
                             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                             // Set the current device.
-                            ALPAKA_CUDA_RT_CHECK(
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                                 cudaSetDevice(
                                     m_dev.m_iDevice));
                             // Allocate the buffer on this device.
-                            ALPAKA_CUDA_RT_CHECK(
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                                 cudaMalloc(
                                     &m_devMem,
                                     static_cast<size_t>(sizeof(int32_t))));
                             // Initiate the memory set.
-                            ALPAKA_CUDA_RT_CHECK(
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                                 cudaMemset(
                                     m_devMem,
                                     static_cast<int>(0u),
@@ -431,11 +431,11 @@ namespace alpaka
                             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                             // Set the current device.
-                            ALPAKA_CUDA_RT_CHECK(
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                                 cudaSetDevice(
                                     m_dev.m_iDevice));
                             // Free the buffer.
-                            ALPAKA_CUDA_RT_CHECK(cudaFree(m_devMem));
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaFree(m_devMem));
                         }
 
                         //-----------------------------------------------------------------------------
@@ -445,11 +445,11 @@ namespace alpaka
                             m_bIsReady = true;
 
                             // Set the current device.
-                            ALPAKA_CUDA_RT_CHECK(
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                                 cudaSetDevice(
                                     m_dev.m_iDevice));
                             // Initiate the memory set.
-                            ALPAKA_CUDA_RT_CHECK(
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                                 cudaMemset(
                                     m_devMem,
                                     static_cast<int>(1u),
@@ -709,16 +709,16 @@ namespace alpaka
                             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                             // Set the current device.
-                            ALPAKA_HIP_RT_CHECK(
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                                 hipSetDevice(
                                     m_dev.m_iDevice));
                             // Allocate the buffer on this device.
-                            ALPAKA_HIP_RT_CHECK(
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                                 hipMalloc(
                                     &m_devMem,
                                     static_cast<size_t>(sizeof(int32_t))));
                             // Initiate the memory set.
-                            ALPAKA_HIP_RT_CHECK(
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                                 hipMemset(
                                     m_devMem,
                                     static_cast<int>(0u),
@@ -737,11 +737,11 @@ namespace alpaka
                         {
                             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                            ALPAKA_HIP_RT_CHECK(
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                                 hipSetDevice(
                                     m_dev.m_iDevice));
                             // Free the buffer.
-                            ALPAKA_HIP_RT_CHECK(hipFree(m_devMem));
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipFree(m_devMem));
                         }
 
                         //-----------------------------------------------------------------------------
@@ -751,11 +751,11 @@ namespace alpaka
                             m_bIsReady = true;
 
                             // Set the current device.
-                            ALPAKA_HIP_RT_CHECK(
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                                 hipSetDevice(
                                     m_dev.m_iDevice));
                             // Initiate the memory set.
-                            ALPAKA_HIP_RT_CHECK(
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                                 hipMemset(
                                     m_devMem,
                                     static_cast<int>(1u),
@@ -930,11 +930,11 @@ namespace alpaka
                     std::cerr << "[Workaround] polling of device-located value in stream, as hipStreamWaitValue32 is not available.\n";
 #endif
                     while(hostMem<0x01010101u) {
-                      ALPAKA_HIP_RT_CHECK(hipMemcpyDtoHAsync(&hostMem,
+                      ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipMemcpyDtoHAsync(&hostMem,
                                                              reinterpret_cast<hipDeviceptr_t>(event.m_spEventImpl->m_devMem),
                                                              sizeof(int32_t),
                                                              queue.m_spQueueImpl->m_UniformCudaHipQueue));
-                      ALPAKA_HIP_RT_CHECK(hipStreamSynchronize(queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                      ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipStreamSynchronize(queue.m_spQueueImpl->m_UniformCudaHipQueue));
                     }
                 }
             };
@@ -971,7 +971,7 @@ namespace alpaka
                     //   the device build upon value-based HIP queue synchronization APIs such as
                     //   cuStreamWaitValue32() and cuStreamWriteValue32().
 #if BOOST_COMP_NVCC
-                    ALPAKA_HIP_RT_CHECK(hipCUResultTohipError(
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipCUResultTohipError(
                         cuStreamWaitValue32(
                             static_cast<CUstream>(queue.m_spQueueImpl->m_UniformCudaHipQueue),
                             reinterpret_cast<CUdeviceptr>(event.m_spEventImpl->m_devMem),
@@ -982,7 +982,7 @@ namespace alpaka
                     std::uint32_t hmem = 0;
                     do {
                         std::this_thread::sleep_for(std::chrono::milliseconds(10u));
-                        ALPAKA_HIP_RT_CHECK(hipMemcpy(&hmem, event.m_spEventImpl->m_devMem, sizeof(std::uint32_t), hipMemcpyDefault));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipMemcpy(&hmem, event.m_spEventImpl->m_devMem, sizeof(std::uint32_t), hipMemcpyDefault));
                     } while(hmem < 0x01010101u);
 
 #endif


### PR DESCRIPTION
This PR is a follow up of #928 to remove most code duplication between CUDA/HIP.

- add macro `ALPAKA_API_PREFIX()` to refix functions and types
- add helper `ALPAKA_PP_CONCAT()` to construct `make_cudaPitched()`
- reduce duplicated runtime error checks for CUDA/HIP

I discussed with @sbastrakov if it is better to use a predefined list of function pointer/function objects or a macro to prefix the functions and types. Using a macro was at the end prepared by us to avoid that we need to maintain a global list of functions and types we are using.
It is also not clear about runtime overhead or compatibility when we use function objects. Function objects avoid inlining and the side effect to separable compile for CUDA and HIP is not clear.


- [x] merge after #941, the first commit contains #941