### PR TITLE
Add set kernel

### DIFF
--- a/include/alpaka/idx/MapIdx.hpp
+++ b/include/alpaka/idx/MapIdx.hpp
@@ -161,17 +161,17 @@ namespace alpaka
         namespace detail
         {
             //#############################################################################
-            //! Maps a linear index to a N dimensional index.
+            //! Maps a linear index to a N dimensional index assuming a buffer wihtout padding.
             template<
                 std::size_t TidxDimOut,
                 std::size_t TidxDimIn,
                 typename TSfinae = void>
-            struct MapIdxPitch;
+            struct MapIdxPitchBytes;
             //#############################################################################
-            //! Maps a N dimensional index to the same N dimensional index.
+            //! Maps a N dimensional index to the same N dimensional index assuming a buffer wihtout padding.
             template<
                 std::size_t TidxDim>
-            struct MapIdxPitch<
+            struct MapIdxPitchBytes<
                 TidxDim,
                 TidxDim>
             {
@@ -179,11 +179,11 @@ namespace alpaka
                 // \tparam TElem Type of the index values.
                 // \param idx Idx to be mapped.
                 // \param pitch Spatial pitch (in elems) to map the index to
-                // \return A N dimensional vector.
+                // \return N dimensional vector.
                 ALPAKA_NO_HOST_ACC_WARNING
                 template<
                     typename TElem>
-                ALPAKA_FN_HOST_ACC static auto mapIdxPitch(
+                ALPAKA_FN_HOST_ACC static auto mapIdxPitchBytes(
                     vec::Vec<dim::DimInt<TidxDim>, TElem> const & idx,
                     vec::Vec<dim::DimInt<TidxDim>, TElem> const & pitch)
                 -> vec::Vec<dim::DimInt<TidxDim>, TElem>
@@ -194,10 +194,10 @@ namespace alpaka
                 }
             };
             //#############################################################################
-            //! Maps a 1 dimensional index to a N dimensional index.
+            //! Maps a 1 dimensional index to a N dimensional index assuming a buffer wihtout padding.
             template<
                 std::size_t TidxDimOut>
-            struct MapIdxPitch<
+            struct MapIdxPitchBytes<
                 TidxDimOut,
                 1u,
                 typename std::enable_if<TidxDimOut != 1u>::type>
@@ -206,11 +206,11 @@ namespace alpaka
                 // \tparam TElem Type of the index values.
                 // \param idx Idx to be mapped.
                 // \param pitch Spatial pitch (in elems) to map the index to
-                // \return A N dimensional vector.
+                // \return N dimensional vector.
                 ALPAKA_NO_HOST_ACC_WARNING
                 template<
                     typename TElem>
-                ALPAKA_FN_HOST_ACC static auto mapIdxPitch(
+                ALPAKA_FN_HOST_ACC static auto mapIdxPitchBytes(
                     vec::Vec<dim::DimInt<1u>, TElem> const & idx,
                     vec::Vec<dim::DimInt<TidxDimOut>, TElem> const & pitch)
                 -> vec::Vec<dim::DimInt<TidxDimOut>, TElem>
@@ -231,10 +231,10 @@ namespace alpaka
                 }
             };
             //#############################################################################
-            //! Maps a N dimensional index to a 1 dimensional index.
+            //! Maps a N dimensional index to a 1 dimensional index assuming a buffer wihtout padding.
             template<
                 std::size_t TidxDimIn>
-            struct MapIdxPitch<
+            struct MapIdxPitchBytes<
                 1u,
                 TidxDimIn,
                 typename std::enable_if<TidxDimIn != 1u>::type>
@@ -247,7 +247,7 @@ namespace alpaka
                 ALPAKA_NO_HOST_ACC_WARNING
                 template<
                     typename TElem>
-                ALPAKA_FN_HOST_ACC static auto mapIdxPitch(
+                ALPAKA_FN_HOST_ACC static auto mapIdxPitchBytes(
                     vec::Vec<dim::DimInt<TidxDimIn>, TElem> const & idx,
                     vec::Vec<dim::DimInt<TidxDimIn>, TElem> const & pitch)
                 -> vec::Vec<dim::DimInt<1u>, TElem>
@@ -264,7 +264,8 @@ namespace alpaka
         }
 
         //#############################################################################
-        //! Maps a N dimensional index to a N dimensional position.
+        //! Maps a N dimensional index to a N dimensional position based on
+        //! pitch in a buffer without padding or a byte buffer.
         //!
         //! \tparam TidxDimOut Dimension of the index vector to map to.
         //! \tparam TidxDimIn Dimension of the index vector to map from.
