### PR TITLE
Rename former alpaka::vec functions

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -79,7 +79,7 @@ namespace alpaka
         public block::BlockSyncBarrierFiber<TIdx>,
         public IntrinsicCpu,
         public rand::RandStdLib,
-        public time::TimeStdLib,
+        public TimeStdLib,
         public warp::WarpSingleThread,
         public concepts::Implements<ConceptAcc, AccCpuFibers<TDim, TIdx>>
     {
@@ -116,7 +116,7 @@ namespace alpaka
                 block::BlockSyncBarrierFiber<TIdx>(
                     getWorkDiv<Block, Threads>(workDiv).prod()),
                 rand::RandStdLib(),
-                time::TimeStdLib(),
+                TimeStdLib(),
                 m_gridBlockIdx(Vec<TDim, TIdx>::zeros())
         {}
 

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -80,7 +80,7 @@ namespace alpaka
         public block::BlockSyncNoOp,
         public IntrinsicCpu,
         public rand::RandStdLib,
-        public time::TimeOmp,
+        public TimeOmp,
         public warp::WarpSingleThread,
         public concepts::Implements<ConceptAcc, AccCpuOmp2Blocks<TDim, TIdx>>
     {
@@ -114,7 +114,7 @@ namespace alpaka
                 block::st::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
                 block::BlockSyncNoOp(),
                 rand::RandStdLib(),
-                time::TimeOmp(),
+                TimeOmp(),
                 m_gridBlockIdx(Vec<TDim, TIdx>::zeros())
         {}
 

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -81,7 +81,7 @@ namespace alpaka
         public block::BlockSyncBarrierOmp,
         public IntrinsicCpu,
         public rand::RandStdLib,
-        public time::TimeOmp,
+        public TimeOmp,
         public warp::WarpSingleThread,
         public concepts::Implements<ConceptAcc, AccCpuOmp2Threads<TDim, TIdx>>
     {
@@ -117,7 +117,7 @@ namespace alpaka
                     [](){return (::omp_get_thread_num() == 0);}),
                 block::BlockSyncBarrierOmp(),
                 rand::RandStdLib(),
-                time::TimeOmp(),
+                TimeOmp(),
                 m_gridBlockIdx(Vec<TDim, TIdx>::zeros())
         {}
 

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -74,7 +74,7 @@ namespace alpaka
         public block::BlockSyncNoOp,
         public IntrinsicCpu,
         public rand::RandStdLib,
-        public time::TimeStdLib,
+        public TimeStdLib,
         public warp::WarpSingleThread,
         public concepts::Implements<ConceptAcc, AccCpuSerial<TDim, TIdx>>
     {
@@ -108,7 +108,7 @@ namespace alpaka
                 block::st::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
                 block::BlockSyncNoOp(),
                 rand::RandStdLib(),
-                time::TimeStdLib(),
+                TimeStdLib(),
                 m_gridBlockIdx(Vec<TDim, TIdx>::zeros())
         {}
 

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -71,7 +71,7 @@ namespace alpaka
         public block::BlockSyncNoOp,
         public IntrinsicCpu,
         public rand::RandStdLib,
-        public time::TimeStdLib,
+        public TimeStdLib,
         public warp::WarpSingleThread,
         public concepts::Implements<ConceptAcc, AccCpuTbbBlocks<TDim, TIdx>>
     {
@@ -105,7 +105,7 @@ namespace alpaka
                 block::st::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
                 block::BlockSyncNoOp(),
                 rand::RandStdLib(),
-                time::TimeStdLib(),
+                TimeStdLib(),
                 m_gridBlockIdx(Vec<TDim, TIdx>::zeros())
         {}
 

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -76,7 +76,7 @@ namespace alpaka
         public block::BlockSyncBarrierThread<TIdx>,
         public IntrinsicCpu,
         public rand::RandStdLib,
-        public time::TimeStdLib,
+        public TimeStdLib,
         public warp::WarpSingleThread,
         public concepts::Implements<ConceptAcc, AccCpuThreads<TDim, TIdx>>
     {
@@ -113,7 +113,7 @@ namespace alpaka
                 block::BlockSyncBarrierThread<TIdx>(
                     getWorkDiv<Block, Threads>(workDiv).prod()),
                 rand::RandStdLib(),
-                time::TimeStdLib(),
+                TimeStdLib(),
                 m_gridBlockIdx(Vec<TDim, TIdx>::zeros())
         {}
 

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -82,7 +82,7 @@ namespace alpaka
         public block::BlockSyncUniformCudaHipBuiltIn,
         public IntrinsicUniformCudaHipBuiltIn,
         public rand::RandUniformCudaHipRand,
-        public time::TimeUniformCudaHipBuiltIn,
+        public TimeUniformCudaHipBuiltIn,
         public warp::WarpUniformCudaHipBuiltIn,
         public concepts::Implements<ConceptAcc, AccGpuUniformCudaHipRt<TDim, TIdx>>
     {
@@ -104,7 +104,7 @@ namespace alpaka
                 block::st::BlockSharedMemStUniformCudaHipBuiltIn(),
                 block::BlockSyncUniformCudaHipBuiltIn(),
                 rand::RandUniformCudaHipRand(),
-                time::TimeUniformCudaHipBuiltIn()
+                TimeUniformCudaHipBuiltIn()
         {}
 
     public:

--- a/include/alpaka/acc/AccOmp5.hpp
+++ b/include/alpaka/acc/AccOmp5.hpp
@@ -78,7 +78,7 @@ namespace alpaka
         // cannot determine which intrinsics are safe to use (depends on target), using fallback
         public IntrinsicFallback,
         public rand::RandStdLib,
-        public time::TimeOmp,
+        public TimeOmp,
         public warp::WarpSingleThread,
         public concepts::Implements<ConceptAcc, AccOmp5<TDim, TIdx>>
     {
@@ -114,7 +114,7 @@ namespace alpaka
                 block::st::BlockSharedMemStOmp5(staticMemBegin(), staticMemCapacity()),
                 block::BlockSyncBarrierOmp(),
                 rand::RandStdLib(),
-                time::TimeOmp()
+                TimeOmp()
         {}
 
     public:

--- a/include/alpaka/idx/bt/IdxBtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/idx/bt/IdxBtUniformCudaHipBuiltIn.hpp
@@ -98,7 +98,7 @@ namespace alpaka
             {
                 alpaka::ignore_unused(idx);
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                return cast<TIdx>(getOffsetVecEnd<TDim>(threadIdx));
+                return castVec<TIdx>(getOffsetVecEnd<TDim>(threadIdx));
 #else
                 return getOffsetVecEnd<TDim>(
                     Vec<std::integral_constant<typename TDim::value_type, 3>, TIdx>(

--- a/include/alpaka/idx/gb/IdxGbUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/idx/gb/IdxGbUniformCudaHipBuiltIn.hpp
@@ -98,7 +98,7 @@ namespace alpaka
             {
                 alpaka::ignore_unused(idx);
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                return cast<TIdx>(getOffsetVecEnd<TDim>(blockIdx));
+                return castVec<TIdx>(getOffsetVecEnd<TDim>(blockIdx));
 #else
                 return getOffsetVecEnd<TDim>(
                     Vec<std::integral_constant<typename TDim::value_type, 3>, TIdx>(

--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -89,8 +89,8 @@ namespace alpaka
                             m_dstMemNative(reinterpret_cast<std::uint8_t *>(view::getPtrNative(viewDst))),
                             m_srcMemNative(reinterpret_cast<std::uint8_t const *>(view::getPtrNative(viewSrc)))
                     {
-                        ALPAKA_ASSERT((cast<DstSize>(m_extent) <= m_dstExtent).foldrAll(std::logical_or<bool>()));
-                        ALPAKA_ASSERT((cast<SrcSize>(m_extent) <= m_srcExtent).foldrAll(std::logical_or<bool>()));
+                        ALPAKA_ASSERT((castVec<DstSize>(m_extent) <= m_dstExtent).foldrAll(std::logical_or<bool>()));
+                        ALPAKA_ASSERT((castVec<SrcSize>(m_extent) <= m_srcExtent).foldrAll(std::logical_or<bool>()));
                         ALPAKA_ASSERT(static_cast<DstSize>(m_extentWidthBytes) <= m_dstPitchBytes[TDim::value - 1u]);
                         ALPAKA_ASSERT(static_cast<SrcSize>(m_extentWidthBytes) <= m_srcPitchBytes[TDim::value - 1u]);
                     }
@@ -167,8 +167,8 @@ namespace alpaka
                                 [&](Vec<DimMin1, ExtentSize> const & idx)
                                 {
                                     std::memcpy(
-                                        reinterpret_cast<void *>(this->m_dstMemNative + (cast<DstSize>(idx) * dstPitchBytesWithoutOutmost).foldrAll(std::plus<DstSize>())),
-                                        reinterpret_cast<void const *>(this->m_srcMemNative + (cast<SrcSize>(idx) * srcPitchBytesWithoutOutmost).foldrAll(std::plus<SrcSize>())),
+                                        reinterpret_cast<void *>(this->m_dstMemNative + (castVec<DstSize>(idx) * dstPitchBytesWithoutOutmost).foldrAll(std::plus<DstSize>())),
+                                        reinterpret_cast<void const *>(this->m_srcMemNative + (castVec<SrcSize>(idx) * srcPitchBytesWithoutOutmost).foldrAll(std::plus<SrcSize>())),
                                         static_cast<std::size_t>(this->m_extentWidthBytes));
                                 });
                         }

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -72,7 +72,7 @@ namespace alpaka
                             m_dstPitchBytes(view::getPitchBytesVec(view)),
                             m_dstMemNative(reinterpret_cast<std::uint8_t *>(view::getPtrNative(view)))
                     {
-                        ALPAKA_ASSERT((cast<DstSize>(m_extent) <= m_dstExtent).foldrAll(std::logical_or<bool>()));
+                        ALPAKA_ASSERT((castVec<DstSize>(m_extent) <= m_dstExtent).foldrAll(std::logical_or<bool>()));
                         ALPAKA_ASSERT(m_extentWidthBytes <= m_dstPitchBytes[TDim::value - 1u]);
                     }
 
@@ -138,7 +138,7 @@ namespace alpaka
                                 {
 
                                     memset(
-                                        reinterpret_cast<void *>(this->m_dstMemNative + (cast<DstSize>(idx) * dstPitchBytesWithoutOutmost).foldrAll(std::plus<DstSize>())),
+                                        reinterpret_cast<void *>(this->m_dstMemNative + (castVec<DstSize>(idx) * dstPitchBytesWithoutOutmost).foldrAll(std::plus<DstSize>())),
                                         this->m_byte,
                                         static_cast<std::size_t>(this->m_extentWidthBytes));
                                 });

--- a/include/alpaka/mem/buf/omp5/Copy.hpp
+++ b/include/alpaka/mem/buf/omp5/Copy.hpp
@@ -77,15 +77,15 @@ namespace alpaka
                         int const & iSrcDevice) :
                             m_iDstDevice(iDstDevice),
                             m_iSrcDevice(iSrcDevice),
-                            m_extent(cast<size_t>(extent::getExtentVec(extent))),
-                            m_dstPitchBytes(cast<size_t>(view::getPitchBytesVec(viewDst))),
-                            m_srcPitchBytes(cast<size_t>(view::getPitchBytesVec(viewSrc))),
+                            m_extent(castVec<size_t>(extent::getExtentVec(extent))),
+                            m_dstPitchBytes(castVec<size_t>(view::getPitchBytesVec(viewDst))),
+                            m_srcPitchBytes(castVec<size_t>(view::getPitchBytesVec(viewSrc))),
                             m_dstMemNative(reinterpret_cast<void *>(view::getPtrNative(viewDst))),
                             m_srcMemNative(reinterpret_cast<void const *>(view::getPtrNative(viewSrc)))
                     {
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                        const auto dstExtent(cast<size_t>(extent::getExtentVec(viewDst)));
-                        const auto srcExtent(cast<size_t>(extent::getExtentVec(viewSrc)));
+                        const auto dstExtent(castVec<size_t>(extent::getExtentVec(viewDst)));
+                        const auto srcExtent(castVec<size_t>(extent::getExtentVec(viewSrc)));
                         for(auto i = static_cast<decltype(TDim::value)>(0u); i < TDim::value; ++i)
                         {
                             ALPAKA_ASSERT(m_extent[i] <= dstExtent[i]);

--- a/include/alpaka/time/TimeOmp.hpp
+++ b/include/alpaka/time/TimeOmp.hpp
@@ -20,50 +20,47 @@
 
 namespace alpaka
 {
-    namespace time
+    //#############################################################################
+    //! The OpenMP accelerator time implementation.
+    class TimeOmp : public concepts::Implements<ConceptTime, TimeOmp>
+    {
+    public:
+        //-----------------------------------------------------------------------------
+        TimeOmp() = default;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST TimeOmp(TimeOmp const &) = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST TimeOmp(TimeOmp &&) = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST auto operator=(TimeOmp const &) -> TimeOmp & = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST auto operator=(TimeOmp &&) -> TimeOmp & = delete;
+        //-----------------------------------------------------------------------------
+        /*virtual*/ ~TimeOmp() = default;
+    };
+
+    namespace traits
     {
         //#############################################################################
-        //! The OpenMP accelerator time implementation.
-        class TimeOmp : public concepts::Implements<ConceptTime, TimeOmp>
+        //! The OpenMP accelerator clock operation.
+        template<>
+        struct Clock<
+            TimeOmp>
         {
-        public:
             //-----------------------------------------------------------------------------
-            TimeOmp() = default;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST TimeOmp(TimeOmp const &) = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST TimeOmp(TimeOmp &&) = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST auto operator=(TimeOmp const &) -> TimeOmp & = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST auto operator=(TimeOmp &&) -> TimeOmp & = delete;
-            //-----------------------------------------------------------------------------
-            /*virtual*/ ~TimeOmp() = default;
-        };
-
-        namespace traits
-        {
-            //#############################################################################
-            //! The OpenMP accelerator clock operation.
-            template<>
-            struct Clock<
-                time::TimeOmp>
+            ALPAKA_FN_HOST static auto clock(
+                TimeOmp const & time)
+            -> std::uint64_t
             {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto clock(
-                    time::TimeOmp const & time)
-                -> std::uint64_t
-                {
-                    alpaka::ignore_unused(time);
-                    // NOTE: We compute the number of clock ticks by dividing the following durations:
-                    // - omp_get_wtime returns the elapsed wall clock time in seconds.
-                    // - omp_get_wtick gets the timer precision, i.e., the number of seconds between two successive clock ticks. 
-                    return
-                        static_cast<std::uint64_t>(
-                            omp_get_wtime() / omp_get_wtick());
-                }
-            };
-        }
+                alpaka::ignore_unused(time);
+                // NOTE: We compute the number of clock ticks by dividing the following durations:
+                // - omp_get_wtime returns the elapsed wall clock time in seconds.
+                // - omp_get_wtick gets the timer precision, i.e., the number of seconds between two successive clock ticks. 
+                return
+                    static_cast<std::uint64_t>(
+                        omp_get_wtime() / omp_get_wtick());
+            }
+        };
     }
 }
 

--- a/include/alpaka/time/TimeStdLib.hpp
+++ b/include/alpaka/time/TimeStdLib.hpp
@@ -18,51 +18,48 @@
 
 namespace alpaka
 {
-    namespace time
+    //#############################################################################
+    //! The CPU fibers accelerator time implementation.
+    class TimeStdLib : public concepts::Implements<ConceptTime, TimeStdLib>
+    {
+    public:
+        //-----------------------------------------------------------------------------
+        TimeStdLib() = default;
+        //-----------------------------------------------------------------------------
+        TimeStdLib(TimeStdLib const &) = delete;
+        //-----------------------------------------------------------------------------
+        TimeStdLib(TimeStdLib &&) = delete;
+        //-----------------------------------------------------------------------------
+        auto operator=(TimeStdLib const &) -> TimeStdLib & = delete;
+        //-----------------------------------------------------------------------------
+        auto operator=(TimeStdLib &&) -> TimeStdLib & = delete;
+        //-----------------------------------------------------------------------------
+        /*virtual*/ ~TimeStdLib() = default;
+    };
+
+    namespace traits
     {
         //#############################################################################
-        //! The CPU fibers accelerator time implementation.
-        class TimeStdLib : public concepts::Implements<ConceptTime, TimeStdLib>
+        //! The CPU fibers accelerator clock operation.
+        template<>
+        struct Clock<
+            TimeStdLib>
         {
-        public:
             //-----------------------------------------------------------------------------
-            TimeStdLib() = default;
-            //-----------------------------------------------------------------------------
-            TimeStdLib(TimeStdLib const &) = delete;
-            //-----------------------------------------------------------------------------
-            TimeStdLib(TimeStdLib &&) = delete;
-            //-----------------------------------------------------------------------------
-            auto operator=(TimeStdLib const &) -> TimeStdLib & = delete;
-            //-----------------------------------------------------------------------------
-            auto operator=(TimeStdLib &&) -> TimeStdLib & = delete;
-            //-----------------------------------------------------------------------------
-            /*virtual*/ ~TimeStdLib() = default;
-        };
-
-        namespace traits
-        {
-            //#############################################################################
-            //! The CPU fibers accelerator clock operation.
-            template<>
-            struct Clock<
-                TimeStdLib>
+            ALPAKA_FN_HOST static auto clock(
+                TimeStdLib const & time)
+            -> std::uint64_t
             {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto clock(
-                    time::TimeStdLib const & time)
-                -> std::uint64_t
-                {
-                    alpaka::ignore_unused(time);
+                alpaka::ignore_unused(time);
 
-                    // NOTE: high_resolution_clock returns a non-steady wall-clock time!
-                    // This means that it is not ensured that the values will always increase monotonically.
-                    return
-                        static_cast<std::uint64_t>(
-                            std::chrono::high_resolution_clock::now()
-                                .time_since_epoch()
-                                    .count());
-                }
-            };
-        }
+                // NOTE: high_resolution_clock returns a non-steady wall-clock time!
+                // This means that it is not ensured that the values will always increase monotonically.
+                return
+                    static_cast<std::uint64_t>(
+                        std::chrono::high_resolution_clock::now()
+                            .time_since_epoch()
+                                .count());
+            }
+        };
     }
 }

--- a/include/alpaka/time/TimeUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/time/TimeUniformCudaHipBuiltIn.hpp
@@ -25,48 +25,45 @@
 
 namespace alpaka
 {
-    namespace time
+    //#############################################################################
+    //! The GPU CUDA accelerator time implementation.
+    class TimeUniformCudaHipBuiltIn : public concepts::Implements<ConceptTime, TimeUniformCudaHipBuiltIn>
+    {
+    public:
+        //-----------------------------------------------------------------------------
+        TimeUniformCudaHipBuiltIn() = default;
+        //-----------------------------------------------------------------------------
+        __device__ TimeUniformCudaHipBuiltIn(TimeUniformCudaHipBuiltIn const &) = delete;
+        //-----------------------------------------------------------------------------
+        __device__ TimeUniformCudaHipBuiltIn(TimeUniformCudaHipBuiltIn &&) = delete;
+        //-----------------------------------------------------------------------------
+        __device__ auto operator=(TimeUniformCudaHipBuiltIn const &) -> TimeUniformCudaHipBuiltIn & = delete;
+        //-----------------------------------------------------------------------------
+        __device__ auto operator=(TimeUniformCudaHipBuiltIn &&) -> TimeUniformCudaHipBuiltIn & = delete;
+        //-----------------------------------------------------------------------------
+        /*virtual*/ ~TimeUniformCudaHipBuiltIn() = default;
+    };
+
+    namespace traits
     {
         //#############################################################################
-        //! The GPU CUDA accelerator time implementation.
-        class TimeUniformCudaHipBuiltIn : public concepts::Implements<ConceptTime, TimeUniformCudaHipBuiltIn>
+        //! The CUDA built-in clock operation.
+        template<>
+        struct Clock<
+            TimeUniformCudaHipBuiltIn>
         {
-        public:
             //-----------------------------------------------------------------------------
-            TimeUniformCudaHipBuiltIn() = default;
-            //-----------------------------------------------------------------------------
-            __device__ TimeUniformCudaHipBuiltIn(TimeUniformCudaHipBuiltIn const &) = delete;
-            //-----------------------------------------------------------------------------
-            __device__ TimeUniformCudaHipBuiltIn(TimeUniformCudaHipBuiltIn &&) = delete;
-            //-----------------------------------------------------------------------------
-            __device__ auto operator=(TimeUniformCudaHipBuiltIn const &) -> TimeUniformCudaHipBuiltIn & = delete;
-            //-----------------------------------------------------------------------------
-            __device__ auto operator=(TimeUniformCudaHipBuiltIn &&) -> TimeUniformCudaHipBuiltIn & = delete;
-            //-----------------------------------------------------------------------------
-            /*virtual*/ ~TimeUniformCudaHipBuiltIn() = default;
-        };
-
-        namespace traits
-        {
-            //#############################################################################
-            //! The CUDA built-in clock operation.
-            template<>
-            struct Clock<
-                time::TimeUniformCudaHipBuiltIn>
+            __device__ static auto clock(
+                TimeUniformCudaHipBuiltIn const &)
+            -> std::uint64_t
             {
-                //-----------------------------------------------------------------------------
-                __device__ static auto clock(
-                    time::TimeUniformCudaHipBuiltIn const &)
-                -> std::uint64_t
-                {
-                    // This can be converted to a wall-clock time in seconds by dividing through the shader clock rate given by uniformCudaHipDeviceProp::clockRate.
-                    // This clock rate is double the main clock rate on Fermi and older cards. 
-                    return
-                        static_cast<std::uint64_t>(
-                            clock64());
-                }
-            };
-        }
+                // This can be converted to a wall-clock time in seconds by dividing through the shader clock rate given by uniformCudaHipDeviceProp::clockRate.
+                // This clock rate is double the main clock rate on Fermi and older cards. 
+                return
+                    static_cast<std::uint64_t>(
+                        clock64());
+            }
+        };
     }
 }
 

--- a/include/alpaka/time/Traits.hpp
+++ b/include/alpaka/time/Traits.hpp
@@ -16,42 +16,37 @@
 
 namespace alpaka
 {
+    struct ConceptTime{};
+
     //-----------------------------------------------------------------------------
-    //! The time traits specifics.
-    namespace time
+    //! The time traits.
+    namespace traits
     {
-        struct ConceptTime{};
-
-        //-----------------------------------------------------------------------------
-        //! The time traits.
-        namespace traits
-        {
-            //#############################################################################
-            //! The clock trait.
-            template<
-                typename TTime,
-                typename TSfinae = void>
-            struct Clock;
-        }
-
-        //-----------------------------------------------------------------------------
-        //! \return A counter that is increasing every clock cycle.
-        //!
-        //! \tparam TTime The time implementation type.
-        //! \param time The time implementation.
-        ALPAKA_NO_HOST_ACC_WARNING
+        //#############################################################################
+        //! The clock trait.
         template<
-            typename TTime>
-        ALPAKA_FN_HOST_ACC auto clock(
-            TTime const & time)
-        -> std::uint64_t
-        {
-            using ImplementationBase = concepts::ImplementationBase<ConceptTime, TTime>;
-            return
-                traits::Clock<
-                    ImplementationBase>
-                ::clock(
-                    time);
-        }
+            typename TTime,
+            typename TSfinae = void>
+        struct Clock;
+    }
+
+    //-----------------------------------------------------------------------------
+    //! \return A counter that is increasing every clock cycle.
+    //!
+    //! \tparam TTime The time implementation type.
+    //! \param time The time implementation.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<
+        typename TTime>
+    ALPAKA_FN_HOST_ACC auto clock(
+        TTime const & time)
+    -> std::uint64_t
+    {
+        using ImplementationBase = concepts::ImplementationBase<ConceptTime, TTime>;
+        return
+            traits::Clock<
+                ImplementationBase>
+            ::clock(
+                time);
     }
 }

--- a/include/alpaka/vec/Traits.hpp
+++ b/include/alpaka/vec/Traits.hpp
@@ -45,7 +45,7 @@ namespace alpaka
         template<
             typename TVec,
             typename TSfinae = void>
-        struct Reverse;
+        struct ReverseVec;
 
         //#############################################################################
         //! Trait for concatenating two vectors.
@@ -144,17 +144,17 @@ namespace alpaka
     }
 
     //-----------------------------------------------------------------------------
-    //! \return The reverse vector.
+    //! \return The reverseVec vector.
     ALPAKA_NO_HOST_ACC_WARNING
     template<
         typename TVec>
-    ALPAKA_FN_HOST_ACC auto reverse(
+    ALPAKA_FN_HOST_ACC auto reverseVec(
         TVec const & vec)
     {
         return
-            traits::Reverse<
+            traits::ReverseVec<
                 TVec>
-            ::reverse(
+            ::reverseVec(
                 vec);
     }
 

--- a/include/alpaka/vec/Traits.hpp
+++ b/include/alpaka/vec/Traits.hpp
@@ -53,7 +53,7 @@ namespace alpaka
             typename TVecL,
             typename TVecR,
             typename TSfinae = void>
-        struct Concat;
+        struct ConcatVec;
     }
 
     //-----------------------------------------------------------------------------
@@ -164,15 +164,15 @@ namespace alpaka
     template<
         typename TVecL,
         typename TVecR>
-    ALPAKA_FN_HOST_ACC auto concat(
+    ALPAKA_FN_HOST_ACC auto concatVec(
         TVecL const & vecL,
         TVecR const & vecR)
     {
         return
-            traits::Concat<
+            traits::ConcatVec<
                 TVecL,
                 TVecR>
-            ::concat(
+            ::concatVec(
                 vecL,
                 vecR);
     }

--- a/include/alpaka/vec/Traits.hpp
+++ b/include/alpaka/vec/Traits.hpp
@@ -38,7 +38,7 @@ namespace alpaka
             typename TVal,
             typename TVec,
             typename TSfinae = void>
-        struct Cast;
+        struct CastVec;
 
         //#############################################################################
         //! Trait for reversing a vector.
@@ -132,14 +132,14 @@ namespace alpaka
     template<
         typename TVal,
         typename TVec>
-    ALPAKA_FN_HOST_ACC auto cast(
+    ALPAKA_FN_HOST_ACC auto castVec(
         TVec const & vec)
     {
         return
-            traits::Cast<
+            traits::CastVec<
                 TVal,
                 TVec>
-            ::cast(
+            ::castVec(
                 vec);
     }
 

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -853,12 +853,12 @@ namespace alpaka
             typename TDimL,
             typename TDimR,
             typename TVal>
-        struct Concat<
+        struct ConcatVec<
             Vec<TDimL, TVal>,
             Vec<TDimR, TVal>>
         {
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto concat(
+            ALPAKA_FN_HOST_ACC static auto concatVec(
                 Vec<TDimL, TVal> const & vecL,
                 Vec<TDimR, TVal> const & vecR)
             -> Vec<DimInt<TDimL::value + TDimR::value>, TVal>

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -785,15 +785,15 @@ namespace alpaka
     namespace traits
     {
         //#############################################################################
-        //! Reverse specialization for Vec.
+        //! ReverseVec specialization for Vec.
         template<
             typename TDim,
             typename TVal>
-        struct Reverse<
+        struct ReverseVec<
             Vec<TDim, TVal>>
         {
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto reverse(
+            ALPAKA_FN_HOST_ACC static auto reverseVec(
                 Vec<TDim, TVal> const & vec)
             -> Vec<TDim, TVal>
             {
@@ -806,14 +806,14 @@ namespace alpaka
         };
 
         //#############################################################################
-        //! (Non-)Reverse specialization for 1D Vec.
+        //! (Non-)ReverseVec specialization for 1D Vec.
         template<
             typename TVal>
-        struct Reverse<
+        struct ReverseVec<
             Vec<DimInt<1u>, TVal>>
         {
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto reverse(
+            ALPAKA_FN_HOST_ACC static auto reverseVec(
                 Vec<DimInt<1u>, TVal> const & vec)
             -> Vec<DimInt<1u>, TVal>
             {

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -716,18 +716,18 @@ namespace alpaka
     namespace traits
     {
         //#############################################################################
-        //! Cast specialization for Vec.
+        //! CastVec specialization for Vec.
         template<
             typename TSizeNew,
             typename TDim,
             typename TVal>
-        struct Cast<
+        struct CastVec<
             TSizeNew,
             Vec<TDim, TVal>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto cast(
+            ALPAKA_FN_HOST_ACC static auto castVec(
                 Vec<TDim, TVal> const & vec)
             -> Vec<TDim, TSizeNew>
             {
@@ -741,18 +741,18 @@ namespace alpaka
         };
 
         //#############################################################################
-        //! (Non-)Cast specialization for Vec when src and dst types are identical.
+        //! (Non-)CastVec specialization for Vec when src and dst types are identical.
         //#############################################################################
         template<
             typename TDim,
             typename TVal>
-        struct Cast<
+        struct CastVec<
             TVal,
             Vec<TDim, TVal>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto cast(
+            ALPAKA_FN_HOST_ACC static auto castVec(
                 Vec<TDim, TVal> const & vec)
             -> Vec<TDim, TVal>
             {

--- a/include/alpaka/workdiv/WorkDivUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/workdiv/WorkDivUniformCudaHipBuiltIn.hpp
@@ -112,7 +112,7 @@ namespace alpaka
             {
                 alpaka::ignore_unused(workDiv);
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                return cast<TIdx>(extent::getExtentVecEnd<TDim>(gridDim));
+                return castVec<TIdx>(extent::getExtentVecEnd<TDim>(gridDim));
 #else
                 return extent::getExtentVecEnd<TDim>(
                     Vec<
@@ -142,7 +142,7 @@ namespace alpaka
             {
                 alpaka::ignore_unused(workDiv);
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                return cast<TIdx>(extent::getExtentVecEnd<TDim>(blockDim));
+                return castVec<TIdx>(extent::getExtentVecEnd<TDim>(blockDim));
 #else
                 return extent::getExtentVecEnd<TDim>(
                     Vec<

--- a/test/common/include/alpaka/test/mem/view/Iterator.hpp
+++ b/test/common/include/alpaka/test/mem/view/Iterator.hpp
@@ -139,7 +139,7 @@ namespace alpaka
                         // [ElemSize]
                         Vec<Dim1, Idx> const elementSizeVec(static_cast<Idx>(sizeof(Elem)));
                         // [py, px] ++ [ElemSize] -> [py, px, ElemSize]
-                        Vec<Dim, Idx> const dstPitchBytes(concat(pitchWithoutOutermost, elementSizeVec));
+                        Vec<Dim, Idx> const dstPitchBytes(concatVec(pitchWithoutOutermost, elementSizeVec));
                         // [py, px, ElemSize] [z, y, x] -> [py*z, px*y, ElemSize*x]
                         auto const dimensionalOffsetsInByte(currentIdxDimx * dstPitchBytes);
                         // sum{[py*z, px*y, ElemSize*x]} -> offset in byte

--- a/test/unit/time/src/ClockTest.cpp
+++ b/test/unit/time/src/ClockTest.cpp
@@ -28,11 +28,11 @@ public:
     -> void
     {
         std::uint64_t const start(
-            alpaka::time::clock(acc));
+            alpaka::clock(acc));
         ALPAKA_CHECK(*success, 0u != start);
 
         std::uint64_t const end(
-            alpaka::time::clock(acc));
+            alpaka::clock(acc));
         ALPAKA_CHECK(*success, 0u != end);
 
         // 'end' has to be greater equal 'start'.

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -113,10 +113,10 @@ TEST_CASE("basicVecTraits", "[vec]")
     }
 
     //-----------------------------------------------------------------------------
-    // alpaka::reverse
+    // alpaka::reverseVec
     {
         auto const vecReverse(
-            alpaka::reverse(
+            alpaka::reverseVec(
                 vec));
 
         for(typename Dim::value_type i(0); i < Dim::value; ++i)

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -126,7 +126,7 @@ TEST_CASE("basicVecTraits", "[vec]")
     }
 
     //-----------------------------------------------------------------------------
-    // alpaka::concat
+    // alpaka::concatVec
     {
         using Dim2 = alpaka::DimInt<2u>;
         alpaka::Vec<Dim2, Idx> const vec2(
@@ -134,7 +134,7 @@ TEST_CASE("basicVecTraits", "[vec]")
             static_cast<Idx>(11u));
 
         auto const vecConcat(
-            alpaka::concat(
+            alpaka::concatVec(
                 vec,
                 vec2));
 

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -89,11 +89,11 @@ TEST_CASE("basicVecTraits", "[vec]")
     }
 
     //-----------------------------------------------------------------------------
-    // alpaka::cast
+    // alpaka::castVec
     {
         using SizeCast = std::uint16_t;
         auto const vecCast(
-            alpaka::cast<
+            alpaka::castVec<
                 SizeCast>(
                     vec));
 


### PR DESCRIPTION
* rename alpaka::reverse/Reverse to alpaka::reverseVec/ReverseVec
* rename alpaka::cast/Cast to alpaka::castVec/CastVec
* rename alpaka::concat/Concat to alpaka::concatVec/ConcatVec

See #1034

Depends on:

- [x] #1166