### PR TITLE
Add /bigobj to all tests on Windows

### DIFF
--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -35,6 +35,7 @@ target_compile_options(${_COMMON_TARGET_NAME}
 
 if(MSVC)
     target_compile_options(${_COMMON_TARGET_NAME} PUBLIC "/wd4996") # This function or variable may be unsafe. Consider using <safe_version> instead.
+    target_compile_options(${_COMMON_TARGET_NAME} PUBLIC "/bigobj")
 endif()
 
 if(ALPAKA_ACC_GPU_CUDA_ENABLE OR (ALPAKA_ACC_GPU_HIP_ENABLE AND HIP_PLATFORM MATCHES "nvcc"))


### PR DESCRIPTION
else the compilation fails