### PR TITLE
activate `-Wconversion` for tests 

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -87,6 +87,7 @@ namespace alpaka
             public warp::WarpSingleThread,
             public concepts::Implements<ConceptAcc, AccCpuFibers<TDim, TIdx>>
         {
+            static_assert(sizeof(TIdx) >= sizeof(int), "Index type is not supported, consider using int or a larger type.");
         public:
             // Partial specialization with the correct TDim and TIdx is not allowed.
             template<

--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -102,7 +102,7 @@ namespace alpaka
                 typename TWorkDiv>
             ALPAKA_FN_HOST AccCpuFibers(
                 TWorkDiv const & workDiv,
-                TIdx const & blockSharedMemDynSizeBytes) :
+                std::size_t const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TIdx>(workDiv),
                     idx::gb::IdxGbRef<TDim, TIdx>(m_gridBlockIdx),
                     idx::bt::IdxBtRefFiberIdMap<TDim, TIdx>(m_fibersToIndices),
@@ -112,7 +112,7 @@ namespace alpaka
                         atomic::AtomicNoOp         // atomics between threads
                     >(),
                     math::MathStdLib(),
-                    block::shared::dyn::BlockSharedMemDynAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
+                    block::shared::dyn::BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
                     block::shared::st::BlockSharedMemStMasterSync(
                         [this](){block::sync::syncBlockThreads(*this);},
                         [this](){return (m_masterFiberId == boost::this_fiber::get_id());}),

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -88,6 +88,7 @@ namespace alpaka
             public warp::WarpSingleThread,
             public concepts::Implements<ConceptAcc, AccCpuOmp2Blocks<TDim, TIdx>>
         {
+            static_assert(sizeof(TIdx) >= sizeof(int), "Index type is not supported, consider using int or a larger type.");
         public:
             // Partial specialization with the correct TDim and TIdx is not allowed.
             template<

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -103,7 +103,7 @@ namespace alpaka
                 typename TWorkDiv>
             ALPAKA_FN_HOST AccCpuOmp2Blocks(
                 TWorkDiv const & workDiv,
-                TIdx const & blockSharedMemDynSizeBytes) :
+                std::size_t const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TIdx>(workDiv),
                     idx::gb::IdxGbRef<TDim, TIdx>(m_gridBlockIdx),
                     idx::bt::IdxBtZero<TDim, TIdx>(),
@@ -113,7 +113,7 @@ namespace alpaka
                         atomic::AtomicNoOp        // atomics between threads
                     >(),
                     math::MathStdLib(),
-                    block::shared::dyn::BlockSharedMemDynMember<>(static_cast<unsigned int>(blockSharedMemDynSizeBytes)),
+                    block::shared::dyn::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
                     block::shared::st::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
                     block::sync::BlockSyncNoOp(),
                     rand::RandStdLib(),

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -89,6 +89,7 @@ namespace alpaka
             public warp::WarpSingleThread,
             public concepts::Implements<ConceptAcc, AccCpuOmp2Threads<TDim, TIdx>>
         {
+            static_assert(sizeof(TIdx) >= sizeof(int), "Index type is not supported, consider using int or a larger type.");
         public:
             // Partial specialization with the correct TDim and TIdx is not allowed.
             template<

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -104,7 +104,7 @@ namespace alpaka
                 typename TWorkDiv>
             ALPAKA_FN_HOST AccCpuOmp2Threads(
                 TWorkDiv const & workDiv,
-                TIdx const & blockSharedMemDynSizeBytes) :
+                std::size_t const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TIdx>(workDiv),
                     idx::gb::IdxGbRef<TDim, TIdx>(m_gridBlockIdx),
                     idx::bt::IdxBtOmp<TDim, TIdx>(),
@@ -114,7 +114,7 @@ namespace alpaka
                         atomic::AtomicOmpBuiltIn  // atomics between threads
                     >(),
                     math::MathStdLib(),
-                    block::shared::dyn::BlockSharedMemDynAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
+                    block::shared::dyn::BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
                     block::shared::st::BlockSharedMemStMasterSync(
                         [this](){block::sync::syncBlockThreads(*this);},
                         [](){return (::omp_get_thread_num() == 0);}),

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -82,6 +82,7 @@ namespace alpaka
             public warp::WarpSingleThread,
             public concepts::Implements<ConceptAcc, AccCpuSerial<TDim, TIdx>>
         {
+            static_assert(sizeof(TIdx) >= sizeof(int), "Index type is not supported, consider using int or a larger type.");
         public:
             // Partial specialization with the correct TDim and TIdx is not allowed.
             template<

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -97,7 +97,7 @@ namespace alpaka
                 typename TWorkDiv>
             ALPAKA_FN_HOST AccCpuSerial(
                 TWorkDiv const & workDiv,
-                TIdx const & blockSharedMemDynSizeBytes) :
+                size_t const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TIdx>(workDiv),
                     idx::gb::IdxGbRef<TDim, TIdx>(m_gridBlockIdx),
                     idx::bt::IdxBtZero<TDim, TIdx>(),
@@ -107,7 +107,7 @@ namespace alpaka
                         atomic::AtomicNoOp         // atomics between threads
                     >(),
                     math::MathStdLib(),
-                    block::shared::dyn::BlockSharedMemDynMember<>(static_cast<unsigned int>(blockSharedMemDynSizeBytes)),
+                    block::shared::dyn::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
                     block::shared::st::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
                     block::sync::BlockSyncNoOp(),
                     rand::RandStdLib(),

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -80,6 +80,7 @@ namespace alpaka
             public warp::WarpSingleThread,
             public concepts::Implements<ConceptAcc, AccCpuTbbBlocks<TDim, TIdx>>
         {
+            static_assert(sizeof(TIdx) >= sizeof(int), "Index type is not supported, consider using int or a larger type.");
         public:
             // Partial specialization with the correct TDim and TIdx is not allowed.
             template<

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -95,7 +95,7 @@ namespace alpaka
                 typename TWorkDiv>
             ALPAKA_FN_HOST AccCpuTbbBlocks(
                 TWorkDiv const & workDiv,
-                TIdx const & blockSharedMemDynSizeBytes) :
+                std::size_t const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TIdx>(workDiv),
                     idx::gb::IdxGbRef<TDim, TIdx>(m_gridBlockIdx),
                     idx::bt::IdxBtZero<TDim, TIdx>(),
@@ -105,7 +105,7 @@ namespace alpaka
                         atomic::AtomicNoOp         // atomics between threads
                     >(),
                     math::MathStdLib(),
-                    block::shared::dyn::BlockSharedMemDynMember<>(static_cast<unsigned int>(blockSharedMemDynSizeBytes)),
+                    block::shared::dyn::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
                     block::shared::st::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
                     block::sync::BlockSyncNoOp(),
                     rand::RandStdLib(),

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -99,7 +99,7 @@ namespace alpaka
                 typename TWorkDiv>
             ALPAKA_FN_HOST AccCpuThreads(
                 TWorkDiv const & workDiv,
-                TIdx const & blockSharedMemDynSizeBytes) :
+                std::size_t const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TIdx>(workDiv),
                     idx::gb::IdxGbRef<TDim, TIdx>(m_gridBlockIdx),
                     idx::bt::IdxBtRefThreadIdMap<TDim, TIdx>(m_threadToIndexMap),
@@ -109,7 +109,7 @@ namespace alpaka
                         atomic::AtomicStdLibLock<16>  // atomics between threads
                     >(),
                     math::MathStdLib(),
-                    block::shared::dyn::BlockSharedMemDynAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
+                    block::shared::dyn::BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
                     block::shared::st::BlockSharedMemStMasterSync(
                         [this](){block::sync::syncBlockThreads(*this);},
                         [this](){return (m_idMasterThread == std::this_thread::get_id());}),

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -84,6 +84,7 @@ namespace alpaka
             public warp::WarpSingleThread,
             public concepts::Implements<ConceptAcc, AccCpuThreads<TDim, TIdx>>
         {
+            static_assert(sizeof(TIdx) >= sizeof(int), "Index type is not supported, consider using int or a larger type.");
         public:
             // Partial specialization with the correct TDim and TIdx is not allowed.
             template<

--- a/include/alpaka/acc/AccDevProps.hpp
+++ b/include/alpaka/acc/AccDevProps.hpp
@@ -29,6 +29,7 @@ namespace alpaka
             typename TIdx>
         struct AccDevProps
         {
+            static_assert(sizeof(TIdx) >= sizeof(int), "Index type is not supported, consider using int or a larger type.");
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST AccDevProps(
                 TIdx const & multiProcessorCount,

--- a/include/alpaka/acc/AccGpuCudaRt.hpp
+++ b/include/alpaka/acc/AccGpuCudaRt.hpp
@@ -57,6 +57,7 @@ namespace alpaka
             public acc::AccGpuUniformCudaHipRt<TDim,TIdx>,
             public concepts::Implements<ConceptUniformCudaHip, AccGpuUniformCudaHipRt<TDim, TIdx>>
         {
+            static_assert(sizeof(TIdx) >= sizeof(int), "Index type is not supported, consider using int or a larger type.");
         public:
             //-----------------------------------------------------------------------------
             __device__ AccGpuCudaRt(

--- a/include/alpaka/acc/AccGpuHipRt.hpp
+++ b/include/alpaka/acc/AccGpuHipRt.hpp
@@ -56,6 +56,7 @@ namespace alpaka
             public acc::AccGpuUniformCudaHipRt<TDim,TIdx>,
             public concepts::Implements<ConceptUniformCudaHip, AccGpuUniformCudaHipRt<TDim, TIdx>>
         {
+            static_assert(sizeof(TIdx) >= sizeof(int), "Index type is not supported, consider using int or a larger type.");
         public:
             //-----------------------------------------------------------------------------
             __device__ AccGpuHipRt(

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -90,6 +90,7 @@ namespace alpaka
             public warp::WarpUniformCudaHipBuiltIn,
             public concepts::Implements<ConceptAcc, AccGpuUniformCudaHipRt<TDim, TIdx>>
         {
+            static_assert(sizeof(TIdx) >= sizeof(int), "Index type is not supported, consider using int or a larger type.");
         public:
             //-----------------------------------------------------------------------------
             __device__ AccGpuUniformCudaHipRt(

--- a/include/alpaka/acc/AccOmp5.hpp
+++ b/include/alpaka/acc/AccOmp5.hpp
@@ -86,6 +86,7 @@ namespace alpaka
             public warp::WarpSingleThread,
             public concepts::Implements<ConceptAcc, AccOmp5<TDim, TIdx>>
         {
+            static_assert(sizeof(TIdx) >= sizeof(int), "Index type is not supported, consider using int or a larger type.");
         public:
             // Partial specialization with the correct TDim and TIdx is not allowed.
             template<

--- a/include/alpaka/acc/AccOmp5.hpp
+++ b/include/alpaka/acc/AccOmp5.hpp
@@ -102,7 +102,7 @@ namespace alpaka
                 vec::Vec<TDim, TIdx> const & blockThreadExtent,
                 vec::Vec<TDim, TIdx> const & threadElemExtent,
                 TIdx const & gridBlockIdx,
-                TIdx const & blockSharedMemDynSizeBytes) :
+                std::size_t const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TIdx>(gridBlockExtent, blockThreadExtent, threadElemExtent),
                     idx::gb::IdxGbLinear<TDim, TIdx>(gridBlockIdx),
                     idx::bt::IdxBtOmp<TDim, TIdx>(),
@@ -112,7 +112,7 @@ namespace alpaka
                         atomic::AtomicOmpBuiltIn  // atomics between threads
                     >(),
                     math::MathStdLib(),
-                    block::shared::dyn::BlockSharedMemDynMember<>(static_cast<unsigned int>(blockSharedMemDynSizeBytes)),
+                    block::shared::dyn::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
                     //! \TODO can with some TMP determine the amount of statically alloced smem from the kernelFuncObj?
                     block::shared::st::BlockSharedMemStOmp5(staticMemBegin(), staticMemCapacity()),
                     block::sync::BlockSyncBarrierOmp(),

--- a/include/alpaka/atomic/Op.hpp
+++ b/include/alpaka/atomic/Op.hpp
@@ -38,8 +38,15 @@ namespace alpaka
                 {
                     auto const old(*addr);
                     auto & ref(*addr);
+#if BOOST_COMP_GNUC 
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wconversion"
+#endif
                     ref += value;
                     return old;
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic pop
+#endif
                 }
             };
             //#############################################################################
@@ -58,7 +65,14 @@ namespace alpaka
                 {
                     auto const old(*addr);
                     auto & ref(*addr);
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wconversion"
+#endif
                     ref -= value;
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic pop
+#endif
                     return old;
                 }
             };
@@ -140,7 +154,7 @@ namespace alpaka
                 {
                     auto const old(*addr);
                     auto & ref(*addr);
-                    ref = ((old >= value) ? 0 : old + 1);
+                    ref = ((old >= value) ? 0 : static_cast<T>(old + 1));
                     return old;
                 }
             };
@@ -162,7 +176,7 @@ namespace alpaka
                 {
                     auto const old(*addr);
                     auto & ref(*addr);
-                    ref = (((old == 0) || (old > value)) ? value : (old - 1));
+                    ref = (((old == 0) || (old > value)) ? value : static_cast<T>(old - 1));
                     return old;
                 }
             };

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -34,11 +34,11 @@ namespace alpaka
                     //! "namespace" for static constexpr members that should be in BlockSharedMemDynMember
                     //! but cannot be because having a static const member breaks GCC 10
                     //! OpenMP target and OpenACC: type not mappable.
-                    template<unsigned int TStaticAllocKiB>
+                    template<std::size_t TStaticAllocKiB>
                     struct BlockSharedMemDynMemberStatic
                     {
                         //! Storage size in bytes
-                        static constexpr unsigned int staticAllocBytes = TStaticAllocKiB<<10;
+                        static constexpr std::size_t staticAllocBytes = TStaticAllocKiB<<10;
                     };
                 }
 
@@ -50,15 +50,15 @@ namespace alpaka
                 //! Dynamic block shared memory provider using fixed-size
                 //! member array to allocate memory on the stack or in shared
                 //! memory.
-                template<unsigned int TStaticAllocKiB = ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB>
+                template<std::size_t TStaticAllocKiB = ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB>
                 class alignas(core::vectorization::defaultAlignment) BlockSharedMemDynMember :
                     public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynMember<TStaticAllocKiB>>
                 {
                 public:
                     //-----------------------------------------------------------------------------
-                    BlockSharedMemDynMember(unsigned int sizeBytes)
-                        : m_dynPitch((sizeBytes/core::vectorization::defaultAlignment
-                             + (sizeBytes%core::vectorization::defaultAlignment>0))*core::vectorization::defaultAlignment)
+                    BlockSharedMemDynMember(std::size_t sizeBytes)
+                        : m_dynPitch((sizeBytes / core::vectorization::defaultAlignment
+                             + (sizeBytes % core::vectorization::defaultAlignment > 0u)) * core::vectorization::defaultAlignment)
                     {
 #if (defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (! defined NDEBUG)
                         ALPAKA_ASSERT(sizeBytes <= staticAllocBytes());
@@ -86,18 +86,18 @@ namespace alpaka
 
                     /*! \return the remaining capacity for static block shared memory.
                      */
-                    unsigned int staticMemCapacity() const
+                    std::size_t staticMemCapacity() const
                     {
                         return staticAllocBytes() - m_dynPitch;
                     }
 
                     //! Storage size in bytes
-                    static constexpr unsigned int staticAllocBytes() {return detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes;}
+                    static constexpr std::size_t staticAllocBytes() {return detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes;}
 
                 private:
 
                     mutable std::array<uint8_t, detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes> m_mem;
-                    unsigned int m_dynPitch;
+                    std::size_t m_dynPitch;
                 };
 #if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
     #pragma warning(pop)
@@ -108,7 +108,7 @@ namespace alpaka
                     //#############################################################################
                     template<
                         typename T,
-                        unsigned int TStaticAllocKiB>
+                        std::size_t TStaticAllocKiB>
                     struct GetMem<
                         T,
                         BlockSharedMemDynMember<TStaticAllocKiB>>

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -29,20 +29,20 @@ namespace alpaka
                 {
                     //#############################################################################
                     //! Implementation of static block shared memory provider.
-                    template<unsigned int TDataAlignBytes = core::vectorization::defaultAlignment>
+                    template<std::size_t TDataAlignBytes = core::vectorization::defaultAlignment>
                     class BlockSharedMemStMemberImpl
                     {
                     public:
                         //-----------------------------------------------------------------------------
 #ifndef NDEBUG
-                        BlockSharedMemStMemberImpl(uint8_t* mem, unsigned int capacity) : m_mem(mem), m_capacity(capacity)
+                        BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t capacity) : m_mem(mem), m_capacity(capacity)
                         {
 #ifdef ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST
                             ALPAKA_ASSERT( ( m_mem == nullptr ) == ( m_capacity == 0u ) );
 #endif
                         }
 #else
-                        BlockSharedMemStMemberImpl(uint8_t* mem, unsigned int) : m_mem(mem) {}
+                        BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t) : m_mem(mem) {}
 #endif
                         //-----------------------------------------------------------------------------
                         BlockSharedMemStMemberImpl(BlockSharedMemStMemberImpl const &) = delete;
@@ -84,19 +84,19 @@ namespace alpaka
                         }
 
                     private:
-                        mutable unsigned int m_allocdBytes = 0;
+                        mutable std::size_t m_allocdBytes = 0;
                         mutable uint8_t* m_mem;
 #ifndef NDEBUG
-                        const unsigned int m_capacity;
+                        const std::size_t m_capacity;
 #endif
 
                         template<typename T>
-                        unsigned int allocPitch() const
+                        std::size_t allocPitch() const
                         {
                             static_assert(
                                 core::vectorization::defaultAlignment >= alignof(T),
                                 "Unable to get block shared static memory for types with alignment higher than defaultAlignment!");
-                            constexpr unsigned int align = std::max(TDataAlignBytes, static_cast<unsigned int>(alignof(T)));
+                            constexpr std::size_t align = std::max(TDataAlignBytes, alignof(T));
                             return (m_allocdBytes/align + (m_allocdBytes%align>0))*align;
                         }
                     };
@@ -105,7 +105,7 @@ namespace alpaka
                 //! Static block shared memory provider using a pointer to
                 //! externally allocated fixed-size memory, likely provided by
                 //! BlockSharedMemDynMember.
-                template<unsigned int TDataAlignBytes = core::vectorization::defaultAlignment>
+                template<std::size_t TDataAlignBytes = core::vectorization::defaultAlignment>
                 class BlockSharedMemStMember :
                     public detail::BlockSharedMemStMemberImpl<TDataAlignBytes>,
                     public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStMember<TDataAlignBytes>>
@@ -119,7 +119,7 @@ namespace alpaka
                     //#############################################################################
                     template<
                         typename T,
-                        unsigned int TDataAlignBytes,
+                        std::size_t TDataAlignBytes,
                         std::size_t TuniqueId>
                     struct AllocVar<
                         T,
@@ -137,7 +137,7 @@ namespace alpaka
                     };
                     //#############################################################################
                     template<
-                        unsigned int TDataAlignBytes>
+                        std::size_t TDataAlignBytes>
                     struct FreeMem<
                         BlockSharedMemStMember<TDataAlignBytes>>
                     {

--- a/include/alpaka/intrinsic/IntrinsicFallback.hpp
+++ b/include/alpaka/intrinsic/IntrinsicFallback.hpp
@@ -24,7 +24,7 @@ namespace alpaka
             static auto popcountFallback(TValue value)
             -> std::int32_t
             {
-                std::uint32_t count = 0;
+                TValue count = 0;
                 while(value != 0)
                 {
                     count += value & 1u;

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -168,7 +168,7 @@ namespace alpaka
                 typename FnObj>
             ALPAKA_FN_HOST auto parallelFn(
                 FnObj const & boundKernelFnObj,
-                TIdx const & blockSharedMemDynSizeBytes,
+                std::size_t const & blockSharedMemDynSizeBytes,
                 TIdx const & numBlocksInGrid,
                 vec::Vec<TDim, TIdx> const & gridBlockExtent) const
             -> void

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -84,7 +84,7 @@ namespace alpaka
                     vec::Vec<TDim, idx::Idx<TAcc>> const & blockThreadExtent,
                     vec::Vec<TDim, idx::Idx<TAcc>> const & threadElemExtent,
                     TArgs const & ... args)
-                -> idx::Idx<TAcc>
+                -> std::size_t
                 {
                     alpaka::ignore_unused(kernelFnObj);
                     alpaka::ignore_unused(blockThreadExtent);
@@ -122,7 +122,7 @@ namespace alpaka
             vec::Vec<TDim, idx::Idx<TAcc>> const & blockThreadExtent,
             vec::Vec<TDim, idx::Idx<TAcc>> const & threadElemExtent,
             TArgs const & ... args)
-        -> idx::Idx<TAcc>
+        -> std::size_t
         {
             return
                 traits::BlockSharedMemDynSizeBytes<

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -91,7 +91,7 @@ namespace alpaka
                     alpaka::ignore_unused(threadElemExtent);
                     alpaka::ignore_unused(args...);
 
-                    return 0;
+                    return 0u;
                 }
             };
         }

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -92,7 +92,7 @@ namespace alpaka
                 {
                     if(val % i == 0)
                     {
-                        divisorSet.insert(val/i);
+                        divisorSet.insert(static_cast<T>(val/i));
                     }
                 }
 

--- a/test/common/devCompileOptions.cmake
+++ b/test/common/devCompileOptions.cmake
@@ -51,6 +51,7 @@ ELSE()
         LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Werror")
         LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wdouble-promotion")
         LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wmissing-include-dirs")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wconversion")
         LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wunknown-pragmas")
         # Higher levels (max is 5) produce some strange warnings
         LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wstrict-overflow=2")

--- a/test/common/include/alpaka/test/idx/TestIdxs.hpp
+++ b/test/common/include/alpaka/test/idx/TestIdxs.hpp
@@ -33,16 +33,12 @@ namespace alpaka
                     std::int64_t,
 #endif
                     std::uint64_t,
-                    std::int32_t,
+                    std::int32_t
 #if !defined(ALPAKA_CI)
-                    std::uint32_t,
-                    std::int16_t,
+                    ,std::uint32_t
 #endif
-                    std::uint16_t/*,
-                    // When Idx is a 8 bit integer, extents within the tests would be extremely limited
-                    // (especially when Dim is 4). Therefore, we do not test it.
-                    std::int8_t,
-                    std::uint8_t*/>;
+                    // index type must be >=32bit
+                >;
         }
     }
 }

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -176,7 +176,6 @@ namespace alpaka
                     TElem const & beta,
                     TElem * const C,
                     TIndex const & ldc)
-                -> TIndex
                 {
                     alpaka::ignore_unused(matMulKernel);
                     alpaka::ignore_unused(m);
@@ -192,7 +191,7 @@ namespace alpaka
                     alpaka::ignore_unused(ldc);
 
                     // Reserve the buffer for the two blocks of A and B.
-                    return 2u * blockThreadExtent.prod() * threadElemExtent.prod() * sizeof(TElem);
+                    return static_cast<std::size_t>(2u * blockThreadExtent.prod() * threadElemExtent.prod()) * sizeof(TElem);
                 }
             };
         }

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -124,10 +124,10 @@ namespace alpaka
                     TVec const & blockThreadExtent,
                     TVec const & threadElemExtent,
                     TArgs && ...)
