### PR TITLE
remove boost::aligned_alloc

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -19,7 +19,7 @@
 #include <alpaka/atomic/AtomicStdLibLock.hpp>
 #include <alpaka/atomic/AtomicHierarchy.hpp>
 #include <alpaka/math/MathStdLib.hpp>
-#include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>
+#include <alpaka/block/shared/dyn/BlockSharedMemDynAlignedAlloc.hpp>
 #include <alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp>
 #include <alpaka/block/sync/BlockSyncBarrierFiber.hpp>
 #include <alpaka/intrinsic/IntrinsicCpu.hpp>
@@ -78,7 +78,7 @@ namespace alpaka
                 atomic::AtomicNoOp         // thread atomics
             >,
             public math::MathStdLib,
-            public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
+            public block::shared::dyn::BlockSharedMemDynAlignedAlloc,
             public block::shared::st::BlockSharedMemStMasterSync,
             public block::sync::BlockSyncBarrierFiber<TIdx>,
             public intrinsic::IntrinsicCpu,
@@ -112,7 +112,7 @@ namespace alpaka
                         atomic::AtomicNoOp         // atomics between threads
                     >(),
                     math::MathStdLib(),
-                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
+                    block::shared::dyn::BlockSharedMemDynAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStMasterSync(
                         [this](){block::sync::syncBlockThreads(*this);},
                         [this](){return (m_masterFiberId == boost::this_fiber::get_id());}),

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -23,7 +23,7 @@
 #include <alpaka/atomic/AtomicOmpBuiltIn.hpp>
 #include <alpaka/atomic/AtomicHierarchy.hpp>
 #include <alpaka/math/MathStdLib.hpp>
-#include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>
+#include <alpaka/block/shared/dyn/BlockSharedMemDynAlignedAlloc.hpp>
 #include <alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp>
 #include <alpaka/block/sync/BlockSyncBarrierOmp.hpp>
 #include <alpaka/intrinsic/IntrinsicCpu.hpp>
@@ -80,7 +80,7 @@ namespace alpaka
                 atomic::AtomicOmpBuiltIn     // thread atomics
             >,
             public math::MathStdLib,
-            public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
+            public block::shared::dyn::BlockSharedMemDynAlignedAlloc,
             public block::shared::st::BlockSharedMemStMasterSync,
             public block::sync::BlockSyncBarrierOmp,
             public intrinsic::IntrinsicCpu,
@@ -114,7 +114,7 @@ namespace alpaka
                         atomic::AtomicOmpBuiltIn  // atomics between threads
                     >(),
                     math::MathStdLib(),
-                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
+                    block::shared::dyn::BlockSharedMemDynAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStMasterSync(
                         [this](){block::sync::syncBlockThreads(*this);},
                         [](){return (::omp_get_thread_num() == 0);}),

--- a/include/alpaka/acc/AccCpuOmp4.hpp
+++ b/include/alpaka/acc/AccCpuOmp4.hpp
@@ -23,7 +23,7 @@
 #include <alpaka/atomic/AtomicOmpBuiltIn.hpp>
 #include <alpaka/atomic/AtomicHierarchy.hpp>
 #include <alpaka/math/MathStdLib.hpp>
-#include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>
+#include <alpaka/block/shared/dyn/BlockSharedMemDynAlignedAlloc.hpp>
 #include <alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp>
 #include <alpaka/block/sync/BlockSyncBarrierOmp.hpp>
 #include <alpaka/intrinsic/IntrinsicCpu.hpp>
@@ -80,7 +80,7 @@ namespace alpaka
                 atomic::AtomicOmpBuiltIn     // thread atomics
             >,
             public math::MathStdLib,
-            public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
+            public block::shared::dyn::BlockSharedMemDynAlignedAlloc,
             public block::shared::st::BlockSharedMemStMasterSync,
             public block::sync::BlockSyncBarrierOmp,
             public intrinsic::IntrinsicCpu,
