### PR TITLE
fix OSX CI

### DIFF
--- a/script/install_tbb.sh
+++ b/script/install_tbb.sh
@@ -20,7 +20,6 @@ then
     travis_retry sudo apt-get -y --quiet --allow-unauthenticated --no-install-recommends install libtbb-dev
 elif [ "$ALPAKA_CI_OS_NAME" = "macOS" ]
 then
-    brew unlink python@2
     brew install tbb
 elif [ "$ALPAKA_CI_OS_NAME" = "Windows" ]
 then


### PR DESCRIPTION
remove unlinking python2 during intel tbb install