### PR TITLE
Fix and improve block shared mem st member sanity checks

### DIFF
--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -58,7 +58,7 @@ namespace alpaka
                             new (buf) T();
                             m_allocdBytes += sizeof(T);
 #if (defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (! defined NDEBUG)
-                            ALPAKA_ASSERT(m_allocdBytes < m_capacity);
+                            ALPAKA_ASSERT(m_allocdBytes <= m_capacity);
 #endif
                         }
 

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -59,8 +59,6 @@ namespace alpaka
                         void alloc() const
                         {
                             m_allocdBytes = allocPitch<T>();
-                            uint8_t* buf = &m_mem[m_allocdBytes];
-                            new (buf) T();
                             m_allocdBytes += sizeof(T);
 #if (defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (! defined NDEBUG)
                             ALPAKA_ASSERT(m_allocdBytes <= m_capacity);

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -35,7 +35,12 @@ namespace alpaka
                     public:
                         //-----------------------------------------------------------------------------
 #ifndef NDEBUG
-                        BlockSharedMemStMemberImpl(uint8_t* mem, unsigned int capacity) : m_mem(mem), m_capacity(capacity) {}
+                        BlockSharedMemStMemberImpl(uint8_t* mem, unsigned int capacity) : m_mem(mem), m_capacity(capacity)
+                        {
+#ifdef ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST
+                            ALPAKA_ASSERT( ( m_mem == nullptr ) == ( m_capacity == 0u ) );
+#endif
+                        }
 #else
                         BlockSharedMemStMemberImpl(uint8_t* mem, unsigned int) : m_mem(mem) {}
 #endif


### PR DESCRIPTION
First, the check was inaccurate: it is fine to allocate exactly the whole size, but the check did not allow it.

Then, moved the check to be before the unsafe part, instead of after. So that now a wrong usage triggers the check rather than crashes the program before it. Note that the case of `m_capacity = 0` and `m_mem = nullptr` is automatically covered now.

Edit: after discussion below, also removed placement `new` and added additional debug asserts.