### PR TITLE
Add cmake example to the documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,6 +47,7 @@ Individual chapters are based on the information of the chapters before.
    usage/intro
    usage/abstraction
    usage/implementation
+   usage/cmake_example
 
 .. toctree::
    :caption: DEVELOPMENT

--- a/docs/source/usage/cmake_example.rst
+++ b/docs/source/usage/cmake_example.rst
@@ -1,0 +1,25 @@
+.. highlight:: bash
+
+CMake Example
+=============
+
+You can integrate Alpaka in you project via ``find_package()`` in your ``CMakeLists.txt``. That requires, that you :doc:`install </install/instructions>` Alpaka. If you do not install Alpaka in a default path such ``/use/local/`` you have to set the ``CMake`` argument ``-Dalpaka_ROOT=/path/to/alpaka/install``.
+
+.. code-block:: cmake
+   :caption: CMakeLists.txt
+
+   cmake_minimum_required(VERSION 3.15)
+
+   set(_TARGET_NAME helloWorld)
+   project(${_TARGET_NAME})
+
+   find_package(alpaka REQUIRED)
+
+   alpaka_add_executable(${_TARGET_NAME} helloWorld.cpp)
+   target_link_libraries(
+     ${_TARGET_NAME}
+     PUBLIC alpaka::alpaka)
+
+.. literalinclude:: ../../../example/helloWorld/src/helloWorld.cpp
+   :language: C++
+   :caption: helloWorld.cpp

--- a/docs/source/usage/cmake_example.rst
+++ b/docs/source/usage/cmake_example.rst
@@ -3,7 +3,7 @@
 CMake Example
 =============
 
-You can integrate Alpaka in you project via ``find_package()`` in your ``CMakeLists.txt``. That requires, that you :doc:`install </install/instructions>` Alpaka. If you do not install Alpaka in a default path such ``/use/local/`` you have to set the ``CMake`` argument ``-Dalpaka_ROOT=/path/to/alpaka/install``.
+You can integrate Alpaka in you project via ``find_package()`` in your ``CMakeLists.txt``. This requires, that you :doc:`install </install/instructions>` Alpaka. If you do not install Alpaka in a default path such as ``/use/local/`` you have to set the ``CMake`` argument ``-Dalpaka_ROOT=/path/to/alpaka/install``.
 
 .. code-block:: cmake
    :caption: CMakeLists.txt

--- a/docs/source/usage/cmake_example.rst
+++ b/docs/source/usage/cmake_example.rst
@@ -3,7 +3,9 @@
 CMake Example
 =============
 
-You can integrate Alpaka in you project via ``find_package()`` in your ``CMakeLists.txt``. This requires, that you :doc:`install </install/instructions>` Alpaka. If you do not install Alpaka in a default path such as ``/usr/local/`` you have to set the ``CMake`` argument ``-Dalpaka_ROOT=/path/to/alpaka/install``.
+You can integrate Alpaka in you project via ``find_package()`` into your ``CMakeLists.txt``.
+This requires, that you :doc:`install </install/instructions>` Alpaka.
+If you do not install Alpaka in a default path such as ``/usr/local/`` you have to set the ``CMake`` argument ``-Dalpaka_ROOT=/path/to/alpaka/install``.
 
 .. code-block:: cmake
    :caption: CMakeLists.txt

--- a/docs/source/usage/cmake_example.rst
+++ b/docs/source/usage/cmake_example.rst
@@ -3,7 +3,7 @@
 CMake Example
 =============
 
-You can integrate Alpaka in you project via ``find_package()`` in your ``CMakeLists.txt``. This requires, that you :doc:`install </install/instructions>` Alpaka. If you do not install Alpaka in a default path such as ``/use/local/`` you have to set the ``CMake`` argument ``-Dalpaka_ROOT=/path/to/alpaka/install``.
+You can integrate Alpaka in you project via ``find_package()`` in your ``CMakeLists.txt``. This requires, that you :doc:`install </install/instructions>` Alpaka. If you do not install Alpaka in a default path such as ``/usr/local/`` you have to set the ``CMake`` argument ``-Dalpaka_ROOT=/path/to/alpaka/install``.
 
 .. code-block:: cmake
    :caption: CMakeLists.txt

--- a/docs/source/usage/cmake_example.rst
+++ b/docs/source/usage/cmake_example.rst
@@ -3,7 +3,7 @@
 CMake Example
 =============
 
-You can integrate Alpaka in you project via ``find_package()`` into your ``CMakeLists.txt``.
+You can integrate Alpaka into your project via ``find_package()`` in your ``CMakeLists.txt``.
 This requires, that you :doc:`install </install/instructions>` Alpaka.
 If you do not install Alpaka in a default path such as ``/usr/local/`` you have to set the ``CMake`` argument ``-Dalpaka_ROOT=/path/to/alpaka/install``.
 


### PR DESCRIPTION
The PR address the Issue #961. The example explains, how you add Alpaka to the `CMakelists.txt` of your project. It really minimalistic and it includes the `helloWorld.cpp` example file. Feel free to give hints, if something is missing, not clear or looks confusing.