### PR TITLE
increase version to 0.7.0-develop

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,9 +11,9 @@ project = 'alpaka'
 copyright = 'Documentation under CC-BY 4.0, Benjamin Worpitz, René Widera, Axel Huebl, Michael Bussmann'
 author = 'Benjamin Worpitz, René Widera, Axel Huebl, Michael Bussmann'
 # The short X.Y version.
-version = u'0.5.0'
+version = u'0.7.0'
 # The full version, including alpha/beta/rc tags.
-release = u'0.5.0'
+release = u'0.7.0-develop'
 
 # The master toctree document.
 master_doc = 'index'

--- a/include/alpaka/version.hpp
+++ b/include/alpaka/version.hpp
@@ -12,7 +12,7 @@
 #include <boost/predef/version_number.h>
 
 #define ALPAKA_VERSION_MAJOR 0
-#define ALPAKA_VERSION_MINOR 5
+#define ALPAKA_VERSION_MINOR 7
 #define ALPAKA_VERSION_PATCH 0
 
 //! The alpaka library version number


### PR DESCRIPTION
This pull request set the development branch to 0.7.0 (next release after our current feature freezed 0.6.0)
Since we have in alpaka/version.hpp no why to express that this is the development branch I set only the flavour `develop` to the documentation version.

I set directly the version to 0.7.0 instead of 0.6.0 because the develop branch is the upcoming 0.7.0.