### PR TITLE
fix uninitialized pitch

### DIFF
--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -471,6 +471,7 @@ namespace alpaka
                         ALPAKA_API_PREFIX(PitchedPtr) pitchedPtrVal;
                         pitchedPtrVal.ptr = nullptr;
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
+                        pitchedPtrVal.pitch = 0u;
                         //FIXME: HIP cannot handle zero-size input
                         if(extentVal.width!=0
                            && extentVal.height!=0


### PR DESCRIPTION
For HIP the pitch was not initialized if a 3D buffer was created because
of zero extent.

The result was that the test cases sometimes crashed, depending on the value in the memory.

- [x] rebase against #965