### PR TITLE
simplify alpaka usage

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -156,8 +156,6 @@ auto main()
     // choose between Blocking and NonBlocking
     using AccQueueProperty = alpaka::queue::Blocking;
     using DevQueue = alpaka::queue::Queue<Acc, AccQueueProperty>;
-    using DevAcc = alpaka::dev::Dev<Acc>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
 
     // Define the device accelerator
     //
@@ -175,12 +173,10 @@ auto main()
     // choose between Blocking and NonBlocking
     using HostQueueProperty = alpaka::queue::Blocking;
     using HostQueue = alpaka::queue::Queue<Host, HostQueueProperty>;
-    using DevHost = alpaka::dev::Dev<Host>;
-    using PltfHost = alpaka::pltf::Pltf<DevHost>;
 
     // Select devices
-    DevAcc const devAcc(alpaka::pltf::getDevByIdx<PltfAcc>(0u));
-    DevHost const devHost(alpaka::pltf::getDevByIdx<PltfHost>(0u));
+    auto const devAcc = alpaka::pltf::getDevByIdx<Acc>(0u);
+    auto const devHost = alpaka::pltf::getDevByIdx<Host>(0u);
 
     // Create queues
     DevQueue devQueue(devAcc);
@@ -220,19 +216,19 @@ auto main()
     //
     // The `alloc` method returns a reference counted buffer handle.
     // When the last such handle is destroyed, the memory is freed automatically.
-    using BufHost = alpaka::mem::buf::Buf<DevHost, Data, Dim, Idx>;
+    using BufHost = alpaka::mem::buf::Buf<Host, Data, Dim, Idx>;
     BufHost hostBuffer(alpaka::mem::buf::alloc<Data, Idx>(devHost, extents));
     // You can also use already allocated memory and wrap it within a view (irrespective of the device type).
     // The view does not own the underlying memory. So you have to make sure that
     // the view does not outlive its underlying memory.
     std::array<Data, nElementsPerDim * nElementsPerDim * nElementsPerDim> plainBuffer;
-    using ViewHost = alpaka::mem::view::ViewPlainPtr<DevHost, Data, Dim, Idx>;
+    using ViewHost = alpaka::mem::view::ViewPlainPtr<Host, Data, Dim, Idx>;
     ViewHost hostViewPlainPtr(plainBuffer.data(), devHost, extents);
 
     // Allocate accelerator memory buffers
     //
     // The interface to allocate a buffer is the same on the host and on the device.
-    using BufAcc = alpaka::mem::buf::Buf<DevAcc, Data, Dim, Idx>;
+    using BufAcc = alpaka::mem::buf::Buf<Acc, Data, Dim, Idx>;
     BufAcc deviceBuffer1(alpaka::mem::buf::alloc<Data, Idx>(devAcc, extents));
     BufAcc deviceBuffer2(alpaka::mem::buf::alloc<Data, Idx>(devAcc, extents));
 

--- a/example/heatEquation/src/heatEquation.cpp
+++ b/example/heatEquation/src/heatEquation.cpp
@@ -125,15 +125,11 @@ auto main( ) -> int
         Idx
     >;
 
-    using DevAcc = alpaka::dev::Dev< Acc >;
-    using PltfAcc = alpaka::pltf::Pltf< DevAcc >;
-
     using DevHost = alpaka::dev::DevCpu;
-    using PltfHost = alpaka::pltf::Pltf< DevHost >;
 
     // Select specific devices
-    DevAcc const devAcc { alpaka::pltf::getDevByIdx< PltfAcc >( 0u ) };
-    DevHost const devHost { alpaka::pltf::getDevByIdx< PltfHost >( 0u ) };
+    auto const devAcc = alpaka::pltf::getDevByIdx< Acc >( 0u );
+    auto const devHost = alpaka::pltf::getDevByIdx< DevHost >( 0u );
 
     // Get valid workdiv for the given problem
     uint32_t elemPerThread = 1;
@@ -200,7 +196,7 @@ auto main( ) -> int
 
     // Accelerator buffer
     using BufAcc = alpaka::mem::buf::Buf<
-        DevAcc,
+        Acc,
         double,
         Dim,
         Idx

--- a/example/helloWorld/src/helloWorld.cpp
+++ b/example/helloWorld/src/helloWorld.cpp
@@ -109,9 +109,6 @@ auto main()
     // choose between Blocking and NonBlocking
     using QueueProperty = alpaka::queue::Blocking;
     using Queue = alpaka::queue::Queue<Acc, QueueProperty>;
