### PR TITLE
ALPAKA_DECAY_T: Fix INTEL detection, Add PGI

### DIFF
--- a/include/alpaka/core/Decay.hpp
+++ b/include/alpaka/core/Decay.hpp
@@ -26,7 +26,7 @@
 // in parameter pack expansion expressions is to avoid warnings from diagnostic
 // tools, and also for brevity.
 //-----------------------------------------------------------------------------
-#ifdef BOOST_COMP_INTEL
+#if BOOST_COMP_INTEL || BOOST_COMP_PGI
     #define ALPAKA_DECAY_T(Type) typename std::decay<Type>::type
 #else
     #define ALPAKA_DECAY_T(Type) std::decay_t<Type>


### PR DESCRIPTION
The test `#ifdef BOOST_COMP_INTEL` thinks every compiler is Intel.