### PR TITLE
Add a guard around sanity checks for Omp2Threads accelerator

### DIFF
--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -162,6 +162,8 @@ namespace alpaka
                         // Therefore we use 'omp parallel' with the specified number of threads in a block.
                         #pragma omp parallel num_threads(iBlockThreadCount)
                         {
+                            // The guard is for gcc internal compiler error, as discussed in #735
+#if (!BOOST_COMP_GNUC) || (BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(8, 1, 0))
                             #pragma omp single nowait
                             {
                                 // The OpenMP runtime does not create a parallel region when only one thread is required in the num_threads clause.
@@ -171,21 +173,13 @@ namespace alpaka
                                     throw std::runtime_error("The OpenMP 2.0 runtime did not create a parallel region!");
                                 }
 
-                                // GCC fails with:
-                                // error: redeclaration of const int& iBlockThreadCount
-                                // if(numThreads != iBlockThreadCount)
-                                //                  ^
-                                // note: const int& iBlockThreadCount previously declared here
-                                // #pragma omp parallel num_threads(iBlockThreadCount)
-                                //         ^
-#if (!BOOST_COMP_GNUC) || (BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(6, 0, 0))
                                 int const numThreads(::omp_get_num_threads());
                                 if(numThreads != iBlockThreadCount)
                                 {
                                     throw std::runtime_error("The OpenMP 2.0 runtime did not use the number of threads that had been required!");
                                 }
-#endif
                             }
+#endif
                             boundKernelFnObj(
                                 acc);
 


### PR DESCRIPTION
The checks sometimes caused internal compiler errors with gcc.
Fixes #765.