-    using Dev = alpaka::dev::Dev<Acc>;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
-
 
     // Select a device
     //
@@ -121,7 +118,7 @@ auto main()
     // by id (0 to the number of devices minus 1) or you
     // can also retrieve all devices in a vector (getDevs()).
     // In this example the first devices is choosen.
-    Dev const devAcc(alpaka::pltf::getDevByIdx<Pltf>(0u));
+    auto const devAcc = alpaka::pltf::getDevByIdx<Acc>(0u);
 
     // Create a queue on the device
     //

--- a/example/helloWorldLambda/src/helloWorldLambda.cpp
+++ b/example/helloWorldLambda/src/helloWorldLambda.cpp
@@ -87,11 +87,9 @@ auto main()
     // choose between Blocking and NonBlocking
     using QueueProperty = alpaka::queue::Blocking;
     using Queue = alpaka::queue::Queue<Acc, QueueProperty>;
-    using Dev = alpaka::dev::Dev<Acc>;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
 
     // Select a device
-    Dev const devAcc(alpaka::pltf::getDevByIdx<Pltf>(0u));
+    auto const devAcc = alpaka::pltf::getDevByIdx<Acc>(0u);
 
     // Create a queue on the device
     Queue queue(devAcc);

--- a/example/reduce/src/alpakaConfig.hpp
+++ b/example/reduce/src/alpakaConfig.hpp
@@ -64,12 +64,6 @@ struct CpuOmp2Blocks
 {
     using Host = alpaka::acc::AccCpuOmp2Blocks<Dim, Extent>;
     using Acc = alpaka::acc::AccCpuOmp2Blocks<Dim, Extent>;
-    using DevHost = alpaka::dev::Dev<Host>;
-    using DevAcc = alpaka::dev::Dev<Acc>;
-    using PltfHost = alpaka::pltf::Pltf<DevHost>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
-    using Stream = alpaka::queue::QueueCpuBlocking;
-    using Event = alpaka::event::Event<Stream>;
     using SmCount = alpaka::dim::DimInt<1u>;
     using MaxBlockSize = alpaka::dim::DimInt<1u>;
 };
@@ -92,12 +86,6 @@ struct CpuOmp4
 {
     using Host = alpaka::acc::AccCpuSerial<Dim, Extent>;
     using Acc = alpaka::acc::AccCpuOmp4<Dim, Extent>;
-    using DevHost = alpaka::dev::Dev<Host>;
-    using DevAcc = alpaka::dev::Dev<Acc>;
-    using PltfHost = alpaka::pltf::Pltf<DevHost>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
-    using Stream = alpaka::queue::QueueCpuBlocking;
-    using Event = alpaka::event::Event<Stream>;
     using MaxBlockSize = alpaka::dim::DimInt<1u>;
 };
 
@@ -118,12 +106,6 @@ struct CpuSerial
 {
     using Host = alpaka::acc::AccCpuSerial<Dim, Extent>;
     using Acc = alpaka::acc::AccCpuSerial<Dim, Extent>;
-    using DevHost = alpaka::dev::Dev<Host>;
-    using DevAcc = alpaka::dev::Dev<Acc>;
-    using PltfHost = alpaka::pltf::Pltf<DevHost>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
-    using Stream = alpaka::queue::QueueCpuBlocking;
-    using Event = alpaka::event::Event<Stream>;
     using MaxBlockSize = alpaka::dim::DimInt<1u>;
 };
 
@@ -143,12 +125,6 @@ struct CpuThreads
 {
     using Host = alpaka::acc::AccCpuThreads<Dim, Extent>;
     using Acc = alpaka::acc::AccCpuThreads<Dim, Extent>;
-    using DevHost = alpaka::dev::Dev<Host>;
-    using DevAcc = alpaka::dev::Dev<Acc>;
-    using PltfHost = alpaka::pltf::Pltf<DevHost>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
-    using Stream = alpaka::queue::QueueCpuBlocking;
-    using Event = alpaka::event::Event<Stream>;
     using MaxBlockSize = alpaka::dim::DimInt<1u>;
 };
 
@@ -165,16 +141,10 @@ struct GetIterator<T, TBuf, alpaka::acc::AccCpuThreads<TArgs...>>
 //! CUDA defines
 //!
 //! Defines Host, Device, etc. for the CUDA/HIP accelerator.