@@ -274,7 +275,7 @@ namespace alpaka
             std::size_t TidxDimOut,
             std::size_t TidxDimIn,
             typename TElem>
-        ALPAKA_FN_HOST_ACC auto mapIdxPitch(
+        ALPAKA_FN_HOST_ACC auto mapIdxPitchBytes(
             vec::Vec<dim::DimInt<TidxDimIn>, TElem> const & idx,
             vec::Vec<dim::DimInt<(TidxDimOut < TidxDimIn) ? TidxDimIn : TidxDimOut>, TElem> const & pitch)
         -> vec::Vec<dim::DimInt<TidxDimOut>, TElem>
@@ -283,10 +284,10 @@ namespace alpaka
             static_assert(TidxDimIn > 0u, "The dimension of the input vector has to be greater than zero!");
 
             return
-                detail::MapIdxPitch<
+                detail::MapIdxPitchBytes<
                     TidxDimOut,
                     TidxDimIn>
-                ::mapIdxPitch(
+                ::mapIdxPitchBytes(
                     idx,
                     pitch);
         }

--- a/include/alpaka/mem/buf/SetKernel.hpp
+++ b/include/alpaka/mem/buf/SetKernel.hpp
@@ -1,0 +1,80 @@
+/* Copyright 2020 Jeffrey Kelling
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/mem/buf/Traits.hpp>
+#include <alpaka/idx/Traits.hpp>
+#include <alpaka/idx/Accessors.hpp>
+#include <alpaka/idx/MapIdx.hpp>
+
+namespace alpaka
+{
+    namespace mem
+    {
+        namespace view
+        {
+            //#############################################################################
+            //! any device ND memory set kernel.
+            class MemSetKernel
+            {
+            public:
+                //-----------------------------------------------------------------------------
+                //! The kernel entry point.
+                //!
+                //! All but the last element of threadElemExtent must be one.
+                //!
+                //! \tparam TAcc The accelerator environment to be executed on.
+                //! \tparam TElem element type.
+                //! \tparam TExtent extent type.
+                //! \param acc The accelerator to be executed on.
+                //! \param val value to set.
+                //! \param dst target mem ptr.
+                //! \param extent area to set.
+                ALPAKA_NO_HOST_ACC_WARNING
+                template<
+                    typename TAcc,
+                    typename TElem,
+                    typename TExtent,
+                    typename TPitch>
+                ALPAKA_FN_ACC auto operator()(
+                    TAcc const & acc,
+                    TElem const val,
+                    TElem * dst,
+                    TExtent extent,
+                    TPitch pitch) const
+                -> void
+                {
+                    using Idx = typename idx::traits::IdxType<TExtent>::type;
+                    auto const gridThreadIdx(alpaka::idx::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+                    auto const threadElemExtent(alpaka::workdiv::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc));
+                    auto const idxThreadFirstElem = idx::getIdxThreadFirstElem(acc, gridThreadIdx, threadElemExtent);
+                    auto idx = idx::mapIdxPitch<1u, dim::Dim<TAcc>::value>(idxThreadFirstElem, pitch)[0];
+                    constexpr auto lastDim = dim::Dim<TAcc>::value - 1;
+                    const auto lastIdx = idx +
+                        std::min(threadElemExtent[lastDim], static_cast<Idx>(extent[lastDim]-idxThreadFirstElem[lastDim]));
+
+                    if ([&idxThreadFirstElem, &extent](){
+                            for(auto i = 0u; i < dim::Dim<TAcc>::value; ++i)
+                                if(idxThreadFirstElem[i] >= extent[i])
+                                    return false;
+                            return true;
+                        }())
+                    {
+                        // assuming elements = {1,1,...,1,n}
+                        for(; idx<lastIdx; ++idx)
+                        {
+                            *(dst + idx) = val;
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/test/unit/idx/src/MapIdxPitch.cpp
+++ b/test/unit/idx/src/MapIdxPitch.cpp
@@ -1,0 +1,56 @@
+/* Copyright 2020 Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <alpaka/idx/Accessors.hpp>
+#include <alpaka/idx/MapIdx.hpp>
+#include <alpaka/dev/Traits.hpp>
+#include <alpaka/mem/view/ViewPlainPtr.hpp>
+#include <alpaka/mem/view/ViewSubView.hpp>
+#include <alpaka/example/ExampleDefaultAcc.hpp>
+
+#include <alpaka/test/dim/TestDims.hpp>
+#include <alpaka/test/Extent.hpp>
+
+#include <catch2/catch.hpp>
+
+//-----------------------------------------------------------------------------
+TEMPLATE_LIST_TEST_CASE( "mapIdxPitch", "[idx]", alpaka::test::dim::TestDims)
+{
+    using Dim = TestType;
+    using Idx = std::size_t;
+    using Vec = alpaka::vec::Vec<Dim, Idx>;
+
+    auto const extentNd(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
+
+    using Acc = alpaka::example::ExampleDefaultAcc<Dim, Idx>;
+    using Dev = alpaka::dev::Dev<Acc>;
+    using Elem = int;
+    auto const devAcc = alpaka::pltf::getDevByIdx<Acc>(0u);
+    alpaka::mem::view::ViewPlainPtr<Dev, Elem, Dim, Idx> parentView( nullptr, devAcc, extentNd );
+
+    auto const offset(Vec::all(4u));
+    auto const extent(Vec::all(4u));
+    auto const idxNd(Vec::all(2u));
+    alpaka::mem::view::ViewSubView<Dev, Elem, Dim, Idx> view( parentView, extent, offset );
+    auto pitch = alpaka::mem::view::getPitchBytesVec(view);
+    for(Idx a = 0; a < Dim::value; ++a)
+        pitch[a] /= sizeof(Elem);
+
+    auto const idx1d(alpaka::idx::mapIdxPitch<1u>(idxNd, pitch));
+    auto const idx1dDelta(alpaka::idx::mapIdx<1u>(idxNd+offset, extentNd)
+            - alpaka::idx::mapIdx<1u>(offset, extentNd));
+
+    auto const idxNdResult(alpaka::idx::mapIdxPitch<Dim::value>(idx1d, pitch));
+
+    // linear index in pitched offset box should be the difference between
+    // linear index in parent box and linear index of offset
+    REQUIRE(idx1d == idx1dDelta);
+    // roundtrip
+    REQUIRE(idxNd == idxNdResult);
+}

--- a/test/unit/idx/src/MapIdxPitchBytes.cpp
+++ b/test/unit/idx/src/MapIdxPitchBytes.cpp
@@ -20,7 +20,7 @@
 #include <catch2/catch.hpp>
 
 //-----------------------------------------------------------------------------
-TEMPLATE_LIST_TEST_CASE( "mapIdxPitch", "[idx]", alpaka::test::dim::TestDims)
+TEMPLATE_LIST_TEST_CASE( "mapIdxPitchBytes", "[idx]", alpaka::test::dim::TestDims)
 {
     using Dim = TestType;
     using Idx = std::size_t;
@@ -30,7 +30,7 @@ TEMPLATE_LIST_TEST_CASE( "mapIdxPitch", "[idx]", alpaka::test::dim::TestDims)
 
     using Acc = alpaka::example::ExampleDefaultAcc<Dim, Idx>;
     using Dev = alpaka::dev::Dev<Acc>;
-    using Elem = int;
+    using Elem = std::uint8_t;
     auto const devAcc = alpaka::pltf::getDevByIdx<Acc>(0u);
     alpaka::mem::view::ViewPlainPtr<Dev, Elem, Dim, Idx> parentView( nullptr, devAcc, extentNd );
 
@@ -39,14 +39,12 @@ TEMPLATE_LIST_TEST_CASE( "mapIdxPitch", "[idx]", alpaka::test::dim::TestDims)
     auto const idxNd(Vec::all(2u));
     alpaka::mem::view::ViewSubView<Dev, Elem, Dim, Idx> view( parentView, extent, offset );
     auto pitch = alpaka::mem::view::getPitchBytesVec(view);
-    for(Idx a = 0; a < Dim::value; ++a)
-        pitch[a] /= sizeof(Elem);
 
-    auto const idx1d(alpaka::idx::mapIdxPitch<1u>(idxNd, pitch));
+    auto const idx1d(alpaka::idx::mapIdxPitchBytes<1u>(idxNd, pitch));
     auto const idx1dDelta(alpaka::idx::mapIdx<1u>(idxNd+offset, extentNd)
             - alpaka::idx::mapIdx<1u>(offset, extentNd));
 
-    auto const idxNdResult(alpaka::idx::mapIdxPitch<Dim::value>(idx1d, pitch));
+    auto const idxNdResult(alpaka::idx::mapIdxPitchBytes<Dim::value>(idx1d, pitch));
 
     // linear index in pitched offset box should be the difference between
     // linear index in parent box and linear index of offset


### PR DESCRIPTION
This PR adds a kernel which implement device memset in a generic way for use by OpenMP 5.0 and OpenAcc backends.

Also introduces ~~`MapIdxPitch`~~`MapIdxPitchBytes` which is similar to `MapIdxExtend` but works based on pitches to support views.