### PR TITLE
Simplify parameter deduction in TaskKernel... implementations with auto

### DIFF
--- a/include/alpaka/kernel/TaskKernelCpuFibers.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuFibers.hpp
@@ -122,7 +122,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](auto const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -152,7 +152,7 @@ namespace alpaka
 
                 auto const boundGridBlockExecHost(
                     meta::apply(
-                        [this, &acc, &blockThreadExtent, &fiberPool](std::decay_t<TArgs> const & ... args)
+                        [this, &acc, &blockThreadExtent, &fiberPool](auto const & ... args)
                         {
                             // Bind the kernel and its arguments to the grid block function.
                             return

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -100,7 +100,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](auto const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -120,7 +120,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](std::decay_t<TArgs> const & ... args)
+                        [this](auto const & ... args)
                         {
                             return
                                 std::bind(

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -99,7 +99,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](auto const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -119,7 +119,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](std::decay_t<TArgs> const & ... args)
+                        [this](auto const & ... args)
                         {
                             return
                                 std::bind(

--- a/include/alpaka/kernel/TaskKernelCpuOmp4.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp4.hpp
@@ -99,7 +99,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](auto const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -119,7 +119,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](std::decay_t<TArgs> const & ... args)
+                        [this](auto const & ... args)
                         {
                             return
                                 std::bind(

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -92,7 +92,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](auto const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -112,7 +112,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](std::decay_t<TArgs> const & ... args)
+                        [this](auto const & ... args)
                         {
                             return
                                 std::bind(

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -98,7 +98,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](auto const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -118,7 +118,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](std::decay_t<TArgs> const & ... args)
+                        [this](auto const & ... args)
                         {
                             return
                                 std::bind(

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -121,7 +121,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](auto const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -147,7 +147,7 @@ namespace alpaka
                 // Bind the kernel and its arguments to the grid block function.
                 auto const boundGridBlockExecHost(
                     meta::apply(
-                        [this, &acc, &blockThreadExtent, &threadPool](std::decay_t<TArgs> const & ... args)
+                        [this, &acc, &blockThreadExtent, &threadPool](auto const & ... args)
                         {
                             return
                                 std::bind(

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -342,7 +342,7 @@ namespace alpaka
                     // Get the size of the block shared dynamic memory.
                     auto const blockSharedMemDynSizeBytes(
                         meta::apply(
-                            [&](auto const & ... args)
+                            [&](std::decay_t<TArgs> const & ... args)
                             {
                                 return
                                     kernel::getBlockSharedMemDynSizeBytes<
@@ -388,7 +388,7 @@ namespace alpaka
                     // This forces the type of a float argument given with std::forward to this function to be of type float instead of e.g. "float const & __ptr64" (MSVC).
                     // If not given by value, the kernel launch code does not copy the value but the pointer to the value location.
                     meta::apply(
-                        [&](auto const & ... args)
+                        [&](std::decay_t<TArgs> const & ... args)
                         {
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                             kernelName<<<
@@ -487,7 +487,7 @@ namespace alpaka
                     // Get the size of the block shared dynamic memory.
                     auto const blockSharedMemDynSizeBytes(
                         meta::apply(
-                            [&](auto const & ... args)
+                            [&](std::decay_t<TArgs> const & ... args)
                             {
                                 return
                                     kernel::getBlockSharedMemDynSizeBytes<
@@ -533,7 +533,7 @@ namespace alpaka
 
                     // Enqueue the kernel execution.
                     meta::apply(
-                        [&](auto const & ... args)
+                        [&](std::decay_t<TArgs> const & ... args)
                         {
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                             kernelName<<<

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -342,7 +342,7 @@ namespace alpaka
                     // Get the size of the block shared dynamic memory.
                     auto const blockSharedMemDynSizeBytes(
                         meta::apply(
-                            [&](std::decay_t<TArgs> const & ... args)
+                            [&](auto const & ... args)
                             {
                                 return
                                     kernel::getBlockSharedMemDynSizeBytes<
@@ -388,7 +388,7 @@ namespace alpaka
                     // This forces the type of a float argument given with std::forward to this function to be of type float instead of e.g. "float const & __ptr64" (MSVC).
                     // If not given by value, the kernel launch code does not copy the value but the pointer to the value location.
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](auto const & ... args)
                         {
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                             kernelName<<<
@@ -487,7 +487,7 @@ namespace alpaka
                     // Get the size of the block shared dynamic memory.
                     auto const blockSharedMemDynSizeBytes(
                         meta::apply(
-                            [&](std::decay_t<TArgs> const & ... args)
+                            [&](auto const & ... args)
                             {
                                 return
                                     kernel::getBlockSharedMemDynSizeBytes<
@@ -533,7 +533,7 @@ namespace alpaka
 
                     // Enqueue the kernel execution.
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](auto const & ... args)
                         {
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                             kernelName<<<


### PR DESCRIPTION
This is only done when the parameters were already of the correct (decayed) types, as stored in the `m_args` tuple. So in some cases I did not make the change, and believe it would have been wrong to do so.
This also works around Intel internal compiler errors when using `std::decay` on empty template parameter packs #995