### PR TITLE
documentation: change C++11 to C++14

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "alpaka: Abstraction Library for Parallel Kernel Acceleration",
-  "description": "The alpaka library is a header-only C++11 abstraction library for accelerator development. Its aim is to provide performance portability across accelerators through the abstraction (not hiding!) of the underlying levels of parallelism.",
+  "description": "The alpaka library is a header-only C++14 abstraction library for accelerator development. Its aim is to provide performance portability across accelerators through the abstraction (not hiding!) of the underlying levels of parallelism.",
   "creators": [
     {
       "affiliation": "LogMeIn, Inc.",

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Dependencies
 The **alpaka** library itself just requires header-only libraries.
 However some of the accelerator back-end implementations require different boost libraries to be built.
 
-When an accelerator back-end using *Boost.Fiber* is enabled, `boost-fiber` and all of its dependencies are required to be built in C++11 mode `./b2 cxxflags="-std=c++14"`.
+When an accelerator back-end using *Boost.Fiber* is enabled, `boost-fiber` and all of its dependencies are required to be built in C++14 mode `./b2 cxxflags="-std=c++14"`.
 When *Boost.Fiber* is enabled and alpaka is built in C++17 mode with clang and libstc++, Boost >= 1.67.0 is required.
 
 When an accelerator back-end using *CUDA* is enabled, version *9.0* of the *CUDA SDK* is the minimum requirement.

--- a/docs/source/usage/implementation.rst
+++ b/docs/source/usage/implementation.rst
@@ -1,7 +1,7 @@
 Implementation
 ==============
 
-The implementation of the library in C++, especially the way C++11 allows to define the abstract concepts and to take advantage of the zero-overhead compile-time polymorphism is explained in this section.
+The implementation of the library in C++, especially the way C++14 allows to define the abstract concepts and to take advantage of the zero-overhead compile-time polymorphism is explained in this section.
 Furthermore, it is described how the abstraction can be mapped to real devices.
 
 .. toctree::

--- a/docs/source/usage/implementation/library.rst
+++ b/docs/source/usage/implementation/library.rst
@@ -4,7 +4,7 @@ Library Interface
 As described in the chapter about the Abstraction, the general design of the library is very similar to *CUDA* and *OpenCL* but extends both by some points, while not requiring any language extensions.
 General interface design as well as interface implementation decisions differentiating *alpaka* from those libraries are described in the Rationale section.
 It uses C++ because it is one of the most performant languages available on nearly all systems.
-Furthermore, C++11 allows to describe the concepts in a very abstract way that is not possible with many other languages.
+Furthermore, C++14 allows to describe the concepts in a very abstract way that is not possible with many other languages.
 The *alpaka* library extensively makes use of advanced functional C++ template meta-programming techniques.
 The Implementation Details section discusses the C++ library and the way it provides extensibility and optimizability.
 

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -146,7 +146,7 @@ auto main()
     Data * const pBufHostB(alpaka::mem::view::getPtrNative(bufHostB));
     Data * const pBufHostC(alpaka::mem::view::getPtrNative(bufHostC));
 
-    // C++11 random generator for uniformly distributed numbers in {1,..,42}
+    // C++14 random generator for uniformly distributed numbers in {1,..,42}
     std::random_device rd{};
     std::default_random_engine eng{ rd() };
     std::uniform_int_distribution<Data> dist(1, 42);


### PR DESCRIPTION
alpaka requires C++14. This PR is changing the usage of C++11 to C++14
in our documentation.