-struct GpuUniformCudaHipRt
+struct GpuCudaRt
 {
     using Host = alpaka::acc::AccCpuSerial<Dim, Extent>;
-    using Acc = alpaka::acc::AccGpuUniformCudaHipRt<Dim, Extent>;
-    using DevHost = alpaka::dev::Dev<Host>;
-    using DevAcc = alpaka::dev::Dev<Acc>;
-    using PltfHost = alpaka::pltf::Pltf<DevHost>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
-    using Stream = alpaka::queue::QueueUniformCudaHipRtNonBlocking;
-    using Event = alpaka::event::Event<Stream>;
+    using Acc = alpaka::acc::AccGpuCudaRt<Dim, Extent>;
     using MaxBlockSize = alpaka::dim::DimInt<1024u>;
 };
 

--- a/example/reduce/src/reduce.cpp
+++ b/example/reduce/src/reduce.cpp
@@ -36,12 +36,10 @@
 //
 using Accelerator = CpuSerial;
 
-using DevAcc = Accelerator::DevAcc;
-using DevHost = Accelerator::DevHost;
-using QueueAcc = Accelerator::Stream;
 using Acc = Accelerator::Acc;
-using PltfAcc = Accelerator::PltfAcc;
-using PltfHost = Accelerator::PltfHost;
+using Host = Accelerator::Host;
+using QueueProperty = alpaka::queue::Blocking;
+using QueueAcc = alpaka::queue::Queue<Acc, QueueProperty>;
 using MaxBlockSize = Accelerator::MaxBlockSize;
 
 //-----------------------------------------------------------------------------
@@ -58,7 +56,7 @@ using MaxBlockSize = Accelerator::MaxBlockSize;
 //! \param func The reduction function.
 //!
 //! Returns true if the reduction was correct and false otherwise.
