### PR TITLE
drop HIP-hcc support

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -791,7 +791,9 @@ if(ALPAKA_ACC_GPU_HIP_ENABLE)
     endif()
     if(ALPAKA_HIP_PLATFORM MATCHES "clang")
         # GFX600, GFX601, GFX700, GFX701, GFX702, GFX703, GFX704, GFX801, GFX802, GFX803, GFX810, GFX900, GFX902
-        target_link_options(alpaka INTERFACE "--amdgpu-target=gfx803 --amdgpu-target=gfx900 --amdgpu-target=gfx906")
+        target_link_options(alpaka INTERFACE "--amdgpu-target=gfx803")
+        target_link_options(alpaka INTERFACE "--amdgpu-target=gfx900")
+        target_link_options(alpaka INTERFACE "--amdgpu-target=gfx906")
     endif()
 endif()
 

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -26,19 +26,13 @@ option(ALPAKA_ACC_GPU_HIP_ONLY_MODE "Only back-ends using HIP can be enabled in 
 
 # Drop-down combo box in cmake-gui for HIP platforms.
 set(ALPAKA_HIP_PLATFORM "nvcc" CACHE STRING "Specify HIP platform")
-set_property(CACHE ALPAKA_HIP_PLATFORM PROPERTY STRINGS "nvcc;hcc;clang")
+set_property(CACHE ALPAKA_HIP_PLATFORM PROPERTY STRINGS "nvcc;clang")
 
-if(ALPAKA_ACC_GPU_HIP_ENABLE AND NOT ALPAKA_ACC_GPU_HIP_ONLY_MODE AND (ALPAKA_HIP_PLATFORM MATCHES "hcc" OR ALPAKA_HIP_PLATFORM MATCHES "nvcc"))
+if(ALPAKA_ACC_GPU_HIP_ENABLE AND NOT ALPAKA_ACC_GPU_HIP_ONLY_MODE AND ALPAKA_HIP_PLATFORM MATCHES "nvcc")
     message(WARNING "HIP back-end must be used together with ALPAKA_ACC_GPU_HIP_ONLY_MODE")
     set(ALPAKA_ACC_GPU_HIP_ENABLE OFF CACHE BOOL "" FORCE)
 endif()
 
-if(ALPAKA_ACC_GPU_HIP_ENABLE AND ALPAKA_HIP_PLATFORM MATCHES "hcc")
-    message(WARNING
-        "The HIP back-end is currently experimental."
-        "Alpaka HIP backend compiled with hcc has a few workarounds."
-        )
-endif()
 if(ALPAKA_ACC_GPU_HIP_ENABLE AND ALPAKA_HIP_PLATFORM MATCHES "clang")
     message(WARNING
         "The HIP back-end is currently experimental."
@@ -687,53 +681,6 @@ if(ALPAKA_ACC_GPU_HIP_ENABLE)
                 target_link_libraries(alpaka INTERFACE ${HIP_RAND_LIBRARY})
             endif() # nvcc
 
-            if(ALPAKA_HIP_PLATFORM MATCHES "hcc")
-
-                # random numbers library ( HIP(HCC) ) /rocrand
-                find_path(ROC_RAND_INC
-                    rocrand_kernel.h
-                    PATHS "${HIP_ROOT_DIR}/rocrand" "${HIP_ROOT_DIR}" "rocrand"
-                    PATHS "/opt/rocm/rocrand"
-                    ENV HIP_PATH
-                    PATH_SUFFIXES "include")
-                find_library(ROC_RAND_LIBRARY
-                    rocrand-d
-                    rocrand
-                    PATHS "${HIP_ROOT_DIR}/rocrand" "${HIP_ROOT_DIR}" "rocrand"
-                    PATHS "/opt/rocm/rocrand"
-                    ENV HIP_PATH
-                    PATH_SUFFIXES "lib" "lib64")
-
-                # random numbers library ( HIP(HCC) ) rocrand/hiprand
-                find_path(HIP_RAND_INC
-                    hiprand_kernel.h
-                    PATHS "${HIP_ROOT_DIR}/hiprand" "${HIP_ROOT_DIR}" "hiprand"
-                    PATHS "/opt/rocm/hiprand"
-                    ENV HIP_PATH
-                    PATH_SUFFIXES "include")
-                find_library(HIP_RAND_LIBRARY
-                    hiprand-d
-                    hiprand
-                    PATHS "${HIP_ROOT_DIR}/hiprand" "${HIP_ROOT_DIR}" "hiprand"
-                    PATHS "/opt/rocm/hiprand"
-                    ENV HIP_PATH
-                    PATH_SUFFIXES "lib" "lib64")
-                if(NOT HIP_RAND_INC OR NOT HIP_RAND_LIBRARY)
-                    message(FATAL_ERROR "Could not find hipRAND library")
-                endif()
-
-                target_include_directories(alpaka INTERFACE ${HIP_RAND_INC})
-                target_link_libraries(alpaka INTERFACE ${HIP_RAND_LIBRARY})
-
-                if(NOT ROC_RAND_INC OR NOT ROC_RAND_LIBRARY)
-                    message(FATAL_ERROR "Could not find rocRAND library")
-                endif()
-
-                target_include_directories(alpaka INTERFACE ${ROC_RAND_INC})
-                target_link_libraries(alpaka INTERFACE ${ROC_RAND_LIBRARY})
-            endif()
-
-
             list(APPEND HIP_HIPCC_FLAGS "-D__HIPCC__")
             list(APPEND HIP_HIPCC_FLAGS "-std=c++${ALPAKA_CXX_STANDARD}")
 
@@ -842,7 +789,7 @@ if(ALPAKA_ACC_GPU_HIP_ENABLE)
         set_property(TARGET alpaka
                      PROPERTY INTERFACE_LINK_LIBRARIES ${_ALPAKA_LINK_LIBRARIES_PUBLIC})
     endif()
-    if(ALPAKA_HIP_PLATFORM MATCHES "hcc")
+    if(ALPAKA_HIP_PLATFORM MATCHES "clang")
         # GFX600, GFX601, GFX700, GFX701, GFX702, GFX703, GFX704, GFX801, GFX802, GFX803, GFX810, GFX900, GFX902
         target_link_options(alpaka INTERFACE "--amdgpu-target=gfx803 --amdgpu-target=gfx900 --amdgpu-target=gfx906")
     endif()

--- a/doc/markdown/user/implementation/mapping/HIP.md
+++ b/doc/markdown/user/implementation/mapping/HIP.md
@@ -1,9 +1,8 @@
-## Current restrictions on HCC platform
+## Current restrictions on HSA platform
 
-- Workaround for unsupported `syncthreads_{count|and|or}`.
+- Workaround for unsupported `syncthreads_{count|and|or}` depending of the hardware.
   - uses temporary shared value and atomics
 - Workaround for buggy `hipStreamQuery`, `hipStreamSynchronize`.
-  - introduces own queue management
   - `hipStreamQuery` and `hipStreamSynchronize` did not work in multithreaded environment
 - Workaround for missing `cuStreamWaitValue32`.
   - polls value each 10ms
@@ -12,20 +11,14 @@
 - exclude `hipMalloc3D` and `hipMallocPitch` when size is zero otherwise they throw an Unknown Error
 - `TestAccs` excludes 3D specialization of Hip back-end for now because `verifyBytesSet` fails in `memView` for 3D specialization
 - `dim3` structure is not available on device (use `alpaka::vec::Vec` instead)
-- Constructors' attributes unified with destructors'.
-  - host/device signature must match in HIP(HCC)
 - a chain of functions must also provide correct host-device signatures
   - e.g. a host function cannot be called from a host-device function
-- recompile your target when HCC linker returned the error:
-"File format not recognized
-clang-7: error: linker command failed with exit code 1"
-- if compile-error occurred, the linker still may link, but without the device code
 - AMD device architecture currently hardcoded in `alpakaConfig.cmake`
 
 ## Compiling HIP from source
 
 Follow [this](https://github.com/ROCm-Developer-Tools/HIP/blob/master/INSTALL.md "HIP installation") guide for installing HIP.
-HIP requires either `nvcc` or `hcc` to be installed on your system (see guide for further details).
+HIP requires either `nvcc` or ROCm with `hcc` to be installed on your system (see guide for further details).
 
 - If you want the hip binaries to be located in a directory that does not require superuser access, be sure to change the install directory of HIP by modifying the `CMAKE_INSTALL_PREFIX` cmake variable.
 - Also, after the installation is complete, add the following line to the `.profile` file in your home directory, in order to add the path to the HIP binaries to PATH:
@@ -46,8 +39,6 @@ Set the appropriate paths (edit `${YOUR_**}` variables).
 export HIP_PATH=${YOUR_HIP_INSTALL_DIR}
 # Paths required by HIP tools
 export CUDA_PATH=${YOUR_CUDA_ROOT}
-# - if required, path to HCC compiler. Default /opt/rocm/hcc.
-export HCC_HOME=${YOUR_HCC_ROOT}
 # - if required, path to HSA include, lib. Default /opt/rocm/hsa.
 export HSA_PATH=${YOUR_HSA_PATH}
 # HIP binaries and libraries
@@ -56,7 +47,7 @@ export LD_LIBRARY_PATH=${HIP_PATH}/lib64:${LD_LIBRARY_PATH}
 ```
 Test the HIP binaries.
 ```bash
-# calls nvcc or hcc
+# calls nvcc or clang
 which hipcc
 hipcc -V
 which hipconfig

--- a/include/alpaka/acc/AccGpuHipRt.hpp
+++ b/include/alpaka/acc/AccGpuHipRt.hpp
@@ -48,7 +48,7 @@ namespace alpaka
         //#############################################################################
         //! The GPU HIP accelerator.
         //!
-        //! This accelerator allows parallel kernel execution on devices supporting HIP or HCC
+        //! This accelerator allows parallel kernel execution on devices supporting HIP
         template<
             typename TDim,
             typename TIdx>

--- a/include/alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp
@@ -76,8 +76,8 @@ namespace alpaka
                         int predicate)
                     -> int
                     {
-#if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && (BOOST_COMP_HCC || BOOST_COMP_HIP)
-                        // workaround for unsupported syncthreads_* operation on HIP(HCC)
+#if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && BOOST_COMP_HIP
+                        // workaround for unsupported syncthreads_* operation on AMD hardware without sync extension
                         __shared__ int tmp;
                         __syncthreads();
                         if(threadIdx.x==0)
@@ -106,8 +106,8 @@ namespace alpaka
                         int predicate)
                     -> int
                     {
-#if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && (BOOST_COMP_HCC || BOOST_COMP_HIP)
-                        // workaround for unsupported syncthreads_* operation on HIP(HCC)
+#if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && BOOST_COMP_HIP
+                        // workaround for unsupported syncthreads_* operation on AMD hardware without sync extension
                         __shared__ int tmp;
                         __syncthreads();
                         if(threadIdx.x==0)
@@ -136,8 +136,8 @@ namespace alpaka
                         int predicate)
                     -> int
                     {
-#if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && (BOOST_COMP_HCC || BOOST_COMP_HIP)
-                        // workaround for unsupported syncthreads_* operation on HIP(HCC)
+#if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && BOOST_COMP_HIP
+                        // workaround for unsupported syncthreads_* operation on AMD hardware without sync extension
                         __shared__ int tmp;
                         __syncthreads();
                         if(threadIdx.x==0)

--- a/include/alpaka/core/Assert.hpp
+++ b/include/alpaka/core/Assert.hpp
@@ -16,39 +16,8 @@
 #include <type_traits>
 
 
-#if !(defined(BOOST_LANG_HIP) && BOOST_LANG_HIP && BOOST_COMP_HCC)
-  #define ALPAKA_ASSERT(EXPRESSION) assert(EXPRESSION)
-#else
 
-  // Including assert.h would interfere with HIP's host-device implementation
-  // see: https://github.com/ROCm-Developer-Tools/HIP/issues/599
-  // However, cassert is still in some header, so we have to do a workaround for HIP.
-  #ifdef NDEBUG
-    #define ALPAKA_ASSERT(EXPRESSION) static_cast<void>(0)
-  #else
-    #define ALPAKA_ASSERT(EXPRESSION) assert_workaround(EXPRESSION)
-
-    #pragma push_macro("__DEVICE__")
-    #define __DEVICE__ extern "C" __device__ __attribute__((always_inline)) \
-            __attribute__((weak))
-
-     __DEVICE__ void __device_trap() __asm("llvm.trap");
-
-     __host__ __device__
-     __attribute__((always_inline))             \
-     __attribute__((weak))
-     void assert_workaround(bool expr) {
-       if(!expr) {
-         printf("assert failed.\n");
-         #if __HIP_DEVICE_COMPILE__==1
-           __device_trap();
-         #else
-           exit(1);
-         #endif
-       }
-     }
-  #endif //NDEBUG
-#endif
+#define ALPAKA_ASSERT(EXPRESSION) assert(EXPRESSION)
 
 namespace alpaka
 {

--- a/include/alpaka/core/BoostPredef.hpp
+++ b/include/alpaka/core/BoostPredef.hpp
@@ -19,9 +19,10 @@
 #endif
 
 //---------------------------------------HIP-----------------------------------
-// __HIPCC__ is defined by hipcc (if either __HCC__ or __CUDACC__ is defined)
+// __HIPCC__ is defined by hipcc (if either __CUDACC__ is defined)
+// https://github.com/ROCm-Developer-Tools/HIP/blob/master/docs/markdown/hip_porting_guide.md#compiler-defines-summary
 #if !defined(BOOST_LANG_HIP)
-  #if defined(__HIPCC__) && ( defined(__CUDACC__) || defined(__HCC__) || defined(__HIP__))
+  #if defined(__HIPCC__) && ( defined(__CUDACC__) || defined(__HIP__))
     #include <hip/hip_runtime.h>
     //HIP defines "abort()" as "{asm("trap;");}", which breaks some kernels
     #undef abort
@@ -37,25 +38,14 @@
 #endif
 
 //-----------------------------------------------------------------------------
-// HSA device architecture detection (HSA generated via HIP(HCC) or HCC directly)
+// HSA device architecture detection (HSA generated via HIP(clang))
 #if !defined(BOOST_ARCH_HSA)
-    #if defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__==1 && defined(__HCC__) \
-        || (defined(__HCC_ACCELERATOR__) && __HCC_ACCELERATOR__!=0)
+    #if defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__==1 && defined(__HIP__)
         // __HIP_DEVICE_COMPILE__ does not represent feature capability of target device like CUDA_ARCH.
         // For feature detection there are special macros, see ROCm's HIP porting guide.
         #define BOOST_ARCH_HSA BOOST_VERSION_NUMBER_AVAILABLE
     #else
         #define BOOST_ARCH_HSA BOOST_VERSION_NUMBER_NOT_AVAILABLE
-    #endif
-#endif
-
-//-----------------------------------------------------------------------------
-// hcc HSA compiler detection
-#if !defined(BOOST_COMP_HCC)
-    #if defined(__HCC__)
-        #define BOOST_COMP_HCC BOOST_VERSION_NUMBER_AVAILABLE
-    #else
-        #define BOOST_COMP_HCC BOOST_VERSION_NUMBER_NOT_AVAILABLE
     #endif
 #endif
 

--- a/include/alpaka/core/Hip.hpp
+++ b/include/alpaka/core/Hip.hpp
@@ -30,7 +30,7 @@
 #include <utility>
 #include <cstddef>
 
-#ifdef __HIP_PLATFORM_HCC__
+#if BOOST_COMP_HIP
   #define HIPRT_CB
 #endif
 

--- a/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/abs/AbsUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/acos/AcosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/asin/AsinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/atan/AtanUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/atan2/Atan2UniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2UniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/cbrt/CbrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/ceil/CeilUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/cos/CosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/erf/ErfUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/exp/ExpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/floor/FloorUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/fmod/FmodUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/log/LogUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/log/LogUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/max/MaxUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxUniformCudaHipBuiltIn.hpp
@@ -24,7 +24,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/min/MinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/min/MinUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/pow/PowUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-    #if BOOST_COMP_HCC || BOOST_COMP_HIP
+    #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/remainder/RemainderUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/round/RoundUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/rsqrt/RsqrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/sin/SinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/sincos/SinCosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sincos/SinCosUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/sqrt/SqrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/tan/TanUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/math/trunc/TruncUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
     #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 0, 0)
         #include <cuda_runtime_api.h>
     #else
-        #if BOOST_COMP_HCC || BOOST_COMP_HIP
+        #if BOOST_COMP_HIP
             #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>

--- a/include/alpaka/mem/alloc/AllocCpuBoostAligned.hpp
+++ b/include/alpaka/mem/alloc/AllocCpuBoostAligned.hpp
@@ -60,7 +60,7 @@ namespace alpaka
                         //
                         // For HIP the required alignment is the size of a cache line.
                         // https://rocm-developer-tools.github.io/HIP/group__Memory.html#gab8258f051e1a1f7385f794a15300e674
-                        // To avoid issues with HIP(cuda) the alignment will be set also for HIP(clang/hcc)
+                        // To avoid issues with HIP(cuda) the alignment will be set also for HIP(clang)
                         // to 4kib.
                         // @todo evaluate requirements when the HIP ecosystem is more stable
                         constexpr size_t minAlignement = 4096;

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -403,7 +403,7 @@ namespace alpaka
                         void * memPtr = nullptr;
                         std::size_t pitchBytes = widthBytes;
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-                        //FIXME: hcc cannot handle zero-size input (throws Unknown Error)
+                        //FIXME: HIP cannot handle zero-size input (throws Unknown Error)
                         if(width!=0 && height!=0)
 #endif
                         {
@@ -471,7 +471,7 @@ namespace alpaka
                         ALPAKA_API_PREFIX(PitchedPtr) pitchedPtrVal;
                         pitchedPtrVal.ptr = nullptr;
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-                        //FIXME: hcc cannot handle zero-size input
+                        //FIXME: HIP cannot handle zero-size input
                         if(extentVal.width!=0
                            && extentVal.height!=0
                            && extentVal.depth!=0)

--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -154,7 +154,6 @@ namespace alpaka
                         ALPAKA_FN_HOST auto operator()() const
                         -> void
                         {
-#if defined(BOOST_COMP_HCC) && !defined(__HIP_DEVICE_COMPILE__)
                             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
@@ -178,7 +177,6 @@ namespace alpaka
                                             static_cast<std::size_t>(this->m_extentWidthBytes));
                                     });
                             }
-#endif
                         }
                     };
 

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -139,13 +139,6 @@ namespace alpaka
                             {
                                 meta::ndLoopIncIdx(
                                     extentWithoutInnermost,
-
-                                    // workaround for HIP(HCC) to
-                                    // avoid forbidden host-call
-                                    // within host-device functions
-                                    #if defined(BOOST_COMP_HCC) && BOOST_COMP_HCC
-                                    ALPAKA_FN_HOST_ACC
-                                    #endif
                                     [&](vec::Vec<DimMin1, ExtentSize> const & idx)
                                     {
 

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -327,8 +327,8 @@ namespace alpaka
                                 reinterpret_cast<void **>(&pMemAcc),
                                 *pMem)));
     #else
