### PR TITLE
Using namespace alpaka::dev and alpaka::pltf into alpaka

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -179,8 +179,8 @@ auto main()
     using HostQueue = alpaka::queue::Queue<Host, HostQueueProperty>;
 
     // Select devices
-    auto const devAcc = alpaka::pltf::getDevByIdx<Acc>(0u);
-    auto const devHost = alpaka::pltf::getDevByIdx<Host>(0u);
+    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const devHost = alpaka::getDevByIdx<Host>(0u);
 
     // Create queues
     DevQueue devQueue(devAcc);

--- a/example/heatEquation/src/heatEquation.cpp
+++ b/example/heatEquation/src/heatEquation.cpp
@@ -123,11 +123,11 @@ auto main( ) -> int
     using Acc = alpaka::example::ExampleDefaultAcc<Dim, Idx>;
     std::cout << "Using alpaka accelerator: " << alpaka::acc::getAccName<Acc>() << std::endl;
 
-    using DevHost = alpaka::dev::DevCpu;
+    using DevHost = alpaka::DevCpu;
 
     // Select specific devices
-    auto const devAcc = alpaka::pltf::getDevByIdx< Acc >( 0u );
-    auto const devHost = alpaka::pltf::getDevByIdx< DevHost >( 0u );
+    auto const devAcc = alpaka::getDevByIdx< Acc >( 0u );
+    auto const devHost = alpaka::getDevByIdx< DevHost >( 0u );
 
     // Get valid workdiv for the given problem
     uint32_t elemPerThread = 1;

--- a/example/helloWorld/src/helloWorld.cpp
+++ b/example/helloWorld/src/helloWorld.cpp
@@ -122,7 +122,7 @@ auto main()
     // by id (0 to the number of devices minus 1) or you
     // can also retrieve all devices in a vector (getDevs()).
     // In this example the first devices is choosen.
-    auto const devAcc = alpaka::pltf::getDevByIdx<Acc>(0u);
+    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
 
     // Create a queue on the device
     //

--- a/example/helloWorldLambda/src/helloWorldLambda.cpp
+++ b/example/helloWorldLambda/src/helloWorldLambda.cpp
@@ -93,7 +93,7 @@ auto main()
     using Queue = alpaka::queue::Queue<Acc, QueueProperty>;
 
     // Select a device
-    auto const devAcc = alpaka::pltf::getDevByIdx<Acc>(0u);
+    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
 
     // Create a queue on the device
     Queue queue(devAcc);

--- a/example/monteCarloIntegration/src/monteCarloIntegration.cpp
+++ b/example/monteCarloIntegration/src/monteCarloIntegration.cpp
@@ -124,9 +124,9 @@ auto main() -> int
     using Acc = alpaka::example::ExampleDefaultAcc<
         Dim,
         Idx>;
-    using Host = alpaka::dev::DevCpu;
-    auto const devAcc = alpaka::pltf::getDevByIdx<Acc>(0u);
-    auto const devHost = alpaka::pltf::getDevByIdx<Host>(0u);
+    using Host = alpaka::DevCpu;
+    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const devHost = alpaka::getDevByIdx<Host>(0u);
     using QueueProperty = alpaka::queue::Blocking;
     using QueueAcc = alpaka::queue::Queue<
         Acc,

