### PR TITLE
Use member array for block shared memory, avoid malloc

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -138,7 +138,7 @@ if(NOT TARGET alpaka)
 endif()
 
 option(ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST "Allow host-only contructs like assert in offload code in debug mode." ON)
-set(ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB "30" CACHE STRING "Kibibytes (1024B) of memory to allocate for block shared memory for backends requiring static allocation (includes CPU_B_OMP2_T_SEQ, CPU_B_TBB_T_SEQ, CPU_B_SEQ_T_SEQ)")
+set(ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB "30" CACHE STRING "Kibibytes (1024B) of memory to allocate for block shared memory for backends requiring static allocation (includes CPU_B_OMP2_T_SEQ, CPU_B_TBB_T_SEQ, CPU_B_SEQ_T_SEQ)")
 
 #-------------------------------------------------------------------------------
 # Debug output of common variables.
@@ -797,7 +797,7 @@ target_compile_definitions(alpaka INTERFACE "ALPAKA_DEBUG=${ALPAKA_DEBUG}")
 if(ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST)
    target_compile_definitions(alpaka INTERFACE "ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST")
 endif()
-target_compile_definitions(alpaka INTERFACE "ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB=${ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB}")
+target_compile_definitions(alpaka INTERFACE "ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB=${ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB}")
 
 if(ALPAKA_CI)
     target_compile_definitions(alpaka INTERFACE "ALPAKA_CI")

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -138,7 +138,7 @@ if(NOT TARGET alpaka)
 endif()
 
 option(ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST "Allow host-only contructs like assert in offload code in debug mode." ON)
-set(ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB "30" CACHE STRING "Kilobytes of memory to allocate for block shared memory for backends requiring static allocation (includes CPU_B_OMP2_T_SEQ, CPU_B_TBB_T_SEQ, CPU_B_SEQ_T_SEQ)")
+set(ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB "30" CACHE STRING "Kibibytes (1024B) of memory to allocate for block shared memory for backends requiring static allocation (includes CPU_B_OMP2_T_SEQ, CPU_B_TBB_T_SEQ, CPU_B_SEQ_T_SEQ)")
 
 #-------------------------------------------------------------------------------
 # Debug output of common variables.

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -137,6 +137,7 @@ if(NOT TARGET alpaka)
     add_library(alpaka::alpaka ALIAS alpaka)
 endif()
 
+option(ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST "Allow host-only contructs like assert in offload code in debug mode." ON)
 set(ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB "30" CACHE STRING "Kilobytes of memory to allocate for block shared memory for backends requiring static allocation (includes CPU_B_OMP2_T_SEQ, CPU_B_TBB_T_SEQ, CPU_B_SEQ_T_SEQ)")
 
 #-------------------------------------------------------------------------------
@@ -793,6 +794,9 @@ if(ALPAKA_EMU_MEMCPY3D)
 endif()
 
 target_compile_definitions(alpaka INTERFACE "ALPAKA_DEBUG=${ALPAKA_DEBUG}")
+if(ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST)
+   target_compile_definitions(alpaka INTERFACE "ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST")
+endif()
 target_compile_definitions(alpaka INTERFACE "ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB=${ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB}")
 
 if(ALPAKA_CI)

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -137,6 +137,8 @@ if(NOT TARGET alpaka)
     add_library(alpaka::alpaka ALIAS alpaka)
 endif()
 
+set(ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB "30" CACHE STRING "Kilobytes of memory to allocate for block shared memory for backends requiring static allocation (includes CPU_B_OMP2_T_SEQ, CPU_B_TBB_T_SEQ, CPU_B_SEQ_T_SEQ)")
+
 #-------------------------------------------------------------------------------
 # Debug output of common variables.
 if(${ALPAKA_DEBUG} GREATER 1)
@@ -791,6 +793,7 @@ if(ALPAKA_EMU_MEMCPY3D)
 endif()
 
 target_compile_definitions(alpaka INTERFACE "ALPAKA_DEBUG=${ALPAKA_DEBUG}")
+target_compile_definitions(alpaka INTERFACE "ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB=${ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB}")
 
 if(ALPAKA_CI)
     target_compile_definitions(alpaka INTERFACE "ALPAKA_CI")

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -24,8 +24,8 @@
 #include <alpaka/atomic/AtomicOmpBuiltIn.hpp>
 #include <alpaka/atomic/AtomicHierarchy.hpp>
 #include <alpaka/math/MathStdLib.hpp>