-                        // FIXME: still does not work in HIP(HCC) (results in hipErrorNotFound)
-                        // HIP_SYMBOL(X) not useful because it only does #X on HIP(HCC), while &X on HIP(NVCC)
+                        // FIXME: still does not work in HIP(clang) (results in hipErrorNotFound)
+                        // HIP_SYMBOL(X) not useful because it only does #X on HIP(clang), while &X on HIP(NVCC)
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             hipGetSymbolAddress(
                                 reinterpret_cast<void **>(&pMemAcc),

--- a/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
@@ -119,12 +119,7 @@ namespace alpaka
 
                 public:
                     dev::DevUniformCudaHipRt const m_dev;   //!< The device this queue is bound to.
-           ALPAKA_API_PREFIX(Stream_t) m_UniformCudaHipQueue;
-#if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
-                    int m_callees = 0;
-                    std::mutex m_mutex;
-#endif
-
+                    ALPAKA_API_PREFIX(Stream_t) m_UniformCudaHipQueue;
                 };
             }
         }
@@ -160,16 +155,8 @@ namespace alpaka
                 return !((*this) == rhs);
             }
             //-----------------------------------------------------------------------------
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
             ~QueueUniformCudaHipRtNonBlocking() = default;
-#else
-            ~QueueUniformCudaHipRtNonBlocking() {
-#if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
-                // we are a non-blocking queue, so we have to wait here with its destruction until all spawned tasks have been processed
-                alpaka::wait::wait(*this);
-#endif
-            }
-#endif
+
         public:
             std::shared_ptr<uniform_cuda_hip::detail::QueueUniformCudaHipRtNonBlockingImpl> m_spQueueImpl;
         };