-template<typename T, typename TFunc>
+template<typename T, typename DevHost, typename DevAcc, typename TFunc>
 T reduce(DevHost devHost, DevAcc devAcc, QueueAcc queue, uint64_t n, alpaka::mem::buf::Buf<DevHost, T, Dim, Idx> hostMemory, TFunc func)
 {
     static constexpr uint64_t blockSize = getMaxBlockSize<Accelerator, 256>();
@@ -66,7 +64,7 @@ T reduce(DevHost devHost, DevAcc devAcc, QueueAcc queue, uint64_t n, alpaka::mem
     // calculate optimal block size (8 times the MP count proved to be
     // relatively near to peak performance in benchmarks)
     uint32_t blockCount = static_cast<uint32_t>(
-        alpaka::acc::getAccDevProps<Acc, DevAcc>(devAcc).m_multiProcessorCount *
+        alpaka::acc::getAccDevProps<Acc>(devAcc).m_multiProcessorCount *
         8);
     uint32_t maxBlockCount = static_cast<uint32_t>(
         (((n + 1) / 2) - 1) / blockSize + 1); // ceil(ceil(n/2.0)/blockSize)
@@ -135,14 +133,14 @@ int main()
     using T = uint32_t;
     static constexpr uint64_t blockSize = getMaxBlockSize<Accelerator, 256>();
 
-    DevAcc devAcc(alpaka::pltf::getDevByIdx<PltfAcc>(dev));
-    DevHost devHost(alpaka::pltf::getDevByIdx<PltfHost>(0u));
+    auto devAcc = alpaka::pltf::getDevByIdx<Acc>(dev);
+    auto devHost = alpaka::pltf::getDevByIdx<Host>(0u);
     QueueAcc queue(devAcc);
 
     // calculate optimal block size (8 times the MP count proved to be
     // relatively near to peak performance in benchmarks)
     uint32_t blockCount = static_cast<uint32_t>(
-        alpaka::acc::getAccDevProps<Acc, DevAcc>(devAcc).m_multiProcessorCount *
+        alpaka::acc::getAccDevProps<Acc>(devAcc).m_multiProcessorCount *
         8);
     uint32_t maxBlockCount = static_cast<uint32_t>(
         (((n + 1) / 2) - 1) / blockSize + 1); // ceil(ceil(n/2.0)/blockSize)

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -96,8 +96,6 @@ auto main()
     // - AccCpuTbbBlocks
     // - AccCpuSerial
     using Acc = alpaka::acc::AccCpuSerial<Dim, Idx>;
-    using DevAcc = alpaka::dev::Dev<Acc>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
 
     // Defines the synchronization behavior of a queue
     //
@@ -106,7 +104,7 @@ auto main()
     using QueueAcc = alpaka::queue::Queue<Acc, QueueProperty>;
 
     // Select a device
-    DevAcc const devAcc(alpaka::pltf::getDevByIdx<PltfAcc>(0u));
+    auto const devAcc = alpaka::pltf::getDevByIdx<Acc>(0u);
 
     // Create a queue on the device
     QueueAcc queue(devAcc);
@@ -130,8 +128,7 @@ auto main()
 
     // Get the host device for allocating memory on the host.
     using DevHost = alpaka::dev::DevCpu;
-    using PltfHost = alpaka::pltf::Pltf<DevHost>;
-    DevHost const devHost(alpaka::pltf::getDevByIdx<PltfHost>(0u));
+    auto const devHost = alpaka::pltf::getDevByIdx<DevHost>(0u);
 
     // Allocate 3 host memory buffers
     using BufHost = alpaka::mem::buf::Buf<DevHost, Data, Dim, Idx>;
@@ -157,7 +154,7 @@ auto main()
     }
 
     // Allocate 3 buffers on the accelerator
-    using BufAcc = alpaka::mem::buf::Buf<DevAcc, Data, Dim, Idx>;
+    using BufAcc = alpaka::mem::buf::Buf<Acc, Data, Dim, Idx>;
     BufAcc bufAccA(alpaka::mem::buf::alloc<Data, Idx>(devAcc, extent));
     BufAcc bufAccB(alpaka::mem::buf::alloc<Data, Idx>(devAcc, extent));
     BufAcc bufAccC(alpaka::mem::buf::alloc<Data, Idx>(devAcc, extent));

--- a/include/alpaka/acc/Traits.hpp
+++ b/include/alpaka/acc/Traits.hpp
@@ -18,7 +18,6 @@
 #include <alpaka/idx/Traits.hpp>
 #include <alpaka/pltf/Traits.hpp>
 #include <alpaka/queue/Traits.hpp>
-#include <alpaka/mem/buf/Traits.hpp>
 
 #include <string>
 #include <typeinfo>
@@ -189,50 +188,6 @@ namespace alpaka
                     using ImplementationBase = typename concepts::ImplementationBase<acc::ConceptUniformCudaHip, TAcc>;
                     using type = typename PltfType<ImplementationBase>::type;
                 };
-
-            //#############################################################################
-            //! Get the device associated with an index
-            //
-            // Call is redirected to the corresponding platform of an accelerator.
-            template<typename TAcc>
-            struct GetDevByIdx<
-                TAcc,
-                typename std::enable_if<
-                    concepts::ImplementsConcept<acc::ConceptAcc, TAcc>::value
-                >::type>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getDevByIdx(
-                    std::size_t const & devIdx)
-                {
-                    return traits::GetDevByIdx<
-                        typename pltf::traits::PltfType<TAcc>::type>
-                            ::getDevByIdx(devIdx);
-                }
-            };
-
-            //#############################################################################
-            //! Get number of devices
-            //
-            // Call is redirected to the corresponding platform of an accelerator.
-            template<typename TAcc>
-            struct GetDevCount<
-                TAcc,
-                typename std::enable_if<
-                    concepts::ImplementsConcept<acc::ConceptAcc, TAcc>::value
-                >::type>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getDevCount()
-                -> std::size_t
-                {
-                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
-
-                    return traits::GetDevCount<
-                        typename pltf::traits::PltfType<TAcc>::type>
-                            ::getDevCount();
-                }
-            };
         }
 
     }
@@ -293,34 +248,6 @@ namespace alpaka
                     TProperty
                 >::type;
             };
-        }
-    }
-
-    namespace mem
-    {
-        namespace buf
-        {
-            namespace traits
-            {
-                //#############################################################################
-                //! The CPU device memory buffer type trait specialization.
-                template<
-                    typename TAcc,
-                    typename TElem,
-                    typename TDim,
-                    typename TIdx
-                    >
-                struct BufType<
-                    TAcc,
-                    TElem,
-                    TDim,
-                    TIdx,
-                    std::enable_if_t<
-                        concepts::ImplementsConcept<acc::ConceptAcc, TAcc>::value>>
-                {
-                    using type = alpaka::mem::buf::Buf<alpaka::dev::Dev<TAcc>, TElem, TDim, TIdx>;
-                };
-            }
         }
     }
 }

