### PR TITLE
Vec: rm unused static constexpr to enable GCC OMP4

### DIFF
--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -110,7 +110,6 @@ namespace alpaka
             static_assert(TDim::value >= 0u, "Invalid dimensionality");
 
             using Dim = TDim;
-            static constexpr auto s_uiDim = TDim::value;
             using Val = TVal;
 
         private:


### PR DESCRIPTION
The static constexpr Vec<>::s_uiDim does not appear to be used by any alpaka example or test and is also not used in PIConGPU.

It triggers a compiler error with OpenMP5 and OpenACC backends in GCC (type cannot be mapped). While this is a problem in with the compiler, removing allows for some Alpaka tests to be compiled. As this constant is unused and also not documented, should maybe be removed anyway.