@@ -290,20 +277,12 @@ namespace alpaka
                 {
 #if BOOST_COMP_HIP
                     // NOTE: hip callbacks are not blocking the stream.
-                    // The workaround used for HIP(hcc) would avoid the usage in a workflow with
-                    // many stream/event synchronizations (e.g. PIConGPU).
                     // @todo remove this assert when hipStreamAddCallback is fixed
                     static_assert(
                                 meta::DependentFalseType<TTask>::value,
                                 "Callbacks are not supported for HIP-clang");
 #endif
-#if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
-                    {
-                        // thread-safe callee incrementing
-                        std::lock_guard<std::mutex> guard(queue.m_spQueueImpl->m_mutex);
-                        queue.m_spQueueImpl->m_callees += 1;
-                    }
-#endif
+
                     auto pCallbackSynchronizationData = std::make_shared<CallbackSynchronizationData>();
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamAddCallback)(
                         queue.m_spQueueImpl->m_UniformCudaHipQueue,
@@ -317,18 +296,7 @@ namespace alpaka
                     // The CUDA/HIP thread is waiting for the std::thread to signal that it is finished executing the task
                     // before it executes the next task in the queue (CUDA/HIP stream).
                     std::thread t(
-                        [pCallbackSynchronizationData,
-                            task
-#if BOOST_COMP_HCC // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
-                         ,&queue // requires queue's destructor to wait for all tasks
-#endif
-                            ](){
-
-#if BOOST_COMP_HCC // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
-                            // thread-safe task execution and callee decrementing
-                            std::lock_guard<std::mutex> guard(queue.m_spQueueImpl->m_mutex);
-#endif
-
+                        [pCallbackSynchronizationData, task](){
                             // If the callback has not yet been called, we wait for it.
                             {
                                 std::unique_lock<std::mutex> lock(pCallbackSynchronizationData->m_mutex);
@@ -348,9 +316,6 @@ namespace alpaka
                                 pCallbackSynchronizationData->state = CallbackState::finished;
                             }
                             pCallbackSynchronizationData->m_event.notify_one();
-#if BOOST_COMP_HCC // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
-                            queue.m_spQueueImpl->m_callees -= 1;
-#endif
                         }
                     );
 
@@ -370,10 +335,6 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-#if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
-                    return (queue.m_spQueueImpl->m_callees==0);
-#else
-
                     // Query is allowed even for queues on non current device.
                     ALPAKA_API_PREFIX(Error_t) ret = ALPAKA_API_PREFIX(Success);
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
@@ -381,8 +342,6 @@ namespace alpaka
                             queue.m_spQueueImpl->m_UniformCudaHipQueue),
                             ALPAKA_API_PREFIX(ErrorNotReady));
                     return (ret == ALPAKA_API_PREFIX(Success));