-#include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>
-#include <alpaka/block/shared/st/BlockSharedMemStNoSync.hpp>
+#include <alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp>
+#include <alpaka/block/shared/st/BlockSharedMemStMember.hpp>
 #include <alpaka/block/sync/BlockSyncNoOp.hpp>
 #include <alpaka/intrinsic/IntrinsicCpu.hpp>
 #include <alpaka/rand/RandStdLib.hpp>
@@ -78,8 +78,8 @@ namespace alpaka
                 atomic::AtomicNoOp           // thread atomics
             >,
             public math::MathStdLib,
-            public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
-            public block::shared::st::BlockSharedMemStNoSync,
+            public block::shared::dyn::BlockSharedMemDynMember<>,
+            public block::shared::st::BlockSharedMemStMember<>,
             public block::sync::BlockSyncNoOp,
             public intrinsic::IntrinsicCpu,
             public rand::RandStdLib,
@@ -111,8 +111,8 @@ namespace alpaka
                         atomic::AtomicNoOp        // atomics between threads
                     >(),
                     math::MathStdLib(),
-                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
-                    block::shared::st::BlockSharedMemStNoSync(),
+                    block::shared::dyn::BlockSharedMemDynMember<>(static_cast<unsigned int>(blockSharedMemDynSizeBytes)),
+                    block::shared::st::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
                     block::sync::BlockSyncNoOp(),
                     rand::RandStdLib(),
                     time::TimeOmp(),

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -19,8 +19,8 @@
 #include <alpaka/atomic/AtomicStdLibLock.hpp>
 #include <alpaka/atomic/AtomicHierarchy.hpp>
 #include <alpaka/math/MathStdLib.hpp>
-#include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>
-#include <alpaka/block/shared/st/BlockSharedMemStNoSync.hpp>
+#include <alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp>
+#include <alpaka/block/shared/st/BlockSharedMemStMember.hpp>
 #include <alpaka/block/sync/BlockSyncNoOp.hpp>
 #include <alpaka/intrinsic/IntrinsicCpu.hpp>
 #include <alpaka/rand/RandStdLib.hpp>
@@ -72,8 +72,8 @@ namespace alpaka
                 atomic::AtomicNoOp         // thread atomics
             >,
             public math::MathStdLib,
-            public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
-            public block::shared::st::BlockSharedMemStNoSync,
+            public block::shared::dyn::BlockSharedMemDynMember<>,
+            public block::shared::st::BlockSharedMemStMember<>,
             public block::sync::BlockSyncNoOp,
             public intrinsic::IntrinsicCpu,
             public rand::RandStdLib,
@@ -105,8 +105,8 @@ namespace alpaka
                         atomic::AtomicNoOp         // atomics between threads
                     >(),
                     math::MathStdLib(),
-                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
-                    block::shared::st::BlockSharedMemStNoSync(),
+                    block::shared::dyn::BlockSharedMemDynMember<>(static_cast<unsigned int>(blockSharedMemDynSizeBytes)),
+                    block::shared::st::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
                     block::sync::BlockSyncNoOp(),
                     rand::RandStdLib(),
                     time::TimeStdLib(),

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -19,8 +19,8 @@
 #include <alpaka/atomic/AtomicStdLibLock.hpp>
 #include <alpaka/atomic/AtomicHierarchy.hpp>
 #include <alpaka/math/MathStdLib.hpp>
-#include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>
-#include <alpaka/block/shared/st/BlockSharedMemStNoSync.hpp>
+#include <alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp>
+#include <alpaka/block/shared/st/BlockSharedMemStMember.hpp>
 #include <alpaka/block/sync/BlockSyncNoOp.hpp>
 #include <alpaka/intrinsic/IntrinsicCpu.hpp>
 #include <alpaka/rand/RandStdLib.hpp>
@@ -70,8 +70,8 @@ namespace alpaka
                 atomic::AtomicNoOp         // thread atomics
             >,
             public math::MathStdLib,
-            public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
-            public block::shared::st::BlockSharedMemStNoSync,
+            public block::shared::dyn::BlockSharedMemDynMember<>,
+            public block::shared::st::BlockSharedMemStMember<>,
             public block::sync::BlockSyncNoOp,
             public intrinsic::IntrinsicCpu,
             public rand::RandStdLib,
