### PR TITLE
CI: Add Latest Intel Compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
         # icpc
         - name: linux_icpc_release
           os: ubuntu-latest
-          env: {TRAVIS_OS_NAME: linux,   CXX: icpc,    CC: icc, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.73.0, ALPAKA_CI_CMAKE_VER: 3.15.7, OMP_NUM_THREADS: 2, ALPAKA_CI_STDLIB: libstdc++, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04"}
+          env: {TRAVIS_OS_NAME: linux,   CXX: icpc,    CC: icc, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.73.0, ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_CI_CMAKE_VER: 3.15.7, OMP_NUM_THREADS: 2, ALPAKA_CI_STDLIB: libstdc++, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04"}
 
         ## CUDA 9.0
         # nvcc + g++

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,11 @@ jobs:
           os: ubuntu-latest
           env: {CXX: clang++, CC: clang,  ALPAKA_CI_CLANG_VER: 10,     ALPAKA_CI_STDLIB: libc++,    CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.73.0, ALPAKA_CI_CMAKE_VER: 3.15.7, OMP_NUM_THREADS: 4, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:20.04", ALPAKA_ACC_CPU_BT_OMP4_ENABLE: OFF}
 
+        # icpc
+        - name: linux_icpc_release
+          os: ubuntu-latest
+          env: {TRAVIS_OS_NAME: linux,   CXX: icpc,    CC: icc, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.66.0, ALPAKA_CI_CMAKE_VER: 3.15.7, OMP_NUM_THREADS: 2, ALPAKA_CI_STDLIB: libstdc++, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04"}
+
         ## CUDA 9.0
         # nvcc + g++
         - name: linux_nvcc-9.0_gcc-5_debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
         # icpc
         - name: linux_icpc_release
           os: ubuntu-latest
-          env: {TRAVIS_OS_NAME: linux,   CXX: icpc,    CC: icc, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.66.0, ALPAKA_CI_CMAKE_VER: 3.15.7, OMP_NUM_THREADS: 2, ALPAKA_CI_STDLIB: libstdc++, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04"}
+          env: {TRAVIS_OS_NAME: linux,   CXX: icpc,    CC: icc, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.73.0, ALPAKA_CI_CMAKE_VER: 3.15.7, OMP_NUM_THREADS: 2, ALPAKA_CI_STDLIB: libstdc++, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04"}
 
         ## CUDA 9.0
         # nvcc + g++

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -17,7 +17,7 @@ source ./script/before_install.sh
 
 if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
 then
-  ./script/docker_install.sh
+  source ./script/docker_install.sh
   ./script/docker_run.sh
 elif [ "$ALPAKA_CI_OS_NAME" = "Windows" ] || [ "$ALPAKA_CI_OS_NAME" = "macOS" ]
 then

--- a/script/install.sh
+++ b/script/install.sh
@@ -52,6 +52,7 @@ then
     if [ "${CXX}" == "g++" ] ;then ./script/install_gcc.sh ;fi
     if [ "${CXX}" == "clang++" ] ;then source ./script/install_clang.sh ;fi
     if [ "${ALPAKA_CI_INSTALL_HIP}" == "ON" ] ;then ./script/install_hip.sh ;fi
+    if [ "${CXX}" == "icpc" ] ;then source ./script/install_icpc.sh ;fi
 elif [ "$ALPAKA_CI_OS_NAME" = "macOS" ]
 then
     sudo xcode-select -s "/Applications/Xcode_${ALPAKA_CI_XCODE_VER}.app/Contents/Developer"

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -36,6 +36,11 @@ then
     (cd "${BOOST_ROOT}"; ./bootstrap.bat)
 elif [ "${CXX}" == "icpc" ]
 then
+    which "${CXX}"
+    ${CXX} -v
+    which "${CC}"
+    ${CC} -v
+    (${CC} -v)
     (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="intel-linux" || cat bootstrap.log)
 else
     (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="${CC}")

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -36,7 +36,7 @@ then
     (cd "${BOOST_ROOT}"; ./bootstrap.bat)
 elif [ "${CXX}" == "icpc" ]
 then
-    (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="intel-linux")
+    (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="intel-linux" || cat bootstrap.log)
 else
     (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="${CC}")
 fi

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -34,6 +34,9 @@ git clone -b "${ALPAKA_CI_BOOST_BRANCH}" --quiet --recursive --single-branch --d
 if [ "$ALPAKA_CI_OS_NAME" = "Windows" ]
 then
     (cd "${BOOST_ROOT}"; ./bootstrap.bat)
+elif [ "${CXX}" == "icpc" ]
+then
+    (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="intel-linux")
 else
     (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="${CC}")
 fi

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -36,9 +36,13 @@ then
     (cd "${BOOST_ROOT}"; ./bootstrap.bat)
 elif [ "${CXX}" == "icpc" ]
 then
-    # outdated icpc/icc flags: https://github.com/boostorg/build/pull/635
-    sed -i 's/-xc++/-std=c++11/g' ${BOOST_ROOT}/tools/build/src/engine/build.sh
-    (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="intel-linux" || cat bootstrap.log)
+    cd $(mktemp -d)
+    BOOST_BUILD_DIR=$PWD
+    cmake ${BOOST_ROOT} -DCMAKE_INSTALL_PREFIX=${ALPAKA_CI_BOOST_LIB_DIR}
+    make -j 2
+    make install
+    cd -
+    rm -rf ${BOOST_BUILD_DIR}
 else
     (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="${CC}")
 fi

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -40,8 +40,6 @@ then
     ${CXX} -v
     which "${CC}"
     ${CC} -v
-    export CXXFLAGS="-std=c++14"
-    export CXX="$(which ${CXX}) -std=c++14"
     (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="cxx" || cat bootstrap.log)
 else
     (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="${CC}")

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -36,11 +36,9 @@ then
     (cd "${BOOST_ROOT}"; ./bootstrap.bat)
 elif [ "${CXX}" == "icpc" ]
 then
-    which "${CXX}"
-    ${CXX} -v
-    which "${CC}"
-    ${CC} -v
-    (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="cxx" || cat bootstrap.log)
+    # outdated icpc/icc flags: https://github.com/boostorg/build/pull/635
+    sed -i 's/-xc++/-std=c++11/g' ${BOOST_ROOT}/tools/build/src/engine/build.sh
+    (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="intel-linux" || cat bootstrap.log)
 else
     (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="${CC}")
 fi

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -40,7 +40,8 @@ then
     ${CXX} -v
     which "${CC}"
     ${CC} -v
-    export CXXFLAGS="-std=c++11"
+    export CXXFLAGS="-std=c++14"
+    export CXX="$(which ${CXX}) -std=c++14"
     (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="cxx" || cat bootstrap.log)
 else
     (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="${CC}")

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -40,8 +40,8 @@ then
     ${CXX} -v
     which "${CC}"
     ${CC} -v
-    (${CC} -v)
-    (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="intel-linux" || cat bootstrap.log)
+    # export CXXFLAGS="${CXXFLAGS} -std=c++11"
+    (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="cxx" || cat bootstrap.log)
 else
     (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="${CC}")
 fi

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -40,7 +40,7 @@ then
     ${CXX} -v
     which "${CC}"
     ${CC} -v
-    # export CXXFLAGS="${CXXFLAGS} -std=c++11"
+    export CXXFLAGS="-std=c++11"
     (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="cxx" || cat bootstrap.log)
 else
     (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="${CC}")

--- a/script/install_icpc.sh
+++ b/script/install_icpc.sh
@@ -30,7 +30,7 @@ travis_retry sudo apt-get update
 travis_retry sudo apt-get install -y intel-oneapi-icc
 
 set +eu
-source /opt/intel/inteloneapi/setvars.sh
+source /opt/intel/oneapi/setvars.sh
 set -eu
 
 which "${CXX}"

--- a/script/install_icpc.sh
+++ b/script/install_icpc.sh
@@ -35,3 +35,5 @@ set -eu
 
 which "${CXX}"
 ${CXX} -v
+which "${CC}"
+${CC} -v

--- a/script/install_icpc.sh
+++ b/script/install_icpc.sh
@@ -27,7 +27,7 @@ sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
 echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
 
 travis_retry sudo apt-get update
-travis_retry sudo apt-get install -y intel-oneapi-icc
+travis_retry sudo apt-get install -y intel-oneapi-icc intel-oneapi-mkl-devel intel-oneapi-openmp intel-oneapi-tbb-devel
 
 set +eu
 source /opt/intel/oneapi/setvars.sh

--- a/script/install_icpc.sh
+++ b/script/install_icpc.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+#
+# Copyright 2020 Axel Huebl
+#
+# This file is part of alpaka.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+source ./script/travis_retry.sh
+
+source ./script/set.sh
+
+: "${CXX?'CXX must be specified'}"
+
+# Ref.: https://github.com/rscohn2/oneapi-ci
+# intel-basekit intel-hpckit are too large in size
+
+travis_retry sudo apt-get -qqq update
+travis_retry sudo apt-get install -y wget build-essential pkg-config cmake ca-certificates gnupg
+travis_retry sudo wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+
+sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+
+travis_retry sudo apt-get update
+travis_retry sudo apt-get install -y intel-oneapi-icc
+
+set +eu
+source /opt/intel/inteloneapi/setvars.sh
+set -eu
+
+which "${CXX}"
+${CXX} -v

--- a/script/run.sh
+++ b/script/run.sh
@@ -127,6 +127,14 @@ then
         CMAKE_EXE_LINKER_FLAGS="${CMAKE_EXE_LINKER_FLAGS} -lc++ -lc++abi"
     fi
 
+    # too hard to forward all Intel oneAPI env vars to docker
+    if [ "${CXX}" == "icpc" ]
+    then
+        set +eu
+        which ${CXX} || source /opt/intel/oneapi/setvars.sh
+        set -eu
+    fi
+
     which "${CXX}"
     ${CXX} -v
 


### PR DESCRIPTION
Add latest `icpc`/`icc` from oneAPI for Linux to CI.

Related to #995

Since it's currently plain impossible to install boost with icc on Linux, we install the header-only variant of boost with GCC and use that (no Boost.Fibers coverage in CI).