### PR TITLE
Add IntrinsicFallback: basic fallback implementations

### DIFF
--- a/include/alpaka/intrinsic/IntrinsicCpu.hpp
+++ b/include/alpaka/intrinsic/IntrinsicCpu.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/BoostPredef.hpp>
 #include <alpaka/intrinsic/Traits.hpp>
+#include <alpaka/intrinsic/IntrinsicFallback.hpp>
 
 #include <bitset>
 
@@ -103,7 +104,7 @@ namespace alpaka
                     else
                         return 0;
 #else
-                    return ffsFallback(value);
+                    return intrinsic::detail::ffsFallback(value);
 #endif
                 }
 
@@ -124,26 +125,8 @@ namespace alpaka
                     else
                         return 0;
 #else
-                    return ffsFallback(value);
+                    return intrinsic::detail::ffsFallback(value);
 #endif
-                }
-            private:
-
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TValue>
-                static auto ffsFallback(TValue value)
-                -> std::int32_t
-                {
-                    if (value == 0)
-                        return 0;
-                    std::int32_t result = 1;
-                    while ((value & 1) == 0)
-                    {
-                        value >>= 1;
-                        result++;
-                    }
-                    return result;
                 }
             };
         }

--- a/include/alpaka/intrinsic/IntrinsicFallback.hpp
+++ b/include/alpaka/intrinsic/IntrinsicFallback.hpp
@@ -1,0 +1,125 @@
+/* Copyright 2020 Sergei Bastrakov, Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/intrinsic/Traits.hpp>
+
+namespace alpaka
+{
+    namespace intrinsic
+    {
+        namespace detail
+        {
+            //#############################################################################
+            //! Fallback implementaion of popcount.
+            template<
+                typename TValue>
+            static auto popcountFallback(TValue value)
+            -> std::int32_t
+            {
+                std::uint32_t count = 0;
+                while(value != 0)
+                {
+                    count += value & 1u;
+                    value >>= 1u;
+                }
+                return static_cast<std::int32_t>(count);
+            }
+
+            //#############################################################################
+            //! Fallback implementaion of ffs.
+            template<
+                typename TValue>
+            static auto ffsFallback(TValue value)
+            -> std::int32_t
+            {
+                if (value == 0)
+                    return 0;
+                std::int32_t result = 1;
+                while ((value & 1) == 0)
+                {
+                    value >>= 1;
+                    result++;
+                }
+                return result;
+            }
+        }
+
+        //#############################################################################
+        //! The Fallback intrinsic.
+        class IntrinsicFallback : public concepts::Implements<ConceptIntrinsic, IntrinsicFallback>
+        {
+        public:
+            //-----------------------------------------------------------------------------
+            IntrinsicFallback() = default;
+            //-----------------------------------------------------------------------------
+            IntrinsicFallback(IntrinsicFallback const &) = delete;
+            //-----------------------------------------------------------------------------
+            IntrinsicFallback(IntrinsicFallback &&) = delete;
+            //-----------------------------------------------------------------------------
+            auto operator=(IntrinsicFallback const &) -> IntrinsicFallback & = delete;
+            //-----------------------------------------------------------------------------
+            auto operator=(IntrinsicFallback &&) -> IntrinsicFallback & = delete;
+            //-----------------------------------------------------------------------------
+            ~IntrinsicFallback() = default;
+        };
+
+        namespace traits
+        {
+            //#############################################################################
+            template<>
+            struct Popcount<
+                IntrinsicFallback>
+            {
+                //-----------------------------------------------------------------------------
+                static auto popcount(
+                    intrinsic::IntrinsicFallback const & /*intrinsic*/,
+                    std::uint32_t value)
+                -> std::int32_t
+                {
+                    return intrinsic::detail::popcountFallback(value);
+                }
+
+                //-----------------------------------------------------------------------------
+                static auto popcount(
+                    intrinsic::IntrinsicFallback const & /*intrinsic*/,
+                    std::uint64_t value)
+                -> std::int32_t
+                {
+                    return intrinsic::detail::popcountFallback(value);
+                }
+            };
+
+            //#############################################################################
+            template<>
+            struct Ffs<
+                IntrinsicFallback>
+            {
+                //-----------------------------------------------------------------------------
+                static auto ffs(
+                    intrinsic::IntrinsicFallback const & /*intrinsic*/,
+                    std::int32_t value)
+                -> std::int32_t
+                {
+                    return intrinsic::detail::ffsFallback(value);
+                }
+
+                //-----------------------------------------------------------------------------
+                static auto ffs(
+                    intrinsic::IntrinsicFallback const & /*intrinsic*/,
+                    std::int64_t value)
+                -> std::int32_t
+                {
+                    return intrinsic::detail::ffsFallback(value);
+                }
+            };
+        }
+    }
+}

--- a/test/unit/warp/src/Activemask.cpp
+++ b/test/unit/warp/src/Activemask.cpp
@@ -103,7 +103,7 @@ TEMPLATE_LIST_TEST_CASE( "activemask", "[warp]", alpaka::test::acc::TestAccs)
     else
     {
         // Work around gcc 7.5 trying and failing to offload for OpenMP 4.0
-#if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 5, 0)) && ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+#if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 5, 0)) && defined ALPAKA_ACC_CPU_BT_OMP4_ENABLED
         return;
 #else
         using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;

--- a/test/unit/warp/src/All.cpp
+++ b/test/unit/warp/src/All.cpp
@@ -107,7 +107,7 @@ TEMPLATE_LIST_TEST_CASE( "all", "[warp]", alpaka::test::acc::TestAccs)
     else
     {
         // Work around gcc 7.5 trying and failing to offload for OpenMP 4.0
-#if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 5, 0)) && ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+#if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 5, 0)) && defined ALPAKA_ACC_CPU_BT_OMP4_ENABLED
         return;
 #else
         using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;

--- a/test/unit/warp/src/Any.cpp
+++ b/test/unit/warp/src/Any.cpp
@@ -107,7 +107,7 @@ TEMPLATE_LIST_TEST_CASE( "any", "[warp]", alpaka::test::acc::TestAccs)
     else
     {
         // Work around gcc 7.5 trying and failing to offload for OpenMP 4.0
-#if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 5, 0)) && ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+#if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 5, 0)) && defined ALPAKA_ACC_CPU_BT_OMP4_ENABLED
         return;
 #else
         using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;

--- a/test/unit/warp/src/Ballot.cpp
+++ b/test/unit/warp/src/Ballot.cpp
@@ -113,7 +113,7 @@ TEMPLATE_LIST_TEST_CASE( "ballot", "[warp]", alpaka::test::acc::TestAccs)
     else
     {
         // Work around gcc 7.5 trying and failing to offload for OpenMP 4.0
-#if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 5, 0)) && ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+#if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 5, 0)) && defined ALPAKA_ACC_CPU_BT_OMP4_ENABLED
         return;
 #else
         using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;


### PR DESCRIPTION
For OpenMP 5.0 target offload  and OpenACC we need basic implementations of these functions. There is currently no simple way of determining what target device code is being compiled for, we cannot safely decide which compiler buildins to call if any.

This PR adds the `IntrinsicFallback` implementation of the `Intrinsic` concept.

It uses the `ffsFallback` code from `IntrinsicCpu`. The actual implementations are located in a `detail` namespace instead of in the class. `IntrinsicCpu` is changed to use `ffsFallback` from there.