### PR TITLE
Remove unnecessary includes of boost/config.hpp

### DIFF
--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -18,23 +18,6 @@
 #endif
 
 //-----------------------------------------------------------------------------
-// Boost does not yet correctly identify clang when compiling CUDA code.
-// After explicitly including <boost/config.hpp> we can safely undefine some of the wrong settings.
-#if BOOST_COMP_CLANG_CUDA
-    #include <boost/config.hpp>
-    #undef BOOST_NO_CXX11_VARIADIC_TEMPLATES
-#endif
-
-//-----------------------------------------------------------------------------
-// Boost disables variadic templates for nvcc (in some cases because it was buggy).
-// However, we rely on it being enabled.
-// After explicitly including <boost/config.hpp> we can safely undefine the wrong setting.
-#if BOOST_COMP_NVCC
-    #include <boost/config.hpp>
-    #undef BOOST_NO_CXX11_VARIADIC_TEMPLATES
-#endif
-
-//-----------------------------------------------------------------------------
 //! All functions that can be used on an accelerator have to be attributed with ALPAKA_FN_ACC or ALPAKA_FN_HOST_ACC.
 //!
 //! Usage:

--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -16,8 +16,7 @@
 // Therefore, we can not even parse those parts when compiling device code.
 //-----------------------------------------------------------------------------
 #include <alpaka/core/Common.hpp>
-
-#include <boost/config.hpp>
+#include <alpaka/core/BoostPredef.hpp>
 
 #include <queue>
 #include <mutex>

--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -11,8 +11,6 @@
 
 #include <alpaka/core/Common.hpp>
 
-#include <boost/config.hpp>
-
 namespace alpaka
 {
     //-----------------------------------------------------------------------------

--- a/include/alpaka/idx/Accessors.hpp
+++ b/include/alpaka/idx/Accessors.hpp
@@ -22,8 +22,6 @@
 
 #include <alpaka/core/Unused.hpp>
 
-#include <boost/config.hpp>
-
 #include <utility>
 
 namespace alpaka

--- a/include/alpaka/math/abs/Traits.hpp
+++ b/include/alpaka/math/abs/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/acos/Traits.hpp
+++ b/include/alpaka/math/acos/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/asin/Traits.hpp
+++ b/include/alpaka/math/asin/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/atan/Traits.hpp
+++ b/include/alpaka/math/atan/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/atan2/Traits.hpp
+++ b/include/alpaka/math/atan2/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/cbrt/Traits.hpp
+++ b/include/alpaka/math/cbrt/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/ceil/Traits.hpp
+++ b/include/alpaka/math/ceil/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/cos/Traits.hpp
+++ b/include/alpaka/math/cos/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/erf/Traits.hpp
+++ b/include/alpaka/math/erf/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/exp/Traits.hpp
+++ b/include/alpaka/math/exp/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/floor/Traits.hpp
+++ b/include/alpaka/math/floor/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/fmod/Traits.hpp
+++ b/include/alpaka/math/fmod/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/log/Traits.hpp
+++ b/include/alpaka/math/log/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/max/Traits.hpp
+++ b/include/alpaka/math/max/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/min/Traits.hpp
+++ b/include/alpaka/math/min/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/pow/Traits.hpp
+++ b/include/alpaka/math/pow/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/remainder/Traits.hpp
+++ b/include/alpaka/math/remainder/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/round/Traits.hpp
+++ b/include/alpaka/math/round/Traits.hpp
@@ -11,9 +11,6 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
-#include <alpaka/core/Unused.hpp>
-
-#include <boost/config.hpp>
 
 #include <type_traits>
 

--- a/include/alpaka/math/rsqrt/Traits.hpp
+++ b/include/alpaka/math/rsqrt/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/sin/Traits.hpp
+++ b/include/alpaka/math/sin/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/sincos/Traits.hpp
+++ b/include/alpaka/math/sincos/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/sqrt/Traits.hpp
+++ b/include/alpaka/math/sqrt/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/tan/Traits.hpp
+++ b/include/alpaka/math/tan/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/math/trunc/Traits.hpp
+++ b/include/alpaka/math/trunc/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -13,8 +13,6 @@
 
 #include <alpaka/core/Common.hpp>
 
-#include <boost/config.hpp>
-
 namespace alpaka
 {
     //-----------------------------------------------------------------------------

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -21,8 +21,6 @@
 #include <alpaka/meta/Fold.hpp>
 #include <alpaka/vec/Vec.hpp>
 
-#include <boost/config.hpp>
-
 #include <iosfwd>
 #include <type_traits>
 

--- a/include/alpaka/meta/ApplyTuple.hpp
+++ b/include/alpaka/meta/ApplyTuple.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <boost/config.hpp>
-
 #include <utility>
 #include <tuple>
 #include <type_traits>

--- a/include/alpaka/pltf/Traits.hpp
+++ b/include/alpaka/pltf/Traits.hpp
@@ -16,8 +16,6 @@
 #include <alpaka/queue/Traits.hpp>
 #include <alpaka/dev/Traits.hpp>
 
-#include <boost/config.hpp>
-
 #include <vector>
 #include <type_traits>
 

--- a/include/alpaka/rand/Traits.hpp
+++ b/include/alpaka/rand/Traits.hpp
@@ -12,8 +12,6 @@
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 
 namespace alpaka

--- a/include/alpaka/vec/Traits.hpp
+++ b/include/alpaka/vec/Traits.hpp
@@ -16,8 +16,6 @@
 #include <alpaka/idx/Traits.hpp>
 #include <alpaka/meta/IntegerSequence.hpp>
 
-#include <boost/config.hpp>
-
 #include <utility>
 
 namespace alpaka

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -25,8 +25,6 @@
 #include <alpaka/meta/IntegerSequence.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <boost/config.hpp>
-
 #include <algorithm>
 #include <cstdint>
 #include <ostream>

--- a/include/alpaka/workdiv/Traits.hpp
+++ b/include/alpaka/workdiv/Traits.hpp
@@ -16,8 +16,6 @@
 #include <alpaka/core/Positioning.hpp>
 #include <alpaka/core/Common.hpp>
 
-#include <boost/config.hpp>
-
 #include <type_traits>
 #include <utility>
 


### PR DESCRIPTION
We use the defines from `boost.predef` and not the ones from `boost.config`.

We do not need the variadic template workarounds for a long time now since we removed the dependency to boost.mpl long ago.