@@ -103,8 +103,8 @@ namespace alpaka
                         atomic::AtomicNoOp         // atomics between threads
                     >(),
                     math::MathStdLib(),
-                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
-                    block::shared::st::BlockSharedMemStNoSync(),
+                    block::shared::dyn::BlockSharedMemDynMember<>(static_cast<unsigned int>(blockSharedMemDynSizeBytes)),
+                    block::shared::st::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
                     block::sync::BlockSyncNoOp(),
                     rand::RandStdLib(),
                     time::TimeStdLib(),

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -46,12 +46,14 @@
         // dynamic
         #include <alpaka/block/shared/dyn/BlockSharedMemDynUniformCudaHipBuiltIn.hpp>
         #include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>
+        #include <alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp>
         #include <alpaka/block/shared/dyn/Traits.hpp>
         //-----------------------------------------------------------------------------
         // static
         #include <alpaka/block/shared/st/BlockSharedMemStUniformCudaHipBuiltIn.hpp>
         #include <alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp>
         #include <alpaka/block/shared/st/BlockSharedMemStNoSync.hpp>
+        #include <alpaka/block/shared/st/BlockSharedMemStMember.hpp>
         #include <alpaka/block/shared/st/Traits.hpp>
     //-----------------------------------------------------------------------------
     // sync

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -28,6 +28,10 @@ namespace alpaka
         {
             namespace dyn
             {
+#if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
+    #pragma warning(push)
+    #pragma warning(disable: 4324)  // warning C4324: structure was padded due to alignment specifier
+#endif
                 //#############################################################################
                 //! Dynamic block shared memory provider using fixed-size
                 //! member array to allocate memory on the stack or in shared
@@ -88,6 +92,9 @@ namespace alpaka
                     mutable std::array<uint8_t, staticAllocBytes> m_mem;
                     unsigned int m_dynSize;
                 };
+#if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
+    #pragma warning(pop)
+#endif
 
                 namespace traits
                 {

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -15,6 +15,10 @@
 #include <type_traits>
 #include <array>
 
+#ifndef ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB
+#define ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB 30
+#endif
+
 namespace alpaka
 {
     namespace block
@@ -27,7 +31,7 @@ namespace alpaka
                 //! Dynamic block shared memory provider using fixed-size
                 //! member array to allocate memory on the stack or in shared
                 //! memory.
-                template<unsigned int TStaticAllocKB = 30>
+                template<unsigned int TStaticAllocKB = ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB>
                 class BlockSharedMemDynMember :
                     public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynMember<TStaticAllocKB>>
                 {

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -33,7 +33,7 @@ namespace alpaka
                 //! member array to allocate memory on the stack or in shared
                 //! memory.
                 template<unsigned int TStaticAllocKiB = ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB>
-                class BlockSharedMemDynMember :
+                class alignas(core::vectorization::defaultAlignment) BlockSharedMemDynMember :
                     public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynMember<TStaticAllocKiB>>
                 {
                 public:
@@ -64,7 +64,7 @@ namespace alpaka
                      *! alignment assumes, that the compiler places the instance
                      *! at architecture-appropriate boundaries.
                      */
-                    template<unsigned int TDataAlignBytes = core::vectorization::defaultAlignment*8>
+                    template<unsigned int TDataAlignBytes = core::vectorization::defaultAlignment>
                     uint8_t* staticMemBegin() const
                     {
                         return m_mem.data() +

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -44,7 +44,9 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     BlockSharedMemDynMember(unsigned int sizeBytes) : m_dynSize(sizeBytes)
                     {
+#if (defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (! defined NDEBUG)
                         ALPAKA_ASSERT(sizeBytes <= staticAllocBytes);
+#endif
                     }
                     //-----------------------------------------------------------------------------
                     BlockSharedMemDynMember(BlockSharedMemDynMember const &) = delete;

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -1,0 +1,106 @@
+/* Copyright 2020 Jeffrey Kelling
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/block/shared/dyn/Traits.hpp>
+#include <alpaka/core/Assert.hpp>
+
+#include <type_traits>
+#include <array>
+
+namespace alpaka
+{
+    namespace block
+    {
+        namespace shared
+        {
+            namespace dyn
+            {
+                //#############################################################################
+                //! Dynamic block shared memory provider using fixed-size
+                //! member array to allocate memory on the stack or in shared
+                //! memory.
+                template<unsigned int TStaticAllocKB = 30>
+                class BlockSharedMemDynMember :
+                    public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynMember<TStaticAllocKB>>
+                {
+                    static constexpr unsigned int staticAllocBytes = TStaticAllocKB<<10;
+
+                    mutable std::array<uint8_t, staticAllocBytes> m_mem;
+                    unsigned int m_dynSize;
+
+                public:
+                    //-----------------------------------------------------------------------------
+                    BlockSharedMemDynMember(unsigned int sizeBytes) : m_dynSize(sizeBytes)
+                    {
+                        ALPAKA_ASSERT(sizeBytes <= staticAllocBytes);
+                    }
+                    //-----------------------------------------------------------------------------
+                    BlockSharedMemDynMember(BlockSharedMemDynMember const &) = delete;
+                    //-----------------------------------------------------------------------------
+                    BlockSharedMemDynMember(BlockSharedMemDynMember &&) = delete;
+                    //-----------------------------------------------------------------------------
+                    auto operator=(BlockSharedMemDynMember const &) -> BlockSharedMemDynMember & = delete;
+                    //-----------------------------------------------------------------------------
+                    auto operator=(BlockSharedMemDynMember &&) -> BlockSharedMemDynMember & = delete;
+                    //-----------------------------------------------------------------------------
+                    /*virtual*/ ~BlockSharedMemDynMember() = default;
+
+                    uint8_t* dynMemBegin() const {return m_mem.data();}
+
+                    /*! \return the pointer to the begin of data after protion allocated as dynamical shared memory.
+                     *!
+                     *! \tparam TDataAlignBytes Round-up offset to multiple of
+                     *! this number of bytes to maintain alignment. This
+                     *! alignment assumes, that the compiler places the instance
+                     *! at architecture-appropriate boundaries.
+                     */
+                    template<unsigned int TDataAlignBytes = 4>
+                    uint8_t* staticMemBegin() const
+                    {
+                        return m_mem.data() +
+                            (m_dynSize/TDataAlignBytes + (m_dynSize%TDataAlignBytes>0)*TDataAlignBytes);
+                    }
+
+                    /*! \return the remaining capacity for static block shared memory.
+                     *!
+                     *! \tparam TDataAlignBytes Multiple of bytes the static offset was rounded-up to
+                     */
+                    template<unsigned int TDataAlignBytes = 4>
+                    unsigned int staticMemCapacity() const
+                    {
+                        return staticAllocBytes -
+                            (m_dynSize/TDataAlignBytes + (m_dynSize%TDataAlignBytes>0)*TDataAlignBytes);
+                    }
+                };
+
+                namespace traits
+                {
+                    //#############################################################################
+                    template<
+                        typename T,
+                        unsigned int TStaticAllocKB>
+                    struct GetMem<
+                        T,
+                        BlockSharedMemDynMember<TStaticAllocKB>>
+                    {
+                        //-----------------------------------------------------------------------------
+                        static auto getMem(
+                            block::shared::dyn::BlockSharedMemDynMember<TStaticAllocKB> const &mem)
+                        -> T *
+                        {
+                            return reinterpret_cast<T*>(mem.dynMemBegin());
+                        }
+                    };
+                }
+            }
+        }
+    }
+}

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -97,6 +97,10 @@ namespace alpaka
                         T,
                         BlockSharedMemDynMember<TStaticAllocKB>>
                     {
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
+#endif
                         //-----------------------------------------------------------------------------
                         static auto getMem(
                             block::shared::dyn::BlockSharedMemDynMember<TStaticAllocKB> const &mem)
@@ -104,6 +108,9 @@ namespace alpaka
                         {
                             return reinterpret_cast<T*>(mem.dynMemBegin());
                         }
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic pop
+#endif
                     };
                 }
             }

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -16,8 +16,8 @@
 #include <type_traits>
 #include <array>
 
