### PR TITLE
Fix atomic hierarchy usage in the cheatsheet

### DIFF
--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -252,7 +252,7 @@ Atomic operations
 
      auto result = atomicOp<Operation>(acc,
                                                arguments,
-                                               OperationHierarchy);
+                                               OperationHierarchy{});
 
   Operation (all in `op`):
      .. code-block:: c++


### PR DESCRIPTION
The original wording used a type, while an object of the type has to be passed.