### PR TITLE
use fixed size integral types

### DIFF
--- a/include/alpaka/intrinsic/IntrinsicCpu.hpp
+++ b/include/alpaka/intrinsic/IntrinsicCpu.hpp
@@ -51,8 +51,8 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 static auto popcount(
                     intrinsic::IntrinsicCpu const & /*intrinsic*/,
-                    unsigned int value)
-                -> int
+                    std::uint32_t value)
+                -> std::int32_t
                 {
 #if BOOST_COMP_GNUC || BOOST_COMP_CLANG || BOOST_COMP_INTEL
                     return __builtin_popcount(value);
@@ -60,23 +60,23 @@ namespace alpaka
                     return __popcnt(value);
 #else
                     // Fallback to standard library
-                    return static_cast<int>(std::bitset<32>(value).count());
+                    return static_cast<std::int32_t>(std::bitset<32>(value).count());
 #endif
                 }
 
                 //-----------------------------------------------------------------------------
                 static auto popcount(
                     intrinsic::IntrinsicCpu const & /*intrinsic*/,
-                    unsigned long long value)
-                -> int
+                    std::uint64_t value)
+                -> std::int32_t
                 {
 #if BOOST_COMP_GNUC || BOOST_COMP_CLANG || BOOST_COMP_INTEL
                     return __builtin_popcountll(value);
 #elif BOOST_COMP_MSVC
-                    return static_cast<int>(__popcnt64(value));
+                    return static_cast<std::int32_t>(__popcnt64(value));
 #else
                     // Fallback to standard library
-                    return static_cast<int>(std::bitset<64>(value).count());
+                    return static_cast<std::int32_t>(std::bitset<64>(value).count());
 #endif
                 }
             };

--- a/include/alpaka/intrinsic/IntrinsicUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/intrinsic/IntrinsicUniformCudaHipBuiltIn.hpp
@@ -56,26 +56,26 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 __device__ static auto popcount(
                     intrinsic::IntrinsicUniformCudaHipBuiltIn const & /*intrinsic*/,
-                    unsigned int value)
-                -> int
+                    std::uint32_t value)
+                -> std::int32_t
                 {
-#if BOOST_COMP_CLANG
+#if BOOST_COMP_CLANG && BOOST_LANG_CUDA
                     return __popc(static_cast<int>(value));
 #else
-                    return __popc(value);
+                    return __popc(static_cast<unsigned int>(value));
 #endif
                 }
 
                 //-----------------------------------------------------------------------------
                 __device__ static auto popcount(
                     intrinsic::IntrinsicUniformCudaHipBuiltIn const & /*intrinsic*/,
-                    unsigned long long value)
-                -> int
+                    std::uint64_t value)
+                -> std::int32_t
                 {
-#if BOOST_COMP_CLANG
+#if BOOST_COMP_CLANG && BOOST_LANG_CUDA
                     return __popcll(static_cast<long long>(value));
 #else
-                    return __popcll(value);
+                    return __popcll(static_cast<unsigned long long>(value));
 #endif
                 }
             };

--- a/include/alpaka/intrinsic/Traits.hpp
+++ b/include/alpaka/intrinsic/Traits.hpp
@@ -53,8 +53,8 @@ namespace alpaka
             typename TIntrinsic>
         ALPAKA_FN_ACC auto popcount(
             TIntrinsic const & intrinsic,
-            unsigned int value)
-        -> int
+            std::uint32_t value)
+        -> std::int32_t
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptIntrinsic, TIntrinsic>;
             return traits::Popcount<
@@ -75,8 +75,8 @@ namespace alpaka
             typename TIntrinsic>
         ALPAKA_FN_ACC auto popcount(
             TIntrinsic const & intrinsic,
-            unsigned long long value)
-        -> int
+            std::uint64_t value)
+        -> std::int32_t
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptIntrinsic, TIntrinsic>;
             return traits::Popcount<

--- a/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
@@ -74,9 +74,9 @@ namespace alpaka
                 __device__ static auto activemask(
                     warp::WarpUniformCudaHipBuiltIn const & /*warp*/)
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                    -> unsigned
+                    -> std::uint32_t
 #else
-                    -> uint64_t
+                    -> std::uint64_t
 #endif
                 {
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
@@ -152,9 +152,9 @@ namespace alpaka
                     std::int32_t predicate)
                     // return type is required by the compiler
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                    -> unsigned
+                    -> std::uint32_t
 #else
-                    -> uint64_t
+                    -> std::uint64_t
 #endif
                 {
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)

--- a/test/unit/intrinsic/src/Popcount.cpp
+++ b/test/unit/intrinsic/src/Popcount.cpp
@@ -65,12 +65,12 @@ TEMPLATE_LIST_TEST_CASE( "popcount", "[intrinsic]", alpaka::test::acc::TestAccs)
     alpaka::test::KernelExecutionFixture<Acc> fixture(
         alpaka::vec::Vec<Dim, Idx>::ones());
 
-    PopcountTestKernel<unsigned int> kernel32bit;
+    PopcountTestKernel<std::uint32_t> kernel32bit;
     REQUIRE(
         fixture(
             kernel32bit));
 
-    PopcountTestKernel<unsigned long long> kernel64bit;
+    PopcountTestKernel<std::uint64_t> kernel64bit;
     REQUIRE(
         fixture(
             kernel64bit));


### PR DESCRIPTION
alpaka is mixing fixed size integral types e.g. `unit32_t`, `uint64_t` in the interfaces with build in types `unsigned long`.
This will produce incompatibilities between compiler or platform.
An interfaces specialized for `unsigned long long` will not fit for `uin64_t` if it is defined as `unsigned long` by the compiler.

This PR is switching to fixed size types so that the user knows exactly which type he can use independent of the compiler/OS.
If a native function call requires `unsigned long` or `unsigned long long` and we pass a fixed size type e.g. `uint64_t` we as developer must cast internally. This will move the pain to us as developer instead of the user.

I run into issue with `intrinsics::popcount(acc, warp::activemask(acc))` because active mask was returning `unsigned long` but some interfaces required `unsigned long long`. The type of parameters was different for CPU and GPU implementations.


follow up of: #1090

- [x] the first commit is #1090