-#endif
-
                 }
             };
         }
@@ -406,15 +365,9 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-#if BOOST_COMP_HCC  // NOTE: workaround for unwanted nonblocking hip streams for HCC (NVCC streams are blocking)
-                    while(queue.m_spQueueImpl->m_callees>0) {
-                        std::this_thread::sleep_for(std::chrono::milliseconds(10u));
-                    }
-#else
                     // Sync is allowed even for queues on non current device.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK( ALPAKA_API_PREFIX(StreamSynchronize)(
                             queue.m_spQueueImpl->m_UniformCudaHipQueue));
-#endif
                 }
             };
         }

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -36,7 +36,7 @@
 // Some compilers do not support the out of class versions:
 // - the nvcc CUDA compiler (at least 8.0)
 // - the intel compiler
-#if BOOST_COMP_HCC || BOOST_COMP_HIP || BOOST_COMP_NVCC || BOOST_COMP_INTEL || (BOOST_COMP_CLANG_CUDA >= BOOST_VERSION_NUMBER(4, 0, 0)) || (BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(8, 0, 0))
+#if BOOST_COMP_HIP || BOOST_COMP_NVCC || BOOST_COMP_INTEL || (BOOST_COMP_CLANG_CUDA >= BOOST_VERSION_NUMBER(4, 0, 0)) || (BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(8, 0, 0))
     #define ALPAKA_CREATE_VEC_IN_CLASS
 #endif
 

