### PR TITLE
fix missing platform concept

### DIFF
--- a/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
+++ b/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
@@ -41,7 +41,8 @@ namespace alpaka
     {
         //#############################################################################
         //! The CUDA RT device manager.
-        class PltfUniformCudaHipRt
+        class PltfUniformCudaHipRt :
+            public concepts::Implements<ConceptPltf, PltfUniformCudaHipRt>
         {
         public:
             //-----------------------------------------------------------------------------


### PR DESCRIPTION
`PltfUniformCudaHipRt` does not define the concept for a platform.

Bug was introduced with #928