--- a/include/alpaka/acc/Traits.hpp
+++ b/include/alpaka/acc/Traits.hpp
@@ -18,6 +18,7 @@
 #include <alpaka/idx/Traits.hpp>
 #include <alpaka/pltf/Traits.hpp>
 #include <alpaka/queue/Traits.hpp>
+#include <alpaka/mem/buf/Traits.hpp>
 
 #include <string>
 #include <typeinfo>
@@ -188,6 +189,50 @@ namespace alpaka
                     using ImplementationBase = typename concepts::ImplementationBase<acc::ConceptUniformCudaHip, TAcc>;
                     using type = typename PltfType<ImplementationBase>::type;
                 };
+
+            //#############################################################################
+            //! Get the device associated with an index
+            //
+            // Call is redirected to the corresponding platform of an accelerator.
+            template<typename TAcc>
+            struct GetDevByIdx<
+                TAcc,
+                typename std::enable_if<
+                    concepts::ImplementsConcept<acc::ConceptAcc, TAcc>::value
+                >::type>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto getDevByIdx(
+                    std::size_t const & devIdx)
+                {
+                    return traits::GetDevByIdx<
+                        typename pltf::traits::PltfType<TAcc>::type>
+                            ::getDevByIdx(devIdx);
+                }
+            };
+
+            //#############################################################################
+            //! Get number of devices
+            //
+            // Call is redirected to the corresponding platform of an accelerator.
+            template<typename TAcc>
+            struct GetDevCount<
+                TAcc,
+                typename std::enable_if<
+                    concepts::ImplementsConcept<acc::ConceptAcc, TAcc>::value
+                >::type>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto getDevCount()
+                -> std::size_t
+                {
+                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
+
+                    return traits::GetDevCount<
+                        typename pltf::traits::PltfType<TAcc>::type>
+                            ::getDevCount();
+                }
+            };
         }
 
     }
@@ -248,6 +293,34 @@ namespace alpaka
                     TProperty
                 >::type;
             };
+        }
+    }
+
+    namespace mem
+    {
+        namespace buf
+        {
+            namespace traits
+            {
+                //#############################################################################
+                //! The CPU device memory buffer type trait specialization.
+                template<
+                    typename TAcc,
+                    typename TElem,
+                    typename TDim,
+                    typename TIdx
+                    >
+                struct BufType<
+                    TAcc,
+                    TElem,
+                    TDim,
+                    TIdx,
+                    std::enable_if_t<
+                        concepts::ImplementsConcept<acc::ConceptAcc, TAcc>::value>>
+                {
+                    using type = alpaka::mem::buf::Buf<alpaka::dev::Dev<TAcc>, TElem, TDim, TIdx>;
+                };
+            }
         }
     }
 }

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -126,7 +126,9 @@ namespace alpaka
 
         //#############################################################################
         //! The CPU device handle.
-        class DevCpu : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, DevCpu>
+        class DevCpu :
+            public concepts::Implements<wait::ConceptCurrentThreadWaitFor, DevCpu>,
+            public concepts::Implements<ConceptDev, DevCpu>
         {
             friend struct pltf::traits::GetDevByIdx<pltf::PltfCpu>;
         protected:

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -59,7 +59,9 @@ namespace alpaka
     {
         //#############################################################################
         //! The CUDA/HIP RT device handle.
-        class DevUniformCudaHipRt : public concepts::Implements<wait::ConceptCurrentThreadWaitFor, DevUniformCudaHipRt>
+        class DevUniformCudaHipRt :
+            public concepts::Implements<wait::ConceptCurrentThreadWaitFor, DevUniformCudaHipRt>,
+            public concepts::Implements<ConceptDev, DevUniformCudaHipRt>
         {
             friend struct pltf::traits::GetDevByIdx<pltf::PltfUniformCudaHipRt>;
 

--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -73,6 +73,9 @@ namespace alpaka
         using Dev = typename traits::DevType<T>::type;
 
         struct ConceptGetDev;
+
+        struct ConceptDev;
+
         //-----------------------------------------------------------------------------
         //! \return The device this object is bound to.
         template<
@@ -146,6 +149,22 @@ namespace alpaka
                 TDev>
             ::reset(
                 dev);
+        }
+
+        namespace traits
+        {
+            //#############################################################################
+            //! Get device type
+            template<typename TDev>
+            struct DevType<
+                TDev,
+                typename std::enable_if<
+                    concepts::ImplementsConcept<dev::ConceptDev, TDev>::value
+                >::type>
+            {
+                using ImplementationBase = typename concepts::ImplementationBase<dev::ConceptDev, TDev>;
+                using type = ImplementationBase;
+            };
         }
     }
 }

