### PR TITLE
CMake: First draft of first-class CUDA support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 ################################################################################
 # Required CMake version
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.18)
 
 cmake_policy(SET CMP0091 OLD)
 

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -296,7 +296,7 @@ if(ALPAKA_ACC_GPU_CUDA_ENABLE)
 
     if(CMAKE_CUDA_COMPILER)
         enable_language(CUDA)
-        find_package(CUDAToolkit VERSION 9.0 REQUIRED)
+        find_package(CUDAToolkit 9.0 REQUIRED)
 
         set_target_properties(alpaka PROPERTIES
                               CUDA_STANDARD ${ALPAKA_CXX_STANDARD}
@@ -765,4 +765,3 @@ if((ALPAKA_ACC_GPU_CUDA_ENABLE OR ALPAKA_ACC_GPU_HIP_ENABLE) AND ALPAKA_CUDA_COM
     string(TOUPPER "${CMAKE_BUILD_TYPE}" build_config)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${build_config}}")
 endif()
-


### PR DESCRIPTION
This is an early draft PR for integrating CMake's first class CUDA support, intended for discussion. Functionality-wise it is mostly the same as our old FindCUDA-based approach. Things that are different:

* No more appending of compiler flags to weird lists. Instead we can now use `target_compile_options`, `target_compile_definitions` and so on.
* The host compiler checks were removed. There is currently no way to identify the host compiler with CMake's first class CUDA support, see https://gitlab.kitware.com/cmake/cmake/-/issues/20901 for reference. Note that the host compiler no longer has to be identical to `CMAKE_CXX_COMPILER`.
* Verbose builds for debugging purposes are now triggered by `cmake --build --verbose` instead of setting an `ALPAKA_DEBUG` level. This is because `CUDA_VERBOSE_BUILD` is no longer available.

TODO:

* Set examples and test cases to CMake 3.18.