### PR TITLE
allow instances of concept definitions

### DIFF
--- a/include/alpaka/acc/Traits.hpp
+++ b/include/alpaka/acc/Traits.hpp
@@ -29,9 +29,9 @@ namespace alpaka
     //! The accelerator specifics.
     namespace acc
     {
-        struct ConceptUniformCudaHip;
+        struct ConceptUniformCudaHip{};
 
-        struct ConceptAcc;
+        struct ConceptAcc{};
         //-----------------------------------------------------------------------------
         //! The accelerator traits.
         namespace traits

--- a/include/alpaka/atomic/Traits.hpp
+++ b/include/alpaka/atomic/Traits.hpp
@@ -21,9 +21,9 @@ namespace alpaka
     //! The atomic operation traits specifics.
     namespace atomic
     {
-        struct ConceptAtomicGrids;
-        struct ConceptAtomicBlocks;
-        struct ConceptAtomicThreads;
+        struct ConceptAtomicGrids{};
+        struct ConceptAtomicBlocks{};
+        struct ConceptAtomicThreads{};
 
         namespace detail
         {

--- a/include/alpaka/block/shared/dyn/Traits.hpp
+++ b/include/alpaka/block/shared/dyn/Traits.hpp
@@ -28,7 +28,7 @@ namespace alpaka
             //! The block shared dynamic memory operation specifics.
             namespace dyn
             {
-                struct ConceptBlockSharedDyn;
+                struct ConceptBlockSharedDyn{};
 
                 //-----------------------------------------------------------------------------
                 //! The block shared dynamic memory operation traits.

--- a/include/alpaka/block/shared/st/Traits.hpp
+++ b/include/alpaka/block/shared/st/Traits.hpp
@@ -28,7 +28,7 @@ namespace alpaka
             //! The block shared static memory operation specifics.
             namespace st
             {
-                struct ConceptBlockSharedSt;
+                struct ConceptBlockSharedSt{};
 
                 //-----------------------------------------------------------------------------
                 //! The block shared static memory operation traits.

--- a/include/alpaka/block/sync/Traits.hpp
+++ b/include/alpaka/block/sync/Traits.hpp
@@ -24,7 +24,7 @@ namespace alpaka
         //! The block synchronization specifics.
         namespace sync
         {
-            struct ConceptBlockSync;
+            struct ConceptBlockSync{};
 
             //-----------------------------------------------------------------------------
             //! The block synchronization traits.

--- a/include/alpaka/idx/Traits.hpp
+++ b/include/alpaka/idx/Traits.hpp
@@ -18,8 +18,8 @@ namespace alpaka
     //! The index specifics.
     namespace idx
     {
-        struct ConceptIdxBt;
-        struct ConceptIdxGb;
+        struct ConceptIdxBt{};
+        struct ConceptIdxGb{};
 
         //-----------------------------------------------------------------------------
         //! The idx traits.

--- a/include/alpaka/math/abs/Traits.hpp
+++ b/include/alpaka/math/abs/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathAbs;
+        struct ConceptMathAbs{};
 
         //-----------------------------------------------------------------------------
         //! The math traits.

--- a/include/alpaka/math/acos/Traits.hpp
+++ b/include/alpaka/math/acos/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathAcos;
+        struct ConceptMathAcos{};
 
         namespace traits
         {

--- a/include/alpaka/math/asin/Traits.hpp
+++ b/include/alpaka/math/asin/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathAsin;
+        struct ConceptMathAsin{};
 
         namespace traits
         {

--- a/include/alpaka/math/atan/Traits.hpp
+++ b/include/alpaka/math/atan/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathAtan;
+        struct ConceptMathAtan{};
 
         namespace traits
         {

--- a/include/alpaka/math/atan2/Traits.hpp
+++ b/include/alpaka/math/atan2/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathAtan2;
+        struct ConceptMathAtan2{};
 
         namespace traits
         {

--- a/include/alpaka/math/cbrt/Traits.hpp
+++ b/include/alpaka/math/cbrt/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathCbrt;
+        struct ConceptMathCbrt{};
 
         namespace traits
         {

--- a/include/alpaka/math/ceil/Traits.hpp
+++ b/include/alpaka/math/ceil/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathCeil;
+        struct ConceptMathCeil{};
 
         namespace traits
         {

--- a/include/alpaka/math/cos/Traits.hpp
+++ b/include/alpaka/math/cos/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathCos;
+        struct ConceptMathCos{};
 
         namespace traits
         {

--- a/include/alpaka/math/erf/Traits.hpp
+++ b/include/alpaka/math/erf/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathErf;
+        struct ConceptMathErf{};
 
         namespace traits
         {

--- a/include/alpaka/math/exp/Traits.hpp
+++ b/include/alpaka/math/exp/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathExp;
+        struct ConceptMathExp{};
 
         namespace traits
         {

--- a/include/alpaka/math/floor/Traits.hpp
+++ b/include/alpaka/math/floor/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathFloor;
+        struct ConceptMathFloor{};
 
         namespace traits
         {

--- a/include/alpaka/math/fmod/Traits.hpp
+++ b/include/alpaka/math/fmod/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathFmod;
+        struct ConceptMathFmod{};
 
         namespace traits
         {

--- a/include/alpaka/math/log/Traits.hpp
+++ b/include/alpaka/math/log/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathLog;
+        struct ConceptMathLog{};
 
         namespace traits
         {

--- a/include/alpaka/math/max/Traits.hpp
+++ b/include/alpaka/math/max/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathMax;
+        struct ConceptMathMax{};
 
         namespace traits
         {

--- a/include/alpaka/math/min/Traits.hpp
+++ b/include/alpaka/math/min/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathMin;
+        struct ConceptMathMin{};
 
         namespace traits
         {

--- a/include/alpaka/math/pow/Traits.hpp
+++ b/include/alpaka/math/pow/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathPow;
+        struct ConceptMathPow{};
 
         namespace traits
         {

--- a/include/alpaka/math/remainder/Traits.hpp
+++ b/include/alpaka/math/remainder/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathRemainder;
+        struct ConceptMathRemainder{};
 
         namespace traits
         {

--- a/include/alpaka/math/round/Traits.hpp
+++ b/include/alpaka/math/round/Traits.hpp
@@ -21,7 +21,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathRound;
+        struct ConceptMathRound{};
 
         namespace traits
         {

--- a/include/alpaka/math/rsqrt/Traits.hpp
+++ b/include/alpaka/math/rsqrt/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathRsqrt;
+        struct ConceptMathRsqrt{};
 
         namespace traits
         {

--- a/include/alpaka/math/sin/Traits.hpp
+++ b/include/alpaka/math/sin/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathSin;
+        struct ConceptMathSin{};
 
         namespace traits
         {

--- a/include/alpaka/math/sincos/Traits.hpp
+++ b/include/alpaka/math/sincos/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathSinCos;
+        struct ConceptMathSinCos{};
 
         namespace traits
         {

--- a/include/alpaka/math/sqrt/Traits.hpp
+++ b/include/alpaka/math/sqrt/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathSqrt;
+        struct ConceptMathSqrt{};
 
         namespace traits
         {

--- a/include/alpaka/math/tan/Traits.hpp
+++ b/include/alpaka/math/tan/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathTan;
+        struct ConceptMathTan{};
 
         namespace traits
         {

--- a/include/alpaka/math/trunc/Traits.hpp
+++ b/include/alpaka/math/trunc/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     namespace math
     {
-        struct ConceptMathTrunc;
+        struct ConceptMathTrunc{};
 
         namespace traits
         {

--- a/include/alpaka/mem/alloc/Traits.hpp
+++ b/include/alpaka/mem/alloc/Traits.hpp
@@ -24,7 +24,7 @@ namespace alpaka
         //! The allocator specifics.
         namespace alloc
         {
-            struct ConceptMemAlloc;
+            struct ConceptMemAlloc{};
 
             //-----------------------------------------------------------------------------
             //! The allocator traits.

--- a/include/alpaka/pltf/Traits.hpp
+++ b/include/alpaka/pltf/Traits.hpp
@@ -27,7 +27,7 @@ namespace alpaka
     //! The platform specifics.
     namespace pltf
     {
-        struct ConceptPltf;
+        struct ConceptPltf{};
 
         //-----------------------------------------------------------------------------
         //! The platform traits.

--- a/include/alpaka/rand/Traits.hpp
+++ b/include/alpaka/rand/Traits.hpp
@@ -22,7 +22,7 @@ namespace alpaka
     //! The random number generation specifics.
     namespace rand
     {
-        struct ConceptRand;
+        struct ConceptRand{};
 
         //-----------------------------------------------------------------------------
         //! The random number generator distribution specifics.

--- a/include/alpaka/time/Traits.hpp
+++ b/include/alpaka/time/Traits.hpp
@@ -20,7 +20,7 @@ namespace alpaka
     //! The time traits specifics.
     namespace time
     {
-        struct ConceptTime;
+        struct ConceptTime{};
 
         //-----------------------------------------------------------------------------
         //! The time traits.

--- a/include/alpaka/wait/Traits.hpp
+++ b/include/alpaka/wait/Traits.hpp
@@ -18,7 +18,7 @@ namespace alpaka
     //! The wait specifics.
     namespace wait
     {
-        struct ConceptCurrentThreadWaitFor;
+        struct ConceptCurrentThreadWaitFor{};
 
         //-----------------------------------------------------------------------------
         //! The wait traits.

--- a/include/alpaka/workdiv/Traits.hpp
+++ b/include/alpaka/workdiv/Traits.hpp
@@ -27,7 +27,7 @@ namespace alpaka
     //! The work division traits specifics.
     namespace workdiv
     {
-        struct ConceptWorkDiv;
+        struct ConceptWorkDiv{};
 
         //-----------------------------------------------------------------------------
         //! The work division traits.

--- a/test/unit/core/src/ConceptsTest.cpp
+++ b/test/unit/core/src/ConceptsTest.cpp
@@ -13,8 +13,8 @@
 
 #include <type_traits>
 
-struct ConceptExample;
-struct ConceptNonMatchingExample;
+struct ConceptExample{};
+struct ConceptNonMatchingExample{};
 
 struct ImplementerNotTagged
 {


### PR DESCRIPTION
Define all concepts as empty implementation to allow instance creation.

This will allow to implement more user friendly ways (optional) to handle concepts.

```
auto conceptImpl = getConcept( ConceptIdxBt{} );
// instead of
auto conceptImpl = getConcept< ConceptIdxBt >();
```

I like to reduce the explicit template usage in `cupla` as much as possible.