--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -155,15 +155,14 @@ namespace alpaka
         {
             //#############################################################################
             //! Get device type
-            template<typename TDev>
+            template<
+                typename TDev>
             struct DevType<
                 TDev,
-                typename std::enable_if<
-                    concepts::ImplementsConcept<dev::ConceptDev, TDev>::value
-                >::type>
+                typename std::enable_if<concepts::ImplementsConcept<dev::ConceptDev, TDev>::value>::type
+            >
             {
-                using ImplementationBase = typename concepts::ImplementationBase<dev::ConceptDev, TDev>;
-                using type = ImplementationBase;
+                using type = typename concepts::ImplementationBase<dev::ConceptDev, TDev>;
             };
         }
     }

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -99,7 +99,8 @@ namespace alpaka
                 typename TElem,
                 typename TDim,
                 typename TIdx>
-            using Buf = typename traits::BufType<TDev, TElem, TDim, TIdx>::type;
+            using Buf = typename traits::BufType<
+                alpaka::dev::Dev<TDev>, TElem, TDim, TIdx>::type;
 
             //-----------------------------------------------------------------------------
             //! Allocates memory on the given device.

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -35,13 +35,15 @@ namespace alpaka
                 static_assert(
                     !std::is_const<TIdx>::value,
                     "The idx type of the view can not be const!");
+
+                using Dev = alpaka::dev::Dev<TDev>;
             public:
                 //-----------------------------------------------------------------------------
                 template<
                     typename TExtent>
                 ALPAKA_FN_HOST ViewPlainPtr(
                     TElem * pMem,
-                    TDev const & dev,
+                    Dev const & dev,
                     TExtent const & extent = TExtent()) :
                         m_pMem(pMem),
                         m_dev(dev),
@@ -55,7 +57,7 @@ namespace alpaka
                     typename TPitch>
                 ALPAKA_FN_HOST ViewPlainPtr(
                     TElem * pMem,
-                    TDev const dev,
+                    Dev const dev,
                     TExtent const & extent,
                     TPitch const & pitchBytes) :
                         m_pMem(pMem),
@@ -110,7 +112,7 @@ namespace alpaka
 
             public:
                 TElem * const m_pMem;
-                TDev const m_dev;
+                Dev const m_dev;
                 vec::Vec<TDim, TIdx> const m_extentElements;
                 vec::Vec<TDim, TIdx> const m_pitchBytes;
             };
@@ -133,7 +135,7 @@ namespace alpaka
             struct DevType<
                 mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx>>
             {
-                using type = TDev;
+                using type = alpaka::dev::Dev<TDev>;
             };
 
             //#############################################################################
@@ -148,7 +150,7 @@ namespace alpaka
             {
                 static auto getDev(
                     mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx> const & view)
-                    -> TDev
+                    -> alpaka::dev::Dev<TDev>
                 {
                     return view.m_dev;
                 }

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -43,6 +43,9 @@ namespace alpaka
                 static_assert(
                     !std::is_const<TIdx>::value,
                     "The idx type of the view can not be const!");
+
+                using Dev = alpaka::dev::Dev<TDev>;
+
             public:
                 //-----------------------------------------------------------------------------
                 //! Constructor.
@@ -68,8 +71,8 @@ namespace alpaka
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                     static_assert(
-                        std::is_same<TDev, dev::Dev<TView>>::value,
-                        "The dev type of TView and the TDev template parameter have to be identical!");
+                        std::is_same<Dev, dev::Dev<TView>>::value,
+                        "The dev type of TView and the Dev template parameter have to be identical!");
 
                     static_assert(
                         std::is_same<TIdx, idx::Idx<TView>>::value,
@@ -117,8 +120,8 @@ namespace alpaka
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                     static_assert(
-                        std::is_same<TDev, dev::Dev<TView>>::value,
-                        "The dev type of TView and the TDev template parameter have to be identical!");
+                        std::is_same<Dev, dev::Dev<TView>>::value,
+                        "The dev type of TView and the Dev template parameter have to be identical!");
 
                     static_assert(
                         std::is_same<TIdx, idx::Idx<TView>>::value,
@@ -172,7 +175,7 @@ namespace alpaka
                 }
 
             public:
