### PR TITLE
Use std::invoke_result_t instead of std::result_of_t when available

### DIFF
--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -156,8 +156,13 @@ namespace alpaka
                     TKernelFnObj const &,
                     TArgs const & ...)
                 {
+#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703
+                    using Result = std::invoke_result_t<TKernelFnObj, TAcc const &, TArgs const & ...>;
+#else
+                    using Result = std::result_of_t<TKernelFnObj(TAcc const &, TArgs const & ...)>;
+#endif
                     static_assert(
-                        std::is_same<std::result_of_t<TKernelFnObj(TAcc const &, TArgs const & ...)>, void>::value,
+                        std::is_same<Result, void>::value,
                         "The TKernelFnObj is required to return void!");
                 }
             };


### PR DESCRIPTION
`std::result_of_t` is deprecated in C++17 and removed in C++20.
Fixes #1046.

Note: I did not check this change, hope for the CI to check it. Edit: the CI indeed pointed out to my mistake in the original version, rebased now.