### PR TITLE
Merge adjacent traits namespaces

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -205,9 +205,7 @@ namespace alpaka
                 return "AccCpuFibers<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU fibers accelerator device type trait specialization.
         template<
@@ -218,9 +216,7 @@ namespace alpaka
         {
             using type = DevCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU fibers accelerator dimension getter trait specialization.
         template<
@@ -231,9 +227,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU fibers accelerator execution task type trait specialization.
         template<
@@ -265,10 +259,7 @@ namespace alpaka
                             std::forward<TArgs>(args)...);
             }
         };
-    }
 
-    namespace traits
-    {
         //#############################################################################
         //! The CPU fibers execution task platform type trait specialization.
         template<
@@ -279,9 +270,7 @@ namespace alpaka
         {
             using type = PltfCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU fibers accelerator idx type trait specialization.
         template<

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -196,9 +196,7 @@ namespace alpaka
                 return "AccCpuOmp2Blocks<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 block accelerator device type trait specialization.
         template<
@@ -209,9 +207,7 @@ namespace alpaka
         {
             using type = DevCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 block accelerator dimension getter trait specialization.
         template<
@@ -222,9 +218,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 block accelerator execution task type trait specialization.
         template<
@@ -256,9 +250,7 @@ namespace alpaka
                             std::forward<TArgs>(args)...);
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 block execution task platform type trait specialization.
         template<
@@ -269,9 +261,7 @@ namespace alpaka
         {
             using type = PltfCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 block accelerator idx type trait specialization.
         template<

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -202,9 +202,7 @@ namespace alpaka
                 return "AccCpuOmp2Threads<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 thread accelerator device type trait specialization.
         template<
@@ -215,9 +213,7 @@ namespace alpaka
         {
             using type = DevCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 thread accelerator dimension getter trait specialization.
         template<
@@ -228,9 +224,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 thread accelerator execution task type trait specialization.
         template<
@@ -262,9 +256,7 @@ namespace alpaka
                             std::forward<TArgs>(args)...);
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 thread execution task platform type trait specialization.
         template<
@@ -275,9 +267,7 @@ namespace alpaka
         {
             using type = PltfCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 thread accelerator idx type trait specialization.
         template<

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -190,9 +190,7 @@ namespace alpaka
                 return "AccCpuSerial<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU serial accelerator device type trait specialization.
         template<
@@ -203,9 +201,7 @@ namespace alpaka
         {
             using type = DevCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU serial accelerator dimension getter trait specialization.
         template<
@@ -216,9 +212,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU serial accelerator execution task type trait specialization.
         template<
@@ -250,9 +244,7 @@ namespace alpaka
                             std::forward<TArgs>(args)...);
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU serial execution task platform type trait specialization.
         template<
@@ -263,9 +255,7 @@ namespace alpaka
         {
             using type = PltfCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU serial accelerator idx type trait specialization.
         template<

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -188,9 +188,7 @@ namespace alpaka
                 return "AccCpuTbbBlocks<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU TBB block accelerator device type trait specialization.
         template<
@@ -201,9 +199,7 @@ namespace alpaka
         {
             using type = DevCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU TBB block accelerator dimension getter trait specialization.
         template<
@@ -214,9 +210,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU TBB block accelerator execution task type trait specialization.
         template<
@@ -248,9 +242,7 @@ namespace alpaka
                             std::forward<TArgs>(args)...);
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU TBB block execution task platform type trait specialization.
         template<
@@ -261,9 +253,7 @@ namespace alpaka
         {
             using type = PltfCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU TBB block accelerator idx type trait specialization.
         template<

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -205,9 +205,7 @@ namespace alpaka
                 return "AccCpuThreads<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU threads accelerator device type trait specialization.
         template<
@@ -218,9 +216,7 @@ namespace alpaka
         {
             using type = DevCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU threads accelerator dimension getter trait specialization.
         template<
@@ -231,9 +227,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU threads accelerator execution task type trait specialization.
         template<
@@ -265,9 +259,7 @@ namespace alpaka
                             std::forward<TArgs>(args)...);
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU threads execution task platform type trait specialization.
         template<
@@ -278,9 +270,7 @@ namespace alpaka
         {
             using type = PltfCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU threads accelerator idx type trait specialization.
         template<

--- a/include/alpaka/acc/AccGpuCudaRt.hpp
+++ b/include/alpaka/acc/AccGpuCudaRt.hpp
@@ -102,9 +102,7 @@ namespace alpaka
                 return "AccGpuCudaRt<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU CUDA accelerator execution task type trait specialization.
         template<

--- a/include/alpaka/acc/AccGpuHipRt.hpp
+++ b/include/alpaka/acc/AccGpuHipRt.hpp
@@ -101,9 +101,7 @@ namespace alpaka
                 return "AccGpuHipRt<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU HIP accelerator execution task type trait specialization.
         template<

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -274,9 +274,7 @@ namespace alpaka
                 return "AccGpuUniformCudaHipRt<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU CUDA accelerator device type trait specialization.
         template<
@@ -287,9 +285,7 @@ namespace alpaka
         {
             using type = DevUniformCudaHipRt;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU CUDA accelerator dimension getter trait specialization.
         template<
@@ -328,7 +324,6 @@ namespace alpaka
             }
         };
     }
-
     namespace traits
     {
         //#############################################################################
@@ -363,9 +358,7 @@ namespace alpaka
                             std::forward<TArgs>(args)...);
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU CUDA execution task platform type trait specialization.
         template<
@@ -376,9 +369,7 @@ namespace alpaka
         {
             using type = PltfUniformCudaHipRt;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU CUDA accelerator idx type trait specialization.
         template<

--- a/include/alpaka/acc/AccOmp5.hpp
+++ b/include/alpaka/acc/AccOmp5.hpp
@@ -217,9 +217,7 @@ namespace alpaka
                 return "AccOmp5<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The OpenMP 5.0 accelerator device type trait specialization.
         template<
@@ -230,9 +228,7 @@ namespace alpaka
         {
             using type = DevOmp5;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The OpenMP 5.0 accelerator dimension getter trait specialization.
         template<
@@ -243,9 +239,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The OpenMP 5.0 accelerator execution task type trait specialization.
         template<
@@ -277,9 +271,7 @@ namespace alpaka
                             std::forward<TArgs>(args)...);
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The OpenMP 5.0 execution task platform type trait specialization.
         template<
@@ -290,9 +282,7 @@ namespace alpaka
         {
             using type = PltfOmp5;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The OpenMP 5.0 accelerator idx type trait specialization.
         template<

--- a/include/alpaka/acc/Traits.hpp
+++ b/include/alpaka/acc/Traits.hpp
@@ -159,9 +159,7 @@ namespace alpaka
             using ImplementationBase = typename concepts::ImplementationBase<ConceptUniformCudaHip, TAcc>;
             using type = typename DevType<ImplementationBase>::type;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU HIP execution task platform type trait specialization.
         template<typename TAcc>
@@ -174,9 +172,7 @@ namespace alpaka
                 using ImplementationBase = typename concepts::ImplementationBase<ConceptUniformCudaHip, TAcc>;
                 using type = typename PltfType<ImplementationBase>::type;
             };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU HIP accelerator dimension getter trait specialization.
         template<typename TAcc>
@@ -189,9 +185,7 @@ namespace alpaka
                 using ImplementationBase = typename concepts::ImplementationBase<ConceptUniformCudaHip, TAcc>;
                 using type = typename DimType<ImplementationBase>::type;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU HIP accelerator idx type trait specialization.
         template<typename TAcc>
@@ -204,10 +198,7 @@ namespace alpaka
             using ImplementationBase = typename concepts::ImplementationBase<ConceptUniformCudaHip, TAcc>;
             using type = typename IdxType<ImplementationBase>::type;
         };
-    }
 
-    namespace traits
-    {
         template<
             typename TAcc,
             typename TProperty>

--- a/include/alpaka/core/Cuda.hpp
+++ b/include/alpaka/core/Cuda.hpp
@@ -286,9 +286,7 @@ namespace alpaka
         {
             using type = DimInt<4u>;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CUDA vectors elem type trait specialization.
         template<
@@ -629,9 +627,7 @@ namespace alpaka
                 offsets.w = offset;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CUDA vectors idx type trait specialization.
         template<

--- a/include/alpaka/core/Hip.hpp
+++ b/include/alpaka/core/Hip.hpp
@@ -243,9 +243,7 @@ namespace alpaka
         {
             using type = DimInt<4u>;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The HIP vectors elem type trait specialization.
         template<
@@ -586,9 +584,7 @@ namespace alpaka
                 offsets.w = offset;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The HIP vectors idx type trait specialization.
         template<

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -311,9 +311,7 @@ namespace alpaka
         {
             using type = QueueOmp5NonBlocking;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The thread Omp5 device wait specialization.
         //!

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -262,9 +262,7 @@ namespace alpaka
         {
             using type = PltfUniformCudaHipRt;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The thread CUDA/HIP device wait specialization.
         //!
@@ -287,9 +285,7 @@ namespace alpaka
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(DeviceSynchronize)());
             }
         };
-    }
-    namespace traits
-    {
+
         template<>
         struct QueueType<
             DevUniformCudaHipRt,

--- a/include/alpaka/event/EventGenericThreads.hpp
+++ b/include/alpaka/event/EventGenericThreads.hpp
@@ -153,29 +153,25 @@ namespace alpaka
                 return event.m_spEventImpl->m_dev;
             }
         };
-    }
-        namespace traits
-        {
-            //#############################################################################
-            //! The CPU device event test trait specialization.
-            template<typename TDev>
-            struct IsComplete<
-                EventGenericThreads<TDev>>
-            {
-                //-----------------------------------------------------------------------------
-                //! \return If the event is not waiting within a queue (not enqueued or already handled).
-                ALPAKA_FN_HOST static auto isComplete(
-                    EventGenericThreads<TDev> const & event)
-                -> bool
-                {
-                    std::lock_guard<std::mutex> lk(event.m_spEventImpl->m_mutex);
 
-                    return event.m_spEventImpl->isReady();
-                }
-            };
-        }
-    namespace traits
-    {
+        //#############################################################################
+        //! The CPU device event test trait specialization.
+        template<typename TDev>
+        struct IsComplete<
+            EventGenericThreads<TDev>>
+        {
+            //-----------------------------------------------------------------------------
+            //! \return If the event is not waiting within a queue (not enqueued or already handled).
+            ALPAKA_FN_HOST static auto isComplete(
+                EventGenericThreads<TDev> const & event)
+            -> bool
+            {
+                std::lock_guard<std::mutex> lk(event.m_spEventImpl->m_mutex);
+
+                return event.m_spEventImpl->isReady();
+            }
+        };
+
         //#############################################################################
         //! The CPU non-blocking device queue enqueue trait specialization.
         template<

--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -165,9 +165,7 @@ namespace alpaka
                 return event.m_spEventImpl->m_dev;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CUDA/HIP RT device event test trait specialization.
         template<>
@@ -190,9 +188,7 @@ namespace alpaka
                 return (ret == ALPAKA_API_PREFIX(Success));
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CUDA/HIP RT queue enqueue trait specialization.
         template<>
@@ -233,9 +229,7 @@ namespace alpaka
                     queue.m_spQueueImpl->m_UniformCudaHipQueue));
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CUDA/HIP RT device event thread wait trait specialization.
         //!

--- a/include/alpaka/idx/Traits.hpp
+++ b/include/alpaka/idx/Traits.hpp
@@ -33,8 +33,6 @@ namespace alpaka
         typename T>
     using Idx = typename traits::IdxType<T>::type;
 
-    //-----------------------------------------------------------------------------
-    // Trait specializations for unsigned integral types.
     namespace traits
     {
         //#############################################################################
@@ -47,12 +45,7 @@ namespace alpaka
         {
             using type = std::decay_t<T>;
         };
-    }
 
-    //-----------------------------------------------------------------------------
-    //! The index traits.
-    namespace traits
-    {
         //#############################################################################
         //! The index get trait.
         template<

--- a/include/alpaka/idx/bt/IdxBtOmp.hpp
+++ b/include/alpaka/idx/bt/IdxBtOmp.hpp
@@ -62,9 +62,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The OpenMP accelerator block thread index get trait specialization.
         template<
@@ -114,9 +112,7 @@ namespace alpaka
                 return Vec<DimInt<1u>, TIdx>(static_cast<TIdx>(::omp_get_thread_num()));
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The OpenMP accelerator block thread index idx type trait specialization.
         template<

--- a/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
@@ -69,9 +69,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU fibers accelerator block thread index get trait specialization.
         template<
@@ -98,9 +96,7 @@ namespace alpaka
                 return fiberEntry->second;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU fibers accelerator block thread index idx type trait specialization.
         template<

--- a/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
@@ -69,9 +69,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU threads accelerator block thread index get trait specialization.
         template<
@@ -98,9 +96,7 @@ namespace alpaka
                 return threadEntry->second;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU threads accelerator block thread index idx type trait specialization.
         template<

--- a/include/alpaka/idx/bt/IdxBtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/idx/bt/IdxBtUniformCudaHipBuiltIn.hpp
@@ -74,9 +74,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU CUDA/HIP accelerator block thread index get trait specialization.
         template<
@@ -108,9 +106,7 @@ namespace alpaka
 #endif
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU CUDA/HIP accelerator block thread index idx type trait specialization.
         template<

--- a/include/alpaka/idx/bt/IdxBtZero.hpp
+++ b/include/alpaka/idx/bt/IdxBtZero.hpp
@@ -55,9 +55,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The zero block thread index provider block thread index get trait specialization.
         template<
@@ -82,9 +80,7 @@ namespace alpaka
                 return Vec<TDim, TIdx>::zeros();
             }
         };
-    }
-    namespace traits
-    {
+ 
         //#############################################################################
         //! The zero block thread index idx type trait specialization.
         template<

--- a/include/alpaka/idx/gb/IdxGbLinear.hpp
+++ b/include/alpaka/idx/gb/IdxGbLinear.hpp
@@ -59,9 +59,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The IdxGbLinear grid block index get trait specialization.
         template<
@@ -107,9 +105,7 @@ namespace alpaka
                 return idx.m_gridBlockIdx;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The IdxGbLinear grid block index idx type trait specialization.
         template<

--- a/include/alpaka/idx/gb/IdxGbRef.hpp
+++ b/include/alpaka/idx/gb/IdxGbRef.hpp
@@ -62,9 +62,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The IdxGbRef grid block index grid block index get trait specialization.
         template<
@@ -88,9 +86,7 @@ namespace alpaka
                 return idx.m_gridBlockIdx;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The IdxGbRef grid block index idx type trait specialization.
         template<

--- a/include/alpaka/idx/gb/IdxGbUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/idx/gb/IdxGbUniformCudaHipBuiltIn.hpp
@@ -74,9 +74,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU CUDA/HIP accelerator grid block index get trait specialization.
         template<
@@ -108,9 +106,7 @@ namespace alpaka
 #endif
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU CUDA/HIP accelerator grid block index idx type trait specialization.
         template<

--- a/include/alpaka/kernel/TaskKernelCpuFibers.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuFibers.hpp
@@ -310,9 +310,7 @@ namespace alpaka
         {
             using type = AccCpuFibers<TDim, TIdx>;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU fibers execution task device type trait specialization.
         template<
@@ -325,9 +323,7 @@ namespace alpaka
         {
             using type = DevCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU fibers execution task dimension getter trait specialization.
         template<
@@ -340,9 +336,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU fibers execution task platform type trait specialization.
         template<
@@ -355,9 +349,7 @@ namespace alpaka
         {
             using type = PltfCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU fibers execution task idx type trait specialization.
         template<

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -237,9 +237,7 @@ namespace alpaka
         {
             using type = AccCpuOmp2Blocks<TDim, TIdx>;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 grid block execution task device type trait specialization.
         template<
@@ -252,9 +250,7 @@ namespace alpaka
         {
             using type = DevCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 grid block execution task dimension getter trait specialization.
         template<
@@ -267,9 +263,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 grid block execution task platform type trait specialization.
         template<
@@ -282,9 +276,7 @@ namespace alpaka
         {
             using type = PltfCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 block execution task idx type trait specialization.
         template<

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -214,9 +214,7 @@ namespace alpaka
         {
             using type = AccCpuOmp2Threads<TDim, TIdx>;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 block thread execution task device type trait specialization.
         template<
@@ -229,9 +227,7 @@ namespace alpaka
         {
             using type = DevCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 block thread execution task dimension getter trait specialization.
         template<
@@ -244,9 +240,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 block thread execution task platform type trait specialization.
         template<
@@ -259,9 +253,7 @@ namespace alpaka
         {
             using type = PltfCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU OpenMP 2.0 block thread execution task idx type trait specialization.
         template<

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -164,9 +164,7 @@ namespace alpaka
         {
             using type = AccCpuSerial<TDim, TIdx>;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU serial execution task device type trait specialization.
         template<
@@ -179,9 +177,7 @@ namespace alpaka
         {
             using type = DevCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU serial execution task dimension getter trait specialization.
         template<
@@ -194,9 +190,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU serial execution task platform type trait specialization.
         template<
@@ -209,9 +203,7 @@ namespace alpaka
         {
             using type = PltfCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU serial execution task idx type trait specialization.
         template<

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -177,9 +177,7 @@ namespace alpaka
         {
             using type = AccCpuTbbBlocks<TDim, TIdx>;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU TBB block execution task device type trait specialization.
         template<
@@ -192,9 +190,7 @@ namespace alpaka
         {
             using type = DevCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU TBB block execution task dimension getter trait specialization.
         template<
@@ -207,9 +203,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU TBB block execution task platform type trait specialization.
         template<
@@ -222,9 +216,7 @@ namespace alpaka
         {
             using type = PltfCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU TBB block execution task idx type trait specialization.
         template<

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -298,53 +298,47 @@ namespace alpaka
         std::tuple<std::decay_t<TArgs>...> m_args;
     };
 
-namespace traits
-{
-    //#############################################################################
-    //! The CPU threads execution task accelerator type trait specialization.
-    template<
-        typename TDim,
-        typename TIdx,
-        typename TKernelFnObj,
-        typename... TArgs>
-    struct AccType<
-        TaskKernelCpuThreads<TDim, TIdx, TKernelFnObj, TArgs...>>
+    namespace traits
     {
-        using type = AccCpuThreads<TDim, TIdx>;
-    };
-}
-namespace traits
-{
-    //#############################################################################
-    //! The CPU threads execution task device type trait specialization.
-    template<
-        typename TDim,
-        typename TIdx,
-        typename TKernelFnObj,
-        typename... TArgs>
-    struct DevType<
-        TaskKernelCpuThreads<TDim, TIdx, TKernelFnObj, TArgs...>>
-    {
-        using type = DevCpu;
-    };
-}
-namespace traits
-{
-    //#############################################################################
-    //! The CPU threads execution task dimension getter trait specialization.
-    template<
-        typename TDim,
-        typename TIdx,
-        typename TKernelFnObj,
+        //#############################################################################
+        //! The CPU threads execution task accelerator type trait specialization.
+        template<
+            typename TDim,
+            typename TIdx,
+            typename TKernelFnObj,
+            typename... TArgs>
+        struct AccType<
+            TaskKernelCpuThreads<TDim, TIdx, TKernelFnObj, TArgs...>>
+        {
+            using type = AccCpuThreads<TDim, TIdx>;
+        };
+
+        //#############################################################################
+        //! The CPU threads execution task device type trait specialization.
+        template<
+            typename TDim,
+            typename TIdx,
+            typename TKernelFnObj,
+            typename... TArgs>
+        struct DevType<
+            TaskKernelCpuThreads<TDim, TIdx, TKernelFnObj, TArgs...>>
+        {
+            using type = DevCpu;
+        };
+
+        //#############################################################################
+        //! The CPU threads execution task dimension getter trait specialization.
+        template<
+            typename TDim,
+            typename TIdx,
+            typename TKernelFnObj,
             typename... TArgs>
         struct DimType<
             TaskKernelCpuThreads<TDim, TIdx, TKernelFnObj, TArgs...>>
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU threads execution task platform type trait specialization.
         template<
@@ -357,9 +351,7 @@ namespace traits
         {
             using type = PltfCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU threads execution task idx type trait specialization.
         template<

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -198,9 +198,7 @@ namespace alpaka
         {
             using type = AccGpuUniformCudaHipRt<TDim, TIdx>;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU CUDA/HIP execution task device type trait specialization.
         template<
@@ -214,9 +212,7 @@ namespace alpaka
         {
             using type = DevUniformCudaHipRt;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU CUDA/HIP execution task dimension getter trait specialization.
         template<
@@ -230,9 +226,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU CUDA/HIP execution task platform type trait specialization.
         template<
@@ -246,9 +240,7 @@ namespace alpaka
         {
             using type = PltfUniformCudaHipRt;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU CUDA/HIP execution task idx type trait specialization.
         template<
@@ -262,9 +254,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CUDA/HIP non-blocking kernel enqueue trait specialization.
         template<

--- a/include/alpaka/kernel/TaskKernelOmp5.hpp
+++ b/include/alpaka/kernel/TaskKernelOmp5.hpp
@@ -251,9 +251,7 @@ namespace alpaka
         {
             using type = AccOmp5<TDim, TIdx>;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The OpenMP 5.0 execution task device type trait specialization.
         template<
@@ -266,9 +264,7 @@ namespace alpaka
         {
             using type = DevOmp5;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The OpenMP 5.0 execution task dimension getter trait specialization.
         template<
@@ -281,9 +277,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The OpenMP 5.0 execution task platform type trait specialization.
         template<
@@ -296,9 +290,7 @@ namespace alpaka
         {
             using type = PltfOmp5;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The OpenMP 5.0 execution task idx type trait specialization.
         template<
@@ -311,10 +303,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    }
 
-    namespace traits
-    {
         template<
             typename TDim,
             typename TIdx,

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -196,9 +196,7 @@ namespace alpaka
                 return buf.m_spBufCpuImpl->m_dev;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The BufCpu dimension getter trait.
         template<
@@ -210,9 +208,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The BufCpu memory element type get trait specialization.
         template<
@@ -604,9 +600,7 @@ namespace alpaka
                 return 0u;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The BufCpu idx type trait specialization.
         template<

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -182,9 +182,7 @@ namespace alpaka
                 return (*buf).m_dev;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The BufOmp5 dimension getter trait specialization.
         template<
@@ -196,9 +194,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The BufOmp5 memory element type get trait specialization.
         template<
@@ -567,9 +563,7 @@ namespace alpaka
                 return 0u;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The BufOmp5 idx type trait specialization.
         template<

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -155,9 +155,7 @@ namespace alpaka
                 return buf.m_dev;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The BufUniformCudaHipRt dimension getter trait specialization.
         template<
@@ -169,9 +167,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The BufUniformCudaHipRt memory element type get trait specialization.
         template<
@@ -640,9 +636,7 @@ namespace alpaka
                 return 0u;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The BufUniformCudaHipRt idx type trait specialization.
         template<

--- a/include/alpaka/mem/view/ViewCompileTimeArray.hpp
+++ b/include/alpaka/mem/view/ViewCompileTimeArray.hpp
@@ -53,9 +53,7 @@ namespace alpaka
                 return getDevByIdx<PltfCpu>(0u);
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The fixed idx array dimension getter trait specialization.
         template<
@@ -66,9 +64,7 @@ namespace alpaka
         {
             using type = DimInt<std::rank<TFixedSizeArray>::value>;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The fixed idx array memory element type get trait specialization.
         template<
@@ -184,9 +180,7 @@ namespace alpaka
                 return 0u;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The std::vector idx type trait specialization.
         template<

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -151,9 +151,7 @@ namespace alpaka
                 return view.m_dev;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The ViewPlainPtr dimension getter trait.
         template<
@@ -166,9 +164,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The ViewPlainPtr memory element type get trait specialization.
         template<
@@ -392,9 +388,7 @@ namespace alpaka
                 return 0u;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The ViewPlainPtr idx type trait specialization.
         template<

--- a/include/alpaka/mem/view/ViewStdArray.hpp
+++ b/include/alpaka/mem/view/ViewStdArray.hpp
@@ -49,9 +49,7 @@ namespace alpaka
                 return getDevByIdx<PltfCpu>(0u);
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The std::array dimension getter trait specialization.
         template<
@@ -62,9 +60,7 @@ namespace alpaka
         {
             using type = DimInt<1u>;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The std::array memory element type get trait specialization.
         template<
@@ -167,9 +163,7 @@ namespace alpaka
                 return 0u;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The std::vector idx type trait specialization.
         template<

--- a/include/alpaka/mem/view/ViewStdVector.hpp
+++ b/include/alpaka/mem/view/ViewStdVector.hpp
@@ -49,9 +49,7 @@ namespace alpaka
                 return getDevByIdx<PltfCpu>(0u);
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The std::vector dimension getter trait specialization.
         template<
@@ -62,9 +60,7 @@ namespace alpaka
         {
             using type = DimInt<1u>;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The std::vector memory element type get trait specialization.
         template<
@@ -166,9 +162,7 @@ namespace alpaka
                 return 0u;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The std::vector idx type trait specialization.
         template<

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -216,9 +216,7 @@ namespace alpaka
                         view.m_viewParentView);
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The ViewSubView dimension getter trait specialization.
         template<
@@ -231,9 +229,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The ViewSubView memory element type get trait specialization.
         template<
@@ -403,9 +399,7 @@ namespace alpaka
                 return offset.m_offsetsElements[TIdxIntegralConst::value];
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The ViewSubView idx type trait specialization.
         template<

--- a/include/alpaka/pltf/PltfCpu.hpp
+++ b/include/alpaka/pltf/PltfCpu.hpp
@@ -39,9 +39,7 @@ namespace alpaka
         {
             using type = DevCpu;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU platform device count get trait specialization.
         template<>

--- a/include/alpaka/pltf/PltfOmp5.hpp
+++ b/include/alpaka/pltf/PltfOmp5.hpp
@@ -45,9 +45,7 @@ namespace alpaka
         {
             using type = DevOmp5;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The OpenMP 5 platform device count get trait specialization.
         template<>

--- a/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
+++ b/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
@@ -57,9 +57,7 @@ namespace alpaka
         {
             using type = DevUniformCudaHipRt;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CUDA/HIP RT platform device count get trait specialization.
         template<>

--- a/include/alpaka/queue/QueueGenericThreadsBlocking.hpp
+++ b/include/alpaka/queue/QueueGenericThreadsBlocking.hpp
@@ -154,9 +154,7 @@ namespace alpaka
                 return queue.m_spQueueImpl->m_dev;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU blocking device queue event type trait specialization.
         template<
@@ -166,9 +164,7 @@ namespace alpaka
         {
             using type = EventGenericThreads<TDev>;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU blocking device queue enqueue trait specialization.
         //! This default implementation for all tasks directly invokes the function call operator of the task.
@@ -209,10 +205,7 @@ namespace alpaka
                 return !queue.m_spQueueImpl->m_bCurrentlyExecutingTask;
             }
         };
-    }
 
-    namespace traits
-    {
         //#############################################################################
         //! The CPU blocking device queue thread wait trait specialization.
         //!

--- a/include/alpaka/queue/QueueGenericThreadsNonBlocking.hpp
+++ b/include/alpaka/queue/QueueGenericThreadsNonBlocking.hpp
@@ -167,9 +167,7 @@ namespace alpaka
                 return queue.m_spQueueImpl->m_dev;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU non-blocking device queue event type trait specialization.
         template<
@@ -179,9 +177,7 @@ namespace alpaka
         {
             using type = EventGenericThreads<TDev>;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU non-blocking device queue enqueue trait specialization.
         //! This default implementation for all tasks directly invokes the function call operator of the task.

--- a/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
@@ -98,9 +98,7 @@ namespace alpaka
         {
             using type = DevUniformCudaHipRt;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CUDA/HIP RT blocking queue event type trait specialization.
         template<>
@@ -109,9 +107,7 @@ namespace alpaka
         {
             using type = EventUniformCudaHipRt;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CUDA/HIP RT blocking queue enqueue trait specialization.
         template<

--- a/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
@@ -98,9 +98,7 @@ namespace alpaka
         {
             using type = DevUniformCudaHipRt;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CUDA/HIP RT non-blocking queue event type trait specialization.
         template<>
@@ -109,9 +107,7 @@ namespace alpaka
         {
             using type = EventUniformCudaHipRt;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CUDA/HIP RT sync queue enqueue trait specialization.
         template<

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -167,9 +167,7 @@ namespace alpaka
                 return queue.m_spQueueImpl->m_dev;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CUDA/HIP RT blocking queue test trait specialization.
         template<>
@@ -191,9 +189,7 @@ namespace alpaka
                 return (ret == ALPAKA_API_PREFIX(Success));
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CUDA/HIP RT blocking queue thread wait trait specialization.
         //!

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -616,9 +616,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The Vec idx type trait specialization.
         template<
@@ -629,10 +627,7 @@ namespace alpaka
         {
             using type = TVal;
         };
-    }
 
-    namespace traits
-    {
         //#############################################################################
         //! Specialization for selecting a sub-vector.
         template<

--- a/include/alpaka/workdiv/WorkDivMembers.hpp
+++ b/include/alpaka/workdiv/WorkDivMembers.hpp
@@ -124,9 +124,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The WorkDivMembers idx type trait specialization.
         template<
@@ -137,9 +135,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The WorkDivMembers grid block extent trait specialization.
         template<

--- a/include/alpaka/workdiv/WorkDivUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/workdiv/WorkDivUniformCudaHipBuiltIn.hpp
@@ -78,9 +78,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU CUDA/HIP accelerator work division idx type trait specialization.
         template<
@@ -91,9 +89,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The GPU CUDA/HIP accelerator work division grid block extent trait specialization.
         template<

--- a/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -253,9 +253,7 @@ namespace alpaka
                 return event.m_spEventImpl->m_dev;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU device event test trait specialization.
         //#############################################################################
@@ -275,9 +273,7 @@ namespace alpaka
                 return event.m_spEventImpl->m_bIsReady;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //!
         //#############################################################################
@@ -569,9 +565,7 @@ namespace alpaka
                 return event.m_spEventImpl->m_dev;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU device event test trait specialization.
         template<>
@@ -589,9 +583,7 @@ namespace alpaka
                 return event.m_spEventImpl->m_bIsReady;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         template<>
         struct Enqueue<
@@ -861,9 +853,7 @@ namespace alpaka
                 return event.m_spEventImpl->m_dev;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU device event test trait specialization.
         template<>
@@ -881,9 +871,7 @@ namespace alpaka
                 return event.m_spEventImpl->m_bIsReady;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         template<>
         struct Enqueue<

--- a/test/common/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
+++ b/test/common/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
@@ -162,9 +162,7 @@ namespace alpaka
                 return queue.m_spQueueImpl->m_dev;
             }
         };
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The CPU blocking device queue event type trait specialization.
         template<>
@@ -173,9 +171,6 @@ namespace alpaka
         {
             using type = EventCpu;
         };
-    }
-    namespace traits
-    {
 
         //#############################################################################
         //! The CPU blocking device queue enqueue trait specialization.
@@ -340,10 +335,7 @@ namespace alpaka
                 // but a specialization is needed to path the EventTests
             }
         };
-    }
 
-    namespace traits
-    {
         //#############################################################################
         //! The CPU blocking device queue thread wait trait specialization.
         //!


### PR DESCRIPTION
This is a simple refactoring. After deleting many namespaces, we had lots of adjacent `traits` namespaces, so I merged them.