-                mem::view::ViewPlainPtr<TDev, TElem, TDim, TIdx> m_viewParentView; // This wraps the parent view.
+                mem::view::ViewPlainPtr<Dev, TElem, TDim, TIdx> m_viewParentView; // This wraps the parent view.
                 vec::Vec<TDim, TIdx> m_extentElements;     // The extent of this view.
                 vec::Vec<TDim, TIdx> m_offsetsElements;    // The offset relative to the parent view.
             };
@@ -195,7 +198,7 @@ namespace alpaka
             struct DevType<
                 mem::view::ViewSubView<TDev, TElem, TDim, TIdx>>
             {
-                using type = TDev;
+                using type = alpaka::dev::Dev<TDev>;
             };
 
             //#############################################################################
@@ -211,7 +214,7 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getDev(
                     mem::view::ViewSubView<TDev, TElem, TDim, TIdx> const & view)
-                -> TDev
+                -> alpaka::dev::Dev<TDev>
                 {
                     return
                         dev::getDev(

--- a/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
+++ b/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
@@ -40,7 +40,7 @@ namespace alpaka
     namespace pltf
     {
         //#############################################################################
-        //! The CUDA RT device manager.
+        //! The CUDA/HIP RT platform.
         class PltfUniformCudaHipRt :
             public concepts::Implements<ConceptPltf, PltfUniformCudaHipRt>
         {
@@ -55,7 +55,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The CUDA RT device manager device type trait specialization.
+            //! The CUDA/HIP RT platform device type trait specialization.
             template<>
             struct DevType<
                 pltf::PltfUniformCudaHipRt>
@@ -69,7 +69,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The CPU platform device count get trait specialization.
+            //! The CUDA/HIP RT platform device count get trait specialization.
             template<>
             struct GetDevCount<
                 pltf::PltfUniformCudaHipRt>
@@ -90,7 +90,7 @@ namespace alpaka
             };
 
             //#############################################################################
-            //! The CPU platform device get trait specialization.
+            //! The CUDA/HIP RT platform device get trait specialization.
             template<>
             struct GetDevByIdx<
                 pltf::PltfUniformCudaHipRt>

--- a/include/alpaka/pltf/Traits.hpp
+++ b/include/alpaka/pltf/Traits.hpp
@@ -10,7 +10,6 @@
 #pragma once
 
 #include <alpaka/core/Common.hpp>
-#include <alpaka/dev/Traits.hpp>
 
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/queue/Traits.hpp>
@@ -38,6 +37,16 @@ namespace alpaka
                 typename TSfinae = void>
             struct PltfType;
 
+            template<
+                typename TPltf>
+            struct PltfType<
+                TPltf,
+                typename std::enable_if<concepts::ImplementsConcept<pltf::ConceptPltf, TPltf>::value>::type
+            >
+            {
+                using type = typename concepts::ImplementationBase<dev::ConceptDev, TPltf>;
+            };
+
             //#############################################################################
             //! The device count get trait.
             template<
@@ -51,50 +60,6 @@ namespace alpaka
                 typename T,
                 typename TSfinae = void>
             struct GetDevByIdx;
-
-            //#############################################################################
-            //! Get the device associated with an index
-            //
-            // Call is redirected to the corresponding platform of the device.
-            template<typename TDev>
-            struct GetDevByIdx<
-                TDev,
-                typename std::enable_if<
-                    concepts::ImplementsConcept<alpaka::dev::ConceptDev, TDev>::value
-                >::type>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getDevByIdx(
-                    std::size_t const & devIdx)
-                {
-                    return traits::GetDevByIdx<
-                        typename pltf::traits::PltfType<TDev>::type>
-                            ::getDevByIdx(devIdx);
-                }
-            };
-
-            //#############################################################################
-            //! Get number of devices
-            //
-            // Call is redirected to the corresponding platform of the device.
-            template<typename TDev>
-            struct GetDevCount<
-                TDev,
-                typename std::enable_if<
-                    concepts::ImplementsConcept<alpaka::dev::ConceptDev, TDev>::value
-                >::type>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getDevCount()
-                -> std::size_t
-                {
-                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
-
-                    return traits::GetDevCount<
-                        typename pltf::traits::PltfType<TDev>::type>
-                            ::getDevCount();
-                }
-            };
         }
 
         //#############################################################################