--- a/example/reduce/src/alpakaConfig.hpp
+++ b/example/reduce/src/alpakaConfig.hpp
@@ -86,10 +86,10 @@ struct Omp5
 {
     using Host = alpaka::acc::AccCpuSerial<Dim, Extent>;
     using Acc = alpaka::acc::AccOmp5<Dim, Extent>;
-    using DevHost = alpaka::dev::Dev<Host>;
-    using DevAcc = alpaka::dev::Dev<Acc>;
-    using PltfHost = alpaka::pltf::Pltf<DevHost>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
+    using DevHost = alpaka::Dev<Host>;
+    using DevAcc = alpaka::Dev<Acc>;
+    using PltfHost = alpaka::Pltf<DevHost>;
+    using PltfAcc = alpaka::Pltf<DevAcc>;
     using Stream = alpaka::queue::QueueCpuBlocking;
     using Event = alpaka::event::Event<Stream>;
     using MaxBlockSize = alpaka::dim::DimInt<1u>;

--- a/example/reduce/src/reduce.cpp
+++ b/example/reduce/src/reduce.cpp
@@ -133,8 +133,8 @@ int main()
     using T = uint32_t;
     static constexpr uint64_t blockSize = getMaxBlockSize<Accelerator, 256>();
 
-    auto devAcc = alpaka::pltf::getDevByIdx<Acc>(dev);
-    auto devHost = alpaka::pltf::getDevByIdx<Host>(0u);
+    auto devAcc = alpaka::getDevByIdx<Acc>(dev);
+    auto devHost = alpaka::getDevByIdx<Host>(0u);
     QueueAcc queue(devAcc);
 
     // calculate optimal block size (8 times the MP count proved to be

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -110,7 +110,7 @@ auto main()
     using QueueAcc = alpaka::queue::Queue<Acc, QueueProperty>;
 
     // Select a device
-    auto const devAcc = alpaka::pltf::getDevByIdx<Acc>(0u);
+    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
 
     // Create a queue on the device
     QueueAcc queue(devAcc);
@@ -133,8 +133,8 @@ auto main()
     using Data = std::uint32_t;
 
     // Get the host device for allocating memory on the host.
-    using DevHost = alpaka::dev::DevCpu;
-    auto const devHost = alpaka::pltf::getDevByIdx<DevHost>(0u);
+    using DevHost = alpaka::DevCpu;
+    auto const devHost = alpaka::getDevByIdx<DevHost>(0u);
 
     // Allocate 3 host memory buffers
     using BufHost = alpaka::mem::buf::Buf<DevHost, Data, Dim, Idx>;

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -205,3 +205,8 @@
 // vec
 #include <alpaka/vec/Vec.hpp>
 #include <alpaka/vec/Traits.hpp>
+
+namespace alpaka {
+    using namespace alpaka::dev;
+    using namespace alpaka::pltf;
+}

--- a/test/common/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/test/common/include/alpaka/test/KernelExecutionFixture.hpp
@@ -28,8 +28,8 @@ namespace alpaka
             using Acc = TAcc;
             using Dim = alpaka::dim::Dim<Acc>;
             using Idx = alpaka::idx::Idx<Acc>;
-            using DevAcc = alpaka::dev::Dev<Acc>;
-            using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
+            using DevAcc = alpaka::Dev<Acc>;
+            using PltfAcc = alpaka::Pltf<DevAcc>;
             using QueueAcc = alpaka::test::queue::DefaultQueue<DevAcc>;
             using WorkDiv = alpaka::workdiv::WorkDivMembers<Dim, Idx>;
 
@@ -39,8 +39,8 @@ namespace alpaka
                 typename TExtent>
             KernelExecutionFixture(
                 TExtent const & extent) :
-                    m_devHost(alpaka::pltf::getDevByIdx<pltf::PltfCpu>(0u)),
-                    m_devAcc(alpaka::pltf::getDevByIdx<PltfAcc>(0u)),
+                    m_devHost(alpaka::getDevByIdx<pltf::PltfCpu>(0u)),
+                    m_devAcc(alpaka::getDevByIdx<PltfAcc>(0u)),
                     m_queue(m_devAcc),
                     m_workDiv(
                         alpaka::workdiv::getValidWorkDiv<Acc>(
@@ -53,8 +53,8 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             KernelExecutionFixture(
                 WorkDiv const & workDiv) :
-                    m_devHost(alpaka::pltf::getDevByIdx<pltf::PltfCpu>(0u)),
-                    m_devAcc(alpaka::pltf::getDevByIdx<PltfAcc>(0u)),
+                    m_devHost(alpaka::getDevByIdx<pltf::PltfCpu>(0u)),
+                    m_devAcc(alpaka::getDevByIdx<PltfAcc>(0u)),
                     m_queue(m_devAcc),
                     m_workDiv(workDiv)
             {}
@@ -93,7 +93,7 @@ namespace alpaka
             }
 
         private:
-            alpaka::dev::DevCpu m_devHost;
+            alpaka::DevCpu m_devHost;
             DevAcc m_devAcc;
             QueueAcc m_queue;
             WorkDiv m_workDiv;

--- a/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -192,7 +192,7 @@ namespace alpaka
                 //#############################################################################
                 template<>
                 struct EventHostManualTriggerType<
-                    alpaka::dev::DevCpu>
+                    alpaka::DevCpu>
                 {
                     using type = alpaka::test::event::EventHostManualTriggerCpu<dev::DevCpu>;
                 };
@@ -202,20 +202,20 @@ namespace alpaka
                 //#############################################################################
                 template<>
                 struct EventHostManualTriggerType<
-                    alpaka::dev::DevOmp5>
+                    alpaka::DevOmp5>
                 {
-                    using type = alpaka::test::event::EventHostManualTriggerCpu<alpaka::dev::DevOmp5>;
+                    using type = alpaka::test::event::EventHostManualTriggerCpu<alpaka::DevOmp5>;
                 };
 #endif
                 //#############################################################################
                 //! The CPU event host manual trigger support get trait specialization.
                 template<>
                 struct IsEventHostManualTriggerSupported<
-                    alpaka::dev::DevCpu>
+                    alpaka::DevCpu>
                 {
                     //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST static auto isSupported(
-                        alpaka::dev::DevCpu const &)
+                        alpaka::DevCpu const &)
                     -> bool
                     {
                         return true;
@@ -226,11 +226,11 @@ namespace alpaka
                 //! The Omp5 event host manual trigger support get trait specialization.
                 template<>
                 struct IsEventHostManualTriggerSupported<
-                    alpaka::dev::DevOmp5>
+                    alpaka::DevOmp5>
                 {
                     //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST static auto isSupported(
-                        alpaka::dev::DevOmp5 const &)
+                        alpaka::DevOmp5 const &)
                     -> bool
                     {
                         return true;
@@ -545,7 +545,7 @@ namespace alpaka
                 //#############################################################################
                 template<>
                 struct EventHostManualTriggerType<
-                    alpaka::dev::DevUniformCudaHipRt>
+                    alpaka::DevUniformCudaHipRt>
                 {
                     using type = alpaka::test::event::EventHostManualTriggerCuda;
                 };
@@ -553,11 +553,11 @@ namespace alpaka
                 //! The CPU event host manual trigger support get trait specialization.
                 template<>
                 struct IsEventHostManualTriggerSupported<
-                    alpaka::dev::DevUniformCudaHipRt>
+                    alpaka::DevUniformCudaHipRt>
                 {
                     //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST static auto isSupported(
-                        alpaka::dev::DevCudaRt const & dev)
+                        alpaka::DevCudaRt const & dev)
                     -> bool
                     {
                         int result = 0;
@@ -851,7 +851,7 @@ namespace alpaka
                 //#############################################################################
                 template<>
                 struct EventHostManualTriggerType<
-                    alpaka::dev::DevHipRt>
+                    alpaka::DevHipRt>
                 {
                     using type = alpaka::test::event::EventHostManualTriggerHip;
                 };
@@ -860,13 +860,13 @@ namespace alpaka
                 //! The HIP event host manual trigger support get trait specialization.
                 template<>
                 struct IsEventHostManualTriggerSupported<
-                    alpaka::dev::DevHipRt>
+                    alpaka::DevHipRt>
                 {
                     //-----------------------------------------------------------------------------
                     // TODO: there is no CUDA_VERSION in the HIP compiler path.
                     // TODO: there is a hipDeviceGetAttribute, but there is no pendant for CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS.
                     ALPAKA_FN_HOST static auto isSupported(
-                        alpaka::dev::DevHipRt const &)
+                        alpaka::DevHipRt const &)
                     -> bool
                     {
                         return false;

--- a/test/common/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/test/common/include/alpaka/test/mem/view/ViewTest.hpp
@@ -48,18 +48,18 @@ namespace alpaka
                 -> void
                 {
                     //-----------------------------------------------------------------------------
-                    // alpaka::dev::traits::DevType
+                    // alpaka::traits::DevType
                     {
                         static_assert(
-                            std::is_same<alpaka::dev::Dev<TView>, TDev>::value,
+                            std::is_same<alpaka::Dev<TView>, TDev>::value,
                             "The device type of the view has to be equal to the specified one.");
                     }
 
                     //-----------------------------------------------------------------------------
-                    // alpaka::dev::traits::GetDev
+                    // alpaka::traits::GetDev
                     {
                         REQUIRE(
-                            dev == alpaka::dev::getDev(view));
+                            dev == alpaka::getDev(view));
                     }
 
                     //-----------------------------------------------------------------------------
@@ -289,14 +289,14 @@ namespace alpaka
                     using Dim = alpaka::dim::Dim<TView>;
                     using Idx = alpaka::idx::Idx<TView>;
 
-                    using DevHost = alpaka::dev::DevCpu;
-                    using PltfHost = alpaka::pltf::Pltf<DevHost>;
+                    using DevHost = alpaka::DevCpu;
+                    using PltfHost = alpaka::Pltf<DevHost>;
 
                     using Elem = alpaka::elem::Elem<TView>;
 
                     using ViewPlainPtr = alpaka::mem::view::ViewPlainPtr<DevHost, Elem, Dim, Idx>;
 
-                    DevHost const devHost(alpaka::pltf::getDevByIdx<PltfHost>(0));
+                    DevHost const devHost(alpaka::getDevByIdx<PltfHost>(0));
 
                     auto const extent(alpaka::extent::getExtentVec(view));
 
@@ -351,7 +351,7 @@ namespace alpaka
                         using Elem = alpaka::elem::Elem<TView>;
                         using Idx = alpaka::idx::Idx<TView>;
 
-                        auto const devAcc = alpaka::dev::getDev(view);
+                        auto const devAcc = alpaka::getDev(view);
 
                         //-----------------------------------------------------------------------------
                         // alpaka::mem::view::copy into given view

--- a/test/common/include/alpaka/test/queue/Queue.hpp
+++ b/test/common/include/alpaka/test/queue/Queue.hpp
@@ -34,7 +34,7 @@ namespace alpaka
                 //! The default queue type trait specialization for the CPU device.
                 template<>
                 struct DefaultQueueType<
-                    alpaka::dev::DevCpu>
+                    alpaka::DevCpu>
                 {
 #if (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
                     using type = alpaka::queue::QueueCpuBlocking;
@@ -49,7 +49,7 @@ namespace alpaka
                 //! The default queue type trait specialization for the CUDA/HIP device.
                 template<>
                 struct DefaultQueueType<
-                    alpaka::dev::DevUniformCudaHipRt>
+                    alpaka::DevUniformCudaHipRt>
                 {
 #if (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
                     using type = alpaka::queue::QueueUniformCudaHipRtBlocking;
@@ -119,7 +119,7 @@ namespace alpaka
                 //! The default queue type trait specialization for the Omp5 device.
                 template<>
                 struct DefaultQueueType<
-                    alpaka::dev::DevOmp5>
+                    alpaka::DevOmp5>
                 {
 #if (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
                     using type = alpaka::queue::QueueOmp5Blocking;
@@ -140,22 +140,22 @@ namespace alpaka
             //! A std::tuple holding tuples of devices and corresponding queue types.
             using TestQueues =
                 std::tuple<
-                    std::tuple<alpaka::dev::DevCpu, alpaka::queue::QueueCpuBlocking>,
-                    std::tuple<alpaka::dev::DevCpu, alpaka::queue::QueueCpuNonBlocking>
+                    std::tuple<alpaka::DevCpu, alpaka::queue::QueueCpuBlocking>,
+                    std::tuple<alpaka::DevCpu, alpaka::queue::QueueCpuNonBlocking>
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                     ,
-                    std::tuple<alpaka::dev::DevUniformCudaHipRt, alpaka::queue::QueueUniformCudaHipRtBlocking>,
-                    std::tuple<alpaka::dev::DevUniformCudaHipRt, alpaka::queue::QueueUniformCudaHipRtNonBlocking>
+                    std::tuple<alpaka::DevUniformCudaHipRt, alpaka::queue::QueueUniformCudaHipRtBlocking>,
+                    std::tuple<alpaka::DevUniformCudaHipRt, alpaka::queue::QueueUniformCudaHipRtNonBlocking>
 #endif
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
                     ,
-                    std::tuple<alpaka::dev::DevHipRt, alpaka::queue::QueueHipRtBlocking>,
-                    std::tuple<alpaka::dev::DevHipRt, alpaka::queue::QueueHipRtNonBlocking>
+                    std::tuple<alpaka::DevHipRt, alpaka::queue::QueueHipRtBlocking>,
+                    std::tuple<alpaka::DevHipRt, alpaka::queue::QueueHipRtNonBlocking>
 #endif
 #ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
                     ,
-                    std::tuple<alpaka::dev::DevOmp5, alpaka::queue::QueueOmp5Blocking>,
-                    std::tuple<alpaka::dev::DevOmp5, alpaka::queue::QueueOmp5NonBlocking>
+                    std::tuple<alpaka::DevOmp5, alpaka::queue::QueueOmp5Blocking>,
+                    std::tuple<alpaka::DevOmp5, alpaka::queue::QueueOmp5NonBlocking>
 #endif
                 >;
         }

--- a/test/common/include/alpaka/test/queue/QueueTestFixture.hpp
+++ b/test/common/include/alpaka/test/queue/QueueTestFixture.hpp
@@ -25,11 +25,11 @@ namespace alpaka
                 using Dev = std::tuple_element_t<0, TDevQueue>;
                 using Queue = std::tuple_element_t<1, TDevQueue>;
 
-                using Pltf = alpaka::pltf::Pltf<Dev>;
+                using Pltf = alpaka::Pltf<Dev>;
 
                 //-----------------------------------------------------------------------------
                 QueueTestFixture() :
-                    m_dev(alpaka::pltf::getDevByIdx<Pltf>(0u)),
+                    m_dev(alpaka::getDevByIdx<Pltf>(0u)),
                     m_queue(m_dev)
                 {
                 }

--- a/test/integ/axpy/src/axpy.cpp
+++ b/test/integ/axpy/src/axpy.cpp
@@ -90,21 +90,21 @@ TEMPLATE_LIST_TEST_CASE( "axpy", "[axpy]", TestAccs)
 #endif
 
     using Val = float;
-    using DevAcc = alpaka::dev::Dev<Acc>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
+    using DevAcc = alpaka::Dev<Acc>;
+    using PltfAcc = alpaka::Pltf<DevAcc>;
     using QueueAcc = alpaka::test::queue::DefaultQueue<DevAcc>;
-    using PltfHost = alpaka::pltf::PltfCpu;
+    using PltfHost = alpaka::PltfCpu;
 
     // Create the kernel function object.
     AxpyKernel kernel;
 
     // Get the host device.
     auto const devHost(
-        alpaka::pltf::getDevByIdx<PltfHost>(0u));
+        alpaka::getDevByIdx<PltfHost>(0u));
 
     // Select a device to execute on.
     auto const devAcc(
-        alpaka::pltf::getDevByIdx<PltfAcc>(0u));
+        alpaka::getDevByIdx<PltfAcc>(0u));
 
     // Get a queue on this device.
     QueueAcc queue(devAcc);

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -326,21 +326,21 @@ TEMPLATE_LIST_TEST_CASE( "mandelbrot", "[mandelbrot]", TestAccs)
     Idx const maxIterations(300u);
 
     using Val = std::uint32_t;
-    using DevAcc = alpaka::dev::Dev<Acc>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
+    using DevAcc = alpaka::Dev<Acc>;
+    using PltfAcc = alpaka::Pltf<DevAcc>;
     using QueueAcc = alpaka::test::queue::DefaultQueue<DevAcc>;
-    using PltfHost = alpaka::pltf::PltfCpu;
+    using PltfHost = alpaka::PltfCpu;
 
     // Create the kernel function object.
     MandelbrotKernel kernel;
 
     // Get the host device.
     auto const devHost(
-        alpaka::pltf::getDevByIdx<PltfHost>(0u));
+        alpaka::getDevByIdx<PltfHost>(0u));
 
     // Select a device to execute on.
     auto const devAcc(
-        alpaka::pltf::getDevByIdx<PltfAcc>(0u));
+        alpaka::getDevByIdx<PltfAcc>(0u));
 
     // Get a queue on this device.
     QueueAcc queue(

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -214,11 +214,11 @@ TEMPLATE_LIST_TEST_CASE( "matMul", "[matMul]", TestAccs)
 
     using Val = std::uint32_t;
     using Vec2 = alpaka::vec::Vec<Dim, Idx>;
-    using DevAcc = alpaka::dev::Dev<Acc>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
-    using QueueAcc = alpaka::test::queue::DefaultQueue<alpaka::dev::Dev<Acc>>;
-    using PltfHost = alpaka::pltf::PltfCpu;
-    using DevHost = alpaka::dev::Dev<PltfHost>;
+    using DevAcc = alpaka::Dev<Acc>;
+    using PltfAcc = alpaka::Pltf<DevAcc>;
+    using QueueAcc = alpaka::test::queue::DefaultQueue<alpaka::Dev<Acc>>;
+    using PltfHost = alpaka::PltfCpu;
+    using DevHost = alpaka::Dev<PltfHost>;
     using QueueHost = alpaka::queue::QueueCpuNonBlocking;
 
     // Create the kernel function object.
@@ -226,7 +226,7 @@ TEMPLATE_LIST_TEST_CASE( "matMul", "[matMul]", TestAccs)
 
     // Get the host device.
     DevHost const devHost(
-        alpaka::pltf::getDevByIdx<PltfHost>(0u));
+        alpaka::getDevByIdx<PltfHost>(0u));
 
     // Get a queue on the host device.
     QueueHost queueHost(
@@ -234,7 +234,7 @@ TEMPLATE_LIST_TEST_CASE( "matMul", "[matMul]", TestAccs)
 
     // Select a device to execute on.
     DevAcc const devAcc(
-        alpaka::pltf::getDevByIdx<PltfAcc>(0u));
+        alpaka::getDevByIdx<PltfAcc>(0u));
 
     // Get a queue on the accelerator device.
     QueueAcc queueAcc(

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -149,8 +149,8 @@ TEMPLATE_LIST_TEST_CASE( "sharedMem", "[sharedMem]", TestAccs)
     using Val = std::int32_t;
     using TnumUselessWork = std::integral_constant<Idx, 100>;
 
-    using DevAcc = alpaka::dev::Dev<Acc>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
+    using DevAcc = alpaka::Dev<Acc>;
+    using PltfAcc = alpaka::Pltf<DevAcc>;
     using QueueAcc = alpaka::test::queue::DefaultQueue<DevAcc>;
 
 
@@ -159,7 +159,7 @@ TEMPLATE_LIST_TEST_CASE( "sharedMem", "[sharedMem]", TestAccs)
 
     // Select a device to execute on.
     auto const devAcc(
-        alpaka::pltf::getDevByIdx<PltfAcc>(0u));
+        alpaka::getDevByIdx<PltfAcc>(0u));
 
     // Get a queue on this device.
     QueueAcc queue(

--- a/test/unit/acc/src/AccDevPropsTest.cpp
+++ b/test/unit/acc/src/AccDevPropsTest.cpp
@@ -18,9 +18,9 @@
 TEMPLATE_LIST_TEST_CASE( "getAccDevProps", "[acc]", alpaka::test::acc::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::dev::Dev<Acc>;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
-    Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+    using Dev = alpaka::Dev<Acc>;
+    using Pltf = alpaka::Pltf<Dev>;
+    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
     auto const devProps = alpaka::acc::getAccDevProps<Acc>(dev);
 
     REQUIRE(devProps.m_gridBlockExtentMax.prod() > 0);

--- a/test/unit/dev/src/DevWarpSizeTest.cpp
+++ b/test/unit/dev/src/DevWarpSizeTest.cpp
@@ -16,9 +16,9 @@
 //-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE( "getWarpSize", "[dev]", alpaka::test::acc::TestAccs)
 {
-    using Dev = alpaka::dev::Dev<TestType>;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
-    Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::dev::getWarpSize(dev);
+    using Dev = alpaka::Dev<TestType>;
+    using Pltf = alpaka::Pltf<Dev>;
+    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const warpExtent = alpaka::getWarpSize(dev);
     REQUIRE(warpExtent > 0);
 }

--- a/test/unit/event/src/EventTest.cpp
+++ b/test/unit/event/src/EventTest.cpp
@@ -20,7 +20,7 @@ using TestQueues = alpaka::meta::Concatenate<
         alpaka::test::queue::TestQueues
  #ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
         ,
-        std::tuple<std::tuple<alpaka::dev::DevCpu, alpaka::queue::QueueCpuOmp2Collective>>
+        std::tuple<std::tuple<alpaka::DevCpu, alpaka::queue::QueueCpuOmp2Collective>>
 #endif
     >;
 

--- a/test/unit/idx/src/MapIdxPitchBytes.cpp
+++ b/test/unit/idx/src/MapIdxPitchBytes.cpp
@@ -29,9 +29,9 @@ TEMPLATE_LIST_TEST_CASE( "mapIdxPitchBytes", "[idx]", alpaka::test::dim::TestDim
     auto const extentNd(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
 
     using Acc = alpaka::example::ExampleDefaultAcc<Dim, Idx>;
-    using Dev = alpaka::dev::Dev<Acc>;
+    using Dev = alpaka::Dev<Acc>;
     using Elem = std::uint8_t;
-    auto const devAcc = alpaka::pltf::getDevByIdx<Acc>(0u);
+    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
     alpaka::mem::view::ViewPlainPtr<Dev, Elem, Dim, Idx> parentView( nullptr, devAcc, extentNd );
 
     auto const offset(Vec::all(4u));

--- a/test/unit/math/src/Buffer.hpp
+++ b/test/unit/math/src/Buffer.hpp
@@ -42,9 +42,9 @@ struct Buffer
     using Idx = typename alpaka::idx::traits::IdxType<TAcc>::type;
 
     // Defines using's for alpaka-buffer.
-    using DevAcc = alpaka::dev::Dev< TAcc >;
-    using DevHost = alpaka::dev::DevCpu;
-    using PltfHost = alpaka::pltf::Pltf< DevHost >;
+    using DevAcc = alpaka::Dev< TAcc >;
+    using DevHost = alpaka::DevCpu;
+    using PltfHost = alpaka::Pltf< DevHost >;
 
     using BufHost = alpaka::mem::buf::Buf<
         DevHost,
@@ -76,7 +76,7 @@ struct Buffer
     // Constructor needs to initialize all Buffer.
     Buffer(const DevAcc & devAcc)
       :
-        devHost{ alpaka::pltf::getDevByIdx< PltfHost >( 0u ) },
+        devHost{ alpaka::getDevByIdx< PltfHost >( 0u ) },
         hostBuffer
         {
             alpaka::mem::buf::alloc<TData, Idx>(devHost, Tcapacity)

--- a/test/unit/math/src/math.cpp
+++ b/test/unit/math/src/math.cpp
@@ -87,10 +87,10 @@ struct TestTemplate
 
         // SETUP (defines and initialising)
         // DevAcc and DevHost are defined in Buffer.hpp too.
-        using DevAcc = alpaka::dev::Dev< TAcc >;
-        using DevHost = alpaka::dev::DevCpu;
-        using PltfAcc = alpaka::pltf::Pltf< DevAcc >;
-        using PltfHost = alpaka::pltf::Pltf< DevHost >;
+        using DevAcc = alpaka::Dev< TAcc >;
+        using DevHost = alpaka::DevCpu;
+        using PltfAcc = alpaka::Pltf< DevAcc >;
+        using PltfHost = alpaka::Pltf< DevHost >;
 
         using Dim = alpaka::dim::DimInt< 1u >;
         using Idx = std::size_t;
@@ -115,8 +115,8 @@ struct TestTemplate
         static constexpr size_t elementsPerThread = 1u;
         static constexpr size_t sizeExtent = 1u;
 
-        DevAcc const devAcc{ alpaka::pltf::getDevByIdx< PltfAcc >( 0u ) };
-        DevHost const devHost{ alpaka::pltf::getDevByIdx< PltfHost >( 0u ) };
+        DevAcc const devAcc{ alpaka::getDevByIdx< PltfAcc >( 0u ) };
+        DevHost const devHost{ alpaka::getDevByIdx< PltfHost >( 0u ) };
 
         QueueAcc queue{ devAcc };
 

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -26,15 +26,15 @@ static auto testBufferMutable(
     alpaka::vec::Vec<alpaka::dim::Dim<TAcc>, alpaka::idx::Idx<TAcc>> const & extent)
 -> void
 {
-    using Dev = alpaka::dev::Dev<TAcc>;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
+    using Dev = alpaka::Dev<TAcc>;
+    using Pltf = alpaka::Pltf<Dev>;
     using Queue = alpaka::test::queue::DefaultQueue<Dev>;
 
     using Elem = float;
     using Dim = alpaka::dim::Dim<TAcc>;
     using Idx = alpaka::idx::Idx<TAcc>;
 
-    Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
     Queue queue(dev);
 
     //-----------------------------------------------------------------------------
@@ -93,14 +93,14 @@ static auto testBufferImmutable(
     alpaka::vec::Vec<alpaka::dim::Dim<TAcc>, alpaka::idx::Idx<TAcc>> const & extent)
 -> void
 {
-    using Dev = alpaka::dev::Dev<TAcc>;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
+    using Dev = alpaka::Dev<TAcc>;
+    using Pltf = alpaka::Pltf<Dev>;
 
     using Elem = float;
     using Dim = alpaka::dim::Dim<TAcc>;
     using Idx = alpaka::idx::Idx<TAcc>;
 
-    Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
     //-----------------------------------------------------------------------------
     // alpaka::mem::buf::alloc

--- a/test/unit/mem/copy/src/BufSlicing.cpp
+++ b/test/unit/mem/copy/src/BufSlicing.cpp
@@ -33,11 +33,11 @@ struct TestContainer
         TAcc,
         AccQueueProperty
     >;
-    using DevAcc = alpaka::dev::Dev<TAcc>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
+    using DevAcc = alpaka::Dev<TAcc>;
+    using PltfAcc = alpaka::Pltf<DevAcc>;
 
-    using DevHost = alpaka::dev::DevCpu;
-    using PltfHost = alpaka::pltf::Pltf<DevHost>;
+    using DevHost = alpaka::DevCpu;
+    using PltfHost = alpaka::Pltf<DevHost>;
 
     using BufHost = alpaka::mem::buf::Buf<
         DevHost,
@@ -66,8 +66,8 @@ struct TestContainer
 
     // Constructor
     TestContainer():
-        devAcc(alpaka::pltf::getDevByIdx<PltfAcc>(0u)),
-        devHost(alpaka::pltf::getDevByIdx<PltfHost>(0u)),
+        devAcc(alpaka::getDevByIdx<PltfAcc>(0u)),
+        devHost(alpaka::getDevByIdx<PltfHost>(0u)),
         devQueue(devAcc)
     {}
 

--- a/test/unit/mem/p2p/src/P2P.cpp
+++ b/test/unit/mem/p2p/src/P2P.cpp
@@ -27,21 +27,21 @@ static auto testP2P(
     alpaka::vec::Vec<alpaka::dim::Dim<TAcc>, alpaka::idx::Idx<TAcc>> const & extent)
 -> void
 {
-    using Dev = alpaka::dev::Dev<TAcc>;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
+    using Dev = alpaka::Dev<TAcc>;
+    using Pltf = alpaka::Pltf<Dev>;
     using Queue = alpaka::test::queue::DefaultQueue<Dev>;
 
     using Elem = std::uint32_t;
     using Idx = alpaka::idx::Idx<TAcc>;
 
-    if(alpaka::pltf::getDevCount<Pltf>()<2) {
+    if(alpaka::getDevCount<Pltf>()<2) {
       std::cerr << "No two devices found to test peer-to-peer copy." << std::endl;
       CHECK(true);
       return;
     }
 
-    Dev const dev0(alpaka::pltf::getDevByIdx<Pltf>(0u));
-    Dev const dev1(alpaka::pltf::getDevByIdx<Pltf>(1u));
+    Dev const dev0(alpaka::getDevByIdx<Pltf>(0u));
+    Dev const dev1(alpaka::getDevByIdx<Pltf>(1u));
     Queue queue0(dev0);
 
     //-----------------------------------------------------------------------------

--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -95,14 +95,14 @@ namespace view
     auto testViewPlainPtr()
     -> void
     {
-        using Dev = alpaka::dev::Dev<TAcc>;
-        using Pltf = alpaka::pltf::Pltf<Dev>;
+        using Dev = alpaka::Dev<TAcc>;
+        using Pltf = alpaka::Pltf<Dev>;
 
         using Dim = alpaka::dim::Dim<TAcc>;
         using Idx = alpaka::idx::Idx<TAcc>;
         using View = alpaka::mem::view::ViewPlainPtr<Dev, TElem, Dim, Idx>;
 
-        Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+        Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
         auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
         auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
@@ -111,7 +111,7 @@ namespace view
         auto const offsetView(alpaka::vec::Vec<Dim, Idx>::all(static_cast<Idx>(0)));
         View view(
             alpaka::mem::view::getPtrNative(buf),
-            alpaka::dev::getDev(buf),
+            alpaka::getDev(buf),
             alpaka::extent::getExtentVec(buf),
             alpaka::mem::view::getPitchBytesVec(buf));
 
@@ -125,14 +125,14 @@ namespace view
     auto testViewPlainPtrConst()
     -> void
     {
-        using Dev = alpaka::dev::Dev<TAcc>;
-        using Pltf = alpaka::pltf::Pltf<Dev>;
+        using Dev = alpaka::Dev<TAcc>;
+        using Pltf = alpaka::Pltf<Dev>;
 
         using Dim = alpaka::dim::Dim<TAcc>;
         using Idx = alpaka::idx::Idx<TAcc>;
         using View = alpaka::mem::view::ViewPlainPtr<Dev, TElem, Dim, Idx>;
 
-        Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+        Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
         auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
         auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
@@ -141,7 +141,7 @@ namespace view
         auto const offsetView(alpaka::vec::Vec<Dim, Idx>::all(static_cast<Idx>(0)));
         View const view(
             alpaka::mem::view::getPtrNative(buf),
-            alpaka::dev::getDev(buf),
+            alpaka::getDev(buf),
             alpaka::extent::getExtentVec(buf),
             alpaka::mem::view::getPitchBytesVec(buf));
 
@@ -155,21 +155,21 @@ namespace view
     auto testViewPlainPtrOperators()
     -> void
     {
-        using Dev = alpaka::dev::Dev<TAcc>;
-        using Pltf = alpaka::pltf::Pltf<Dev>;
+        using Dev = alpaka::Dev<TAcc>;
+        using Pltf = alpaka::Pltf<Dev>;
 
         using Dim = alpaka::dim::Dim<TAcc>;
         using Idx = alpaka::idx::Idx<TAcc>;
         using View = alpaka::mem::view::ViewPlainPtr<Dev, TElem, Dim, Idx>;
 
-        Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+        Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
         auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
         auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
 
         View view(
             alpaka::mem::view::getPtrNative(buf),
-            alpaka::dev::getDev(buf),
+            alpaka::getDev(buf),
             alpaka::extent::getExtentVec(buf),
             alpaka::mem::view::getPitchBytesVec(buf));
 

--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -68,9 +68,9 @@ using TestAccs = alpaka::test::acc::EnabledAccs<Dim, Idx>;
 TEMPLATE_LIST_TEST_CASE( "staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAccs)
 {
     using Acc = TestType;
-    using DevAcc = alpaka::dev::Dev<Acc>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
-    DevAcc devAcc(alpaka::pltf::getDevByIdx<PltfAcc>(0u));
+    using DevAcc = alpaka::Dev<Acc>;
+    using PltfAcc = alpaka::Pltf<DevAcc>;
+    DevAcc devAcc(alpaka::getDevByIdx<PltfAcc>(0u));
 
     alpaka::vec::Vec<Dim, Idx> const extent(3u, 2u);
 
@@ -96,8 +96,8 @@ TEMPLATE_LIST_TEST_CASE( "staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestA
     //-----------------------------------------------------------------------------
     // uninitialized static constant device memory
     {
-        using PltfHost = alpaka::pltf::PltfCpu;
-        auto devHost(alpaka::pltf::getDevByIdx<PltfHost>(0u));
+        using PltfHost = alpaka::PltfCpu;
+        auto devHost(alpaka::getDevByIdx<PltfHost>(0u));
 
         using QueueAcc = alpaka::test::queue::DefaultQueue<DevAcc>;
         QueueAcc queueAcc(devAcc);
@@ -141,9 +141,9 @@ ALPAKA_STATIC_ACC_MEM_GLOBAL Elem g_globalMemory2DUninitialized[3][2];
 TEMPLATE_LIST_TEST_CASE( "staticDeviceMemoryConstant", "[viewStaticAccMem]", TestAccs)
 {
     using Acc = TestType;
-    using DevAcc = alpaka::dev::Dev<Acc>;
-    using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
-    DevAcc devAcc(alpaka::pltf::getDevByIdx<PltfAcc>(0u));
+    using DevAcc = alpaka::Dev<Acc>;
+    using PltfAcc = alpaka::Pltf<DevAcc>;
+    DevAcc devAcc(alpaka::getDevByIdx<PltfAcc>(0u));
 
     alpaka::vec::Vec<Dim, Idx> const extent(3u, 2u);
 
@@ -171,8 +171,8 @@ TEMPLATE_LIST_TEST_CASE( "staticDeviceMemoryConstant", "[viewStaticAccMem]", Tes
     //-----------------------------------------------------------------------------
     // uninitialized static global device memory
     {
-        using PltfHost = alpaka::pltf::PltfCpu;
-        auto devHost(alpaka::pltf::getDevByIdx<PltfHost>(0u));
+        using PltfHost = alpaka::PltfCpu;
+        auto devHost(alpaka::getDevByIdx<PltfHost>(0u));
 
         using QueueAcc = alpaka::test::queue::DefaultQueue<DevAcc>;
         QueueAcc queueAcc(devAcc);

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -133,14 +133,14 @@ namespace view
     auto testViewSubViewNoOffset()
     -> void
     {
-        using Dev = alpaka::dev::Dev<TAcc>;
-        using Pltf = alpaka::pltf::Pltf<Dev>;
+        using Dev = alpaka::Dev<TAcc>;
+        using Pltf = alpaka::Pltf<Dev>;
 
         using Dim = alpaka::dim::Dim<TAcc>;
         using Idx = alpaka::idx::Idx<TAcc>;
         using View = alpaka::mem::view::ViewSubView<Dev, TElem, Dim, Idx>;
 
-        Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+        Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
         auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
         auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
@@ -159,14 +159,14 @@ namespace view
     auto testViewSubViewOffset()
     -> void
     {
-        using Dev = alpaka::dev::Dev<TAcc>;
-        using Pltf = alpaka::pltf::Pltf<Dev>;
+        using Dev = alpaka::Dev<TAcc>;
+        using Pltf = alpaka::Pltf<Dev>;
 
         using Dim = alpaka::dim::Dim<TAcc>;
         using Idx = alpaka::idx::Idx<TAcc>;
         using View = alpaka::mem::view::ViewSubView<Dev, TElem, Dim, Idx>;
 
-        Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+        Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
         auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
         auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
@@ -185,14 +185,14 @@ namespace view
     auto testViewSubViewOffsetConst()
     -> void
     {
-        using Dev = alpaka::dev::Dev<TAcc>;
-        using Pltf = alpaka::pltf::Pltf<Dev>;
+        using Dev = alpaka::Dev<TAcc>;
+        using Pltf = alpaka::Pltf<Dev>;
 
         using Dim = alpaka::dim::Dim<TAcc>;
         using Idx = alpaka::idx::Idx<TAcc>;
         using View = alpaka::mem::view::ViewSubView<Dev, TElem, Dim, Idx>;
 
-        Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+        Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
         auto const extentBuf(alpaka::vec::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>());
         auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));

--- a/test/unit/queue/src/CollectiveQueue.cpp
+++ b/test/unit/queue/src/CollectiveQueue.cpp
@@ -45,12 +45,12 @@ TEST_CASE("queueCollective", "[queue]")
 
     // Define the accelerator
     using Acc = alpaka::acc::AccCpuOmp2Blocks<Dim, Idx>;
-    using Dev = alpaka::dev::Dev<Acc>;
+    using Dev = alpaka::Dev<Acc>;
 
     using Queue = alpaka::queue::QueueCpuOmp2Collective;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
+    using Pltf = alpaka::Pltf<Dev>;
 
-    auto dev = alpaka::pltf::getDevByIdx<Pltf>(0u);
+    auto dev = alpaka::getDevByIdx<Pltf>(0u);
     Queue queue(dev);
 
     std::vector<int> results(4, -1);
@@ -93,12 +93,12 @@ TEST_CASE("TestCollectiveMemcpy", "[queue]")
 
     // Define the accelerator
     using Acc = alpaka::acc::AccCpuOmp2Blocks<Dim, Idx>;
-    using Dev = alpaka::dev::Dev<Acc>;
+    using Dev = alpaka::Dev<Acc>;
 
     using Queue = alpaka::queue::QueueCpuOmp2Collective;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
+    using Pltf = alpaka::Pltf<Dev>;
 
-    auto dev = alpaka::pltf::getDevByIdx<Pltf>(0u);
+    auto dev = alpaka::getDevByIdx<Pltf>(0u);
     Queue queue(dev);
 
     std::vector<int> results(4, -1);

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -24,7 +24,7 @@ using TestQueues = alpaka::meta::Concatenate<
         alpaka::test::queue::TestQueues
  #ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
         ,
-        std::tuple<std::tuple<alpaka::dev::DevCpu, alpaka::queue::QueueCpuOmp2Collective>>
+        std::tuple<std::tuple<alpaka::DevCpu, alpaka::queue::QueueCpuOmp2Collective>>
 #endif
     >;
 

--- a/test/unit/warp/src/Activemask.cpp
+++ b/test/unit/warp/src/Activemask.cpp
@@ -83,13 +83,13 @@ public:
 TEMPLATE_LIST_TEST_CASE( "activemask", "[warp]", alpaka::test::acc::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::dev::Dev<Acc>;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
+    using Dev = alpaka::Dev<Acc>;
+    using Pltf = alpaka::Pltf<Dev>;
     using Dim = alpaka::dim::Dim<Acc>;
     using Idx = alpaka::idx::Idx<Acc>;
 
-    Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::dev::getWarpSize(dev);
+    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const warpExtent = alpaka::getWarpSize(dev);
     if (warpExtent == 1)
     {
         Idx const gridThreadExtentPerDim = 4;

--- a/test/unit/warp/src/All.cpp
+++ b/test/unit/warp/src/All.cpp
@@ -87,13 +87,13 @@ public:
 TEMPLATE_LIST_TEST_CASE( "all", "[warp]", alpaka::test::acc::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::dev::Dev<Acc>;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
+    using Dev = alpaka::Dev<Acc>;
+    using Pltf = alpaka::Pltf<Dev>;
     using Dim = alpaka::dim::Dim<Acc>;
     using Idx = alpaka::idx::Idx<Acc>;
 
-    Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::dev::getWarpSize(dev);
+    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const warpExtent = alpaka::getWarpSize(dev);
     if (warpExtent == 1)
     {
         Idx const gridThreadExtentPerDim = 4;

--- a/test/unit/warp/src/Any.cpp
+++ b/test/unit/warp/src/Any.cpp
@@ -87,13 +87,13 @@ public:
 TEMPLATE_LIST_TEST_CASE( "any", "[warp]", alpaka::test::acc::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::dev::Dev<Acc>;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
+    using Dev = alpaka::Dev<Acc>;
+    using Pltf = alpaka::Pltf<Dev>;
     using Dim = alpaka::dim::Dim<Acc>;
     using Idx = alpaka::idx::Idx<Acc>;
 
-    Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::dev::getWarpSize(dev);
+    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const warpExtent = alpaka::getWarpSize(dev);
     if (warpExtent == 1)
     {
         Idx const gridThreadExtentPerDim = 4;

--- a/test/unit/warp/src/Ballot.cpp
+++ b/test/unit/warp/src/Ballot.cpp
@@ -93,13 +93,13 @@ public:
 TEMPLATE_LIST_TEST_CASE( "ballot", "[warp]", alpaka::test::acc::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::dev::Dev<Acc>;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
+    using Dev = alpaka::Dev<Acc>;
+    using Pltf = alpaka::Pltf<Dev>;
     using Dim = alpaka::dim::Dim<Acc>;
     using Idx = alpaka::idx::Idx<Acc>;
 
-    Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::dev::getWarpSize(dev);
+    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const warpExtent = alpaka::getWarpSize(dev);
     if (warpExtent == 1)
     {
         Idx const gridThreadExtentPerDim = 4;

--- a/test/unit/warp/src/GetSize.cpp
+++ b/test/unit/warp/src/GetSize.cpp
@@ -40,13 +40,13 @@ public:
 TEMPLATE_LIST_TEST_CASE( "getSize", "[warp]", alpaka::test::acc::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::dev::Dev<Acc>;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
+    using Dev = alpaka::Dev<Acc>;
+    using Pltf = alpaka::Pltf<Dev>;
     using Dim = alpaka::dim::Dim<Acc>;
     using Idx = alpaka::idx::Idx<Acc>;
 
-    Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
-    auto const expectedWarpSize = static_cast<int>(alpaka::dev::getWarpSize(dev));
+    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const expectedWarpSize = static_cast<int>(alpaka::getWarpSize(dev));
     Idx const gridThreadExtentPerDim = 8;
     alpaka::test::KernelExecutionFixture<Acc> fixture(
         alpaka::vec::Vec<Dim, Idx>::all(gridThreadExtentPerDim));

--- a/test/unit/workDiv/src/WorkDivHelpersTest.cpp
+++ b/test/unit/workDiv/src/WorkDivHelpersTest.cpp
@@ -22,12 +22,12 @@ namespace
     template< typename TAcc >
     auto getWorkDiv()
     {
-        using Dev = alpaka::dev::Dev<TAcc>;
-        using Pltf = alpaka::pltf::Pltf<Dev>;
+        using Dev = alpaka::Dev<TAcc>;
+        using Pltf = alpaka::Pltf<Dev>;
         using Dim = alpaka::dim::Dim<TAcc>;
         using Idx = alpaka::idx::Idx<TAcc>;
 
-        Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+        Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
         auto const gridThreadExtent = alpaka::vec::Vec<Dim, Idx>::all(10);
         auto const threadElementExtent = alpaka::vec::Vec<Dim, Idx>::ones();
         auto workDiv = alpaka::workdiv::getValidWorkDiv<TAcc>(
@@ -53,10 +53,10 @@ TEMPLATE_LIST_TEST_CASE( "getValidWorkDiv", "[workDiv]", alpaka::test::acc::Test
 TEMPLATE_LIST_TEST_CASE( "isValidWorkDiv", "[workDiv]", alpaka::test::acc::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::dev::Dev<Acc>;
-    using Pltf = alpaka::pltf::Pltf<Dev>;
+    using Dev = alpaka::Dev<Acc>;
+    using Pltf = alpaka::Pltf<Dev>;
 
-    Dev dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+    Dev dev(alpaka::getDevByIdx<Pltf>(0u));
     auto workDiv = getWorkDiv< Acc >();
     // Test both overloads
     REQUIRE( alpaka::workdiv::isValidWorkDiv(


### PR DESCRIPTION
See #1034

This PR simplifies the API on the user's side. But it is just one of many options we have. This PR is the least disruptive, since I do not change the existing namespace hierarchy inside of alpaka. Is this something we like and we care for?

Alternatively, we can also *remove* the namespaces `dev` and `pltf` and spill all their entities into the `alpaka` namespace directly.