### PR TITLE
fix HIP math include

### DIFF
--- a/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/abs/AbsUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/acos/AcosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/asin/AsinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/atan/AtanUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/atan2/Atan2UniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2UniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/cbrt/CbrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/ceil/CeilUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/cos/CosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/erf/ErfUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/exp/ExpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/floor/FloorUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/fmod/FmodUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/log/LogUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/log/LogUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/max/MaxUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxUniformCudaHipBuiltIn.hpp
@@ -25,7 +25,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/min/MinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/min/MinUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/pow/PowUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
     #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/remainder/RemainderUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/round/RoundUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/rsqrt/RsqrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/sin/SinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/sincos/SinCosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sincos/SinCosUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/sqrt/SqrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/tan/TanUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif

--- a/include/alpaka/math/trunc/TruncUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncUniformCudaHipBuiltIn.hpp
@@ -26,7 +26,7 @@
         #include <cuda_runtime_api.h>
     #else
         #if BOOST_COMP_HCC || BOOST_COMP_HIP
-            #include <math_functions.h>
+            #include <hip/math_functions.h>
         #else
             #include <math_functions.hpp>
         #endif


### PR DESCRIPTION
The math functions for HIP must be included with a prefix path `hip`.
It worked before because we always set `CPLUS_INCLUDE_PATH` in our
environment.