### PR TITLE
Use structured offset for SubView tests instead of uniform 1

### DIFF
--- a/test/common/include/alpaka/test/Extent.hpp
+++ b/test/common/include/alpaka/test/Extent.hpp
@@ -15,50 +15,57 @@ namespace alpaka
     //! The test specifics.
     namespace test
     {
-        //#############################################################################
-        //! 1D: (5)
-        //! 2D: (5, 4)
-        //! 3D: (5, 4, 3)
-        //! 4D: (5, 4, 3, 2)
-        // We have to be careful with the extents used.
-        // When TIdx is a 8 bit signed integer and Dim is 4, the extent is extremely limited.
         template<
-            std::size_t Tidx>
-        struct CreateExtentBufVal
+            typename TIdx>
+        struct CreateVecWithIdx
         {
-            //-----------------------------------------------------------------------------
-            ALPAKA_NO_HOST_ACC_WARNING
+            //#############################################################################
+            //! 1D: (16)
+            //! 2D: (16, 14)
+            //! 3D: (16, 14, 12)
+            //! 4D: (16, 14, 12, 10)
             template<
-                typename TIdx>
-            ALPAKA_FN_HOST_ACC
-            static auto create(
-                TIdx)
-            -> TIdx
+                std::size_t Tidx>
+            struct ForExtentBuf
             {
-                return static_cast<TIdx>(5u - Tidx);
-            }
-        };
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST_ACC static auto create()
+                {
+                    return static_cast<TIdx>(16u - (Tidx*2u));
+                }
+            };
 
-        //#############################################################################
-        //! 1D: (4)
-        //! 2D: (4, 3)
-        //! 3D: (4, 3, 2)
-        //! 4D: (4, 3, 2, 1)
-        template<
-            std::size_t Tidx>
-        struct CreateExtentViewVal
-        {
-            //-----------------------------------------------------------------------------
-            ALPAKA_NO_HOST_ACC_WARNING
+            //#############################################################################
+            //! 1D: (11)
+            //! 2D: (11, 8)
+            //! 3D: (11, 8, 5)
+            //! 4D: (11, 8, 5, 2)
             template<
-                typename TIdx>
-            ALPAKA_FN_HOST_ACC
-            static auto create(
-                TIdx)
-            -> TIdx
+                std::size_t Tidx>
+            struct ForExtentSubView
             {
-                return static_cast<TIdx>(4u - Tidx);
-            }
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST_ACC static auto create()
+                {
+                    return static_cast<TIdx>(11u - (Tidx*3u));
+                }
+            };
+
+            //#############################################################################
+            //! 1D: (2)
+            //! 2D: (2, 3)
+            //! 3D: (2, 3, 4)
+            //! 4D: (2, 3, 4, 5)
+            template<
+                std::size_t Tidx>
+            struct ForOffset
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST_ACC static auto create()
+                {
+                    return static_cast<TIdx>(2u + Tidx);
+                }
+            };
         };
     }
 }

--- a/test/unit/idx/src/MapIdx.cpp
+++ b/test/unit/idx/src/MapIdx.cpp
@@ -12,28 +12,9 @@
 
 #include <alpaka/meta/ForEachType.hpp>
 #include <alpaka/test/dim/TestDims.hpp>
+#include <alpaka/test/Extent.hpp>
 
 #include <catch2/catch.hpp>
-
-//#############################################################################
-//! 1D: (17)
-//! 2D: (17, 14)
-//! 3D: (17, 14, 11)
-//! 4D: (17, 14, 11, 8)
-template<
-    std::size_t Tidx>
-struct CreateExtentVal
-{
-    //-----------------------------------------------------------------------------
-    template<
-        typename TIdx>
-    ALPAKA_FN_HOST_ACC static auto create(
-        TIdx)
-    -> TIdx
-    {
-        return  static_cast<TIdx>(17u - (Tidx*3u));
-    }
-};
 
 //-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE( "mapIdx", "[idx]", alpaka::test::dim::TestDims)