@@ -111,7 +76,7 @@ namespace alpaka
         {
             return
                 traits::GetDevCount<
-                    TPltf>
+                    Pltf<TPltf>>
                 ::getDevCount();
         }
 
@@ -124,7 +89,7 @@ namespace alpaka
         {
             return
                 traits::GetDevByIdx<
-                    TPltf>
+                    Pltf<TPltf>>
                 ::getDevByIdx(
                     devIdx);
         }
@@ -134,19 +99,20 @@ namespace alpaka
         template<
             typename TPltf>
         ALPAKA_FN_HOST auto getDevs()
-        -> std::vector<dev::Dev<TPltf>>
+        -> std::vector<dev::Dev<Pltf<TPltf>>>
         {
-            std::vector<dev::Dev<TPltf>> devs;
+            std::vector<dev::Dev<Pltf<TPltf>>> devs;
 
-            std::size_t const devCount(getDevCount<TPltf>());
+            std::size_t const devCount(getDevCount<Pltf<TPltf>>());
             for(std::size_t devIdx(0); devIdx < devCount; ++devIdx)
             {
-                devs.push_back(getDevByIdx<TPltf>(devIdx));
+                devs.push_back(getDevByIdx<Pltf<TPltf>>(devIdx));
             }
 
             return devs;
         }
     }
+
     namespace queue
     {
         namespace traits

--- a/include/alpaka/pltf/Traits.hpp
+++ b/include/alpaka/pltf/Traits.hpp
@@ -51,6 +51,50 @@ namespace alpaka
                 typename T,
                 typename TSfinae = void>
             struct GetDevByIdx;
+
+            //#############################################################################
+            //! Get the device associated with an index
+            //
+            // Call is redirected to the corresponding platform of the device.
+            template<typename TDev>
+            struct GetDevByIdx<
+                TDev,
+                typename std::enable_if<
+                    concepts::ImplementsConcept<alpaka::dev::ConceptDev, TDev>::value
+                >::type>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto getDevByIdx(
+                    std::size_t const & devIdx)
+                {
+                    return traits::GetDevByIdx<
+                        typename pltf::traits::PltfType<TDev>::type>
+                            ::getDevByIdx(devIdx);
+                }
+            };
+
+            //#############################################################################
+            //! Get number of devices
+            //
+            // Call is redirected to the corresponding platform of the device.
+            template<typename TDev>
+            struct GetDevCount<
+                TDev,
+                typename std::enable_if<
+                    concepts::ImplementsConcept<alpaka::dev::ConceptDev, TDev>::value
+                >::type>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto getDevCount()
+                -> std::size_t
+                {
+                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
+
+                    return traits::GetDevCount<
+                        typename pltf::traits::PltfType<TDev>::type>
+                            ::getDevCount();
+                }
+            };
         }
 
         //#############################################################################


### PR DESCRIPTION
# Motivation 

Currently alpaka is hard to use because the user needs to know how all concepts e.g platform, accelerator, device, queue,... and how they are connected to each other and which concept must be used where.
I started a discussion in  #944 to simplify the interface for alpaka.
This PR is introducing a full change of the usage, instead it provides the required trait specifications to allow the user a accelerator based programming. This means instead that the user needs to handle device and platform types he can use the accelerator to allocate buffers, query device information. 
Before this PR the user got the device type from an accelerator and used the device type to get the platform. This explicit traversing over types with a 1:1 relation is removed by forwarding traits to the next hierarchy level when needed. 

# General Simple Workflow

1. define an accelerator type `Acc`
2. get the device instance based on `Acc`
3. use `Acc` to create buffers

# Changes 

- accelerator
  - specialize platform traits to query device information (redirect to
platform trait)
  - specialize buffer for accelerators
- device
  - add concept `ConceptDev`
  - specialize `DevType` for a device
  - specialize platform traits to query device information (redirect to
platform trait)
- mem
   - Buffer and views not using the template parameter `TDev` directly.
     Instead `TDev` is handled as concept and the device type is first
evaluated.
- Use the simplified accelerator centric view for all examples.