### PR TITLE
Allow to filter specific jobs based on commit message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,10 +491,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+      if: (!contains(github.event.head_commit.message, 'ci_filter') || contains(github.event.head_commit.message, matrix.name ))
     - name: build + test
-      if: runner.os == 'Windows'
+      if: (!contains(github.event.head_commit.message, 'ci_filter') || contains(github.event.head_commit.message, matrix.name )) && (runner.os == 'Windows')
       shell: bash
       run: cd ${GITHUB_WORKSPACE} && ./script/ci.sh
     - name: build + test
-      if: runner.os == 'Linux' || runner.os == 'macOS'
+      if: (!contains(github.event.head_commit.message, 'ci_filter') || contains(github.event.head_commit.message, matrix.name )) && (runner.os == 'Linux' || runner.os == 'macOS')
       run: cd ${GITHUB_WORKSPACE} && ./script/ci.sh


### PR DESCRIPTION
By adding the word `ci_filter` to the last commit of a branch, only jobs
that are listed in the commit message via their name will be executed.

ci_filter: [linux_nvcc-10.2_gcc-5_debug, linux_clang-7_release_c++17, windows_nvcc-10.0_cl-2017_debug, macos_xcode-11.1_release]