### PR TITLE
fix error handling CUDA/HIP

### DIFF
--- a/include/alpaka/core/UniformCudaHip.hpp
+++ b/include/alpaka/core/UniformCudaHip.hpp
@@ -90,6 +90,11 @@ namespace alpaka
                     {
                         rtCheck(error, ("'" + std::string(cmd) + "' returned error ").c_str(), file, line);
                     }
+                    else
+                    {
+                        // reset the last error to avoid propagation to the next CUDA/HIP API call
+                        ALPAKA_API_PREFIX(GetLastError)();
+                    }
                 }
             }
             //-----------------------------------------------------------------------------


### PR DESCRIPTION
Avoid that an error from CUDA/HIP which is ignored by alpaka is throwing with the next API call.

A typical case in alpaka is the error: `cudaErrorNotReady` if we do an event querry.