-#ifndef ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB
-#define ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB 30
+#ifndef ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB
+#define ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB 30
 #endif
 
 namespace alpaka
@@ -32,9 +32,9 @@ namespace alpaka
                 //! Dynamic block shared memory provider using fixed-size
                 //! member array to allocate memory on the stack or in shared
                 //! memory.
-                template<unsigned int TStaticAllocKB = ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB>
+                template<unsigned int TStaticAllocKiB = ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB>
                 class BlockSharedMemDynMember :
-                    public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynMember<TStaticAllocKB>>
+                    public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynMember<TStaticAllocKiB>>
                 {
                 public:
                     //-----------------------------------------------------------------------------
@@ -83,7 +83,7 @@ namespace alpaka
                     }
 
                 private:
-                    static constexpr unsigned int staticAllocBytes = TStaticAllocKB<<10;
+                    static constexpr unsigned int staticAllocBytes = TStaticAllocKiB<<10;
 
                     mutable std::array<uint8_t, staticAllocBytes> m_mem;
                     unsigned int m_dynSize;
@@ -94,10 +94,10 @@ namespace alpaka
                     //#############################################################################
                     template<
                         typename T,
-                        unsigned int TStaticAllocKB>
+                        unsigned int TStaticAllocKiB>
                     struct GetMem<
                         T,
