### PR TITLE
BoostPredef.hpp: Add redefinition of BOOST_COMP_PGI

### DIFF
--- a/include/alpaka/core/BoostPredef.hpp
+++ b/include/alpaka/core/BoostPredef.hpp
@@ -127,3 +127,11 @@
     #undef BOOST_COMP_INTEL
     #define BOOST_COMP_INTEL BOOST_COMP_INTEL_EMULATED
 #endif
+
+//-----------------------------------------------------------------------------
+// PGI and NV HPC SDK compiler detection
+// BOOST_COMP_PGI_EMULATED is defined by boost instead of BOOST_COMP_PGI
+#if defined(BOOST_COMP_PGI) && defined(BOOST_COMP_PGI_EMULATED)
+    #undef BOOST_COMP_PGI
+    #define BOOST_COMP_PGI BOOST_COMP_PGI_EMULATED
+#endif


### PR DESCRIPTION
BoostPredef fix like PGI/NV HPC analogous to the same thing for intel in https://github.com/alpaka-group/alpaka/pull/1070 .

Testing for PGI is required in the OpenACC backend.