### PR TITLE
Extend AccDevProps with shared memory size per block

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -172,8 +172,6 @@ namespace alpaka
                     dev::DevCpu const & dev)
                 -> alpaka::acc::AccDevProps<TDim, TIdx>
                 {
-                    alpaka::ignore_unused(dev);
-
 #ifdef ALPAKA_CI
                     auto const blockThreadCountMax(static_cast<TIdx>(3));
 #else
@@ -193,7 +191,9 @@ namespace alpaka
                         // m_threadElemExtentMax
                         vec::Vec<TDim, TIdx>::all(std::numeric_limits<TIdx>::max()),
                         // m_threadElemCountMax
-                        std::numeric_limits<TIdx>::max()};
+                        std::numeric_limits<TIdx>::max(),
+                        // m_sharedMemSizeBytes
+                        dev::getMemBytes( dev )};
                 }
             };
             //#############################################################################

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -182,7 +182,9 @@ namespace alpaka
                         // m_threadElemExtentMax
                         vec::Vec<TDim, TIdx>::all(std::numeric_limits<TIdx>::max()),
                         // m_threadElemCountMax
-                        std::numeric_limits<TIdx>::max()};
+                        std::numeric_limits<TIdx>::max(),
+                        // m_sharedMemSizeBytes
+                        static_cast<size_t>( acc::AccCpuOmp2Blocks<TDim, TIdx>::staticAllocBytes )};
                 }
             };
             //#############################################################################

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -169,8 +169,6 @@ namespace alpaka
                     dev::DevCpu const & dev)
                 -> alpaka::acc::AccDevProps<TDim, TIdx>
                 {
-                    alpaka::ignore_unused(dev);
-
 #ifdef ALPAKA_CI
                     auto const blockThreadCountMax(alpaka::core::clipCast<TIdx>(std::min(4, ::omp_get_max_threads())));
 #else
@@ -190,7 +188,9 @@ namespace alpaka
                         // m_threadElemExtentMax
                         vec::Vec<TDim, TIdx>::all(std::numeric_limits<TIdx>::max()),
                         // m_threadElemCountMax
-                        std::numeric_limits<TIdx>::max()};
+                        std::numeric_limits<TIdx>::max(),
+                        // m_sharedMemSizeBytes
+                        dev::getMemBytes( dev )};
                 }
             };
             //#############################################################################

--- a/include/alpaka/acc/AccCpuOmp4.hpp
+++ b/include/alpaka/acc/AccCpuOmp4.hpp
@@ -169,8 +169,6 @@ namespace alpaka
                     dev::DevCpu const & dev)
                 -> acc::AccDevProps<TDim, TIdx>
                 {
-                    alpaka::ignore_unused(dev);
-
 #ifdef ALPAKA_CI
                     auto const blockThreadCountMax(alpaka::core::clipCast<TIdx>(std::min(4, ::omp_get_max_threads())));
 #else
@@ -190,7 +188,9 @@ namespace alpaka
                         // m_threadElemExtentMax
                         vec::Vec<TDim, TIdx>::all(std::numeric_limits<TIdx>::max()),
                         // m_threadElemCountMax
-                        std::numeric_limits<TIdx>::max()};
+                        std::numeric_limits<TIdx>::max(),
+                        // m_sharedMemSizeBytes
+                        dev::getMemBytes( dev )};
                 }
             };
             //#############################################################################

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -176,7 +176,9 @@ namespace alpaka
                         // m_threadElemExtentMax
                         vec::Vec<TDim, TIdx>::all(std::numeric_limits<TIdx>::max()),
                         // m_threadElemCountMax
-                        std::numeric_limits<TIdx>::max()};
+                        std::numeric_limits<TIdx>::max(),
+                        // m_sharedMemSizeBytes
+                        static_cast< size_t >( acc::AccCpuSerial<TDim, TIdx>::staticAllocBytes )};
                 }
             };
             //#############################################################################

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -174,7 +174,9 @@ namespace alpaka
                         // m_threadElemExtentMax
                         vec::Vec<TDim, TIdx>::all(std::numeric_limits<TIdx>::max()),
                         // m_threadElemCountMax
-                        std::numeric_limits<TIdx>::max()};
+                        std::numeric_limits<TIdx>::max(),
+                        // m_sharedMemSizeBytes
+                        static_cast< size_t >( acc::AccCpuTbbBlocks<TDim, TIdx>::staticAllocBytes )};
                 }
 
             };

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -170,8 +170,6 @@ namespace alpaka
                     dev::DevCpu const & dev)
                 -> acc::AccDevProps<TDim, TIdx>
                 {
-                    alpaka::ignore_unused(dev);
-
 #ifdef ALPAKA_CI
                     auto const blockThreadCountMax(static_cast<TIdx>(8));
 #else
@@ -193,7 +191,9 @@ namespace alpaka
                         // m_threadElemExtentMax
                         vec::Vec<TDim, TIdx>::all(std::numeric_limits<TIdx>::max()),
                         // m_threadElemCountMax
-                        std::numeric_limits<TIdx>::max()};
+                        std::numeric_limits<TIdx>::max(),
+                        // m_sharedMemSizeBytes
+                        dev::getMemBytes( dev )};
                 }
             };
             //#############################################################################

--- a/include/alpaka/acc/AccDevProps.hpp
+++ b/include/alpaka/acc/AccDevProps.hpp
@@ -24,7 +24,6 @@ namespace alpaka
         //
         // \TODO:
         //  TIdx m_maxClockFrequencyHz;            //!< Maximum clock frequency of the device in Hz.
