### PR TITLE
fix intrinsic `ffs` for HIP

### DIFF
--- a/include/alpaka/intrinsic/IntrinsicUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/intrinsic/IntrinsicUniformCudaHipBuiltIn.hpp
@@ -91,7 +91,7 @@ namespace alpaka
                     std::int32_t value)
                 -> std::int32_t
                 {
-                    return __ffs(value);
+                    return __ffs(static_cast<int>(value));
                 }
 
                 //-----------------------------------------------------------------------------
@@ -100,7 +100,7 @@ namespace alpaka
                     std::int64_t value)
                 -> std::int32_t
                 {
-                    return __ffsll(value);
+                    return __ffsll(static_cast<long long>(value));
                 }
             };
         }


### PR DESCRIPTION
Native HIP function `__ffs` and `__ffsll` is used with the wrong data
type.

- [x] do not merge I need to check the types again based on https://github.com/ComputationalRadiationPhysics/mallocMC/pull/182#discussion_r447641126 