@@ -114,7 +114,7 @@ namespace alpaka
                         atomic::AtomicOmpBuiltIn  // atomics between threads
                     >(),
                     math::MathStdLib(),
-                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
+                    block::shared::dyn::BlockSharedMemDynAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStMasterSync(
                         [this](){block::sync::syncBlockThreads(*this);},
                         [](){return (::omp_get_thread_num() == 0);}),

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -18,7 +18,7 @@
 #include <alpaka/atomic/AtomicStdLibLock.hpp>
 #include <alpaka/atomic/AtomicHierarchy.hpp>
 #include <alpaka/math/MathStdLib.hpp>
-#include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>
+#include <alpaka/block/shared/dyn/BlockSharedMemDynAlignedAlloc.hpp>
 #include <alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp>
 #include <alpaka/block/sync/BlockSyncBarrierThread.hpp>
 #include <alpaka/intrinsic/IntrinsicCpu.hpp>
@@ -75,7 +75,7 @@ namespace alpaka
                 atomic::AtomicStdLibLock<16>  // thread atomics
             >,
             public math::MathStdLib,
-            public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
+            public block::shared::dyn::BlockSharedMemDynAlignedAlloc,
             public block::shared::st::BlockSharedMemStMasterSync,
             public block::sync::BlockSyncBarrierThread<TIdx>,
             public intrinsic::IntrinsicCpu,
@@ -109,7 +109,7 @@ namespace alpaka
                         atomic::AtomicStdLibLock<16>  // atomics between threads
                     >(),
                     math::MathStdLib(),
-                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
+                    block::shared::dyn::BlockSharedMemDynAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStMasterSync(
                         [this](){block::sync::syncBlockThreads(*this);},
                         [this](){return (m_idMasterThread == std::this_thread::get_id());}),

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -45,7 +45,7 @@
         //-----------------------------------------------------------------------------
         // dynamic
         #include <alpaka/block/shared/dyn/BlockSharedMemDynUniformCudaHipBuiltIn.hpp>
-        #include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>
+        #include <alpaka/block/shared/dyn/BlockSharedMemDynAlignedAlloc.hpp>
         #include <alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp>
         #include <alpaka/block/shared/dyn/Traits.hpp>
         //-----------------------------------------------------------------------------
@@ -67,6 +67,7 @@
 // core
 #include <alpaka/core/Assert.hpp>
 #include <alpaka/core/Align.hpp>
+#include <alpaka/core/AlignedAlloc.hpp>
 #include <alpaka/core/BarrierThread.hpp>
 #include <alpaka/core/BoostPredef.hpp>
 #include <alpaka/core/ClipCast.hpp>
@@ -130,7 +131,7 @@
 #include <alpaka/math/MathStdLib.hpp>
 //-----------------------------------------------------------------------------
 // mem
-#include <alpaka/mem/alloc/AllocCpuBoostAligned.hpp>
+#include <alpaka/mem/alloc/AllocCpuAligned.hpp>
 #include <alpaka/mem/alloc/AllocCpuNew.hpp>
 #include <alpaka/mem/alloc/Traits.hpp>
 

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynAlignedAlloc.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynAlignedAlloc.hpp
@@ -12,9 +12,8 @@
 #include <alpaka/core/Vectorize.hpp>
 #include <alpaka/block/shared/dyn/Traits.hpp>
 
+#include <alpaka/core/AlignedAlloc.hpp>
 #include <alpaka/core/Common.hpp>
-
-#include <boost/align.hpp>
 
 #include <vector>
 #include <memory>