-                        BlockSharedMemDynMember<TStaticAllocKB>>
+                        BlockSharedMemDynMember<TStaticAllocKiB>>
                     {
 #if BOOST_COMP_GNUC
     #pragma GCC diagnostic push
@@ -105,7 +105,7 @@ namespace alpaka
 #endif
                         //-----------------------------------------------------------------------------
                         static auto getMem(
-                            block::shared::dyn::BlockSharedMemDynMember<TStaticAllocKB> const &mem)
+                            block::shared::dyn::BlockSharedMemDynMember<TStaticAllocKiB> const &mem)
                         -> T *
                         {
                             return reinterpret_cast<T*>(mem.dynMemBegin());

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -86,9 +86,10 @@ namespace alpaka
 #endif
 
                         template<typename T>
-                        static constexpr size_t alignPitch()
+                        static constexpr unsigned int alignPitch()
                         {
-                            return (sizeof(T)/TDataAlignBytes + (sizeof(T)%TDataAlignBytes>0))*TDataAlignBytes;
+                            return (static_cast<unsigned int>(sizeof(T))/TDataAlignBytes
+                                + static_cast<unsigned int>(sizeof(T))%TDataAlignBytes>0)*TDataAlignBytes;
                         }
                     };
                 }

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -71,11 +71,18 @@ namespace alpaka
 #endif
                         }
 
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
+#endif
                         template <typename T>
                         T& getLatestVar() const
                         {
                            return *reinterpret_cast<T*>(&m_mem[m_allocdBytes-alignPitch<T>()]);
                         }
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic pop
+#endif
 
                         void free() const
                         {

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/block/shared/st/Traits.hpp>
 #include <alpaka/core/Assert.hpp>
+#include <alpaka/core/Vectorize.hpp>
 
 #include <type_traits>
 #include <cstdint>
@@ -27,21 +28,9 @@ namespace alpaka
                 {
                     //#############################################################################
                     //! Implementation of static block shared memory provider.
-                    template<unsigned int TDataAlignBytes = 4>
+                    template<unsigned int TDataAlignBytes = core::vectorization::defaultAlignment*8>
                     class BlockSharedMemStMemberImpl
                     {
-                        mutable unsigned int m_allocdBytes = 0;
-                        mutable uint8_t* m_mem;
-#ifndef NDEBUG
-                        const unsigned int m_capacity;
-#endif
-
-                        template<typename T>
-                        static constexpr size_t alignPitch()
-                        {
-                            return (sizeof(T)/TDataAlignBytes + (sizeof(T)%TDataAlignBytes>0))*TDataAlignBytes;
-                        }
-
                     public:
                         //-----------------------------------------------------------------------------
 #ifndef NDEBUG
@@ -89,13 +78,25 @@ namespace alpaka
                             m_allocdBytes = 0u;
                         }
 
+                    private:
+                        mutable unsigned int m_allocdBytes = 0;
+                        mutable uint8_t* m_mem;
+#ifndef NDEBUG
+                        const unsigned int m_capacity;
+#endif
+
+                        template<typename T>
+                        static constexpr size_t alignPitch()
+                        {
+                            return (sizeof(T)/TDataAlignBytes + (sizeof(T)%TDataAlignBytes>0))*TDataAlignBytes;
+                        }
                     };
                 }
                 //#############################################################################
                 //! Static block shared memory provider using a pointer to
                 //! externally allocated fixed-size memory, likely provided by
                 //! BlockSharedMemDynMember.