@@ -42,7 +23,7 @@ TEMPLATE_LIST_TEST_CASE( "mapIdx", "[idx]", alpaka::test::dim::TestDims)
     using Idx = std::size_t;
     using Vec = alpaka::vec::Vec<Dim, Idx>;
 
-    auto const extentNd(alpaka::vec::createVecFromIndexedFn<Dim, CreateExtentVal>(Idx()));
+    auto const extentNd(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
     auto const idxNd(extentNd - Vec::all(4u));
 
     auto const idx1d(alpaka::idx::mapIdx<1u>(idxNd, extentNd));

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -64,7 +64,7 @@ TEMPLATE_LIST_TEST_CASE( "memBufBasicTest", "[memBuf]", alpaka::test::acc::TestA
     using Dim = alpaka::dim::Dim<Acc>;
     using Idx = alpaka::idx::Idx<Acc>;
 
-    auto const extent(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateExtentBufVal>(Idx()));
+    auto const extent(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
 
     testBufferMutable<
         Acc>(
@@ -123,7 +123,7 @@ TEMPLATE_LIST_TEST_CASE( "memBufConstTest", "[memBuf]", alpaka::test::acc::TestA
     using Dim = alpaka::dim::Dim<Acc>;
     using Idx = alpaka::idx::Idx<Acc>;
 
-    auto const extent(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateExtentBufVal>(Idx()));
+    auto const extent(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
 
     testBufferImmutable<
         Acc>(

--- a/test/unit/mem/p2p/src/P2P.cpp
+++ b/test/unit/mem/p2p/src/P2P.cpp
@@ -72,7 +72,7 @@ TEMPLATE_LIST_TEST_CASE( "memP2PTest", "[memP2P]", alpaka::test::acc::TestAccs)
     using Dim = alpaka::dim::Dim<Acc>;
     using Idx = alpaka::idx::Idx<Acc>;
 
-    auto const extent(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateExtentBufVal>(Idx()));
+    auto const extent(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
 
     testP2P<Acc>( extent );
 #endif

--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -104,7 +104,7 @@ namespace view
 
         Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
 
-        auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateExtentBufVal>(Idx()));
+        auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
         auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
 
         auto const extentView(extentBuf);
@@ -134,7 +134,7 @@ namespace view
 
         Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
 
-        auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateExtentBufVal>(Idx()));
+        auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
         auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
 
         auto const extentView(extentBuf);
@@ -164,7 +164,7 @@ namespace view
 
         Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
 
-        auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateExtentBufVal>(Idx()));
+        auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
         auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
 
         View view(

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -142,7 +142,7 @@ namespace view
 
         Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
 
-        auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateExtentBufVal>(Idx()));
+        auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
         auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
 
         auto const extentView(extentBuf);
@@ -168,11 +168,11 @@ namespace view
 
         Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
 
-        auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateExtentBufVal>(Idx()));
+        auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
         auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
 
-        auto const extentView(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateExtentViewVal>(Idx()));
-        auto const offsetView(alpaka::vec::Vec<Dim, Idx>::all(static_cast<Idx>(1)));
+        auto const extentView(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentSubView>());
+        auto const offsetView(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>());
         View view(buf, extentView, offsetView);
 
         alpaka::test::mem::view::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
@@ -194,11 +194,11 @@ namespace view
 
         Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
 
-        auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, CreateExtentBufVal>(Idx()));
+        auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
         auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
 
-        auto const extentView(alpaka::vec::createVecFromIndexedFn<Dim, CreateExtentViewVal>(Idx()));
-        auto const offsetView(alpaka::vec::Vec<Dim, Idx>::all(static_cast<Idx>(1)));
+        auto const extentView(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentSubView>());
+        auto const offsetView(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>());
         View const view(buf, extentView, offsetView);
 
         alpaka::test::mem::view::testViewSubViewImmutable<TAcc>(view, buf, dev, extentView, offsetView);


### PR DESCRIPTION
This increases the buffer sizes, sub-view sizes and sub-view offsets used in the tests.
Especially the offset was previously set to 1 in all dimensions and is now non-uniform.