### PR TITLE
 Work around Intel ICE when using std::decay on empty template parameter packs

### DIFF
--- a/include/alpaka/core/BoostPredef.hpp
+++ b/include/alpaka/core/BoostPredef.hpp
@@ -119,3 +119,11 @@
 #else
     #define BOOST_COMP_CLANG_CUDA BOOST_VERSION_NUMBER_NOT_AVAILABLE
 #endif
+
+//-----------------------------------------------------------------------------
+// Intel compiler detection
+// BOOST_COMP_INTEL_EMULATED is defined by boost instead of BOOST_COMP_INTEL
+#if defined(BOOST_COMP_INTEL) && defined(BOOST_COMP_INTEL_EMULATED)
+    #undef BOOST_COMP_INTEL
+    #define BOOST_COMP_INTEL BOOST_COMP_INTEL_EMULATED
+#endif

--- a/include/alpaka/core/Decay.hpp
+++ b/include/alpaka/core/Decay.hpp
@@ -1,0 +1,33 @@
+/* Copyright 2020 Sergei Bastrakov
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/BoostPredef.hpp>
+
+#include <type_traits>
+
+//-----------------------------------------------------------------------------
+//! Wrapper around std::decay_t for parameter pack expansion expressions
+//
+// Works around Intel compiler internal error when used in empty template pack
+// extension as discussed in #995. It seems not possible to make a workaround
+// with pure C++ tools, like an alias template, so macro it is. Note that
+// there is no known issue outside of empty parameter pack expansions,
+// so the normal std::decay_t can and should be used there.
+//
+// The choice of macro over writing typename std::decay<Type>::type explicitly
+// in parameter pack expansion expressions is to avoid warnings from diagnostic
+// tools, and also for brevity.
+//-----------------------------------------------------------------------------
+#ifdef BOOST_COMP_INTEL
+    #define ALPAKA_DECAY_T(Type) typename std::decay<Type>::type
+#else
+    #define ALPAKA_DECAY_T(Type) std::decay_t<Type>
+#endif

--- a/include/alpaka/kernel/TaskKernelCpuFibers.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuFibers.hpp
@@ -20,6 +20,7 @@
 
 // Implementation details.
 #include <alpaka/acc/AccCpuFibers.hpp>
+#include <alpaka/core/Decay.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 #include <alpaka/kernel/Traits.hpp>
 #include <alpaka/workdiv/WorkDivMembers.hpp>
@@ -122,7 +123,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -152,7 +153,7 @@ namespace alpaka
 
                 auto const boundGridBlockExecHost(
                     meta::apply(
-                        [this, &acc, &blockThreadExtent, &fiberPool](std::decay_t<TArgs> const & ... args)
+                        [this, &acc, &blockThreadExtent, &fiberPool](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
                             // Bind the kernel and its arguments to the grid block function.
                             return

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -24,6 +24,7 @@
 
 // Implementation details.
 #include <alpaka/acc/AccCpuOmp2Blocks.hpp>
+#include <alpaka/core/Decay.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 #include <alpaka/idx/MapIdx.hpp>
 #include <alpaka/kernel/Traits.hpp>
@@ -100,7 +101,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -120,7 +121,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](std::decay_t<TArgs> const & ... args)
+                        [this](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
                             return
                                 std::bind(

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -24,6 +24,7 @@
 
 // Implementation details.
 #include <alpaka/acc/AccCpuOmp2Threads.hpp>
+#include <alpaka/core/Decay.hpp>
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 #include <alpaka/kernel/Traits.hpp>
@@ -99,7 +100,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -119,7 +120,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](std::decay_t<TArgs> const & ... args)
+                        [this](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
                             return
                                 std::bind(

--- a/include/alpaka/kernel/TaskKernelCpuOmp4.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp4.hpp
@@ -24,6 +24,7 @@
 
 // Implementation details.
 #include <alpaka/acc/AccCpuOmp4.hpp>
+#include <alpaka/core/Decay.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 #include <alpaka/idx/MapIdx.hpp>
 #include <alpaka/kernel/Traits.hpp>
@@ -99,7 +100,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -119,7 +120,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](std::decay_t<TArgs> const & ... args)
+                        [this](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
                             return
                                 std::bind(

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -20,6 +20,7 @@
 
 // Implementation details.
 #include <alpaka/acc/AccCpuSerial.hpp>
+#include <alpaka/core/Decay.hpp>
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 #include <alpaka/kernel/Traits.hpp>
@@ -92,7 +93,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -112,7 +113,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](std::decay_t<TArgs> const & ... args)
+                        [this](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
                             return
                                 std::bind(

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -20,6 +20,7 @@
 
 // Implementation details.
 #include <alpaka/acc/AccCpuTbbBlocks.hpp>
+#include <alpaka/core/Decay.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 #include <alpaka/idx/MapIdx.hpp>
 #include <alpaka/kernel/Traits.hpp>
@@ -98,7 +99,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -118,7 +119,7 @@ namespace alpaka
                 // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
                 auto const boundKernelFnObj(
                     meta::apply(
-                        [this](std::decay_t<TArgs> const & ... args)
+                        [this](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
                             return
                                 std::bind(

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -20,6 +20,7 @@
 
 // Implementation details.
 #include <alpaka/acc/AccCpuThreads.hpp>
+#include <alpaka/core/Decay.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 #include <alpaka/kernel/Traits.hpp>
 #include <alpaka/workdiv/WorkDivMembers.hpp>
@@ -121,7 +122,7 @@ namespace alpaka
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes(
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
@@ -147,7 +148,7 @@ namespace alpaka
                 // Bind the kernel and its arguments to the grid block function.
                 auto const boundGridBlockExecHost(
                     meta::apply(
-                        [this, &acc, &blockThreadExtent, &threadPool](std::decay_t<TArgs> const & ... args)
+                        [this, &acc, &blockThreadExtent, &threadPool](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
                             return
                                 std::bind(

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -38,6 +38,7 @@
 
 // Implementation details.
 #include <alpaka/acc/AccGpuUniformCudaHipRt.hpp>
+#include <alpaka/core/Decay.hpp>
 #include <alpaka/dev/DevUniformCudaHipRt.hpp>
 #include <alpaka/kernel/Traits.hpp>
 #include <alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp>
@@ -342,7 +343,7 @@ namespace alpaka
                     // Get the size of the block shared dynamic memory.
                     auto const blockSharedMemDynSizeBytes(
                         meta::apply(
-                            [&](std::decay_t<TArgs> const & ... args)
+                            [&](ALPAKA_DECAY_T(TArgs) const & ... args)
                             {
                                 return
                                     kernel::getBlockSharedMemDynSizeBytes<
@@ -388,7 +389,7 @@ namespace alpaka
                     // This forces the type of a float argument given with std::forward to this function to be of type float instead of e.g. "float const & __ptr64" (MSVC).
                     // If not given by value, the kernel launch code does not copy the value but the pointer to the value location.
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                             kernelName<<<
@@ -487,7 +488,7 @@ namespace alpaka
                     // Get the size of the block shared dynamic memory.
                     auto const blockSharedMemDynSizeBytes(
                         meta::apply(
-                            [&](std::decay_t<TArgs> const & ... args)
+                            [&](ALPAKA_DECAY_T(TArgs) const & ... args)
                             {
                                 return
                                     kernel::getBlockSharedMemDynSizeBytes<
@@ -533,7 +534,7 @@ namespace alpaka
 
                     // Enqueue the kernel execution.
                     meta::apply(
-                        [&](std::decay_t<TArgs> const & ... args)
+                        [&](ALPAKA_DECAY_T(TArgs) const & ... args)
                         {
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                             kernelName<<<


### PR DESCRIPTION
Fixes #995.

This is a simple workaround to get it fixed. My earlier PR #1067 attempted a more general change that gets rid of these `decay`s along the way. However, that one has its own issues, that will take time to resolve. So I will close that one for now.

To do:
- [x] merge #1070, this PR uses a commit from there.

Thanks to @krzikalla for communicating the way to fix.