### PR TITLE
BlockSharedMemDynMember::staticAllocBytes: -> function

### DIFF
--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -184,7 +184,7 @@ namespace alpaka
                         // m_threadElemCountMax
                         std::numeric_limits<TIdx>::max(),
                         // m_sharedMemSizeBytes
-                        static_cast<size_t>( acc::AccCpuOmp2Blocks<TDim, TIdx>::staticAllocBytes )};
+                        static_cast<size_t>( acc::AccCpuOmp2Blocks<TDim, TIdx>::staticAllocBytes() )};
                 }
             };
             //#############################################################################

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -178,7 +178,7 @@ namespace alpaka
                         // m_threadElemCountMax
                         std::numeric_limits<TIdx>::max(),
                         // m_sharedMemSizeBytes
-                        static_cast< size_t >( acc::AccCpuSerial<TDim, TIdx>::staticAllocBytes )};
+                        static_cast< size_t >( acc::AccCpuSerial<TDim, TIdx>::staticAllocBytes() )};
                 }
             };
             //#############################################################################

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -176,7 +176,7 @@ namespace alpaka
                         // m_threadElemCountMax
                         std::numeric_limits<TIdx>::max(),
                         // m_sharedMemSizeBytes
-                        static_cast< size_t >( acc::AccCpuTbbBlocks<TDim, TIdx>::staticAllocBytes )};
+                        static_cast< size_t >( acc::AccCpuTbbBlocks<TDim, TIdx>::staticAllocBytes() )};
                 }
 
             };


### PR DESCRIPTION
GCC does not allow static const/constexpr data members in types mapped to a targetd device in OpenMP 4.5 and OpenACC. At the moment, GCC is the only compiler which can compile some alpaka examples (helloWorld, vectorAdd) with OpenACC and give something that runs successfully (compile with `-foffload=disabled` and run with `export ACC_DEVICE_TYPE=host`), but this at least provides some syntax checking.

I hoped, that `BlockSharedMemDynMember::staticAllocBytes` would remain private and thus only had this workaround on the OpenACC branch. Because it became `public` the workaround needs to be public, too.