### PR TITLE
Fix doxygen html generation

### DIFF
--- a/script/push_doc.sh
+++ b/script/push_doc.sh
@@ -19,7 +19,7 @@ cd docs/doxygen/html
 git config --global user.email "action@github.com"
 git config --global user.name "GitHub Action"
 
-git add --force .
+git add .
 
 git log -n 3
 

--- a/script/run_doxygen.sh
+++ b/script/run_doxygen.sh
@@ -29,10 +29,9 @@ git clone -b gh-pages https://x-access-token:${2}@github.com/${1}.git docs/doxyg
 
 cd docs/
 
-rm -rf doxygen/*
+rm -rf doxygen/html/*
+rm -rf doxygen/xml/*
 
-# enable HTML output in our Doxyfile
-sed -i -E 's/(GENERATE_HTML\s*=\s*)NO/\1YES/g' Doxyfile
 doxygen Doxyfile
 
 cd ../


### PR DESCRIPTION
This should fix #1037

By deleting `doxygen/*` the repository we checked out before was deleted.
We only want to delete the content `doxygen/html/*` but not the hidden
`.git` directory. After fixing this, we should not need to force add
files anymore.

We do not need to enable `GENERATE_HTML` because it is enabled by default.