--- a/script/travis/before_install.sh
+++ b/script/travis/before_install.sh
@@ -64,7 +64,7 @@ then
     # if platform is nvcc, CUDA part is already processed in this file.
     if [ "${ALPAKA_HIP_PLATFORM}" == "hcc" ]
     then
-        echo "HIP(hcc) not supported yet."
+        echo "HIP(hcc) is not supported."
         exit 1
     fi
 fi

--- a/script/travis/run.sh
+++ b/script/travis/run.sh
@@ -98,7 +98,7 @@ then
     # TODO: rely on CI vars for platform and architecture
     export HIP_PLATFORM=nvcc
     export HIP_RUNTIME=nvcc
-    # calls nvcc or hcc
+    # calls nvcc or clang
     which hipcc
     hipcc -V
     which hipconfig

--- a/test/common/include/alpaka/test/acc/TestAccs.hpp
+++ b/test/common/include/alpaka/test/acc/TestAccs.hpp
@@ -23,7 +23,7 @@
 // Else the log length would be exceeded.
 #if defined(ALPAKA_CI)
   #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA \
-   || defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP && !BOOST_COMP_HCC
+   || defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP
     #define ALPAKA_CUDA_CI
   #endif
 #endif

--- a/test/common/include/alpaka/test/dim/TestDims.hpp
+++ b/test/common/include/alpaka/test/dim/TestDims.hpp
@@ -18,7 +18,7 @@
 // Else the log length would be exceeded.
 #if defined(ALPAKA_CI)
   #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA \
