### PR TITLE
Examples: Enable subdirectories and use alpaka_ROOT

### DIFF
--- a/example/bufferCopy/CMakeLists.txt
+++ b/example/bufferCopy/CMakeLists.txt
@@ -34,9 +34,15 @@ project(${_TARGET_NAME})
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    set(ALPAKA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../" CACHE STRING "The location of alpakaConfig.cmake")
-    list(APPEND CMAKE_MODULE_PATH "${ALPAKA_ROOT}")
-    find_package(alpaka REQUIRED)
+    option(USE_ALPAKA_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+
+    if(USE_ALPAKA_SOURCE_TREE)
+        # Don't build the examples recursively
+        set(alpaka_BUILD_EXAMPLES OFF)
+        add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")
+    else()
+        find_package(alpaka REQUIRED)
+    endif()
 endif()
 
 #-------------------------------------------------------------------------------

--- a/example/heatEquation/CMakeLists.txt
+++ b/example/heatEquation/CMakeLists.txt
@@ -35,9 +35,15 @@ project(${_TARGET_NAME})
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    set(ALPAKA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../" CACHE STRING "The location of the alpaka library")
-    list(APPEND CMAKE_MODULE_PATH "${ALPAKA_ROOT}")
-    find_package(alpaka REQUIRED)
+    option(USE_ALPAKA_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+
+    if(USE_ALPAKA_SOURCE_TREE)
+        # Don't build the examples recursively
+        set(alpaka_BUILD_EXAMPLES OFF)
+        add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")
+    else()
+        find_package(alpaka REQUIRED)
+    endif()
 endif()
 
 #-------------------------------------------------------------------------------

--- a/example/helloWorld/CMakeLists.txt
+++ b/example/helloWorld/CMakeLists.txt
@@ -34,9 +34,15 @@ project(${_TARGET_NAME})
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    set(ALPAKA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../" CACHE STRING "The location of alpakaConfig.cmake")
-    list(APPEND CMAKE_MODULE_PATH "${ALPAKA_ROOT}")
-    find_package(alpaka REQUIRED)
+    option(USE_ALPAKA_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+
+    if(USE_ALPAKA_SOURCE_TREE)
+        # Don't build the examples recursively
+        set(alpaka_BUILD_EXAMPLES OFF)
+        add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")
+    else()
+        find_package(alpaka REQUIRED)
+    endif()
 endif()
 
 #-------------------------------------------------------------------------------

--- a/example/helloWorldLambda/CMakeLists.txt
+++ b/example/helloWorldLambda/CMakeLists.txt
@@ -34,9 +34,15 @@ project(${_TARGET_NAME})
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    set(ALPAKA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../" CACHE STRING "The location of alpakaConfig.cmake")
-    list(APPEND CMAKE_MODULE_PATH "${ALPAKA_ROOT}")
-    find_package(alpaka REQUIRED)
+    option(USE_ALPAKA_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+
+    if(USE_ALPAKA_SOURCE_TREE)
+        # Don't build the examples recursively
+        set(alpaka_BUILD_EXAMPLES OFF)
+        add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")
+    else()
+        find_package(alpaka REQUIRED)
+    endif()
 endif()
 
 #-------------------------------------------------------------------------------

--- a/example/reduce/CMakeLists.txt
+++ b/example/reduce/CMakeLists.txt
@@ -34,9 +34,15 @@ project(${_TARGET_NAME})
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    set(ALPAKA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../" CACHE STRING "The location of alpakaConfig.cmake")
-    list(APPEND CMAKE_MODULE_PATH "${ALPAKA_ROOT}")
-    find_package(alpaka REQUIRED)
+    option(USE_ALPAKA_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+
+    if(USE_ALPAKA_SOURCE_TREE)
+        # Don't build the examples recursively
+        set(alpaka_BUILD_EXAMPLES OFF)
+        add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")
+    else()
+        find_package(alpaka REQUIRED)
+    endif()
 endif()
 
 #-------------------------------------------------------------------------------

--- a/example/vectorAdd/CMakeLists.txt
+++ b/example/vectorAdd/CMakeLists.txt
@@ -35,9 +35,15 @@ project(${_TARGET_NAME})
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    set(ALPAKA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../" CACHE STRING "The location of the alpaka library")
-    list(APPEND CMAKE_MODULE_PATH "${ALPAKA_ROOT}")
-    find_package(alpaka REQUIRED)
+    option(USE_ALPAKA_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+
+    if(USE_ALPAKA_SOURCE_TREE)
+        # Don't build the examples recursively
+        set(alpaka_BUILD_EXAMPLES OFF)
+        add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")
+    else()
+        find_package(alpaka REQUIRED)
+    endif()
 endif()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This enables easier out-of-source builds for the examples. Instead of pointing CMake to `/path/to/installed/alpaka/lib/cmake/you/get/the/idea` it is now sufficient to point to `/path/to/installed/alpaka`.

This should be merged into the new release branch as we need this for the CERN workshop.