### PR TITLE
fix windows CI builds

### DIFF
--- a/script/run_build.sh
+++ b/script/run_build.sh
@@ -118,7 +118,7 @@ then
     make VERBOSE=1
 elif [ "$TRAVIS_OS_NAME" = "windows" ]
 then
-    "$MSBUILD_EXECUTABLE" "alpaka.sln" -p:Configuration=${CMAKE_BUILD_TYPE} -maxcpucount:2 -verbosity:minimal
+    "$MSBUILD_EXECUTABLE" "alpaka.sln" -p:Configuration=${CMAKE_BUILD_TYPE} -maxcpucount:1 -verbosity:minimal
 fi
 
 cd ..


### PR DESCRIPTION
fix #964

Remove build concurrency for windows CI.

This is a temporary solution for the CI build errors so that we can go on with merging other PR's and not get stuck because of the CI.