@@ -29,35 +28,35 @@ namespace alpaka
             {
                 //#############################################################################
                 //! The block shared dynamic memory allocator without synchronization.
-                class BlockSharedMemDynBoostAlignedAlloc : public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynBoostAlignedAlloc>
+                class BlockSharedMemDynAlignedAlloc : public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynAlignedAlloc>
                 {
                 public:
                     //-----------------------------------------------------------------------------
-                    BlockSharedMemDynBoostAlignedAlloc(
+                    BlockSharedMemDynAlignedAlloc(
                         std::size_t const & blockSharedMemDynSizeBytes)
                     {
                         if(blockSharedMemDynSizeBytes > 0u)
                         {
                             m_blockSharedMemDyn.reset(
                                 reinterpret_cast<uint8_t *>(
-                                    boost::alignment::aligned_alloc(core::vectorization::defaultAlignment, blockSharedMemDynSizeBytes)));
+                                    core::alignedAlloc(core::vectorization::defaultAlignment, blockSharedMemDynSizeBytes)));
                         }
                     }
                     //-----------------------------------------------------------------------------
-                    BlockSharedMemDynBoostAlignedAlloc(BlockSharedMemDynBoostAlignedAlloc const &) = delete;
+                    BlockSharedMemDynAlignedAlloc(BlockSharedMemDynAlignedAlloc const &) = delete;
                     //-----------------------------------------------------------------------------
-                    BlockSharedMemDynBoostAlignedAlloc(BlockSharedMemDynBoostAlignedAlloc &&) = delete;
+                    BlockSharedMemDynAlignedAlloc(BlockSharedMemDynAlignedAlloc &&) = delete;
                     //-----------------------------------------------------------------------------
-                    auto operator=(BlockSharedMemDynBoostAlignedAlloc const &) -> BlockSharedMemDynBoostAlignedAlloc & = delete;
+                    auto operator=(BlockSharedMemDynAlignedAlloc const &) -> BlockSharedMemDynAlignedAlloc & = delete;
                     //-----------------------------------------------------------------------------
-                    auto operator=(BlockSharedMemDynBoostAlignedAlloc &&) -> BlockSharedMemDynBoostAlignedAlloc & = delete;
+                    auto operator=(BlockSharedMemDynAlignedAlloc &&) -> BlockSharedMemDynAlignedAlloc & = delete;
                     //-----------------------------------------------------------------------------
-                    /*virtual*/ ~BlockSharedMemDynBoostAlignedAlloc() = default;
+                    /*virtual*/ ~BlockSharedMemDynAlignedAlloc() = default;
 
                 public:
                     std::unique_ptr<
                         uint8_t,
-                        boost::alignment::aligned_delete> mutable
+                        core::AlignedDelete> mutable
                             m_blockSharedMemDyn;  //!< Block shared dynamic memory.
                 };
 
@@ -72,11 +71,11 @@ namespace alpaka
                         typename T>
                     struct GetMem<
                         T,
-                        BlockSharedMemDynBoostAlignedAlloc>
+                        BlockSharedMemDynAlignedAlloc>
                     {
                         //-----------------------------------------------------------------------------
                         ALPAKA_FN_HOST static auto getMem(
-                            block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc const & blockSharedMemDyn)
+                            block::shared::dyn::BlockSharedMemDynAlignedAlloc const & blockSharedMemDyn)
                         -> T *
                         {
                             static_assert(

--- a/include/alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp
@@ -12,9 +12,8 @@
 #include <alpaka/core/Vectorize.hpp>
 #include <alpaka/block/shared/st/Traits.hpp>
 
+#include <alpaka/core/AlignedAlloc.hpp>
 #include <alpaka/core/Common.hpp>
-
-#include <boost/align.hpp>
 
 #include <vector>
 #include <memory>
@@ -57,7 +56,7 @@ namespace alpaka
                     std::vector<
                         std::unique_ptr<
                             uint8_t,
-                            boost::alignment::aligned_delete>> mutable
+                            core::AlignedDelete>> mutable
                         m_sharedAllocs;
 
                     std::function<void()> m_syncFn;
@@ -93,7 +92,7 @@ namespace alpaka
                             {
                                 blockSharedMemSt.m_sharedAllocs.emplace_back(
                                     reinterpret_cast<uint8_t *>(
-                                        boost::alignment::aligned_alloc(alignmentInBytes, sizeof(T))));
+                                        core::alignedAlloc(alignmentInBytes, sizeof(T))));
                             }
                             blockSharedMemSt.m_syncFn();
 