-   || defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP && !BOOST_COMP_HCC
+   || defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP
     #define ALPAKA_CUDA_CI
   #endif
 #endif

--- a/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -978,7 +978,7 @@ namespace alpaka
                             0x01010101u,
                             CU_STREAM_WAIT_VALUE_GEQ)));
 #else
-                    // workaround for missing cuStreamWaitValue32 in HIP(HCC)
+                    // workaround for missing cuStreamWaitValue32 in HIP
                     std::uint32_t hmem = 0;
                     do {
                         std::this_thread::sleep_for(std::chrono::milliseconds(10u));

--- a/test/unit/core/src/BoostPredefTest.cpp
+++ b/test/unit/core/src/BoostPredefTest.cpp
@@ -31,9 +31,6 @@ TEST_CASE("printDefines", "[core]")
 #if BOOST_COMP_NVCC
     std::cout << "BOOST_COMP_NVCC:" << BOOST_COMP_NVCC << std::endl;
 #endif
-#if BOOST_COMP_HCC
-    std::cout << "BOOST_COMP_HCC:" << BOOST_COMP_HCC << std::endl;
-#endif
 #if BOOST_COMP_HIP
     std::cout << "BOOST_COMP_HIP:" << BOOST_COMP_HIP << std::endl;
 #endif

--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -79,8 +79,8 @@ TEMPLATE_LIST_TEST_CASE( "staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestA
     StaticDeviceMemoryTestKernel kernel;
 
     //-----------------------------------------------------------------------------
-    // FIXME: constant memory in HIP(HCC) is still not working
-#if !BOOST_COMP_HCC && !BOOST_COMP_HIP
+    // FIXME: constant memory in HIP is still not working
+#if !BOOST_COMP_HIP
     // initialized static constant device memory
     {
         auto const viewConstantMemInitialized(
@@ -152,8 +152,8 @@ TEMPLATE_LIST_TEST_CASE( "staticDeviceMemoryConstant", "[viewStaticAccMem]", Tes
     StaticDeviceMemoryTestKernel kernel;
 
     //-----------------------------------------------------------------------------
-    // FIXME: static device memory in HIP(HCC) is still not working
-#if !BOOST_COMP_HCC && !BOOST_COMP_HIP
+    // FIXME: static device memory in HIP is still not working
+#if !BOOST_COMP_HIP
     // initialized static global device memory
     {
         auto const viewGlobalMemInitialized(


### PR DESCRIPTION
HIP-hcc is depricated and we are handling a few workarounds which
increases the amount of maintenaince work.

This pull request is removing any HIP-hcc support.