### PR TITLE
emulate hip/cuda-Memcpy3D with a kernel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,7 +459,7 @@ jobs:
           env: {TRAVIS_OS_NAME: linux,   CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 7,        CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.67.0, ALPAKA_CI_CMAKE_VER: 3.17.1,                     ALPAKA_CI_STDLIB: libstdc++, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:20.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "10.2", ALPAKA_CUDA_COMPILER: nvcc}
         - name: linux_nvcc-10.2_gcc-8_release
           os: ubuntu-latest
-          env: {TRAVIS_OS_NAME: linux,   CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 8,        CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.69.0, ALPAKA_CI_CMAKE_VER: 3.15.7,                     ALPAKA_CI_STDLIB: libstdc++, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "10.2", ALPAKA_CUDA_COMPILER: nvcc, ALPAKA_CUDA_ARCH: "30;35"}
+          env: {TRAVIS_OS_NAME: linux,   CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 8,        CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.69.0, ALPAKA_CI_CMAKE_VER: 3.15.7,                     ALPAKA_CI_STDLIB: libstdc++, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "10.2", ALPAKA_CUDA_COMPILER: nvcc, ALPAKA_CUDA_ARCH: "30;35", ALPAKA_EMU_MEMCPY3D: ON}
         # nvcc + clang++
         - name: linux_nvcc-10.2_clang-4_release
           os: ubuntu-latest