-                -> idx::Idx<TAcc>
+                -> std::size_t
                 {
                     alpaka::ignore_unused(sharedMemKernel);
-                    return blockThreadExtent.prod() * threadElemExtent.prod() * static_cast<idx::Idx<TAcc>>(sizeof(Val));
+                    return static_cast<std::size_t>(blockThreadExtent.prod() * threadElemExtent.prod()) * sizeof(Val);
                 }
             };
         }

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -39,7 +39,7 @@ ALPAKA_FN_ACC auto testAtomicAdd(
                 &operand,
                 value);
     ALPAKA_CHECK(*success, operandOrig == ret);
-    T const reference = operandOrig + value;
+    T const reference = static_cast<T>(operandOrig + value);
     ALPAKA_CHECK(*success, operand == reference);
 }
 
@@ -64,7 +64,7 @@ ALPAKA_FN_ACC auto testAtomicSub(
                 &operand,
                 value);
     ALPAKA_CHECK(*success, operandOrig == ret);
-    T const reference = operandOrig - value;
+    T const reference = static_cast<T>(operandOrig - value);
     ALPAKA_CHECK(*success, operand == reference);
 }
 
@@ -165,7 +165,7 @@ ALPAKA_FN_ACC auto testAtomicInc(
                 &operand,
                 value);
     ALPAKA_CHECK(*success, operandOrig == ret);