-                template<unsigned int TDataAlignBytes = 4>
+                template<unsigned int TDataAlignBytes = core::vectorization::defaultAlignment*8>
                 class BlockSharedMemStMember :
                     public detail::BlockSharedMemStMemberImpl<TDataAlignBytes>,
                     public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStMember<TDataAlignBytes>>

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -28,7 +28,7 @@ namespace alpaka
                 {
                     //#############################################################################
                     //! Implementation of static block shared memory provider.
-                    template<unsigned int TDataAlignBytes = core::vectorization::defaultAlignment*8>
+                    template<unsigned int TDataAlignBytes = core::vectorization::defaultAlignment>
                     class BlockSharedMemStMemberImpl
                     {
                     public:
@@ -96,7 +96,7 @@ namespace alpaka
                 //! Static block shared memory provider using a pointer to
                 //! externally allocated fixed-size memory, likely provided by
                 //! BlockSharedMemDynMember.
-                template<unsigned int TDataAlignBytes = core::vectorization::defaultAlignment*8>
+                template<unsigned int TDataAlignBytes = core::vectorization::defaultAlignment>
                 class BlockSharedMemStMember :
                     public detail::BlockSharedMemStMemberImpl<TDataAlignBytes>,
                     public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStMember<TDataAlignBytes>>

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -1,0 +1,137 @@
+/* Copyright 2020 Jeffrey Kelling
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/block/shared/st/Traits.hpp>
+#include <alpaka/core/Assert.hpp>
+
+#include <type_traits>
+#include <cstdint>
+
+namespace alpaka
+{
+    namespace block
+    {
+        namespace shared
+        {
+            namespace st
+            {
+                namespace detail
+                {
+                    //#############################################################################
+                    //! Implementation of static block shared memory provider.
+                    template<unsigned int TDataAlignBytes = 4>
+                    class BlockSharedMemStMemberImpl
+                    {
+                        mutable unsigned int m_allocdBytes = 0;
+                        mutable uint8_t* m_mem;
+#ifndef NDEBUG
+                        const unsigned int m_capacity;
+#endif
+
+                        template<typename T>
+                        static constexpr size_t alignPitch()
+                        {
+                            return (sizeof(T)/TDataAlignBytes + (sizeof(T)%TDataAlignBytes>0))*TDataAlignBytes;
+                        }
+
+                    public:
+                        //-----------------------------------------------------------------------------
+#ifndef NDEBUG
+                        BlockSharedMemStMemberImpl(uint8_t* mem, unsigned int capacity) : m_mem(mem), m_capacity(capacity) {}
+#else
+                        BlockSharedMemStMemberImpl(uint8_t* mem, unsigned int) : m_mem(mem) {}
+#endif
+                        //-----------------------------------------------------------------------------
+                        BlockSharedMemStMemberImpl(BlockSharedMemStMemberImpl const &) = delete;
+                        //-----------------------------------------------------------------------------
+                        BlockSharedMemStMemberImpl(BlockSharedMemStMemberImpl &&) = delete;
+                        //-----------------------------------------------------------------------------
+                        auto operator=(BlockSharedMemStMemberImpl const &) -> BlockSharedMemStMemberImpl & = delete;
+                        //-----------------------------------------------------------------------------
+                        auto operator=(BlockSharedMemStMemberImpl &&) -> BlockSharedMemStMemberImpl & = delete;
+                        //-----------------------------------------------------------------------------
+                        /*virtual*/ ~BlockSharedMemStMemberImpl() = default;
+
+                        template <typename T>
+                        void alloc() const
+                        {
+                            uint8_t* buf = &m_mem[m_allocdBytes];
+                            new (buf) T();
+                            m_allocdBytes += alignPitch<T>();
+                            ALPAKA_ASSERT(m_allocdBytes < m_capacity);
+                        }
+
+                        template <typename T>
+                        T& getLatestVar() const
+                        {
+                           return *reinterpret_cast<T*>(&m_mem[m_allocdBytes-alignPitch<T>()]);
+                        }
+
+                        void free() const
+                        {
+                            m_allocdBytes = 0u;
+                        }
+
+                    };
+                }
+                //#############################################################################
+                //! Static block shared memory provider using a pointer to
+                //! externally allocated fixed-size memory, likely provided by
+                //! BlockSharedMemDynMember.
+                template<unsigned int TDataAlignBytes = 4>
+                class BlockSharedMemStMember :
+                    public detail::BlockSharedMemStMemberImpl<TDataAlignBytes>,
+                    public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStMember<TDataAlignBytes>>
+                {
+                public:
+                    using detail::BlockSharedMemStMemberImpl<TDataAlignBytes>::BlockSharedMemStMemberImpl;
+                };
+
+                namespace traits
+                {
+                    //#############################################################################
+                    template<
+                        typename T,
+                        unsigned int TDataAlignBytes,
+                        std::size_t TuniqueId>
+                    struct AllocVar<
+                        T,
+                        TuniqueId,
+                        BlockSharedMemStMember<TDataAlignBytes>>
+                    {
+                        //-----------------------------------------------------------------------------
+                        static auto allocVar(
+                            block::shared::st::BlockSharedMemStMember<TDataAlignBytes> const &smem)
+                        -> T &
+                        {
+                            smem.template alloc<T>();
+                            return smem.template getLatestVar<T>();
+                        }
+                    };
+                    //#############################################################################
+                    template<
+                        unsigned int TDataAlignBytes>
+                    struct FreeMem<
+                        BlockSharedMemStMember<TDataAlignBytes>>
+                    {
+                        //-----------------------------------------------------------------------------
+                        static auto freeMem(
+                            block::shared::st::BlockSharedMemStMember<TDataAlignBytes> const &mem)
+                        -> void
+                        {
+                            mem.free();
+                        }
+                    };
+                }
+            }
+        }
+    }
+}

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -66,7 +66,9 @@ namespace alpaka
                             uint8_t* buf = &m_mem[m_allocdBytes];
                             new (buf) T();
                             m_allocdBytes += alignPitch<T>();
