### PR TITLE
fix CUDA/HIP accelerator concept usage

### DIFF
--- a/include/alpaka/acc/AccGpuCudaRt.hpp
+++ b/include/alpaka/acc/AccGpuCudaRt.hpp
@@ -55,8 +55,7 @@ namespace alpaka
             typename TIdx>
         class AccGpuCudaRt final :
             public acc::AccGpuUniformCudaHipRt<TDim,TIdx>,
-            public concepts::Implements<ConceptUniformCudaHip, AccGpuUniformCudaHipRt<TDim, TIdx>>,
-            public concepts::Implements<ConceptAcc, AccGpuCudaRt<TDim, TIdx>>
+            public concepts::Implements<ConceptUniformCudaHip, AccGpuUniformCudaHipRt<TDim, TIdx>>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/acc/AccGpuHipRt.hpp
+++ b/include/alpaka/acc/AccGpuHipRt.hpp
@@ -54,8 +54,7 @@ namespace alpaka
             typename TIdx>
         class AccGpuHipRt final :
             public acc::AccGpuUniformCudaHipRt<TDim,TIdx>,
-            public concepts::Implements<ConceptUniformCudaHip, AccGpuUniformCudaHipRt<TDim, TIdx>>,
-            public concepts::Implements<ConceptAcc, AccGpuHipRt<TDim, TIdx>>
+            public concepts::Implements<ConceptUniformCudaHip, AccGpuUniformCudaHipRt<TDim, TIdx>>
         {
         public:
             //-----------------------------------------------------------------------------

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -85,7 +85,8 @@ namespace alpaka
             public block::sync::BlockSyncUniformCudaHipBuiltIn,
             public intrinsic::IntrinsicUniformCudaHipBuiltIn,
             public rand::RandUniformCudaHipRand,
-            public time::TimeUniformCudaHipBuiltIn
+            public time::TimeUniformCudaHipBuiltIn,
+            public concepts::Implements<ConceptAcc, AccGpuUniformCudaHipRt<TDim, TIdx>>
         {
         public:
             //-----------------------------------------------------------------------------


### PR DESCRIPTION
`AccGpuUniformCudaHipRt` was not defined to follow the concept
`ConceptAcc`. Since we do not disallow the direct usage of this
accelerator the concept should be set.

This PR fixes compile time issue in #1024. It was not possible to derive the queue type from the accelerator `AccGpuUniformCudaHipRt`.