-    T const reference = operandOrig + 1;
+    T const reference = static_cast<T>(operandOrig + 1);
     ALPAKA_CHECK(*success, operand == reference);
 }
 
@@ -191,7 +191,7 @@ ALPAKA_FN_ACC auto testAtomicDec(
                 &operand,
                 value);
     ALPAKA_CHECK(*success, operandOrig == ret);
-    T const reference = operandOrig - 1;
+    T const reference = static_cast<T>(operandOrig - 1);
     ALPAKA_CHECK(*success, operand == reference);
 }
 
@@ -258,7 +258,7 @@ ALPAKA_FN_ACC auto testAtomicXor(
 {
     auto & operand = alpaka::block::shared::st::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
-    T const value = operandOrig + static_cast<T>(4);
+    T const value = static_cast<T>(operandOrig + static_cast<T>(4));
     T const ret =
         alpaka::atomic::atomicOp<
             alpaka::atomic::op::Xor>(
@@ -305,7 +305,7 @@ ALPAKA_FN_ACC auto testAtomicCas(
     // without match
     {
         operand = operandOrig;
-        T const compare = operandOrig + static_cast<T>(1);
+        T const compare = static_cast<T>(operandOrig + static_cast<T>(1));
         T const value = static_cast<T>(4);
         T const ret =
             alpaka::atomic::atomicOp<

--- a/test/unit/block/shared/src/BlockSharedMemDyn.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemDyn.cpp
@@ -65,12 +65,12 @@ namespace alpaka
                     TVec const & blockThreadExtent,
                     TVec const & threadElemExtent,
                     bool * success)
-                -> idx::Idx<TAcc>
+                -> std::size_t
                 {
                     alpaka::ignore_unused(blockSharedMemDyn);
                     alpaka::ignore_unused(success);
-                    return
-                        static_cast<idx::Idx<TAcc>>(sizeof(std::uint32_t)) * blockThreadExtent.prod() * threadElemExtent.prod();
+                    auto const gridSize = blockThreadExtent.prod() * threadElemExtent.prod();
+                    return static_cast<std::size_t>(gridSize) * sizeof(std::uint32_t);
                 }
             };
         }

--- a/test/unit/block/sync/src/BlockSync.cpp
+++ b/test/unit/block/sync/src/BlockSync.cpp
@@ -77,15 +77,14 @@ namespace alpaka
                     TVec const & blockThreadExtent,
                     TVec const & threadElemExtent,
                     bool * success)
-                -> idx::Idx<TAcc>
+                -> std::size_t
                 {
                     using Idx = alpaka::idx::Idx<TAcc>;
 
                     alpaka::ignore_unused(blockSharedMemDyn);
                     alpaka::ignore_unused(threadElemExtent);
                     alpaka::ignore_unused(success);
-                    return
-                        static_cast<idx::Idx<TAcc>>(sizeof(Idx)) * blockThreadExtent.prod();
+                    return static_cast<std::size_t>(blockThreadExtent.prod()) * sizeof(Idx);
                 }
             };
         }


### PR DESCRIPTION
* change interface `getBlockSharedMemDynSizeBytes`
  - trait is now always returning  `std::size_t`, before the return type was the index type of the accelerator
* add `-Wconversion` to the developer GCC options
* restrict types which can be used as index type for the accelerator
  - remove tests for accelerator index types `uint16_t` and `int16_t`

The shared memory traits and implementation mixed before the usage of `size_t`, `unsigned int` and accelerator index type.
This behaviour is changed by using always similar to the STL `size_t` as return value for the size.

Reasons for the index type restriction of an accelerator:
An operator e.g. `+`,`-` with types smaller than integer can return an `integer`. see https://stackoverflow.com/a/39061103
This behaviour results into sign errors/warning on every place in the code were we calculate with index types. 
It should not be an problem to remove the usage of 16bit and 8bit if we can increase the code quality/stability because of this restriction.

An additional motivation to check for conversion issues is that DLR require that alpaka compiles without conversion warnings/errors.