+#if (defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (! defined NDEBUG)
                             ALPAKA_ASSERT(m_allocdBytes < m_capacity);
+#endif
                         }
 
                         template <typename T>


### PR DESCRIPTION
This PR adds block shared memory implementations `BlockSharedMemDynMember` and `BlockSharedMemStMember`, which replace `BlockSharedMemDynBoostAlignedAlloc` and `BlockSharedMemStNoSync` in the backends [AccCpuOmp2Blocks](https://github.com/alpaka-group/alpaka/compare/develop...jkelling:blockSharedMember?expand=1#diff-3337e4cfdef9f4f15dafba232a45d250), [AccCpuSerial](https://github.com/alpaka-group/alpaka/compare/develop...jkelling:blockSharedMember?expand=1#diff-8528393b30e927eea71a9d4bfb86057f) and [AccCpuTbbBlocks](https://github.com/alpaka-group/alpaka/compare/develop...jkelling:blockSharedMember?expand=1#diff-e65bf721c1e9ed77791f535d7e8c8c69) (I did not test TBB).

Here `BlockSharedMemDynMember` contains a member array which provides memory for the dynamic block shared memory and a small object allocator for static block shared memory. This implementation is akin to a patch proposed in https://github.com/alpaka-group/alpaka/issues/409 . The same strategy is also employed in the upcoming  OpenMP and OpenACC backends: https://github.com/jkelling/alpaka/tree/blockSharedMemberOpenacc .

## Features
* The size of the member array can be controlled through the cmake variable/preprocessor macro `ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KB`, the default is 30KB.
* `BlockSharedMemStNoSync` has a template parameter `unsigend int TDataAlignBytes` which controls the alignment of allocations. This only works as long as the `TDataAlignBytes` is less or equal to the alignment of the `BlockSharedMemDynMember` instance, because this is where the underlying memory is coming from.
* Commit https://github.com/alpaka-group/alpaka/commit/2392b3b807ec81c2eb2c5df88bdb3a6e03a1e5c8 adds an alpaka option/preprocessor macro `ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST` which defaults to `true`. There are asserts inside the alloc() function and the ctor of `BlockSharedMemDynMember` to provide a check if the static array is overflowing in a debug build. However, assert does not work in code offloaded to GPU (i.e. OpenMP, OpenACC), so the point of this option is to enable debug builds with offloading.
* `BlockSharedMemStMember::alloc` calls the default ctor of the allocated type via placement-new. Maybe there could be an alternative to alloc() which is a variadic template which calls a ctor for the allocated object (in a master thread) so the user can get initialized memory directly.

## Benefits

* There are cases, where removing malloc improves performance: https://github.com/ComputationalRadiationPhysics/picongpu/issues/2280 . There are other cases where there is no measurable difference.
* This unifies small-object allocation for static shared memory for multiple, including future backends.