### PR TITLE
build type compiler flags not passed to nvcc

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -888,5 +888,10 @@ if((ALPAKA_ACC_GPU_CUDA_ENABLE OR ALPAKA_ACC_GPU_HIP_ENABLE) AND ALPAKA_CUDA_COM
                  PROPERTY INTERFACE_COMPILE_OPTIONS)
     string(REPLACE ";" " " _ALPAKA_COMPILE_OPTIONS_STRING "${_ALPAKA_COMPILE_OPTIONS_PUBLIC}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_ALPAKA_COMPILE_OPTIONS_STRING}")
+
+    # Append CMAKE_CXX_FLAGS_[Release|Debug|RelWithDebInfo] to CMAKE_CXX_FLAGS
+    # because FindCUDA only propagates the latter to nvcc.
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" build_config)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${build_config}}")
 endif()
 


### PR DESCRIPTION
nvcc is only forwarding `CMAKE_CXX_FLAGS` via `-Xcompiler` to the host compiler.
`CMAKE_CXX_FLAGS_[Release|Debug|RELWITHDEBINFO]` will be ignored.
The result can be slow code if `CMAKE_BUILD_TYPE=Release` is used. CMake
build releases by default with `-O3`

I saw this [issue](https://github.com/ComputationalRadiationPhysics/mallocMC/issues/183#issue-651570072) together with PIConGPU and a new version of mallocMC where we used alpaka.
I reproduced the behavior also when compiling the alpaka examples. The `-O3` flags from `CMAKE_CXX_FLGS_RELEASE` will never be used in the current alpaka version.