### PR TITLE
Update install instructions with cmake --install instead of make install

### DIFF
--- a/docs/source/install/instructions.rst
+++ b/docs/source/install/instructions.rst
@@ -18,7 +18,7 @@ alpaka Installation
   # cd alpaka
   mkdir build && cd build
   cmake -DCMAKE_INSTALL_PREFIX=/install/ ..
-  make install
+  cmake --install .
 
 * Configure Accelerators
 


### PR DESCRIPTION
This is the cross platform way, and also what we recommend in the workshop.