--- a/include/alpaka/block/shared/st/BlockSharedMemStNoSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStNoSync.hpp
@@ -12,9 +12,8 @@
 #include <alpaka/core/Vectorize.hpp>
 #include <alpaka/block/shared/st/Traits.hpp>
 
+#include <alpaka/core/AlignedAlloc.hpp>
 #include <alpaka/core/Common.hpp>
-
-#include <boost/align.hpp>
 
 #include <vector>
 #include <memory>
@@ -51,7 +50,7 @@ namespace alpaka
                     std::vector<
                         std::unique_ptr<
                             uint8_t,
-                            boost::alignment::aligned_delete>> mutable
+                            core::AlignedDelete>> mutable
                         m_sharedAllocs;
                 };
 
@@ -79,7 +78,7 @@ namespace alpaka
 
                             blockSharedMemSt.m_sharedAllocs.emplace_back(
                                 reinterpret_cast<uint8_t *>(
-                                    boost::alignment::aligned_alloc(alignmentInBytes, sizeof(T))));
+                                    core::alignedAlloc(alignmentInBytes, sizeof(T))));
                             return
                                 std::ref(
                                     *reinterpret_cast<T*>(

--- a/include/alpaka/core/AlignedAlloc.hpp
+++ b/include/alpaka/core/AlignedAlloc.hpp
@@ -1,0 +1,72 @@
+/* Copyright 2020 René Widera
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/BoostPredef.hpp>
+#include <alpaka/core/Common.hpp>
+
+#if BOOST_COMP_MSVC
+    #include <malloc.h>
+#else
+    #include <cstdlib>
+#endif
+
+namespace alpaka
+{
+    namespace core
+    {
+        //-----------------------------------------------------------------------------
+        //! Rounds to the next higher power of two (if not already power of two).
+        // Adapted from llvm/ADT/SmallPtrSet.h
+        ALPAKA_FN_INLINE ALPAKA_FN_HOST
+        void* alignedAlloc(size_t alignment, size_t size)
+        {
+#if BOOST_OS_WINDOWS
+            return _aligned_malloc(size, alignment);
+#elif BOOST_OS_MACOS
+            void * ptr = nullptr;
+            posix_memalign(&ptr, alignment, size);
+            return ptr;
+#else
+            // the amount of bytes to allocate must be a multiple of the alignment
+            size_t sizeToAllocate = ((size + alignment - 1u) / alignment) * alignment;
+            return ::aligned_alloc(alignment, sizeToAllocate);
+#endif
+        }
+
+        ALPAKA_FN_INLINE ALPAKA_FN_HOST
+        void alignedFree(void* ptr)
+        {
+#if BOOST_OS_WINDOWS
+            _aligned_free(ptr);
+#else
+            // linux and macos
+            free(ptr);
+#endif
+        }
+
+        //#############################################################################
+        //! destroy aligned object and free aligned memory
+        struct AlignedDelete
+        {
+            constexpr AlignedDelete() = default;
+
+            //-----------------------------------------------------------------------------
+            //! Calls ~T() on ptr to destroy the object and then calls aligned_free to free the allocated memory.
+            template<typename T>
+            void operator()(T* ptr) const
+            {
+                if (ptr)
+                    ptr->~T();
+                alignedFree(reinterpret_cast<void*>(ptr));
+            }
+        };
+    }
+}

--- a/include/alpaka/mem/alloc/AllocCpuAligned.hpp
+++ b/include/alpaka/mem/alloc/AllocCpuAligned.hpp
@@ -11,10 +11,9 @@
 
 #include <alpaka/mem/alloc/Traits.hpp>
 
+#include <alpaka/core/AlignedAlloc.hpp>
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Unused.hpp>
-
-#include <boost/align.hpp>
 
 #include <algorithm>
 
@@ -32,7 +31,7 @@ namespace alpaka
             //! \tparam TAlignment An integral constant containing the alignment.
             template<
                 typename TAlignment>
-            class AllocCpuBoostAligned : public concepts::Implements<ConceptMemAlloc, AllocCpuBoostAligned<TAlignment>>
+            class AllocCpuAligned : public concepts::Implements<ConceptMemAlloc, AllocCpuAligned<TAlignment>>
             {
             };
 
@@ -45,11 +44,11 @@ namespace alpaka
                     typename TAlignment>
                 struct Alloc<
                     T,
-                    AllocCpuBoostAligned<TAlignment>>
+                    AllocCpuAligned<TAlignment>>
                 {
                     //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST static auto alloc(
-                        AllocCpuBoostAligned<TAlignment> const & alloc,
+                        AllocCpuAligned<TAlignment> const & alloc,
                         std::size_t const & sizeElems)
                     -> T *
                     {
@@ -70,7 +69,7 @@ namespace alpaka
                         alpaka::ignore_unused(alloc);
                         return
                             reinterpret_cast<T *>(
-                                boost::alignment::aligned_alloc(std::max(TAlignment::value, minAlignement), sizeElems * sizeof(T)));
+                                core::alignedAlloc(std::max(TAlignment::value, minAlignement), sizeElems * sizeof(T)));
                     }
                 };
 
@@ -81,16 +80,16 @@ namespace alpaka
                     typename TAlignment>
                 struct Free<
                     T,
-                    AllocCpuBoostAligned<TAlignment>>
+                    AllocCpuAligned<TAlignment>>
                 {
                     //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST static auto free(
-                        AllocCpuBoostAligned<TAlignment> const & alloc,
+                        AllocCpuAligned<TAlignment> const & alloc,
                         T const * const ptr)
                     -> void
                     {
                         alpaka::ignore_unused(alloc);
-                            boost::alignment::aligned_free(
+                            core::alignedFree(
                                 const_cast<void *>(
                                     reinterpret_cast<void const *>(ptr)));
                     }

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -25,7 +25,7 @@
     #include <alpaka/core/Hip.hpp>
 #endif
 
-#include <alpaka/mem/alloc/AllocCpuBoostAligned.hpp>
+#include <alpaka/mem/alloc/AllocCpuAligned.hpp>
 
 #include <alpaka/meta/DependentFalseType.hpp>
 
@@ -49,7 +49,7 @@ namespace alpaka
                         typename TDim,
                         typename TIdx>
                     class BufCpuImpl final :
-                        public mem::alloc::AllocCpuBoostAligned<std::integral_constant<std::size_t, core::vectorization::defaultAlignment>>
+                        public mem::alloc::AllocCpuAligned<std::integral_constant<std::size_t, core::vectorization::defaultAlignment>>
                     {
                         static_assert(
                             !std::is_const<TElem>::value,
@@ -64,7 +64,7 @@ namespace alpaka
                         ALPAKA_FN_HOST BufCpuImpl(
                             dev::DevCpu const & dev,
                             TExtent const & extent) :
-                                mem::alloc::AllocCpuBoostAligned<std::integral_constant<std::size_t, core::vectorization::defaultAlignment>>(),
+                                mem::alloc::AllocCpuAligned<std::integral_constant<std::size_t, core::vectorization::defaultAlignment>>(),
                                 m_dev(dev),
                                 m_extentElements(extent::getExtentVecEnd<TDim>(extent)),
                                 m_pMem(mem::alloc::alloc<TElem>(*this, static_cast<std::size_t>(computeElementCount(extent)))),


### PR DESCRIPTION
based on the suggestions from https://github.com/alpaka-group/alpaka/issues/481#issuecomment-472366903 and https://github.com/alpaka-group/alpaka/issues/481#issuecomment-659666315

- remove dependency to boost aligned allocation
- remove boost in filenames which was providing aligned memory via boost
implementations
- add `AlignedAlloc.hpp`

- [x] need tests on OpenPower system

