### PR TITLE
Simplify shared memory usage in tests

### DIFF
--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -29,7 +29,7 @@ ALPAKA_FN_ACC auto testAtomicAdd(
     T operandOrig)
 -> void
 {
-    auto && operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -54,7 +54,7 @@ ALPAKA_FN_ACC auto testAtomicSub(
     T operandOrig)
 -> void
 {
-    auto && operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -79,7 +79,7 @@ ALPAKA_FN_ACC auto testAtomicMin(
     T operandOrig)
 -> void
 {
-    auto && operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -104,7 +104,7 @@ ALPAKA_FN_ACC auto testAtomicMax(
     T operandOrig)
 -> void
 {
-    auto && operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -129,7 +129,7 @@ ALPAKA_FN_ACC auto testAtomicExch(
     T operandOrig)
 -> void
 {
-    auto && operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -155,7 +155,7 @@ ALPAKA_FN_ACC auto testAtomicInc(
 -> void
 {
     // \TODO: Check reset to 0 at 'value'.
-    auto && operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(42);
     T const ret =
@@ -181,7 +181,7 @@ ALPAKA_FN_ACC auto testAtomicDec(
 -> void
 {
     // \TODO: Check reset to 'value' at 0.
-    auto && operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(42);
     T const ret =
@@ -206,7 +206,7 @@ ALPAKA_FN_ACC auto testAtomicAnd(
     T operandOrig)
 -> void
 {
-    auto && operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -231,7 +231,7 @@ ALPAKA_FN_ACC auto testAtomicOr(
     T operandOrig)
 -> void
 {
-    auto && operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -256,7 +256,7 @@ ALPAKA_FN_ACC auto testAtomicXor(
     T operandOrig)
 -> void
 {
-    auto && operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = operandOrig + static_cast<T>(4);
     T const ret =
@@ -281,7 +281,7 @@ ALPAKA_FN_ACC auto testAtomicCas(
     T operandOrig)
 -> void
 {
-    auto && operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
 
     //-----------------------------------------------------------------------------
     // with match

--- a/test/unit/block/shared/src/BlockSharedMemDyn.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemDyn.cpp
@@ -29,15 +29,15 @@ public:
     -> void
     {
         // Assure that the pointer is non null.
-        auto && a = alpaka::block::shared::dyn::getMem<std::uint32_t>(acc);
+        auto a = alpaka::block::shared::dyn::getMem<std::uint32_t>(acc);
         ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != a);
 
         // Each call should return the same pointer ...
-        auto && b = alpaka::block::shared::dyn::getMem<std::uint32_t>(acc);
+        auto b = alpaka::block::shared::dyn::getMem<std::uint32_t>(acc);
         ALPAKA_CHECK(*success, a == b);
 
         // ... even for different types.
-        auto && c = alpaka::block::shared::dyn::getMem<float>(acc);
+        auto c = alpaka::block::shared::dyn::getMem<float>(acc);
         ALPAKA_CHECK(*success, a == reinterpret_cast<std::uint32_t *>(c));
     }
 };

--- a/test/unit/block/shared/src/BlockSharedMemSt.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemSt.cpp
@@ -36,29 +36,29 @@ public:
         // Multiple runs to make sure it really works.
         for(std::size_t i=0u; i<10; ++i)
         {
-            auto && a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &a);
 
-            auto && b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &b);
 
-            auto && c = alpaka::block::shared::st::allocVar<float, __COUNTER__>(acc);
+            auto & c = alpaka::block::shared::st::allocVar<float, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<float *>(nullptr) != &c);
 
-            auto && d = alpaka::block::shared::st::allocVar<double, __COUNTER__>(acc);
+            auto & d = alpaka::block::shared::st::allocVar<double, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<double *>(nullptr) != &d);
 
-            auto && e = alpaka::block::shared::st::allocVar<std::uint64_t, __COUNTER__>(acc);
+            auto & e = alpaka::block::shared::st::allocVar<std::uint64_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint64_t *>(nullptr) != &e);
 
 
-            auto && f = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            auto & f = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &f[0]);
 
-            auto && g = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            auto & g = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &g[0]);
 
-            auto && h = alpaka::block::shared::st::allocVar<alpaka::test::Array<double, 16>, __COUNTER__>(acc);
+            auto & h = alpaka::block::shared::st::allocVar<alpaka::test::Array<double, 16>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<double *>(nullptr) != &h[0]);
         }
 #if BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(6, 0, 0)
@@ -99,19 +99,19 @@ public:
         // Multiple runs to make sure it really works.
         for(std::size_t i=0u; i<10; ++i)
         {
-            auto && a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-            auto && b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, &a != &b);
-            auto && c = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & c = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, &b != &c);
             ALPAKA_CHECK(*success, &a != &c);
             ALPAKA_CHECK(*success, &b != &c);
 
-            auto && d = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            auto & d = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, &a != &d[0]);
             ALPAKA_CHECK(*success, &b != &d[0]);
             ALPAKA_CHECK(*success, &c != &d[0]);
-            auto && e = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            auto & e = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, &a != &e[0]);
             ALPAKA_CHECK(*success, &b != &e[0]);
             ALPAKA_CHECK(*success, &c != &e[0]);


### PR DESCRIPTION
It unnecessarily used forwarding references instead of normal ones for static memory, and forwarding references to pointers instead of just pointers for dynamic. It changed nothing, just complicated the code. Also, now the use of shared memory is conformant to the cheatsheet.

Closes #1053.