@@ -483,7 +483,7 @@ jobs:
           env: {TRAVIS_OS_NAME: linux,   CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.67.0, ALPAKA_CI_CMAKE_VER: 3.15.7,                     ALPAKA_CI_STDLIB: libstdc++, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:16.04", ALPAKA_ACC_GPU_HIP_ENABLE: ON, ALPAKA_ACC_GPU_HIP_ONLY_MODE: ON, ALPAKA_CI_HIP_BRANCH: "rocm-3.3.0", ALPAKA_CUDA_VERSION: "9.2", ALPAKA_HIP_PLATFORM: nvcc, ALPAKA_CUDA_COMPILER: nvcc, ALPAKA_CUDA_ARCH: "30;35"}
         - name: linux_hip_nvcc-9.2_gcc-5_release_hip_only
           os: ubuntu-latest
-          env: {TRAVIS_OS_NAME: linux,   CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.71.0, ALPAKA_CI_CMAKE_VER: 3.17.1,                     ALPAKA_CI_STDLIB: libstdc++, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:16.04", ALPAKA_ACC_GPU_HIP_ENABLE: ON, ALPAKA_ACC_GPU_HIP_ONLY_MODE: ON, ALPAKA_CI_HIP_BRANCH: "rocm-3.3.0", ALPAKA_CUDA_VERSION: "9.2", ALPAKA_HIP_PLATFORM: nvcc, ALPAKA_CUDA_COMPILER: nvcc, ALPAKA_CUDA_ARCH: "30;35"}
+          env: {TRAVIS_OS_NAME: linux,   CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.71.0, ALPAKA_CI_CMAKE_VER: 3.17.1,                     ALPAKA_CI_STDLIB: libstdc++, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:16.04", ALPAKA_ACC_GPU_HIP_ENABLE: ON, ALPAKA_ACC_GPU_HIP_ONLY_MODE: ON, ALPAKA_CI_HIP_BRANCH: "rocm-3.3.0", ALPAKA_CUDA_VERSION: "9.2", ALPAKA_HIP_PLATFORM: nvcc, ALPAKA_CUDA_COMPILER: nvcc, ALPAKA_CUDA_ARCH: "30;35", ALPAKA_EMU_MEMCPY3D: ON}
 
     steps:
     - uses: actions/checkout@v1

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -1,5 +1,6 @@
 #
 # Copyright 2014-2020 Benjamin Worpitz, Erik Zenker, Axel Huebl, Jan Stephan
+#                     Rene Widera
 #
 # This file is part of Alpaka.
 #
@@ -19,6 +20,8 @@ set(ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE_DEFAULT ON)
 set(ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE_DEFAULT ON)
 set(ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE_DEFAULT ON)
 set(ALPAKA_ACC_CPU_BT_OMP4_ENABLE_DEFAULT ON)
+
+set(ALPAKA_EMU_MEMCPY3D_DEFAULT OFF)
 
 # HIP and platform selection and warning about unsupported features
 option(ALPAKA_ACC_GPU_HIP_ENABLE "Enable the HIP back-end (all other back-ends must be disabled)" OFF)
@@ -68,6 +71,7 @@ endif()
 
 if(ALPAKA_ACC_GPU_HIP_ENABLE)
     set(ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE_DEFAULT OFF)
+    set(ALPAKA_EMU_MEMCPY3D_DEFAULT ON)
 endif()
 
 if(ALPAKA_ACC_GPU_CUDA_ONLY_MODE AND NOT ALPAKA_ACC_GPU_CUDA_ENABLE)
@@ -86,6 +90,8 @@ option(ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE "Enable the TBB CPU grid block back-end
 option(ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE "Enable the OpenMP 2.0 CPU grid block back-end" ${ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE_DEFAULT})
 option(ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE "Enable the OpenMP 2.0 CPU block thread back-end" ${ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE_DEFAULT})
 option(ALPAKA_ACC_CPU_BT_OMP4_ENABLE "Enable the OpenMP 4.0 CPU block and block thread back-end" ${ALPAKA_ACC_CPU_BT_OMP4_ENABLE_DEFAULT})
+
+option(ALPAKA_EMU_MEMCPY3D "Emulate internal used hip/cuda-Memcpy3D(async) with a kernel" ${ALPAKA_EMU_MEMCPY3D_DEFAULT})
 
 if((ALPAKA_ACC_GPU_CUDA_ONLY_MODE OR ALPAKA_ACC_GPU_HIP_ONLY_MODE)
    AND
@@ -778,6 +784,10 @@ endif()
 if(ALPAKA_ACC_GPU_HIP_ENABLE)
     target_compile_definitions(alpaka INTERFACE "ALPAKA_ACC_GPU_HIP_ENABLED")
     message(STATUS ALPAKA_ACC_GPU_HIP_ENABLED)
+endif()
+
+if(ALPAKA_EMU_MEMCPY3D)
+    target_compile_definitions(alpaka INTERFACE "ALPAKA_EMU_MEMCPY3D_ENABLED")
 endif()
 
 target_compile_definitions(alpaka INTERFACE "ALPAKA_DEBUG=${ALPAKA_DEBUG}")

--- a/script/run_generate.sh
+++ b/script/run_generate.sh
@@ -82,6 +82,7 @@ cd build/
     "$(env2cmake ALPAKA_ACC_GPU_CUDA_ENABLE)" "$(env2cmake ALPAKA_CUDA_VERSION)" "$(env2cmake ALPAKA_ACC_GPU_CUDA_ONLY_MODE)" "$(env2cmake ALPAKA_CUDA_ARCH)" "$(env2cmake ALPAKA_CUDA_COMPILER)" \
     "$(env2cmake ALPAKA_CUDA_FAST_MATH)" "$(env2cmake ALPAKA_CUDA_FTZ)" "$(env2cmake ALPAKA_CUDA_SHOW_REGISTER)" "$(env2cmake ALPAKA_CUDA_KEEP_FILES)" "$(env2cmake ALPAKA_CUDA_NVCC_EXPT_EXTENDED_LAMBDA)" "$(env2cmake ALPAKA_CUDA_NVCC_SEPARABLE_COMPILATION)" \
     "$(env2cmake ALPAKA_ACC_GPU_HIP_ENABLE)" "$(env2cmake ALPAKA_ACC_GPU_HIP_ONLY_MODE)" "$(env2cmake ALPAKA_HIP_PLATFORM)" \
+    "$(env2cmake ALPAKA_EMU_MEMCPY3D)" \
     "$(env2cmake ALPAKA_DEBUG)" "$(env2cmake ALPAKA_CI)" "$(env2cmake ALPAKA_CI_ANALYSIS)" "$(env2cmake ALPAKA_CXX_STANDARD)" \
     ".."
 


### PR DESCRIPTION
- add kernel to emulate hip/cuda-Memcpy3D
- add CMake option to enable/disable emulated memory copy (by default
only for HIP enabled)
- enable `ALPAKA_EMU_MEMCPY3D` for one HIP and one CUDA CI test

This optimization based on my [HIP issue](https://github.com/ROCm-Developer-Tools/HIP/issues/1815) and will increase the memory copy performance for device to device copies on the same device. 
I enabled the emulated copy only for HIP, for CUDA it can be optional enabled but is not showing any improvement. I assume the CUDA driver is already using a kernel instead of looping over the rows and call 1D mem-copies.