### PR TITLE
Pgi std atomic workaround

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -96,6 +96,11 @@ if(NOT TARGET alpaka)
     add_library(alpaka INTERFACE)
 
     target_compile_features(alpaka INTERFACE cxx_std_${ALPAKA_CXX_STANDARD})
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
+        # Workaround for STL atomic issue: https://forums.developer.nvidia.com/t/support-for-atomic-in-libstdc-missing/135403/2
+        # still appears in NVHPC 20.7
+        target_compile_definitions(alpaka INTERFACE "__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1")
+    endif()
 
     add_library(alpaka::alpaka ALIAS alpaka)
 endif()

--- a/test/catch_main/CMakeLists.txt
+++ b/test/catch_main/CMakeLists.txt
@@ -30,6 +30,11 @@ set_target_properties(CatchMain PROPERTIES
 )
 
 target_compile_definitions(CatchMain PUBLIC "CATCH_CONFIG_FAST_COMPILE")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
+    # Workaround for STL atomic issue: https://forums.developer.nvidia.com/t/support-for-atomic-in-libstdc-missing/135403/2
+    # still appears in NVHPC 20.7
+    target_compile_definitions(CatchMain PUBLIC "__GCC_ATOMIC_TEST_AND_SET_TRUEVAL=1")
+endif()
 if(MSVC)
     target_compile_definitions(CatchMain PUBLIC "CATCH_CONFIG_WINDOWS_CRTDBG")
     target_compile_options(CatchMain PUBLIC "/bigobj")

--- a/test/unit/mem/copy/CMakeLists.txt
+++ b/test/unit/mem/copy/CMakeLists.txt
@@ -21,4 +21,8 @@ target_link_libraries(
 
 set_target_properties(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "PGI")
+    target_compile_options(${_TARGET_NAME} PRIVATE "-Wc,--pending_instantiations=196")
+endif()
+
 add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME} ${_ALPAKA_TEST_OPTIONS})


### PR DESCRIPTION
This issue seems to have appeared with PGI before, but I noticed it first with NVHPC 20.7.
https://forums.developer.nvidia.com/t/support-for-atomic-in-libstdc-missing/135403/2

Not sure if we should put it this workaround in the code or if we should just wait for the next version...