-        //  TIdx m_sharedMemSizeBytes;             //!< Idx of the available block shared memory in bytes.
         template<
             typename TDim,
             typename TIdx>
@@ -38,14 +37,16 @@ namespace alpaka
                 vec::Vec<TDim, TIdx> const & blockThreadExtentMax,
                 TIdx const & blockThreadCountMax,
                 vec::Vec<TDim, TIdx> const & threadElemExtentMax,
-                TIdx const & threadElemCountMax) :
+                TIdx const & threadElemCountMax,
+                size_t const & sharedMemSizeBytes) :
                     m_gridBlockExtentMax(gridBlockExtentMax),
                     m_blockThreadExtentMax(blockThreadExtentMax),
                     m_threadElemExtentMax(threadElemExtentMax),
                     m_gridBlockCountMax(gridBlockCountMax),
                     m_blockThreadCountMax(blockThreadCountMax),
                     m_threadElemCountMax(threadElemCountMax),
-                    m_multiProcessorCount(multiProcessorCount)
+                    m_multiProcessorCount(multiProcessorCount),
+                    m_sharedMemSizeBytes(sharedMemSizeBytes)
             {}
 
             // NOTE: The members have been reordered from the order in the constructor because gcc is buggy for some TDim and TIdx and generates invalid assembly.
@@ -58,6 +59,7 @@ namespace alpaka
             TIdx m_threadElemCountMax;                 //!< The maximum number of elements in a threads.
 
             TIdx m_multiProcessorCount;                //!< The number of multiprocessors.
+            size_t m_sharedMemSizeBytes;               //!< The size of shared memory per block
         };
     }
 }

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -197,6 +197,12 @@ namespace alpaka
                         cudaDevAttrMaxThreadsPerBlock,
                         dev.m_iDevice));
 
+                    int sharedMemSizeBytes = {};
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
+                        &sharedMemSizeBytes,
+                        cudaDevAttrMaxSharedMemoryPerBlock,
+                        dev.m_iDevice));
+
                     return {
                         // m_multiProcessorCount
                         alpaka::core::clipCast<TIdx>(multiProcessorCount),
@@ -219,7 +225,9 @@ namespace alpaka
                         // m_threadElemExtentMax
                         vec::Vec<TDim, TIdx>::all(std::numeric_limits<TIdx>::max()),
                         // m_threadElemCountMax
-                        std::numeric_limits<TIdx>::max()
+                        std::numeric_limits<TIdx>::max(),
+                        // m_sharedMemSizeBytes
+                        static_cast<size_t>(sharedMemSizeBytes)
                     };
 
 #else
@@ -250,7 +258,9 @@ namespace alpaka
                         // m_threadElemExtentMax
                         vec::Vec<TDim, TIdx>::all(std::numeric_limits<TIdx>::max()),
                         // m_threadElemCountMax
-                        std::numeric_limits<TIdx>::max()
+                        std::numeric_limits<TIdx>::max(),
+                        // m_sharedMemSizeBytes
+                        static_cast<size_t>(hipDevProp.sharedMemPerBlock)
                     };
 #endif
                 }

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -77,9 +77,10 @@ namespace alpaka
                         return staticAllocBytes - m_dynPitch;
                     }
 
-                private:
+                    //! Storage size in bytes
                     static constexpr unsigned int staticAllocBytes = TStaticAllocKiB<<10;
 
+                private:
                     mutable std::array<uint8_t, staticAllocBytes> m_mem;
                     unsigned int m_dynPitch;
                 };

--- a/test/unit/acc/src/AccDevPropsTest.cpp
+++ b/test/unit/acc/src/AccDevPropsTest.cpp
@@ -1,0 +1,36 @@
+/* Copyright 2020 Sergei Bastrakov
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <alpaka/acc/AccDevProps.hpp>
+#include <alpaka/acc/Traits.hpp>
+
+#include <alpaka/test/acc/TestAccs.hpp>
+
+#include <catch2/catch.hpp>
+
+//-----------------------------------------------------------------------------
+TEMPLATE_LIST_TEST_CASE( "getAccDevProps", "[acc]", alpaka::test::acc::TestAccs)
+{
+    using Acc = TestType;
+    using Dev = alpaka::dev::Dev<Acc>;
+    using Pltf = alpaka::pltf::Pltf<Dev>;
+    Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+    auto const devProps = alpaka::acc::getAccDevProps<Acc>(dev);
+
+    REQUIRE(devProps.m_gridBlockExtentMax.prod() > 0);
+    // Note: this causes signed overflow for some configurations,
+    // will be fixed separately
+    // REQUIRE(devProps.m_blockThreadExtentMax.prod() > 0);
+    REQUIRE(devProps.m_threadElemExtentMax.prod() > 0);
+    REQUIRE(devProps.m_gridBlockCountMax > 0);
+    REQUIRE(devProps.m_blockThreadCountMax > 0);
+    REQUIRE(devProps.m_threadElemCountMax > 0);
+    REQUIRE(devProps.m_multiProcessorCount > 0);
+    REQUIRE(devProps.m_sharedMemSizeBytes > 0);
+}


### PR DESCRIPTION
Implements [this comment](https://github.com/alpaka-group/alpaka/issues/21#issuecomment-659234862). Since this is a property of a particular device, not accelerator, I believe a device trait is a better way to implement it than `AccDevProps`. Perhaps the contents of that struct should be also moved as device traits.

For CPUs perhaps a proper way to implement would be using memory available per NUMA node as discussed in #21. But for now I only made a stub that returns the overall memory size. CUDA / HIP access it properly via device properties.

cc @krzikalla