### PR TITLE
fix CMake error

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -495,7 +495,7 @@ if(ALPAKA_ACC_GPU_CUDA_ENABLE)
 
                 set(CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
 
-                if((${CMAKE_BUILD_TYPE} STREQUAL "Debug") OR (${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo"))
+                if((CMAKE_BUILD_TYPE STREQUAL "Debug") OR (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
                     list(APPEND CUDA_NVCC_FLAGS -g)
                     if(MSVC)
                         message(WARNING "${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} does not support -G with CUDA! "
@@ -630,7 +630,7 @@ if(ALPAKA_ACC_GPU_HIP_ENABLE)
                 list(APPEND HIP_NVCC_FLAGS -ccbin ${CMAKE_CXX_COMPILER})
                 list(APPEND HIP_NVCC_FLAGS -Xcompiler -g)
 
-                if((${CMAKE_BUILD_TYPE} STREQUAL "Debug") OR (${CMAKE_BUILD_TYPE} STREQUAL "RelWithDebInfo"))
+                if((CMAKE_BUILD_TYPE STREQUAL "Debug") OR (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
                     list(APPEND HIP_NVCC_FLAGS -G)
                 endif()
                 # propage host flags


### PR DESCRIPTION
```
CMake Error at cmake/alpakaCommon.cmake:498 (if):
  if given arguments:

    "(" "STREQUAL" "Debug" ")" "OR" "(" "STREQUAL" "RelWithDebInfo" ")"

  Unknown arguments specified
Call Stack (most recent call first):
  CMakeLists.txt:75 (include)

-- Configuring incomplete, errors occurred!
```

This bug was already fixed at some places during the cmake refactoring #921 https://github.com/ComputationalRadiationPhysics/alpaka/pull/921#pullrequestreview-364739699 but was missed in a few places.