### PR TITLE
Remove namespace alpaka::view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - renamed function `alpaka::buf::alloc` to `alpaka::allocBuf`
 - removed namespace `alpaka::alloc`
 - removed namespace `alpaka::buf`
+- renamed function `alpaka::view::set` to `alpaka::memset`
+- renamed function `alpaka::view::copy` to `alpaka::memcpy`
+- removed namespace `alpaka::view`
 
 ## [0.5.0] - 2020-06-26
 ### Compatibility Changes:

--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -225,7 +225,7 @@ auto main()
     // The view does not own the underlying memory. So you have to make sure that
     // the view does not outlive its underlying memory.
     std::array<Data, nElementsPerDim * nElementsPerDim * nElementsPerDim> plainBuffer;
-    using ViewHost = alpaka::view::ViewPlainPtr<Host, Data, Dim, Idx>;
+    using ViewHost = alpaka::ViewPlainPtr<Host, Data, Dim, Idx>;
     ViewHost hostViewPlainPtr(plainBuffer.data(), devHost, extents);
 
     // Allocate accelerator memory buffers
@@ -242,7 +242,7 @@ auto main()
     // elements of a buffer directly, but
     // you can get the pointer to the memory
     // (getPtrNative).
-    Data * const pHostBuffer = alpaka::view::getPtrNative(hostBuffer);
+    Data * const pHostBuffer = alpaka::getPtrNative(hostBuffer);
 
     // This pointer can be used to directly write
     // some values into the buffer memory.
@@ -256,7 +256,7 @@ auto main()
     // Memory views and buffers can also be initialized by executing a kernel.
     // To pass a buffer into a kernel, you can pass the
     // native pointer into the kernel invocation.
-    Data * const pHostViewPlainPtr = alpaka::view::getPtrNative(hostViewPlainPtr);
+    Data * const pHostViewPlainPtr = alpaka::getPtrNative(hostViewPlainPtr);
 
     FillBufferKernel fillBufferKernel;
 
@@ -279,25 +279,25 @@ auto main()
     // not currently supported.
     // In this example both host buffers are copied
     // into device buffers.
-    alpaka::view::copy(devQueue, deviceBuffer1, hostViewPlainPtr, extents);
-    alpaka::view::copy(devQueue, deviceBuffer2, hostBuffer, extents);
+    alpaka::copy(devQueue, deviceBuffer1, hostViewPlainPtr, extents);
+    alpaka::copy(devQueue, deviceBuffer2, hostBuffer, extents);
 
     // Depending on the accelerator, the allocation function may introduce
     // padding between rows/planes of multidimensional memory allocations.
     // Therefore the pitch (distance between consecutive rows/planes) may be
     // greater than the space required for the data.
-    Idx const deviceBuffer1Pitch(alpaka::view::getPitchBytes<2u>(deviceBuffer1) / sizeof(Data));
-    Idx const deviceBuffer2Pitch(alpaka::view::getPitchBytes<2u>(deviceBuffer2) / sizeof(Data));
-    Idx const hostBuffer1Pitch(alpaka::view::getPitchBytes<2u>(hostBuffer) / sizeof(Data));
-    Idx const hostViewPlainPtrPitch(alpaka::view::getPitchBytes<2u>(hostViewPlainPtr) / sizeof(Data));
+    Idx const deviceBuffer1Pitch(alpaka::getPitchBytes<2u>(deviceBuffer1) / sizeof(Data));
+    Idx const deviceBuffer2Pitch(alpaka::getPitchBytes<2u>(deviceBuffer2) / sizeof(Data));
+    Idx const hostBuffer1Pitch(alpaka::getPitchBytes<2u>(hostBuffer) / sizeof(Data));
+    Idx const hostViewPlainPtrPitch(alpaka::getPitchBytes<2u>(hostViewPlainPtr) / sizeof(Data));
 
     // Test device Buffer
     //
     // This kernel tests if the copy operations
     // were successful. In the case something
     // went wrong an assert will fail.
-    Data const * const pDeviceBuffer1 = alpaka::view::getPtrNative(deviceBuffer1);
-    Data const * const pDeviceBuffer2 = alpaka::view::getPtrNative(deviceBuffer2);
+    Data const * const pDeviceBuffer1 = alpaka::getPtrNative(deviceBuffer1);
+    Data const * const pDeviceBuffer2 = alpaka::getPtrNative(deviceBuffer2);
 
     TestBufferKernel testBufferKernel;
     alpaka::exec<Acc>(

--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -279,8 +279,8 @@ auto main()
     // not currently supported.
     // In this example both host buffers are copied
     // into device buffers.
-    alpaka::copy(devQueue, deviceBuffer1, hostViewPlainPtr, extents);
-    alpaka::copy(devQueue, deviceBuffer2, hostBuffer, extents);
+    alpaka::memcpy(devQueue, deviceBuffer1, hostViewPlainPtr, extents);
+    alpaka::memcpy(devQueue, deviceBuffer2, hostBuffer, extents);
 
     // Depending on the accelerator, the allocation function may introduce
     // padding between rows/planes of multidimensional memory allocations.

--- a/example/heatEquation/src/heatEquation.cpp
+++ b/example/heatEquation/src/heatEquation.cpp
@@ -229,14 +229,14 @@ auto main( ) -> int
     HeatEquationKernel kernel;
 
     // Copy host -> device
-    alpaka::copy(
+    alpaka::memcpy(
         queue,
         uCurrBufAcc,
         uCurrBufHost,
         extent
     );
     // Copy to the buffer for next as well to have boundary values set
-    alpaka::copy(
+    alpaka::memcpy(
         queue,
         uNextBufAcc,
         uCurrBufAcc,
@@ -268,7 +268,7 @@ auto main( ) -> int
     }
 
     // Copy device -> host
-    alpaka::copy(
+    alpaka::memcpy(
         queue,
         uNextBufHost,
         uNextBufAcc,

--- a/example/heatEquation/src/heatEquation.cpp
+++ b/example/heatEquation/src/heatEquation.cpp
@@ -185,8 +185,8 @@ auto main( ) -> int
         )
     };
 
-    double * const pCurrHost = alpaka::view::getPtrNative( uCurrBufHost );
-    double * const pNextHost = alpaka::view::getPtrNative( uNextBufHost );
+    double * const pCurrHost = alpaka::getPtrNative( uCurrBufHost );
+    double * const pNextHost = alpaka::getPtrNative( uNextBufHost );
 
     // Accelerator buffer
     using BufAcc = alpaka::Buf<
@@ -214,8 +214,8 @@ auto main( ) -> int
         )
     };
 
-    double * pCurrAcc = alpaka::view::getPtrNative( uCurrBufAcc );
-    double * pNextAcc = alpaka::view::getPtrNative( uNextBufAcc );
+    double * pCurrAcc = alpaka::getPtrNative( uCurrBufAcc );
+    double * pNextAcc = alpaka::getPtrNative( uNextBufAcc );
 
     // Apply initial conditions for the test problem
     for( uint32_t i = 0; i < numNodesX; i++ )
@@ -229,14 +229,14 @@ auto main( ) -> int
     HeatEquationKernel kernel;
 
     // Copy host -> device
-    alpaka::view::copy(
+    alpaka::copy(
         queue,
         uCurrBufAcc,
         uCurrBufHost,
         extent
     );
     // Copy to the buffer for next as well to have boundary values set
-    alpaka::view::copy(
+    alpaka::copy(
         queue,
         uNextBufAcc,
         uCurrBufAcc,
@@ -268,7 +268,7 @@ auto main( ) -> int
     }
 
     // Copy device -> host
-    alpaka::view::copy(
+    alpaka::copy(
         queue,
         uNextBufHost,
         uNextBufAcc,

--- a/example/monteCarloIntegration/src/monteCarloIntegration.cpp
+++ b/example/monteCarloIntegration/src/monteCarloIntegration.cpp
@@ -166,18 +166,18 @@ auto main() -> int
             Idx>(
             devHost,
             extent)};
-    uint32_t *const ptrBufHost{alpaka::view::getPtrNative(bufHost)};
+    uint32_t *const ptrBufHost{alpaka::getPtrNative(bufHost)};
     BufAcc bufAcc{
         alpaka::allocBuf<
             uint32_t,
             Idx>(
             devAcc,
             extent)};
-    uint32_t *const ptrBufAcc{alpaka::view::getPtrNative(bufAcc)};
+    uint32_t *const ptrBufAcc{alpaka::getPtrNative(bufAcc)};
 
     // Initialize the global count to 0.
     ptrBufHost[0] = 0.0f;
-    alpaka::view::copy(
+    alpaka::copy(
         queue,
         bufAcc,
         bufHost,
@@ -191,7 +191,7 @@ auto main() -> int
         numPoints,
         ptrBufAcc,
         Function{});
-    alpaka::view::copy(
+    alpaka::copy(
         queue,
         bufHost,
         bufAcc,

--- a/example/monteCarloIntegration/src/monteCarloIntegration.cpp
+++ b/example/monteCarloIntegration/src/monteCarloIntegration.cpp
@@ -177,7 +177,7 @@ auto main() -> int
 
     // Initialize the global count to 0.
     ptrBufHost[0] = 0.0f;
-    alpaka::copy(
+    alpaka::memcpy(
         queue,
         bufAcc,
         bufHost,
@@ -191,7 +191,7 @@ auto main() -> int
         numPoints,
         ptrBufAcc,
         Function{});
-    alpaka::copy(
+    alpaka::memcpy(
         queue,
         bufHost,
         bufAcc,

--- a/example/reduce/src/reduce.cpp
+++ b/example/reduce/src/reduce.cpp
@@ -80,7 +80,7 @@ T reduce(DevHost devHost, DevAcc devAcc, QueueAcc queue, uint64_t n, alpaka::Buf
             devAcc, static_cast<Extent>(blockCount));
 
     // copy the data to the GPU
-    alpaka::view::copy(queue, sourceDeviceMemory, hostMemory, n);
+    alpaka::copy(queue, sourceDeviceMemory, hostMemory, n);
 
     // create kernels with their workdivs
     ReduceKernel<blockSize, T, TFunc> kernel1, kernel2;
@@ -95,8 +95,8 @@ T reduce(DevHost devHost, DevAcc devAcc, QueueAcc queue, uint64_t n, alpaka::Buf
     auto const taskKernelReduceMain(alpaka::createTaskKernel<Acc>(
         workDiv1,
         kernel1,
-        alpaka::view::getPtrNative(sourceDeviceMemory),
-        alpaka::view::getPtrNative(destinationDeviceMemory),
+        alpaka::getPtrNative(sourceDeviceMemory),
+        alpaka::getPtrNative(destinationDeviceMemory),
         n,
         func));
 
@@ -104,8 +104,8 @@ T reduce(DevHost devHost, DevAcc devAcc, QueueAcc queue, uint64_t n, alpaka::Buf
     auto const taskKernelReduceLastBlock(alpaka::createTaskKernel<Acc>(
         workDiv2,
         kernel2,
-        alpaka::view::getPtrNative(destinationDeviceMemory),
-        alpaka::view::getPtrNative(destinationDeviceMemory),
+        alpaka::getPtrNative(destinationDeviceMemory),
+        alpaka::getPtrNative(destinationDeviceMemory),
         blockCount,
         func));
 
@@ -116,10 +116,10 @@ T reduce(DevHost devHost, DevAcc devAcc, QueueAcc queue, uint64_t n, alpaka::Buf
     //  download result from GPU
     T resultGpuHost;
     auto resultGpuDevice =
-        alpaka::view::ViewPlainPtr<DevHost, T, Dim, Idx>(
+        alpaka::ViewPlainPtr<DevHost, T, Dim, Idx>(
             &resultGpuHost, devHost, static_cast<Extent>(blockSize));
 
-    alpaka::view::copy(queue, resultGpuDevice, destinationDeviceMemory, 1);
+    alpaka::copy(queue, resultGpuDevice, destinationDeviceMemory, 1);
 
     return resultGpuHost;
 }
@@ -151,7 +151,7 @@ int main()
     // allocate memory
     auto hostMemory = alpaka::allocBuf<T, Idx>(devHost, n);
 
-    T *nativeHostMemory = alpaka::view::getPtrNative(hostMemory);
+    T *nativeHostMemory = alpaka::getPtrNative(hostMemory);
 
     // fill array with data
     for (uint64_t i = 0; i < n; i++)

--- a/example/reduce/src/reduce.cpp
+++ b/example/reduce/src/reduce.cpp
@@ -80,7 +80,7 @@ T reduce(DevHost devHost, DevAcc devAcc, QueueAcc queue, uint64_t n, alpaka::Buf
             devAcc, static_cast<Extent>(blockCount));
 
     // copy the data to the GPU
-    alpaka::copy(queue, sourceDeviceMemory, hostMemory, n);
+    alpaka::memcpy(queue, sourceDeviceMemory, hostMemory, n);
 
     // create kernels with their workdivs
     ReduceKernel<blockSize, T, TFunc> kernel1, kernel2;
@@ -119,7 +119,7 @@ T reduce(DevHost devHost, DevAcc devAcc, QueueAcc queue, uint64_t n, alpaka::Buf
         alpaka::ViewPlainPtr<DevHost, T, Dim, Idx>(
             &resultGpuHost, devHost, static_cast<Extent>(blockSize));
 
-    alpaka::copy(queue, resultGpuDevice, destinationDeviceMemory, 1);
+    alpaka::memcpy(queue, resultGpuDevice, destinationDeviceMemory, 1);
 
     return resultGpuHost;
 }

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -165,9 +165,9 @@ auto main()
     BufAcc bufAccC(alpaka::allocBuf<Data, Idx>(devAcc, extent));
 
     // Copy Host -> Acc
-    alpaka::copy(queue, bufAccA, bufHostA, extent);
-    alpaka::copy(queue, bufAccB, bufHostB, extent);
-    alpaka::copy(queue, bufAccC, bufHostC, extent);
+    alpaka::memcpy(queue, bufAccA, bufHostA, extent);
+    alpaka::memcpy(queue, bufAccB, bufHostB, extent);
+    alpaka::memcpy(queue, bufAccC, bufHostC, extent);
 
     // Instantiate the kernel function object
     VectorAddKernel kernel;
@@ -193,7 +193,7 @@ auto main()
     // Copy back the result
     {
         auto beginT = std::chrono::high_resolution_clock::now();
-        alpaka::copy(queue, bufHostC, bufAccC, extent);
+        alpaka::memcpy(queue, bufHostC, bufAccC, extent);
         alpaka::wait(queue);
         const auto endT = std::chrono::high_resolution_clock::now();
         std::cout << "Time for HtoD copy: " << std::chrono::duration<double>(endT-beginT).count() << 's' << std::endl;

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -142,9 +142,9 @@ auto main()
     BufHost bufHostC(alpaka::allocBuf<Data, Idx>(devHost, extent));
 
     // Initialize the host input vectors A and B
-    Data * const pBufHostA(alpaka::view::getPtrNative(bufHostA));
-    Data * const pBufHostB(alpaka::view::getPtrNative(bufHostB));
-    Data * const pBufHostC(alpaka::view::getPtrNative(bufHostC));
+    Data * const pBufHostA(alpaka::getPtrNative(bufHostA));
+    Data * const pBufHostB(alpaka::getPtrNative(bufHostB));
+    Data * const pBufHostC(alpaka::getPtrNative(bufHostC));
 
     // C++14 random generator for uniformly distributed numbers in {1,..,42}
     std::random_device rd{};
@@ -165,9 +165,9 @@ auto main()
     BufAcc bufAccC(alpaka::allocBuf<Data, Idx>(devAcc, extent));
 
     // Copy Host -> Acc
-    alpaka::view::copy(queue, bufAccA, bufHostA, extent);
-    alpaka::view::copy(queue, bufAccB, bufHostB, extent);
-    alpaka::view::copy(queue, bufAccC, bufHostC, extent);
+    alpaka::copy(queue, bufAccA, bufHostA, extent);
+    alpaka::copy(queue, bufAccB, bufHostB, extent);
+    alpaka::copy(queue, bufAccC, bufHostC, extent);
 
     // Instantiate the kernel function object
     VectorAddKernel kernel;
@@ -176,9 +176,9 @@ auto main()
     auto const taskKernel(alpaka::createTaskKernel<Acc>(
         workDiv,
         kernel,
-        alpaka::view::getPtrNative(bufAccA),
-        alpaka::view::getPtrNative(bufAccB),
-        alpaka::view::getPtrNative(bufAccC),
+        alpaka::getPtrNative(bufAccA),
+        alpaka::getPtrNative(bufAccB),
+        alpaka::getPtrNative(bufAccC),
         numElements));
 
     // Enqueue the kernel execution task
@@ -193,7 +193,7 @@ auto main()
     // Copy back the result
     {
         auto beginT = std::chrono::high_resolution_clock::now();
-        alpaka::view::copy(queue, bufHostC, bufAccC, extent);
+        alpaka::copy(queue, bufHostC, bufAccC, extent);
         alpaka::wait(queue);
         const auto endT = std::chrono::high_resolution_clock::now();
         std::cout << "Time for HtoD copy: " << std::chrono::duration<double>(endT-beginT).count() << 's' << std::endl;

--- a/include/alpaka/intrinsic/IntrinsicCpu.hpp
+++ b/include/alpaka/intrinsic/IntrinsicCpu.hpp
@@ -102,7 +102,7 @@ namespace alpaka
                 else
                     return 0;
 #else
-                return detail::ffsFallback(value);
+                return alpaka::detail::ffsFallback(value);
 #endif
             }
 
@@ -123,7 +123,7 @@ namespace alpaka
                 else
                     return 0;
 #else
-                return detail::ffsFallback(value);
+                return alpaka::detail::ffsFallback(value);
 #endif
             }
         };

--- a/include/alpaka/intrinsic/IntrinsicFallback.hpp
+++ b/include/alpaka/intrinsic/IntrinsicFallback.hpp
@@ -82,7 +82,7 @@ namespace alpaka
                 std::uint32_t value)
             -> std::int32_t
             {
-                return detail::popcountFallback(value);
+                return alpaka::detail::popcountFallback(value);
             }
 
             //-----------------------------------------------------------------------------
@@ -91,7 +91,7 @@ namespace alpaka
                 std::uint64_t value)
             -> std::int32_t
             {
-                return detail::popcountFallback(value);
+                return alpaka::detail::popcountFallback(value);
             }
         };
 
@@ -106,7 +106,7 @@ namespace alpaka
                 std::int32_t value)
             -> std::int32_t
             {
-                return detail::ffsFallback(value);
+                return alpaka::detail::ffsFallback(value);
             }
 
             //-----------------------------------------------------------------------------
@@ -115,7 +115,7 @@ namespace alpaka
                 std::int64_t value)
             -> std::int32_t
             {
-                return detail::ffsFallback(value);
+                return alpaka::detail::ffsFallback(value);
             }
         };
     }

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -242,98 +242,92 @@ namespace alpaka
             };
         }
     }
-    namespace view
-    {
-        namespace traits
-        {
-            //#############################################################################
-            //! The BufCpu native pointer get trait specialization.
-            template<
-                typename TElem,
-                typename TDim,
-                typename TIdx>
-            struct GetPtrNative<
-                BufCpu<TElem, TDim, TIdx>>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrNative(
-                    BufCpu<TElem, TDim, TIdx> const & buf)
-                -> TElem const *
-                {
-                    return buf.m_spBufCpuImpl->m_pMem;
-                }
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrNative(
-                    BufCpu<TElem, TDim, TIdx> & buf)
-                -> TElem *
-                {
-                    return buf.m_spBufCpuImpl->m_pMem;
-                }
-            };
-            //#############################################################################
-            //! The BufCpu pointer on device get trait specialization.
-            template<
-                typename TElem,
-                typename TDim,
-                typename TIdx>
-            struct GetPtrDev<
-                BufCpu<TElem, TDim, TIdx>,
-                DevCpu>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrDev(
-                    BufCpu<TElem, TDim, TIdx> const & buf,
-                    DevCpu const & dev)
-                -> TElem const *
-                {
-                    if(dev == getDev(buf))
-                    {
-                        return buf.m_spBufCpuImpl->m_pMem;
-                    }
-                    else
-                    {
-                        throw std::runtime_error("The buffer is not accessible from the given device!");
-                    }
-                }
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrDev(
-                    BufCpu<TElem, TDim, TIdx> & buf,
-                    DevCpu const & dev)
-                -> TElem *
-                {
-                    if(dev == getDev(buf))
-                    {
-                        return buf.m_spBufCpuImpl->m_pMem;
-                    }
-                    else
-                    {
-                        throw std::runtime_error("The buffer is not accessible from the given device!");
-                    }
-                }
-            };
-            //#############################################################################
-            //! The BufCpu pitch get trait specialization.
-            template<
-                typename TElem,
-                typename TDim,
-                typename TIdx>
-            struct GetPitchBytes<
-                DimInt<TDim::value - 1u>,
-                BufCpu<TElem, TDim, TIdx>>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPitchBytes(
-                    BufCpu<TElem, TDim, TIdx> const & pitch)
-                -> TIdx
-                {
-                    return pitch.m_spBufCpuImpl->m_pitchBytes;
-                }
-            };
-        }
-    }
-
     namespace traits
     {
+        //#############################################################################
+        //! The BufCpu native pointer get trait specialization.
+        template<
+            typename TElem,
+            typename TDim,
+            typename TIdx>
+        struct GetPtrNative<
+            BufCpu<TElem, TDim, TIdx>>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrNative(
+                BufCpu<TElem, TDim, TIdx> const & buf)
+            -> TElem const *
+            {
+                return buf.m_spBufCpuImpl->m_pMem;
+            }
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrNative(
+                BufCpu<TElem, TDim, TIdx> & buf)
+            -> TElem *
+            {
+                return buf.m_spBufCpuImpl->m_pMem;
+            }
+        };
+        //#############################################################################
+        //! The BufCpu pointer on device get trait specialization.
+        template<
+            typename TElem,
+            typename TDim,
+            typename TIdx>
+        struct GetPtrDev<
+            BufCpu<TElem, TDim, TIdx>,
+            DevCpu>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrDev(
+                BufCpu<TElem, TDim, TIdx> const & buf,
+                DevCpu const & dev)
+            -> TElem const *
+            {
+                if(dev == getDev(buf))
+                {
+                    return buf.m_spBufCpuImpl->m_pMem;
+                }
+                else
+                {
+                    throw std::runtime_error("The buffer is not accessible from the given device!");
+                }
+            }
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrDev(
+                BufCpu<TElem, TDim, TIdx> & buf,
+                DevCpu const & dev)
+            -> TElem *
+            {
+                if(dev == getDev(buf))
+                {
+                    return buf.m_spBufCpuImpl->m_pMem;
+                }
+                else
+                {
+                    throw std::runtime_error("The buffer is not accessible from the given device!");
+                }
+            }
+        };
+        //#############################################################################
+        //! The BufCpu pitch get trait specialization.
+        template<
+            typename TElem,
+            typename TDim,
+            typename TIdx>
+        struct GetPitchBytes<
+            DimInt<TDim::value - 1u>,
+            BufCpu<TElem, TDim, TIdx>>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPitchBytes(
+                BufCpu<TElem, TDim, TIdx> const & pitch)
+            -> TIdx
+            {
+                return pitch.m_spBufCpuImpl->m_pitchBytes;
+            }
+        };
+
         //#############################################################################
         //! The BufCpu memory allocation trait specialization.
         template<
@@ -441,7 +435,7 @@ namespace alpaka
                         //   The memory returned by this call will be considered as pinned memory by all CUDA contexts, not just the one that performed the allocation.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
                             ALPAKA_API_PREFIX(HostRegister)(
-                                const_cast<void *>(reinterpret_cast<void const *>(view::getPtrNative(buf))),
+                                const_cast<void *>(reinterpret_cast<void const *>(getPtrNative(buf))),
                                 extent::getExtentProduct(buf) * sizeof(Elem<BufCpu<TElem, TDim, TIdx>>),
                                 ALPAKA_API_PREFIX(HostRegisterDefault)),
                             ALPAKA_API_PREFIX(ErrorHostMemoryAlreadyRegistered));
@@ -480,11 +474,11 @@ namespace alpaka
             typename TDim,
             typename TIdx>
         struct Unpin<
-            detail::BufCpuImpl<TElem, TDim, TIdx>>
+            alpaka::detail::BufCpuImpl<TElem, TDim, TIdx>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto unpin(
-                detail::BufCpuImpl<TElem, TDim, TIdx> & bufImpl)
+                alpaka::detail::BufCpuImpl<TElem, TDim, TIdx> & bufImpl)
             -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -530,11 +524,11 @@ namespace alpaka
             typename TDim,
             typename TIdx>
         struct IsPinned<
-            detail::BufCpuImpl<TElem, TDim, TIdx>>
+            alpaka::detail::BufCpuImpl<TElem, TDim, TIdx>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto isPinned(
-                detail::BufCpuImpl<TElem, TDim, TIdx> const & bufImpl)
+                alpaka::detail::BufCpuImpl<TElem, TDim, TIdx> const & bufImpl)
             -> bool
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -227,98 +227,93 @@ namespace alpaka
             };
         }
     }
-    namespace view
-    {
-        namespace traits
-        {
-            //#############################################################################
-            //! The BufOmp5 native pointer get trait specialization.
-            template<
-                typename TElem,
-                typename TDim,
-                typename TIdx>
-            struct GetPtrNative<
-                BufOmp5<TElem, TDim, TIdx>>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrNative(
-                    BufOmp5<TElem, TDim, TIdx> const & buf)
-                -> TElem const *
-                {
-                    return (*buf).m_pMem;
-                }
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrNative(
-                    BufOmp5<TElem, TDim, TIdx> & buf)
-                -> TElem *
-                {
-                    return (*buf).m_pMem;
-                }
-            };
-            //#############################################################################
-            //! The BufOmp5 pointer on device get trait specialization.
-            template<
-                typename TElem,
-                typename TDim,
-                typename TIdx>
-            struct GetPtrDev<
-                BufOmp5<TElem, TDim, TIdx>,
-                DevOmp5>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrDev(
-                    BufOmp5<TElem, TDim, TIdx> const & buf,
-                    DevOmp5 const & dev)
-                -> TElem const *
-                {
-                    if(dev == getDev(buf))
-                    {
-                        return *buf.m_pMem;
-                    }
-                    else
-                    {
-                        throw std::runtime_error("The buffer is not accessible from the given device!");
-                    }
-                }
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrDev(
-                    BufOmp5<TElem, TDim, TIdx> & buf,
-                    DevOmp5 const & dev)
-                -> TElem *
-                {
-                    if(dev == getDev(buf))
-                    {
-                        return *buf.m_pMem;
-                    }
-                    else
-                    {
-                        throw std::runtime_error("The buffer is not accessible from the given device!");
-                    }
-                }
-            };
-            //#############################################################################
-            //! The BufOmp5 pitch get trait specialization.
-            template<
-                typename TIdxIntegralConst,
-                typename TElem,
-                typename TDim,
-                typename TIdx>
-            struct GetPitchBytes<
-                TIdxIntegralConst,
-                BufOmp5<TElem, TDim, TIdx>>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPitchBytes(
-                    BufOmp5<TElem, TDim, TIdx> const & pitch)
-                -> TIdx
-                {
-                    return (*pitch).m_pitchBytes[TIdxIntegralConst::value];
-                }
-            };
-        }
-    }
     namespace traits
     {
+        //#############################################################################
+        //! The BufOmp5 native pointer get trait specialization.
+        template<
+            typename TElem,
+            typename TDim,
+            typename TIdx>
+        struct GetPtrNative<
+            BufOmp5<TElem, TDim, TIdx>>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrNative(
+                BufOmp5<TElem, TDim, TIdx> const & buf)
+            -> TElem const *
+            {
+                return (*buf).m_pMem;
+            }
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrNative(
+                BufOmp5<TElem, TDim, TIdx> & buf)
+            -> TElem *
+            {
+                return (*buf).m_pMem;
+            }
+        };
+        //#############################################################################
+        //! The BufOmp5 pointer on device get trait specialization.
+        template<
+            typename TElem,
+            typename TDim,
+            typename TIdx>
+        struct GetPtrDev<
+            BufOmp5<TElem, TDim, TIdx>,
+            DevOmp5>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrDev(
+                BufOmp5<TElem, TDim, TIdx> const & buf,
+                DevOmp5 const & dev)
+            -> TElem const *
+            {
+                if(dev == getDev(buf))
+                {
+                    return *buf.m_pMem;
+                }
+                else
+                {
+                    throw std::runtime_error("The buffer is not accessible from the given device!");
+                }
+            }
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrDev(
+                BufOmp5<TElem, TDim, TIdx> & buf,
+                DevOmp5 const & dev)
+            -> TElem *
+            {
+                if(dev == getDev(buf))
+                {
+                    return *buf.m_pMem;
+                }
+                else
+                {
+                    throw std::runtime_error("The buffer is not accessible from the given device!");
+                }
+            }
+        };
+        //#############################################################################
+        //! The BufOmp5 pitch get trait specialization.
+        template<
+            typename TIdxIntegralConst,
+            typename TElem,
+            typename TDim,
+            typename TIdx>
+        struct GetPitchBytes<
+            TIdxIntegralConst,
+            BufOmp5<TElem, TDim, TIdx>>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPitchBytes(
+                BufOmp5<TElem, TDim, TIdx> const & pitch)
+            -> TIdx
+            {
+                return (*pitch).m_pitchBytes[TIdxIntegralConst::value];
+            }
+        };
+
         //#############################################################################
         //! The BufOmp5 1D memory allocation trait specialization.
         template<
@@ -616,39 +611,34 @@ namespace alpaka
                 // If it is already the same device, nothing has to be unmapped.
             }
         };
-    }
-    namespace view
-    {
-        namespace traits
+
+        //#############################################################################
+        //! The BufCpu pointer on CUDA device get trait specialization.
+        template<
+            typename TElem,
+            typename TDim,
+            typename TIdx>
+        struct GetPtrDev<
+            BufCpu<TElem, TDim, TIdx>,
+            DevOmp5>
         {
-            //#############################################################################
-            //! The BufCpu pointer on CUDA device get trait specialization.
-            template<
-                typename TElem,
-                typename TDim,
-                typename TIdx>
-            struct GetPtrDev<
-                BufCpu<TElem, TDim, TIdx>,
-                DevOmp5>
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrDev(
+                BufCpu<TElem, TDim, TIdx> const &,
+                DevOmp5 const &)
+            -> TElem const *
             {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrDev(
-                    BufCpu<TElem, TDim, TIdx> const &,
-                    DevOmp5 const &)
-                -> TElem const *
-                {
-                    throw std::runtime_error("Mapping host memory to OMP5 device not implemented!");
-                }
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrDev(
-                    BufCpu<TElem, TDim, TIdx> &,
-                    DevOmp5 const &)
-                -> TElem *
-                {
-                    throw std::runtime_error("Mapping host memory to OMP5 device not implemented!");
-                }
-            };
-        }
+                throw std::runtime_error("Mapping host memory to OMP5 device not implemented!");
+            }
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrDev(
+                BufCpu<TElem, TDim, TIdx> &,
+                DevOmp5 const &)
+            -> TElem *
+            {
+                throw std::runtime_error("Mapping host memory to OMP5 device not implemented!");
+            }
+        };
     }
 }
 

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -203,98 +203,92 @@ namespace alpaka
             };
         }
     }
-    namespace view
-    {
-        namespace traits
-        {
-            //#############################################################################
-            //! The BufUniformCudaHipRt native pointer get trait specialization.
-            template<
-                typename TElem,
-                typename TDim,
-                typename TIdx>
-            struct GetPtrNative<
-                BufUniformCudaHipRt<TElem, TDim, TIdx>>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrNative(
-                    BufUniformCudaHipRt<TElem, TDim, TIdx> const & buf)
-                -> TElem const *
-                {
-                    return buf.m_spMem.get();
-                }
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrNative(
-                    BufUniformCudaHipRt<TElem, TDim, TIdx> & buf)
-                -> TElem *
-                {
-                    return buf.m_spMem.get();
-                }
-            };
-            //#############################################################################
-            //! The BufUniformCudaHipRt pointer on device get trait specialization.
-            template<
-                typename TElem,
-                typename TDim,
-                typename TIdx>
-            struct GetPtrDev<
-                BufUniformCudaHipRt<TElem, TDim, TIdx>,
-                DevUniformCudaHipRt>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrDev(
-                    BufUniformCudaHipRt<TElem, TDim, TIdx> const & buf,
-                    DevUniformCudaHipRt const & dev)
-                -> TElem const *
-                {
-                    if(dev == getDev(buf))
-                    {
-                        return buf.m_spMem.get();
-                    }
-                    else
-                    {
-                        throw std::runtime_error("The buffer is not accessible from the given device!");
-                    }
-                }
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrDev(
-                    BufUniformCudaHipRt<TElem, TDim, TIdx> & buf,
-                    DevUniformCudaHipRt const & dev)
-                -> TElem *
-                {
-                    if(dev == getDev(buf))
-                    {
-                        return buf.m_spMem.get();
-                    }
-                    else
-                    {
-                        throw std::runtime_error("The buffer is not accessible from the given device!");
-                    }
-                }
-            };
-            //#############################################################################
-            //! The BufUniformCudaHipRt pitch get trait specialization.
-            template<
-                typename TElem,
-                typename TDim,
-                typename TIdx>
-            struct GetPitchBytes<
-                DimInt<TDim::value - 1u>,
-                BufUniformCudaHipRt<TElem, TDim, TIdx>>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPitchBytes(
-                    BufUniformCudaHipRt<TElem, TDim, TIdx> const & buf)
-                -> TIdx
-                {
-                    return buf.m_pitchBytes;
-                }
-            };
-        }
-    }
-
     namespace traits
     {
+        //#############################################################################
+        //! The BufUniformCudaHipRt native pointer get trait specialization.
+        template<
+            typename TElem,
+            typename TDim,
+            typename TIdx>
+        struct GetPtrNative<
+            BufUniformCudaHipRt<TElem, TDim, TIdx>>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrNative(
+                BufUniformCudaHipRt<TElem, TDim, TIdx> const & buf)
+            -> TElem const *
+            {
+                return buf.m_spMem.get();
+            }
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrNative(
+                BufUniformCudaHipRt<TElem, TDim, TIdx> & buf)
+            -> TElem *
+            {
+                return buf.m_spMem.get();
+            }
+        };
+        //#############################################################################
+        //! The BufUniformCudaHipRt pointer on device get trait specialization.
+        template<
+            typename TElem,
+            typename TDim,
+            typename TIdx>
+        struct GetPtrDev<
+            BufUniformCudaHipRt<TElem, TDim, TIdx>,
+            DevUniformCudaHipRt>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrDev(
+                BufUniformCudaHipRt<TElem, TDim, TIdx> const & buf,
+                DevUniformCudaHipRt const & dev)
+            -> TElem const *
+            {
+                if(dev == getDev(buf))
+                {
+                    return buf.m_spMem.get();
+                }
+                else
+                {
+                    throw std::runtime_error("The buffer is not accessible from the given device!");
+                }
+            }
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrDev(
+                BufUniformCudaHipRt<TElem, TDim, TIdx> & buf,
+                DevUniformCudaHipRt const & dev)
+            -> TElem *
+            {
+                if(dev == getDev(buf))
+                {
+                    return buf.m_spMem.get();
+                }
+                else
+                {
+                    throw std::runtime_error("The buffer is not accessible from the given device!");
+                }
+            }
+        };
+        //#############################################################################
+        //! The BufUniformCudaHipRt pitch get trait specialization.
+        template<
+            typename TElem,
+            typename TDim,
+            typename TIdx>
+        struct GetPitchBytes<
+            DimInt<TDim::value - 1u>,
+            BufUniformCudaHipRt<TElem, TDim, TIdx>>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPitchBytes(
+                BufUniformCudaHipRt<TElem, TDim, TIdx> const & buf)
+            -> TIdx
+            {
+                return buf.m_pitchBytes;
+            }
+        };
+
         //#############################################################################
         //! The CUDA/HIP 1D memory allocation trait specialization.
         template<
@@ -668,7 +662,7 @@ namespace alpaka
                     //   This feature is available only on GPUs with compute capability greater than or equal to 1.1.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                         ALPAKA_API_PREFIX(HostRegister)(
-                            const_cast<void *>(reinterpret_cast<void const *>(view::getPtrNative(buf))),
+                            const_cast<void *>(reinterpret_cast<void const *>(getPtrNative(buf))),
                             extent::getExtentProduct(buf) * sizeof(Elem<BufCpu<TElem, TDim, TIdx>>),
                             ALPAKA_API_PREFIX(HostRegisterMapped)));
                 }
@@ -698,62 +692,57 @@ namespace alpaka
                     // \FIXME: If the memory has separately been pinned before we destroy the pinning state.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                         ALPAKA_API_PREFIX(HostUnregister)(
-                            const_cast<void *>(reinterpret_cast<void const *>(view::getPtrNative(buf)))));
+                            const_cast<void *>(reinterpret_cast<void const *>(getPtrNative(buf)))));
                 }
                 // If it is already the same device, nothing has to be unmapped.
             }
         };
-    }
-    namespace view
-    {
-        namespace traits
+
+        //#############################################################################
+        //! The BufCpu pointer on CUDA/HIP device get trait specialization.
+        template<
+            typename TElem,
+            typename TDim,
+            typename TIdx>
+        struct GetPtrDev<
+            BufCpu<TElem, TDim, TIdx>,
+            DevUniformCudaHipRt>
         {
-            //#############################################################################
-            //! The BufCpu pointer on CUDA/HIP device get trait specialization.
-            template<
-                typename TElem,
-                typename TDim,
-                typename TIdx>
-            struct GetPtrDev<
-                BufCpu<TElem, TDim, TIdx>,
-                DevUniformCudaHipRt>
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrDev(
+                BufCpu<TElem, TDim, TIdx> const & buf,
+                DevUniformCudaHipRt const &)
+            -> TElem const *
             {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrDev(
-                    BufCpu<TElem, TDim, TIdx> const & buf,
-                    DevUniformCudaHipRt const &)
-                -> TElem const *
-                {
-                    // TODO: Check if the memory is mapped at all!
-                    TElem * pDev(nullptr);
+                // TODO: Check if the memory is mapped at all!
+                TElem * pDev(nullptr);
 
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        ALPAKA_API_PREFIX(HostGetDevicePointer)(
-                            &pDev,
-                            const_cast<void *>(reinterpret_cast<void const *>(view::getPtrNative(buf))),
-                            0));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(HostGetDevicePointer)(
+                        &pDev,
+                        const_cast<void *>(reinterpret_cast<void const *>(getPtrNative(buf))),
+                        0));
 
-                    return pDev;
-                }
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrDev(
-                    BufCpu<TElem, TDim, TIdx> & buf,
-                    DevUniformCudaHipRt const &)
-                -> TElem *
-                {
-                    // TODO: Check if the memory is mapped at all!
-                    TElem * pDev(nullptr);
+                return pDev;
+            }
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrDev(
+                BufCpu<TElem, TDim, TIdx> & buf,
+                DevUniformCudaHipRt const &)
+            -> TElem *
+            {
+                // TODO: Check if the memory is mapped at all!
+                TElem * pDev(nullptr);
 
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        ALPAKA_API_PREFIX(HostGetDevicePointer)(
-                            &pDev,
-                            view::getPtrNative(buf),
-                            0));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(HostGetDevicePointer)(
+                        &pDev,
+                        getPtrNative(buf),
+                        0));
 
-                    return pDev;
-                }
-            };
-        }
+                return pDev;
+            }
+        };
     }
 }
 

--- a/include/alpaka/mem/buf/SetKernel.hpp
+++ b/include/alpaka/mem/buf/SetKernel.hpp
@@ -17,54 +17,51 @@
 
 namespace alpaka
 {
-    namespace view
+    //#############################################################################
+    //! any device ND memory set kernel.
+    class MemSetKernel
     {
-        //#############################################################################
-        //! any device ND memory set kernel.
-        class MemSetKernel
+    public:
+        //-----------------------------------------------------------------------------
+        //! The kernel entry point.
+        //!
+        //! All but the last element of threadElemExtent must be one.
+        //!
+        //! \tparam TAcc The accelerator environment to be executed on.
+        //! \tparam TExtent extent type.
+        //! \param acc The accelerator to be executed on.
+        //! \param val value to set.
+        //! \param dst target mem ptr.
+        //! \param extent area to set.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename TAcc,
+            typename TExtent,
+            typename TPitch>
+        ALPAKA_FN_ACC auto operator()(
+            TAcc const & acc,
+            std::uint8_t const val,
+            std::uint8_t * dst,
+            TExtent extent,
+            TPitch pitch) const
+        -> void
         {
-        public:
-            //-----------------------------------------------------------------------------
-            //! The kernel entry point.
-            //!
-            //! All but the last element of threadElemExtent must be one.
-            //!
-            //! \tparam TAcc The accelerator environment to be executed on.
-            //! \tparam TExtent extent type.
-            //! \param acc The accelerator to be executed on.
-            //! \param val value to set.
-            //! \param dst target mem ptr.
-            //! \param extent area to set.
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename TAcc,
-                typename TExtent,
-                typename TPitch>
-            ALPAKA_FN_ACC auto operator()(
-                TAcc const & acc,
-                std::uint8_t const val,
-                std::uint8_t * dst,
-                TExtent extent,
-                TPitch pitch) const
-            -> void
-            {
-                using Idx = typename alpaka::traits::IdxType<TExtent>::type;
-                auto const gridThreadIdx(alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc));
-                auto const threadElemExtent(alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc));
-                auto const idxThreadFirstElem = getIdxThreadFirstElem(acc, gridThreadIdx, threadElemExtent);
-                auto idx = mapIdxPitchBytes<1u, Dim<TAcc>::value>(idxThreadFirstElem, pitch)[0];
-                constexpr auto lastDim = Dim<TAcc>::value - 1;
-                const auto lastIdx = idx +
-                    std::min(threadElemExtent[lastDim], static_cast<Idx>(extent[lastDim]-idxThreadFirstElem[lastDim]));
+            using Idx = typename alpaka::traits::IdxType<TExtent>::type;
+            auto const gridThreadIdx(alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+            auto const threadElemExtent(alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc));
+            auto const idxThreadFirstElem = getIdxThreadFirstElem(acc, gridThreadIdx, threadElemExtent);
+            auto idx = mapIdxPitchBytes<1u, Dim<TAcc>::value>(idxThreadFirstElem, pitch)[0];
+            constexpr auto lastDim = Dim<TAcc>::value - 1;
+            const auto lastIdx = idx +
+                std::min(threadElemExtent[lastDim], static_cast<Idx>(extent[lastDim]-idxThreadFirstElem[lastDim]));
 
-                if( (idxThreadFirstElem < extent).foldrAll(std::logical_and<bool>()) )
+            if( (idxThreadFirstElem < extent).foldrAll(std::logical_and<bool>()) )
+            {
+                for(; idx<lastIdx; ++idx)
                 {
-                    for(; idx<lastIdx; ++idx)
-                    {
-                        *(dst + idx) = val;
-                    }
+                    *(dst + idx) = val;
                 }
             }
-        };
-    }
+        }
+    };
 }

--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -214,7 +214,7 @@ namespace alpaka
         //! Copies from CPU memory into CPU memory.
         template<
             typename TDim>
-        struct CreateTaskCopy<
+        struct CreateTaskMemcpy<
             TDim,
             DevCpu,
             DevCpu>
@@ -224,7 +224,7 @@ namespace alpaka
                 typename TExtent,
                 typename TViewSrc,
                 typename TViewDst>
-            ALPAKA_FN_HOST static auto createTaskCopy(
+            ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst & viewDst,
                 TViewSrc const & viewSrc,
                 TExtent const & extent)

--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -25,228 +25,225 @@ namespace alpaka
 
 namespace alpaka
 {
-    namespace view
+    namespace detail
     {
-        namespace detail
+        //#############################################################################
+        //! The CPU device memory copy task base.
+        //!
+        //! Copies from CPU memory into CPU memory.
+        template<
+            typename TDim,
+            typename TViewDst,
+            typename TViewSrc,
+            typename TExtent>
+        struct TaskCopyCpuBase
         {
-            //#############################################################################
-            //! The CPU device memory copy task base.
-            //!
-            //! Copies from CPU memory into CPU memory.
-            template<
-                typename TDim,
-                typename TViewDst,
-                typename TViewSrc,
-                typename TExtent>
-            struct TaskCopyCpuBase
-            {
-                using ExtentSize = Idx<TExtent>;
-                using DstSize = Idx<TViewDst>;
-                using SrcSize = Idx<TViewSrc>;
-                using Elem = alpaka::Elem<TViewSrc>;
+            using ExtentSize = Idx<TExtent>;
+            using DstSize = Idx<TViewDst>;
+            using SrcSize = Idx<TViewSrc>;
+            using Elem = alpaka::Elem<TViewSrc>;
 
-                static_assert(
-                    !std::is_const<TViewDst>::value,
-                    "The destination view can not be const!");
+            static_assert(
+                !std::is_const<TViewDst>::value,
+                "The destination view can not be const!");
 
-                static_assert(
-                    Dim<TViewDst>::value == Dim<TViewSrc>::value,
-                    "The source and the destination view are required to have the same dimensionality!");
-                static_assert(
-                    Dim<TViewDst>::value == Dim<TExtent>::value,
-                    "The views and the extent are required to have the same dimensionality!");
-                static_assert(
-                    Dim<TViewDst>::value == TDim::value,
-                    "The destination view and the input TDim are required to have the same dimensionality!");
+            static_assert(
+                Dim<TViewDst>::value == Dim<TViewSrc>::value,
+                "The source and the destination view are required to have the same dimensionality!");
+            static_assert(
+                Dim<TViewDst>::value == Dim<TExtent>::value,
+                "The views and the extent are required to have the same dimensionality!");
+            static_assert(
+                Dim<TViewDst>::value == TDim::value,
+                "The destination view and the input TDim are required to have the same dimensionality!");
 
-                static_assert(
-                    meta::IsIntegralSuperset<DstSize, ExtentSize>::value,
-                    "The destination view and the extent are required to have compatible idx type!");
-                static_assert(
-                    meta::IsIntegralSuperset<SrcSize, ExtentSize>::value,
-                    "The source view and the extent are required to have compatible idx type!");
+            static_assert(
+                meta::IsIntegralSuperset<DstSize, ExtentSize>::value,
+                "The destination view and the extent are required to have compatible idx type!");
+            static_assert(
+                meta::IsIntegralSuperset<SrcSize, ExtentSize>::value,
+                "The source view and the extent are required to have compatible idx type!");
 
-                static_assert(
-                    std::is_same<alpaka::Elem<TViewDst>, std::remove_const_t<alpaka::Elem<TViewSrc>>>::value,
-                    "The source and the destination view are required to have the same element type!");
+            static_assert(
+                std::is_same<alpaka::Elem<TViewDst>, std::remove_const_t<alpaka::Elem<TViewSrc>>>::value,
+                "The source and the destination view are required to have the same element type!");
 
-                //-----------------------------------------------------------------------------
-                TaskCopyCpuBase(
-                    TViewDst & viewDst,
-                    TViewSrc const & viewSrc,
-                    TExtent const & extent) :
-                        m_extent(extent::getExtentVec(extent)),
-                        m_extentWidthBytes(m_extent[TDim::value - 1u] * static_cast<ExtentSize>(sizeof(Elem))),
+            //-----------------------------------------------------------------------------
+            TaskCopyCpuBase(
+                TViewDst & viewDst,
+                TViewSrc const & viewSrc,
+                TExtent const & extent) :
+                    m_extent(extent::getExtentVec(extent)),
+                    m_extentWidthBytes(m_extent[TDim::value - 1u] * static_cast<ExtentSize>(sizeof(Elem))),
 #if (!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-                        m_dstExtent(extent::getExtentVec(viewDst)),
-                        m_srcExtent(extent::getExtentVec(viewSrc)),
+                    m_dstExtent(extent::getExtentVec(viewDst)),
+                    m_srcExtent(extent::getExtentVec(viewSrc)),
 #endif
-                        m_dstPitchBytes(view::getPitchBytesVec(viewDst)),
-                        m_srcPitchBytes(view::getPitchBytesVec(viewSrc)),
+                    m_dstPitchBytes(getPitchBytesVec(viewDst)),
+                    m_srcPitchBytes(getPitchBytesVec(viewSrc)),
 
-                        m_dstMemNative(reinterpret_cast<std::uint8_t *>(view::getPtrNative(viewDst))),
-                        m_srcMemNative(reinterpret_cast<std::uint8_t const *>(view::getPtrNative(viewSrc)))
-                {
-                    ALPAKA_ASSERT((castVec<DstSize>(m_extent) <= m_dstExtent).foldrAll(std::logical_or<bool>()));
-                    ALPAKA_ASSERT((castVec<SrcSize>(m_extent) <= m_srcExtent).foldrAll(std::logical_or<bool>()));
-                    ALPAKA_ASSERT(static_cast<DstSize>(m_extentWidthBytes) <= m_dstPitchBytes[TDim::value - 1u]);
-                    ALPAKA_ASSERT(static_cast<SrcSize>(m_extentWidthBytes) <= m_srcPitchBytes[TDim::value - 1u]);
-                }
+                    m_dstMemNative(reinterpret_cast<std::uint8_t *>(getPtrNative(viewDst))),
+                    m_srcMemNative(reinterpret_cast<std::uint8_t const *>(getPtrNative(viewSrc)))
+            {
+                ALPAKA_ASSERT((castVec<DstSize>(m_extent) <= m_dstExtent).foldrAll(std::logical_or<bool>()));
+                ALPAKA_ASSERT((castVec<SrcSize>(m_extent) <= m_srcExtent).foldrAll(std::logical_or<bool>()));
+                ALPAKA_ASSERT(static_cast<DstSize>(m_extentWidthBytes) <= m_dstPitchBytes[TDim::value - 1u]);
+                ALPAKA_ASSERT(static_cast<SrcSize>(m_extentWidthBytes) <= m_srcPitchBytes[TDim::value - 1u]);
+            }
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST auto printDebug() const
-                -> void
-                {
-                    std::cout << __func__
-                        << " e: " << m_extent
-                        << " ewb: " << this->m_extentWidthBytes
-                        << " de: " << m_dstExtent
-                        << " dptr: " << reinterpret_cast<void *>(m_dstMemNative)
-                        << " dpitchb: " << m_dstPitchBytes
-                        << " se: " << m_srcExtent
-                        << " sptr: " << reinterpret_cast<void const *>(m_srcMemNative)
-                        << " spitchb: " << m_srcPitchBytes
-                        << std::endl;
-                }
-#endif
-
-                Vec<TDim, ExtentSize> const m_extent;
-                ExtentSize const m_extentWidthBytes;
-#if (!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-                Vec<TDim, DstSize> const m_dstExtent;
-                Vec<TDim, SrcSize> const m_srcExtent;
-#endif
-                Vec<TDim, DstSize> const m_dstPitchBytes;
-                Vec<TDim, SrcSize> const m_srcPitchBytes;
-
-                std::uint8_t * const m_dstMemNative;
-                std::uint8_t const * const m_srcMemNative;
-            };
-
-
-
-            //#############################################################################
-            //! The CPU device ND memory copy task.
-            template<
-                typename TDim,
-                typename TViewDst,
-                typename TViewSrc,
-                typename TExtent>
-            struct TaskCopyCpu : public TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST auto printDebug() const
+            -> void
             {
-                using DimMin1 = DimInt<TDim::value - 1u>;
-                using typename TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::ExtentSize;
-                using typename TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::DstSize;
-                using typename TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::SrcSize;
+                std::cout << __func__
+                    << " e: " << m_extent
+                    << " ewb: " << this->m_extentWidthBytes
+                    << " de: " << m_dstExtent
+                    << " dptr: " << reinterpret_cast<void *>(m_dstMemNative)
+                    << " dpitchb: " << m_dstPitchBytes
+                    << " se: " << m_srcExtent
+                    << " sptr: " << reinterpret_cast<void const *>(m_srcMemNative)
+                    << " spitchb: " << m_srcPitchBytes
+                    << std::endl;
+            }
+#endif
 
-                //-----------------------------------------------------------------------------
-                using TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::TaskCopyCpuBase;
+            Vec<TDim, ExtentSize> const m_extent;
+            ExtentSize const m_extentWidthBytes;
+#if (!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
+            Vec<TDim, DstSize> const m_dstExtent;
+            Vec<TDim, SrcSize> const m_srcExtent;
+#endif
+            Vec<TDim, DstSize> const m_dstPitchBytes;
+            Vec<TDim, SrcSize> const m_srcPitchBytes;
 
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST auto operator()() const
-                -> void
-                {
-                    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+            std::uint8_t * const m_dstMemNative;
+            std::uint8_t const * const m_srcMemNative;
+        };
+
+
+
+        //#############################################################################
+        //! The CPU device ND memory copy task.
+        template<
+            typename TDim,
+            typename TViewDst,
+            typename TViewSrc,
+            typename TExtent>
+        struct TaskCopyCpu : public TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>
+        {
+            using DimMin1 = DimInt<TDim::value - 1u>;
+            using typename TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::ExtentSize;
+            using typename TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::DstSize;
+            using typename TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::SrcSize;
+
+            //-----------------------------------------------------------------------------
+            using TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::TaskCopyCpuBase;
+
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST auto operator()() const
+            -> void
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    this->printDebug();
+                this->printDebug();
 #endif
-                    // [z, y, x] -> [z, y] because all elements with the innermost x dimension are handled within one iteration.
-                    Vec<DimMin1, ExtentSize> const extentWithoutInnermost(subVecBegin<DimMin1>(this->m_extent));
-                    // [z, y, x] -> [y, x] because the z pitch (the full size of the buffer) is not required.
-                    Vec<DimMin1, DstSize> const dstPitchBytesWithoutOutmost(subVecEnd<DimMin1>(this->m_dstPitchBytes));
-                    Vec<DimMin1, SrcSize> const srcPitchBytesWithoutOutmost(subVecEnd<DimMin1>(this->m_srcPitchBytes));
+                // [z, y, x] -> [z, y] because all elements with the innermost x dimension are handled within one iteration.
+                Vec<DimMin1, ExtentSize> const extentWithoutInnermost(subVecBegin<DimMin1>(this->m_extent));
+                // [z, y, x] -> [y, x] because the z pitch (the full size of the buffer) is not required.
+                Vec<DimMin1, DstSize> const dstPitchBytesWithoutOutmost(subVecEnd<DimMin1>(this->m_dstPitchBytes));
+                Vec<DimMin1, SrcSize> const srcPitchBytesWithoutOutmost(subVecEnd<DimMin1>(this->m_srcPitchBytes));
 
-                    if(static_cast<std::size_t>(this->m_extent.prod()) != 0u)
-                    {
-                        meta::ndLoopIncIdx(
-                            extentWithoutInnermost,
-                            [&](Vec<DimMin1, ExtentSize> const & idx)
-                            {
-                                std::memcpy(
-                                    reinterpret_cast<void *>(this->m_dstMemNative + (castVec<DstSize>(idx) * dstPitchBytesWithoutOutmost).foldrAll(std::plus<DstSize>())),
-                                    reinterpret_cast<void const *>(this->m_srcMemNative + (castVec<SrcSize>(idx) * srcPitchBytesWithoutOutmost).foldrAll(std::plus<SrcSize>())),
-                                    static_cast<std::size_t>(this->m_extentWidthBytes));
-                            });
-                    }
+                if(static_cast<std::size_t>(this->m_extent.prod()) != 0u)
+                {
+                    meta::ndLoopIncIdx(
+                        extentWithoutInnermost,
+                        [&](Vec<DimMin1, ExtentSize> const & idx)
+                        {
+                            std::memcpy(
+                                reinterpret_cast<void *>(this->m_dstMemNative + (castVec<DstSize>(idx) * dstPitchBytesWithoutOutmost).foldrAll(std::plus<DstSize>())),
+                                reinterpret_cast<void const *>(this->m_srcMemNative + (castVec<SrcSize>(idx) * srcPitchBytesWithoutOutmost).foldrAll(std::plus<SrcSize>())),
+                                static_cast<std::size_t>(this->m_extentWidthBytes));
+                        });
                 }
-            };
+            }
+        };
 
-            //#############################################################################
-            //! The CPU device 1D memory copy task.
+        //#############################################################################
+        //! The CPU device 1D memory copy task.
+        template<
+            typename TViewDst,
+            typename TViewSrc,
+            typename TExtent>
+        struct TaskCopyCpu<
+            DimInt<1u>,
+            TViewDst,
+            TViewSrc,
+            TExtent> : public TaskCopyCpuBase<DimInt<1u>, TViewDst, TViewSrc, TExtent>
+        {
+            //-----------------------------------------------------------------------------
+            using TaskCopyCpuBase<DimInt<1u>, TViewDst, TViewSrc, TExtent>::TaskCopyCpuBase;
+
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST auto operator()() const
+            -> void
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                this->printDebug();
+#endif
+                if(static_cast<std::size_t>(this->m_extent.prod()) != 0u)
+                {
+                    std::memcpy(
+                        reinterpret_cast<void *>(this->m_dstMemNative),
+                        reinterpret_cast<void const *>(this->m_srcMemNative),
+                        static_cast<std::size_t>(this->m_extentWidthBytes));
+                }
+            }
+        };
+    }
+
+    namespace traits
+    {
+        //#############################################################################
+        //! The CPU device memory copy trait specialization.
+        //!
+        //! Copies from CPU memory into CPU memory.
+        template<
+            typename TDim>
+        struct CreateTaskCopy<
+            TDim,
+            DevCpu,
+            DevCpu>
+        {
+            //-----------------------------------------------------------------------------
             template<
-                typename TViewDst,
+                typename TExtent,
                 typename TViewSrc,
-                typename TExtent>
-            struct TaskCopyCpu<
-                DimInt<1u>,
+                typename TViewDst>
+            ALPAKA_FN_HOST static auto createTaskCopy(
+                TViewDst & viewDst,
+                TViewSrc const & viewSrc,
+                TExtent const & extent)
+            -> alpaka::detail::TaskCopyCpu<
+                TDim,
                 TViewDst,
                 TViewSrc,
-                TExtent> : public TaskCopyCpuBase<DimInt<1u>, TViewDst, TViewSrc, TExtent>
+                TExtent>
             {
-                //-----------------------------------------------------------------------------
-                using TaskCopyCpuBase<DimInt<1u>, TViewDst, TViewSrc, TExtent>::TaskCopyCpuBase;
-
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST auto operator()() const
-                -> void
-                {
-                    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    this->printDebug();
-#endif
-                    if(static_cast<std::size_t>(this->m_extent.prod()) != 0u)
-                    {
-                        std::memcpy(
-                            reinterpret_cast<void *>(this->m_dstMemNative),
-                            reinterpret_cast<void const *>(this->m_srcMemNative),
-                            static_cast<std::size_t>(this->m_extentWidthBytes));
-                    }
-                }
-            };
-        }
-
-        namespace traits
-        {
-            //#############################################################################
-            //! The CPU device memory copy trait specialization.
-            //!
-            //! Copies from CPU memory into CPU memory.
-            template<
-                typename TDim>
-            struct CreateTaskCopy<
-                TDim,
-                DevCpu,
-                DevCpu>
-            {
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TExtent,
-                    typename TViewSrc,
-                    typename TViewDst>
-                ALPAKA_FN_HOST static auto createTaskCopy(
-                    TViewDst & viewDst,
-                    TViewSrc const & viewSrc,
-                    TExtent const & extent)
-                -> view::detail::TaskCopyCpu<
-                    TDim,
-                    TViewDst,
-                    TViewSrc,
-                    TExtent>
-                {
-                    return
-                        view::detail::TaskCopyCpu<
-                            TDim,
-                            TViewDst,
-                            TViewSrc,
-                            TExtent>(
-                                viewDst,
-                                viewSrc,
-                                extent);
-                }
-            };
-        }
+                return
+                    alpaka::detail::TaskCopyCpu<
+                        TDim,
+                        TViewDst,
+                        TViewSrc,
+                        TExtent>(
+                            viewDst,
+                            viewSrc,
+                            extent);
+            }
+        };
     }
 }

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -21,195 +21,189 @@
 namespace alpaka
 {
     class DevCpu;
-}
 
-namespace alpaka
-{
-    namespace view
+    namespace detail
     {
-        namespace detail
+        //#############################################################################
+        //! The CPU device ND memory set task base.
+        template<
+            typename TDim,
+            typename TView,
+            typename TExtent>
+        struct TaskSetCpuBase
         {
-            //#############################################################################
-            //! The CPU device ND memory set task base.
-            template<
-                typename TDim,
-                typename TView,
-                typename TExtent>
-            struct TaskSetCpuBase
-            {
-                using ExtentSize = Idx<TExtent>;
-                using DstSize = Idx<TView>;
-                using Elem = alpaka::Elem<TView>;
+            using ExtentSize = Idx<TExtent>;
+            using DstSize = Idx<TView>;
+            using Elem = alpaka::Elem<TView>;
 
-                static_assert(
-                    !std::is_const<TView>::value,
-                    "The destination view can not be const!");
+            static_assert(
+                !std::is_const<TView>::value,
+                "The destination view can not be const!");
 
-                static_assert(
-                    Dim<TView>::value == Dim<TExtent>::value,
-                    "The destination view and the extent are required to have the same dimensionality!");
-                static_assert(
-                    Dim<TView>::value == TDim::value,
-                    "The destination view and the input TDim are required to have the same dimensionality!");
+            static_assert(
+                Dim<TView>::value == Dim<TExtent>::value,
+                "The destination view and the extent are required to have the same dimensionality!");
+            static_assert(
+                Dim<TView>::value == TDim::value,
+                "The destination view and the input TDim are required to have the same dimensionality!");
 
-                static_assert(
-                    meta::IsIntegralSuperset<DstSize, ExtentSize>::value,
-                    "The view and the extent are required to have compatible idx type!");
+            static_assert(
+                meta::IsIntegralSuperset<DstSize, ExtentSize>::value,
+                "The view and the extent are required to have compatible idx type!");
 
-                //-----------------------------------------------------------------------------
-                TaskSetCpuBase(
-                    TView & view,
-                    std::uint8_t const & byte,
-                    TExtent const & extent) :
-                        m_byte(byte),
-                        m_extent(extent::getExtentVec(extent)),
-                        m_extentWidthBytes(m_extent[TDim::value - 1u] * static_cast<ExtentSize>(sizeof(Elem))),
+            //-----------------------------------------------------------------------------
+            TaskSetCpuBase(
+                TView & view,
+                std::uint8_t const & byte,
+                TExtent const & extent) :
+                    m_byte(byte),
+                    m_extent(extent::getExtentVec(extent)),
+                    m_extentWidthBytes(m_extent[TDim::value - 1u] * static_cast<ExtentSize>(sizeof(Elem))),
 #if (!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-                        m_dstExtent(extent::getExtentVec(view)),
+                    m_dstExtent(extent::getExtentVec(view)),
 #endif
-                        m_dstPitchBytes(view::getPitchBytesVec(view)),
-                        m_dstMemNative(reinterpret_cast<std::uint8_t *>(view::getPtrNative(view)))
-                {
-                    ALPAKA_ASSERT((castVec<DstSize>(m_extent) <= m_dstExtent).foldrAll(std::logical_or<bool>()));
-                    ALPAKA_ASSERT(m_extentWidthBytes <= m_dstPitchBytes[TDim::value - 1u]);
-                }
+                    m_dstPitchBytes(getPitchBytesVec(view)),
+                    m_dstMemNative(reinterpret_cast<std::uint8_t *>(getPtrNative(view)))
+            {
+                ALPAKA_ASSERT((castVec<DstSize>(m_extent) <= m_dstExtent).foldrAll(std::logical_or<bool>()));
+                ALPAKA_ASSERT(m_extentWidthBytes <= m_dstPitchBytes[TDim::value - 1u]);
+            }
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST auto printDebug() const
-                -> void
-                {
-                    std::cout << __func__
-                        << " e: " << this->m_extent
-                        << " ewb: " << this->m_extentWidthBytes
-                        << " de: " << this->m_dstExtent
-                        << " dptr: " << reinterpret_cast<void *>(this->m_dstMemNative)
-                        << " dpitchb: " << this->m_dstPitchBytes
-                        << std::endl;
-                }
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST auto printDebug() const
+            -> void
+            {
+                std::cout << __func__
+                    << " e: " << this->m_extent
+                    << " ewb: " << this->m_extentWidthBytes
+                    << " de: " << this->m_dstExtent
+                    << " dptr: " << reinterpret_cast<void *>(this->m_dstMemNative)
+                    << " dpitchb: " << this->m_dstPitchBytes
+                    << std::endl;
+            }
 #endif
 
-                std::uint8_t const m_byte;
-                Vec<TDim, ExtentSize> const m_extent;
-                ExtentSize const m_extentWidthBytes;
+            std::uint8_t const m_byte;
+            Vec<TDim, ExtentSize> const m_extent;
+            ExtentSize const m_extentWidthBytes;
 #if (!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-                Vec<TDim, DstSize> const m_dstExtent;
+            Vec<TDim, DstSize> const m_dstExtent;
 #endif
-                Vec<TDim, DstSize> const m_dstPitchBytes;
-                std::uint8_t * const m_dstMemNative;
-            };
+            Vec<TDim, DstSize> const m_dstPitchBytes;
+            std::uint8_t * const m_dstMemNative;
+        };
 
-            //#############################################################################
-            //! The CPU device ND memory set task.
-            template<
-                typename TDim,
-                typename TView,
-                typename TExtent>
-            struct TaskSetCpu : public TaskSetCpuBase<TDim, TView, TExtent>
-            {
-                using DimMin1 = DimInt<TDim::value - 1u>;
-                using typename TaskSetCpuBase<TDim, TView, TExtent>::ExtentSize;
-                using typename TaskSetCpuBase<TDim, TView, TExtent>::DstSize;
-
-                //-----------------------------------------------------------------------------
-                using TaskSetCpuBase<TDim, TView, TExtent>::TaskSetCpuBase;
-
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST auto operator()() const
-                -> void
-                {
-                    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    this->printDebug();
-#endif
-                    // [z, y, x] -> [z, y] because all elements with the innermost x dimension are handled within one iteration.
-                    Vec<DimMin1, ExtentSize> const extentWithoutInnermost(subVecBegin<DimMin1>(this->m_extent));
-                    // [z, y, x] -> [y, x] because the z pitch (the full idx of the buffer) is not required.
-                    Vec<DimMin1, DstSize> const dstPitchBytesWithoutOutmost(subVecEnd<DimMin1>(this->m_dstPitchBytes));
-
-                    if(static_cast<std::size_t>(this->m_extent.prod()) != 0u)
-                    {
-                        meta::ndLoopIncIdx(
-                            extentWithoutInnermost,
-                            [&](Vec<DimMin1, ExtentSize> const & idx)
-                            {
-
-                                memset(
-                                    reinterpret_cast<void *>(this->m_dstMemNative + (castVec<DstSize>(idx) * dstPitchBytesWithoutOutmost).foldrAll(std::plus<DstSize>())),
-                                    this->m_byte,
-                                    static_cast<std::size_t>(this->m_extentWidthBytes));
-                            });
-                    }
-                }
-            };
-
-            //#############################################################################
-            //! The CPU device 1D memory set task.
-            template<
-                typename TView,
-                typename TExtent>
-            struct TaskSetCpu<
-                DimInt<1u>,
-                TView,
-                TExtent> : public TaskSetCpuBase<DimInt<1u>, TView, TExtent>
-            {
-                //-----------------------------------------------------------------------------
-                using TaskSetCpuBase<DimInt<1u>, TView, TExtent>::TaskSetCpuBase;
-
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST auto operator()() const
-                -> void
-                {
-                    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    this->printDebug();
-#endif
-                    if(static_cast<std::size_t>(this->m_extent.prod()) != 0u)
-                    {
-                        std::memset(
-                            reinterpret_cast<void *>(this->m_dstMemNative),
-                            this->m_byte,
-                            static_cast<std::size_t>(this->m_extentWidthBytes));
-                    }
-                }
-            };
-        }
-
-        namespace traits
+        //#############################################################################
+        //! The CPU device ND memory set task.
+        template<
+            typename TDim,
+            typename TView,
+            typename TExtent>
+        struct TaskSetCpu : public TaskSetCpuBase<TDim, TView, TExtent>
         {
-            //#############################################################################
-            //! The CPU device memory set trait specialization.
+            using DimMin1 = DimInt<TDim::value - 1u>;
+            using typename TaskSetCpuBase<TDim, TView, TExtent>::ExtentSize;
+            using typename TaskSetCpuBase<TDim, TView, TExtent>::DstSize;
+
+            //-----------------------------------------------------------------------------
+            using TaskSetCpuBase<TDim, TView, TExtent>::TaskSetCpuBase;
+
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST auto operator()() const
+            -> void
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                this->printDebug();
+#endif
+                // [z, y, x] -> [z, y] because all elements with the innermost x dimension are handled within one iteration.
+                Vec<DimMin1, ExtentSize> const extentWithoutInnermost(subVecBegin<DimMin1>(this->m_extent));
+                // [z, y, x] -> [y, x] because the z pitch (the full idx of the buffer) is not required.
+                Vec<DimMin1, DstSize> const dstPitchBytesWithoutOutmost(subVecEnd<DimMin1>(this->m_dstPitchBytes));
+
+                if(static_cast<std::size_t>(this->m_extent.prod()) != 0u)
+                {
+                    meta::ndLoopIncIdx(
+                        extentWithoutInnermost,
+                        [&](Vec<DimMin1, ExtentSize> const & idx)
+                        {
+
+                            memset(
+                                reinterpret_cast<void *>(this->m_dstMemNative + (castVec<DstSize>(idx) * dstPitchBytesWithoutOutmost).foldrAll(std::plus<DstSize>())),
+                                this->m_byte,
+                                static_cast<std::size_t>(this->m_extentWidthBytes));
+                        });
+                }
+            }
+        };
+
+        //#############################################################################
+        //! The CPU device 1D memory set task.
+        template<
+            typename TView,
+            typename TExtent>
+        struct TaskSetCpu<
+            DimInt<1u>,
+            TView,
+            TExtent> : public TaskSetCpuBase<DimInt<1u>, TView, TExtent>
+        {
+            //-----------------------------------------------------------------------------
+            using TaskSetCpuBase<DimInt<1u>, TView, TExtent>::TaskSetCpuBase;
+
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST auto operator()() const
+            -> void
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                this->printDebug();
+#endif
+                if(static_cast<std::size_t>(this->m_extent.prod()) != 0u)
+                {
+                    std::memset(
+                        reinterpret_cast<void *>(this->m_dstMemNative),
+                        this->m_byte,
+                        static_cast<std::size_t>(this->m_extentWidthBytes));
+                }
+            }
+        };
+    }
+
+    namespace traits
+    {
+        //#############################################################################
+        //! The CPU device memory set trait specialization.
+        template<
+            typename TDim>
+        struct CreateTaskSet<
+            TDim,
+            DevCpu>
+        {
+            //-----------------------------------------------------------------------------
             template<
-                typename TDim>
-            struct CreateTaskSet<
+                typename TExtent,
+                typename TView>
+            ALPAKA_FN_HOST static auto createTaskSet(
+                TView & view,
+                std::uint8_t const & byte,
+                TExtent const & extent)
+            -> alpaka::detail::TaskSetCpu<
                 TDim,
-                DevCpu>
+                TView,
+                TExtent>
             {
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TExtent,
-                    typename TView>
-                ALPAKA_FN_HOST static auto createTaskSet(
-                    TView & view,
-                    std::uint8_t const & byte,
-                    TExtent const & extent)
-                -> view::detail::TaskSetCpu<
-                    TDim,
-                    TView,
-                    TExtent>
-                {
-                    return
-                        view::detail::TaskSetCpu<
-                            TDim,
-                            TView,
-                            TExtent>(
-                                view,
-                                byte,
-                                extent);
-                }
-            };
-        }
+                return
+                    alpaka::detail::TaskSetCpu<
+                        TDim,
+                        TView,
+                        TExtent>(
+                            view,
+                            byte,
+                            extent);
+            }
+        };
     }
 }

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -130,7 +130,7 @@ namespace alpaka
                         [&](Vec<DimMin1, ExtentSize> const & idx)
                         {
 
-                            memset(
+                            std::memset(
                                 reinterpret_cast<void *>(this->m_dstMemNative + (castVec<DstSize>(idx) * dstPitchBytesWithoutOutmost).foldrAll(std::plus<DstSize>())),
                                 this->m_byte,
                                 static_cast<std::size_t>(this->m_extentWidthBytes));
@@ -178,7 +178,7 @@ namespace alpaka
         //! The CPU device memory set trait specialization.
         template<
             typename TDim>
-        struct CreateTaskSet<
+        struct CreateTaskMemset<
             TDim,
             DevCpu>
         {
@@ -186,7 +186,7 @@ namespace alpaka
             template<
                 typename TExtent,
                 typename TView>
-            ALPAKA_FN_HOST static auto createTaskSet(
+            ALPAKA_FN_HOST static auto createTaskMemset(
                 TView & view,
                 std::uint8_t const & byte,
                 TExtent const & extent)

--- a/include/alpaka/mem/buf/omp5/Copy.hpp
+++ b/include/alpaka/mem/buf/omp5/Copy.hpp
@@ -33,417 +33,414 @@
 
 namespace alpaka
 {
-    namespace view
+    namespace detail
+    {
+        //#############################################################################
+        //! The Omp5 memory copy trait.
+        template<
+            typename TDim,
+            typename TViewDst,
+            typename TViewSrc,
+            typename TExtent>
+        struct TaskCopyOmp5
+        {
+            static_assert(
+                !std::is_const<TViewDst>::value,
+                "The destination view can not be const!");
+
+            static_assert(
+                Dim<TViewSrc>::value == TDim::value,
+                "The source view is required to have dimensionality TDim!");
+            static_assert(
+                Dim<TViewDst>::value == Dim<TViewSrc>::value,
+                "The source and the destination view are required to have the same dimensionality!");
+            static_assert(
+                Dim<TViewDst>::value == Dim<TExtent>::value,
+                "The views and the extent are required to have the same dimensionality!");
+            // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
+            static_assert(
+                std::is_same<Elem<TViewDst>, typename std::remove_const<Elem<TViewSrc>>::type>::value,
+                "The source and the destination view are required to have the same element type!");
+
+            using Idx = alpaka::Idx<TExtent>;
+
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST TaskCopyOmp5(
+                TViewDst & viewDst,
+                TViewSrc const & viewSrc,
+                TExtent const & extent,
+                int const & iDstDevice,
+                int const & iSrcDevice) :
+                    m_iDstDevice(iDstDevice),
+                    m_iSrcDevice(iSrcDevice),
+                    m_extent(castVec<size_t>(extent::getExtentVec(extent))),
+                    m_dstPitchBytes(castVec<size_t>(getPitchBytesVec(viewDst))),
+                    m_srcPitchBytes(castVec<size_t>(getPitchBytesVec(viewSrc))),
+                    m_dstMemNative(reinterpret_cast<void *>(getPtrNative(viewDst))),
+                    m_srcMemNative(reinterpret_cast<void const *>(getPtrNative(viewSrc)))
+            {
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                const auto dstExtent(castVec<size_t>(extent::getExtentVec(viewDst)));
+                const auto srcExtent(castVec<size_t>(extent::getExtentVec(viewSrc)));
+                for(auto i = static_cast<decltype(TDim::value)>(0u); i < TDim::value; ++i)
+                {
+                    ALPAKA_ASSERT(m_extent[i] <= dstExtent[i]);
+                    ALPAKA_ASSERT(m_extent[i] <= srcExtent[i]);
+                }
+                std::cout << "TaskCopyOmp5<" << TDim::value << ",...>::ctor\tsrcExtent="
+                    << srcExtent << ", dstExtent=" << dstExtent << std::endl;
+#endif
+            }
+
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST auto printDebug() const
+            -> void
+            {
+                std::cout << __func__
+                    << " ddev: " << m_iDstDevice
+                    << " ew: " << m_extent
+                    << " dptr: " << m_dstMemNative
+                    << " sdev: " << m_iSrcDevice
+                    << " sptr: " << m_srcMemNative
+                    << std::endl;
+            }
+#endif
+            int m_iDstDevice;
+            int m_iSrcDevice;
+            Vec<TDim, size_t> m_extent;
+            Vec<TDim, size_t> m_dstPitchBytes;
+            Vec<TDim, size_t> m_srcPitchBytes;
+            void * m_dstMemNative;
+            void const * m_srcMemNative;
+
+            //-----------------------------------------------------------------------------
+            //! Executes the kernel function object.
+            ALPAKA_FN_HOST auto operator()() const
+            -> void
+            {
+                ALPAKA_DEBUG_FULL_LOG_SCOPE;
+
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                printDebug();
+#endif
+                constexpr auto lastDim = TDim::value - 1;
+
+                if(m_extent.prod() > 0)
+                {
+                    // offsets == 0 by ptr shift (?)
+                    auto dstOffset(Vec<TDim, size_t>::zeros());
+                    auto srcOffset(Vec<TDim, size_t>::zeros());
+
+                    auto dstExtentFull(Vec<TDim, size_t>::zeros());
+                    auto srcExtentFull(Vec<TDim, size_t>::zeros());
+
+                    const size_t elementSize =
+                        ( m_dstPitchBytes[0]%sizeof(Elem<TViewDst>) || m_srcPitchBytes[0]%sizeof(Elem<TViewDst>) )
+                        ? 1 : sizeof(Elem<TViewDst>);
+
+                    dstExtentFull[lastDim] = m_dstPitchBytes[lastDim]/elementSize;
+                    srcExtentFull[lastDim] = m_srcPitchBytes[lastDim]/elementSize;
+                    for(int i = lastDim - 1; i >= 0; --i)
+                    {
+                        dstExtentFull[i] = m_dstPitchBytes[i]/m_dstPitchBytes[i+1];
+                        srcExtentFull[i] = m_srcPitchBytes[i]/m_srcPitchBytes[i+1];
+                    }
+
+                    ALPAKA_OMP5_CHECK(
+                        omp_target_memcpy_rect(
+                            m_dstMemNative, const_cast<void*>(m_srcMemNative),
+                            sizeof(Elem<TViewDst>),
+                            TDim::value,
+                            reinterpret_cast<size_t const *>(&m_extent),
+                            reinterpret_cast<size_t const *>(&dstOffset),
+                            reinterpret_cast<size_t const *>(&srcOffset),
+                            reinterpret_cast<size_t const *>(&dstExtentFull),
+                            reinterpret_cast<size_t const *>(&srcExtentFull),
+                            m_iDstDevice, m_iSrcDevice));
+                }
+            }
+        };
+
+        //#############################################################################
+        //! The Omp5 memory copy trait.
+        template<
+            typename TViewDst,
+            typename TViewSrc,
+            typename TExtent>
+        struct TaskCopyOmp5<
+            DimInt<1>,
+            TViewDst,
+            TViewSrc,
+            TExtent>
+        {
+            static_assert(
+                !std::is_const<TViewDst>::value,
+                "The destination view can not be const!");
+
+            static_assert(
+                Dim<TViewSrc>::value == 1,
+                "The source view is required to have dimensionality 1!");
+            static_assert(
+                Dim<TViewDst>::value == 1,
+                "The source view is required to have dimensionality 1!");
+            static_assert(
+                Dim<TExtent>::value == 1,
+                "The extent is required to have dimensionality 1!");
+            // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
+            static_assert(
+                std::is_same<Elem<TViewDst>, typename std::remove_const<Elem<TViewSrc>>::type>::value,
+                "The source and the destination view are required to have the same element type!");
+
+            using Idx = alpaka::Idx<TExtent>;
+
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST TaskCopyOmp5(
+                TViewDst & viewDst,
+                TViewSrc const & viewSrc,
+                TExtent const & extent,
+                int const & iDstDevice,
+                int const & iSrcDevice) :
+                    m_iDstDevice(iDstDevice),
+                    m_iSrcDevice(iSrcDevice),
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                    m_extentWidth(extent::getWidth(extent)),
+                    m_dstWidth(static_cast<Idx>(extent::getWidth(viewDst))),
+                    m_srcWidth(static_cast<Idx>(extent::getWidth(viewSrc))),
+#endif
+                    m_extentWidthBytes(extent::getWidth(extent) * static_cast<Idx>(sizeof(Elem<TViewDst>))),
+                    m_dstMemNative(reinterpret_cast<void *>(getPtrNative(viewDst))),
+                    m_srcMemNative(reinterpret_cast<void const *>(getPtrNative(viewSrc)))
+            {
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                ALPAKA_ASSERT(m_extentWidth <= m_dstWidth);
+                ALPAKA_ASSERT(m_extentWidth <= m_srcWidth);
+#endif
+            }
+
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST auto printDebug() const
+            -> void
+            {
+                std::cout << __func__
+                    << " ddev: " << m_iDstDevice
+                    << " ew: " << m_extentWidth
+                    << " ewb: " << m_extentWidthBytes
+                    << " dw: " << m_dstWidth
+                    << " dptr: " << m_dstMemNative
+                    << " sdev: " << m_iSrcDevice
+                    << " sw: " << m_srcWidth
+                    << " sptr: " << m_srcMemNative
+                    << std::endl;
+            }
+#endif
+            int m_iDstDevice;
+            int m_iSrcDevice;
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+            Idx m_extentWidth;
+            Idx m_dstWidth;
+            Idx m_srcWidth;
+#endif
+            Idx m_extentWidthBytes;
+            void * m_dstMemNative;
+            void const * m_srcMemNative;
+
+            //-----------------------------------------------------------------------------
+            //! Executes the kernel function object.
+            ALPAKA_FN_HOST auto operator()() const
+            -> void
+            {
+                ALPAKA_DEBUG_FULL_LOG_SCOPE;
+
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                printDebug();
+#endif
+                if(m_extentWidthBytes == 0)
+                {
+                    return;
+                }
+
+                ALPAKA_OMP5_CHECK(
+                    omp_target_memcpy(
+                        m_dstMemNative, const_cast<void*>(m_srcMemNative),
+                        static_cast<std::size_t>(m_extentWidthBytes),
+                        0,0, m_iDstDevice, m_iSrcDevice));
+            }
+        };
+    }
+
+    //-----------------------------------------------------------------------------
+    // Trait specializations for CreateTaskCopy.
+    namespace traits
     {
         namespace detail
         {
             //#############################################################################
-            //! The Omp5 memory copy trait.
+            //! The Omp5 memory copy task creation trait detail.
             template<
                 typename TDim,
-                typename TViewDst,
-                typename TViewSrc,
-                typename TExtent>
-            struct TaskCopyOmp5
+                typename TDevDst,
+                typename TDevSrc>
+            struct CreateTaskCopyImpl
             {
-                static_assert(
-                    !std::is_const<TViewDst>::value,
-                    "The destination view can not be const!");
-
-                static_assert(
-                    Dim<TViewSrc>::value == TDim::value,
-                    "The source view is required to have dimensionality TDim!");
-                static_assert(
-                    Dim<TViewDst>::value == Dim<TViewSrc>::value,
-                    "The source and the destination view are required to have the same dimensionality!");
-                static_assert(
-                    Dim<TViewDst>::value == Dim<TExtent>::value,
-                    "The views and the extent are required to have the same dimensionality!");
-                // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
-                static_assert(
-                    std::is_same<Elem<TViewDst>, typename std::remove_const<Elem<TViewSrc>>::type>::value,
-                    "The source and the destination view are required to have the same element type!");
-
-                using Idx = alpaka::Idx<TExtent>;
-
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST TaskCopyOmp5(
+                template<
+                    typename TExtent,
+                    typename TViewSrc,
+                    typename TViewDst>
+                ALPAKA_FN_HOST static auto createTaskCopy(
                     TViewDst & viewDst,
                     TViewSrc const & viewSrc,
                     TExtent const & extent,
-                    int const & iDstDevice,
-                    int const & iSrcDevice) :
-                        m_iDstDevice(iDstDevice),
-                        m_iSrcDevice(iSrcDevice),
-                        m_extent(castVec<size_t>(extent::getExtentVec(extent))),
-                        m_dstPitchBytes(castVec<size_t>(view::getPitchBytesVec(viewDst))),
-                        m_srcPitchBytes(castVec<size_t>(view::getPitchBytesVec(viewSrc))),
-                        m_dstMemNative(reinterpret_cast<void *>(view::getPtrNative(viewDst))),
-                        m_srcMemNative(reinterpret_cast<void const *>(view::getPtrNative(viewSrc)))
-                {
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    const auto dstExtent(castVec<size_t>(extent::getExtentVec(viewDst)));
-                    const auto srcExtent(castVec<size_t>(extent::getExtentVec(viewSrc)));
-                    for(auto i = static_cast<decltype(TDim::value)>(0u); i < TDim::value; ++i)
-                    {
-                        ALPAKA_ASSERT(m_extent[i] <= dstExtent[i]);
-                        ALPAKA_ASSERT(m_extent[i] <= srcExtent[i]);
-                    }
-                    std::cout << "TaskCopyOmp5<" << TDim::value << ",...>::ctor\tsrcExtent="
-                        << srcExtent << ", dstExtent=" << dstExtent << std::endl;
-#endif
-                }
-
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST auto printDebug() const
-                -> void
-                {
-                    std::cout << __func__
-                        << " ddev: " << m_iDstDevice
-                        << " ew: " << m_extent
-                        << " dptr: " << m_dstMemNative
-                        << " sdev: " << m_iSrcDevice
-                        << " sptr: " << m_srcMemNative
-                        << std::endl;
-                }
-#endif
-                int m_iDstDevice;
-                int m_iSrcDevice;
-                Vec<TDim, size_t> m_extent;
-                Vec<TDim, size_t> m_dstPitchBytes;
-                Vec<TDim, size_t> m_srcPitchBytes;
-                void * m_dstMemNative;
-                void const * m_srcMemNative;
-
-                //-----------------------------------------------------------------------------
-                //! Executes the kernel function object.
-                ALPAKA_FN_HOST auto operator()() const
-                -> void
+                    int iDeviceDst = 0,
+                    int iDeviceSrc = 0
+                    )
+                -> alpaka::detail::TaskCopyOmp5<
+                    TDim,
+                    TViewDst,
+                    TViewSrc,
+                    TExtent>
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    printDebug();
-#endif
-                    constexpr auto lastDim = TDim::value - 1;
-
-                    if(m_extent.prod() > 0)
-                    {
-                        // offsets == 0 by ptr shift (?)
-                        auto dstOffset(Vec<TDim, size_t>::zeros());
-                        auto srcOffset(Vec<TDim, size_t>::zeros());
-
-                        auto dstExtentFull(Vec<TDim, size_t>::zeros());
-                        auto srcExtentFull(Vec<TDim, size_t>::zeros());
-
-                        const size_t elementSize =
-                            ( m_dstPitchBytes[0]%sizeof(Elem<TViewDst>) || m_srcPitchBytes[0]%sizeof(Elem<TViewDst>) )
-                            ? 1 : sizeof(Elem<TViewDst>);
-
-                        dstExtentFull[lastDim] = m_dstPitchBytes[lastDim]/elementSize;
-                        srcExtentFull[lastDim] = m_srcPitchBytes[lastDim]/elementSize;
-                        for(int i = lastDim - 1; i >= 0; --i)
-                        {
-                            dstExtentFull[i] = m_dstPitchBytes[i]/m_dstPitchBytes[i+1];
-                            srcExtentFull[i] = m_srcPitchBytes[i]/m_srcPitchBytes[i+1];
-                        }
-
-                        ALPAKA_OMP5_CHECK(
-                            omp_target_memcpy_rect(
-                                m_dstMemNative, const_cast<void*>(m_srcMemNative),
-                                sizeof(Elem<TViewDst>),
-                                TDim::value,
-                                reinterpret_cast<size_t const *>(&m_extent),
-                                reinterpret_cast<size_t const *>(&dstOffset),
-                                reinterpret_cast<size_t const *>(&srcOffset),
-                                reinterpret_cast<size_t const *>(&dstExtentFull),
-                                reinterpret_cast<size_t const *>(&srcExtentFull),
-                                m_iDstDevice, m_iSrcDevice));
-                    }
+                    return
+                        alpaka::detail::TaskCopyOmp5<
+                            TDim,
+                            TViewDst,
+                            TViewSrc,
+                            TExtent>(
+                                viewDst,
+                                viewSrc,
+                                extent,
+                                iDeviceDst,
+                                iDeviceSrc);
                 }
             };
+        }
 
-            //#############################################################################
-            //! The Omp5 memory copy trait.
+        //#############################################################################
+        //! The CPU to Omp5 memory copy trait specialization.
+        template<
+            typename TDim>
+        struct CreateTaskCopy<
+            TDim,
+            DevOmp5,
+            DevCpu>
+        {
+            //-----------------------------------------------------------------------------
             template<
-                typename TViewDst,
+                typename TExtent,
                 typename TViewSrc,
-                typename TExtent>
-            struct TaskCopyOmp5<
-                DimInt<1>,
+                typename TViewDst>
+            ALPAKA_FN_HOST static auto createTaskCopy(
+                TViewDst & viewDst,
+                TViewSrc const & viewSrc,
+                TExtent const & extent)
+            -> alpaka::detail::TaskCopyOmp5<
+                TDim,
                 TViewDst,
                 TViewSrc,
                 TExtent>
             {
-                static_assert(
-                    !std::is_const<TViewDst>::value,
-                    "The destination view can not be const!");
+                ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                static_assert(
-                    Dim<TViewSrc>::value == 1,
-                    "The source view is required to have dimensionality 1!");
-                static_assert(
-                    Dim<TViewDst>::value == 1,
-                    "The source view is required to have dimensionality 1!");
-                static_assert(
-                    Dim<TExtent>::value == 1,
-                    "The extent is required to have dimensionality 1!");
-                // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
-                static_assert(
-                    std::is_same<Elem<TViewDst>, typename std::remove_const<Elem<TViewSrc>>::type>::value,
-                    "The source and the destination view are required to have the same element type!");
-
-                using Idx = alpaka::Idx<TExtent>;
-
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST TaskCopyOmp5(
-                    TViewDst & viewDst,
-                    TViewSrc const & viewSrc,
-                    TExtent const & extent,
-                    int const & iDstDevice,
-                    int const & iSrcDevice) :
-                        m_iDstDevice(iDstDevice),
-                        m_iSrcDevice(iSrcDevice),
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                        m_extentWidth(extent::getWidth(extent)),
-                        m_dstWidth(static_cast<Idx>(extent::getWidth(viewDst))),
-                        m_srcWidth(static_cast<Idx>(extent::getWidth(viewSrc))),
-#endif
-                        m_extentWidthBytes(extent::getWidth(extent) * static_cast<Idx>(sizeof(Elem<TViewDst>))),
-                        m_dstMemNative(reinterpret_cast<void *>(view::getPtrNative(viewDst))),
-                        m_srcMemNative(reinterpret_cast<void const *>(view::getPtrNative(viewSrc)))
-                {
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    ALPAKA_ASSERT(m_extentWidth <= m_dstWidth);
-                    ALPAKA_ASSERT(m_extentWidth <= m_srcWidth);
-#endif
-                }
-
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST auto printDebug() const
-                -> void
-                {
-                    std::cout << __func__
-                        << " ddev: " << m_iDstDevice
-                        << " ew: " << m_extentWidth
-                        << " ewb: " << m_extentWidthBytes
-                        << " dw: " << m_dstWidth
-                        << " dptr: " << m_dstMemNative
-                        << " sdev: " << m_iSrcDevice
-                        << " sw: " << m_srcWidth
-                        << " sptr: " << m_srcMemNative
-                        << std::endl;
-                }
-#endif
-                int m_iDstDevice;
-                int m_iSrcDevice;
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                Idx m_extentWidth;
-                Idx m_dstWidth;
-                Idx m_srcWidth;
-#endif
-                Idx m_extentWidthBytes;
-                void * m_dstMemNative;
-                void const * m_srcMemNative;
-
-                //-----------------------------------------------------------------------------
-                //! Executes the kernel function object.
-                ALPAKA_FN_HOST auto operator()() const
-                -> void
-                {
-                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
-
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    printDebug();
-#endif
-                    if(m_extentWidthBytes == 0)
-                    {
-                        return;
-                    }
-
-                    ALPAKA_OMP5_CHECK(
-                        omp_target_memcpy(
-                            m_dstMemNative, const_cast<void*>(m_srcMemNative),
-                            static_cast<std::size_t>(m_extentWidthBytes),
-                            0,0, m_iDstDevice, m_iSrcDevice));
-                }
-            };
-        }
-
-        //-----------------------------------------------------------------------------
-        // Trait specializations for CreateTaskCopy.
-        namespace traits
-        {
-            namespace detail
-            {
-                //#############################################################################
-                //! The Omp5 memory copy task creation trait detail.
-                template<
-                    typename TDim,
-                    typename TDevDst,
-                    typename TDevSrc>
-                struct CreateTaskCopyImpl
-                {
-                    //-----------------------------------------------------------------------------
-                    template<
-                        typename TExtent,
-                        typename TViewSrc,
-                        typename TViewDst>
-                    ALPAKA_FN_HOST static auto createTaskCopy(
-                        TViewDst & viewDst,
-                        TViewSrc const & viewSrc,
-                        TExtent const & extent,
-                        int iDeviceDst = 0,
-                        int iDeviceSrc = 0
-                        )
-                    -> view::detail::TaskCopyOmp5<
+                return
+                    alpaka::detail::TaskCopyOmp5<
                         TDim,
                         TViewDst,
                         TViewSrc,
-                        TExtent>
-                    {
-                        ALPAKA_DEBUG_FULL_LOG_SCOPE;
-
-                        return
-                            view::detail::TaskCopyOmp5<
-                                TDim,
-                                TViewDst,
-                                TViewSrc,
-                                TExtent>(
-                                    viewDst,
-                                    viewSrc,
-                                    extent,
-                                    iDeviceDst,
-                                    iDeviceSrc);
-                    }
-                };
+                        TExtent>(
+                            viewDst,
+                            viewSrc,
+                            extent,
+                            getDev(viewDst).m_spDevOmp5Impl->iDevice(),
+                            omp_get_initial_device()
+                            );
             }
+        };
 
-            //#############################################################################
-            //! The CPU to Omp5 memory copy trait specialization.
+        //#############################################################################
+        //! The Omp5 to CPU memory copy trait specialization.
+        template<
+            typename TDim>
+        struct CreateTaskCopy<
+            TDim,
+            DevCpu,
+            DevOmp5>
+        {
+            //-----------------------------------------------------------------------------
             template<
-                typename TDim>
-            struct CreateTaskCopy<
+                typename TExtent,
+                typename TViewSrc,
+                typename TViewDst>
+            ALPAKA_FN_HOST static auto createTaskCopy(
+                TViewDst & viewDst,
+                TViewSrc const & viewSrc,
+                TExtent const & extent)
+            -> alpaka::detail::TaskCopyOmp5<
                 TDim,
-                DevOmp5,
-                DevCpu>
+                TViewDst,
+                TViewSrc,
+                TExtent>
             {
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TExtent,
-                    typename TViewSrc,
-                    typename TViewDst>
-                ALPAKA_FN_HOST static auto createTaskCopy(
-                    TViewDst & viewDst,
-                    TViewSrc const & viewSrc,
-                    TExtent const & extent)
-                -> view::detail::TaskCopyOmp5<
-                    TDim,
-                    TViewDst,
-                    TViewSrc,
-                    TExtent>
-                {
-                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
+                ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                    return
-                        view::detail::TaskCopyOmp5<
-                            TDim,
-                            TViewDst,
-                            TViewSrc,
-                            TExtent>(
-                                viewDst,
-                                viewSrc,
-                                extent,
-                                getDev(viewDst).m_spDevOmp5Impl->iDevice(),
-                                omp_get_initial_device()
-                                );
-                }
-            };
+                return
+                    alpaka::detail::TaskCopyOmp5<
+                        TDim,
+                        TViewDst,
+                        TViewSrc,
+                        TExtent>(
+                            viewDst,
+                            viewSrc,
+                            extent,
+                            omp_get_initial_device(),
+                            getDev(viewSrc).m_spDevOmp5Impl->iDevice()
+                            );
+            }
+        };
 
-            //#############################################################################
-            //! The Omp5 to CPU memory copy trait specialization.
+        //#############################################################################
+        //! The Omp5 to Omp5 memory copy trait specialization.
+        template<
+            typename TDim>
+        struct CreateTaskCopy<
+            TDim,
+            DevOmp5,
+            DevOmp5>
+        {
+            //-----------------------------------------------------------------------------
             template<
-                typename TDim>
-            struct CreateTaskCopy<
+                typename TExtent,
+                typename TViewSrc,
+                typename TViewDst>
+            ALPAKA_FN_HOST static auto createTaskCopy(
+                TViewDst & viewDst,
+                TViewSrc const & viewSrc,
+                TExtent const & extent)
+            -> alpaka::detail::TaskCopyOmp5<
                 TDim,
-                DevCpu,
-                DevOmp5>
+                TViewDst,
+                TViewSrc,
+                TExtent>
             {
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TExtent,
-                    typename TViewSrc,
-                    typename TViewDst>
-                ALPAKA_FN_HOST static auto createTaskCopy(
-                    TViewDst & viewDst,
-                    TViewSrc const & viewSrc,
-                    TExtent const & extent)
-                -> view::detail::TaskCopyOmp5<
-                    TDim,
-                    TViewDst,
-                    TViewSrc,
-                    TExtent>
-                {
-                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
+                ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                    return
-                        view::detail::TaskCopyOmp5<
-                            TDim,
-                            TViewDst,
-                            TViewSrc,
-                            TExtent>(
-                                viewDst,
-                                viewSrc,
-                                extent,
-                                omp_get_initial_device(),
-                                getDev(viewSrc).m_spDevOmp5Impl->iDevice()
-                                );
-                }
-            };
-
-            //#############################################################################
-            //! The Omp5 to Omp5 memory copy trait specialization.
-            template<
-                typename TDim>
-            struct CreateTaskCopy<
-                TDim,
-                DevOmp5,
-                DevOmp5>
-            {
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TExtent,
-                    typename TViewSrc,
-                    typename TViewDst>
-                ALPAKA_FN_HOST static auto createTaskCopy(
-                    TViewDst & viewDst,
-                    TViewSrc const & viewSrc,
-                    TExtent const & extent)
-                -> view::detail::TaskCopyOmp5<
-                    TDim,
-                    TViewDst,
-                    TViewSrc,
-                    TExtent>
-                {
-                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
-
-                    return
-                        view::detail::TaskCopyOmp5<
-                            TDim,
-                            TViewDst,
-                            TViewSrc,
-                            TExtent>(
-                                viewDst,
-                                viewSrc,
-                                extent,
-                                getDev(viewDst).m_spDevOmp5Impl->iDevice(),
-                                getDev(viewSrc).m_spDevOmp5Impl->iDevice()
-                                );
-                }
-            };
-        }
+                return
+                    alpaka::detail::TaskCopyOmp5<
+                        TDim,
+                        TViewDst,
+                        TViewSrc,
+                        TExtent>(
+                            viewDst,
+                            viewSrc,
+                            extent,
+                            getDev(viewDst).m_spDevOmp5Impl->iDevice(),
+                            getDev(viewSrc).m_spDevOmp5Impl->iDevice()
+                            );
+            }
+        };
     }
 }
 

--- a/include/alpaka/mem/buf/omp5/Copy.hpp
+++ b/include/alpaka/mem/buf/omp5/Copy.hpp
@@ -271,7 +271,7 @@ namespace alpaka
     }
 
     //-----------------------------------------------------------------------------
-    // Trait specializations for CreateTaskCopy.
+    // Trait specializations for CreateTaskMemcpy.
     namespace traits
     {
         namespace detail
@@ -289,7 +289,7 @@ namespace alpaka
                     typename TExtent,
                     typename TViewSrc,
                     typename TViewDst>
-                ALPAKA_FN_HOST static auto createTaskCopy(
+                ALPAKA_FN_HOST static auto createTaskMemcpy(
                     TViewDst & viewDst,
                     TViewSrc const & viewSrc,
                     TExtent const & extent,
@@ -323,7 +323,7 @@ namespace alpaka
         //! The CPU to Omp5 memory copy trait specialization.
         template<
             typename TDim>
-        struct CreateTaskCopy<
+        struct CreateTaskMemcpy<
             TDim,
             DevOmp5,
             DevCpu>
@@ -333,7 +333,7 @@ namespace alpaka
                 typename TExtent,
                 typename TViewSrc,
                 typename TViewDst>
-            ALPAKA_FN_HOST static auto createTaskCopy(
+            ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst & viewDst,
                 TViewSrc const & viewSrc,
                 TExtent const & extent)
@@ -364,7 +364,7 @@ namespace alpaka
         //! The Omp5 to CPU memory copy trait specialization.
         template<
             typename TDim>
-        struct CreateTaskCopy<
+        struct CreateTaskMemcpy<
             TDim,
             DevCpu,
             DevOmp5>
@@ -374,7 +374,7 @@ namespace alpaka
                 typename TExtent,
                 typename TViewSrc,
                 typename TViewDst>
-            ALPAKA_FN_HOST static auto createTaskCopy(
+            ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst & viewDst,
                 TViewSrc const & viewSrc,
                 TExtent const & extent)
@@ -405,7 +405,7 @@ namespace alpaka
         //! The Omp5 to Omp5 memory copy trait specialization.
         template<
             typename TDim>
-        struct CreateTaskCopy<
+        struct CreateTaskMemcpy<
             TDim,
             DevOmp5,
             DevOmp5>
@@ -415,7 +415,7 @@ namespace alpaka
                 typename TExtent,
                 typename TViewSrc,
                 typename TViewDst>
-            ALPAKA_FN_HOST static auto createTaskCopy(
+            ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst & viewDst,
                 TViewSrc const & viewSrc,
                 TExtent const & extent)

--- a/include/alpaka/mem/buf/omp5/Set.hpp
+++ b/include/alpaka/mem/buf/omp5/Set.hpp
@@ -44,7 +44,7 @@ namespace alpaka
         //! The OMP5 device memory set trait specialization.
         template<
             typename TDim>
-        struct CreateTaskSet<
+        struct CreateTaskMemset<
             TDim,
             DevOmp5>
         {
@@ -52,7 +52,7 @@ namespace alpaka
             template<
                 typename TExtent,
                 typename TView>
-            ALPAKA_FN_HOST static auto createTaskSet(
+            ALPAKA_FN_HOST static auto createTaskMemset(
                 TView & view,
                 std::uint8_t const & byte,
                 TExtent const & extent)

--- a/include/alpaka/mem/buf/omp5/Set.hpp
+++ b/include/alpaka/mem/buf/omp5/Set.hpp
@@ -37,77 +37,71 @@
 namespace alpaka
 {
     class DevOmp5;
-}
 
-namespace alpaka
-{
-    namespace view
+    namespace traits
     {
-        namespace traits
+        //#############################################################################
+        //! The OMP5 device memory set trait specialization.
+        template<
+            typename TDim>
+        struct CreateTaskSet<
+            TDim,
+            DevOmp5>
         {
-            //#############################################################################
-            //! The OMP5 device memory set trait specialization.
+            //-----------------------------------------------------------------------------
             template<
-                typename TDim>
-            struct CreateTaskSet<
-                TDim,
-                DevOmp5>
+                typename TExtent,
+                typename TView>
+            ALPAKA_FN_HOST static auto createTaskSet(
+                TView & view,
+                std::uint8_t const & byte,
+                TExtent const & extent)
             {
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TExtent,
-                    typename TView>
-                ALPAKA_FN_HOST static auto createTaskSet(
-                    TView & view,
-                    std::uint8_t const & byte,
-                    TExtent const & extent)
-                {
-                    using Idx = typename alpaka::traits::IdxType<TExtent>::type;
-                    auto pitch = view::getPitchBytesVec(view);
-                    auto byteExtent = extent::getExtentVec(extent);
-                    constexpr auto lastDim = TDim::value - 1;
-                    byteExtent[lastDim] *= static_cast<Idx>(sizeof(Elem<TView>));
+                using Idx = typename alpaka::traits::IdxType<TExtent>::type;
+                auto pitch = getPitchBytesVec(view);
+                auto byteExtent = extent::getExtentVec(extent);
+                constexpr auto lastDim = TDim::value - 1;
+                byteExtent[lastDim] *= static_cast<Idx>(sizeof(Elem<TView>));
 
-                    if(pitch[0] == 0)
-                    {
-                        return createTaskKernel<AccOmp5<TDim,Idx>>(
-                                WorkDivMembers<TDim, Idx>(
-                                    Vec<TDim, Idx>::zeros(),
-                                    Vec<TDim, Idx>::zeros(),
-                                    Vec<TDim, Idx>::zeros()),
-                                view::MemSetKernel(),
-                                byte,
-                                reinterpret_cast<std::uint8_t*>(alpaka::view::getPtrNative(view)),
-                                byteExtent,
-                                pitch
-                            ); // NOP if size is zero
-                    }
+                if(pitch[0] == 0)
+                {
+                    return createTaskKernel<AccOmp5<TDim,Idx>>(
+                            WorkDivMembers<TDim, Idx>(
+                                Vec<TDim, Idx>::zeros(),
+                                Vec<TDim, Idx>::zeros(),
+                                Vec<TDim, Idx>::zeros()),
+                            MemSetKernel(),
+                            byte,
+                            reinterpret_cast<std::uint8_t*>(alpaka::getPtrNative(view)),
+                            byteExtent,
+                            pitch
+                        ); // NOP if size is zero
+                }
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    std::cout << "Set TDim=" << TDim::value << " pitch=" << pitch << " byteExtent=" << byteExtent << std::endl;
+                std::cout << "Set TDim=" << TDim::value << " pitch=" << pitch << " byteExtent=" << byteExtent << std::endl;
 #endif
-                    auto elementsPerThread = Vec<TDim, Idx>::all(static_cast<Idx>(1u));
-                    elementsPerThread[lastDim] = 4;
-                    // Let alpaka calculate good block and grid sizes given our full problem extent
-                    WorkDivMembers<TDim, Idx> const workDiv(
-                        getValidWorkDiv<AccOmp5<TDim,Idx>>(
-                            getDev(view),
+                auto elementsPerThread = Vec<TDim, Idx>::all(static_cast<Idx>(1u));
+                elementsPerThread[lastDim] = 4;
+                // Let alpaka calculate good block and grid sizes given our full problem extent
+                WorkDivMembers<TDim, Idx> const workDiv(
+                    getValidWorkDiv<AccOmp5<TDim,Idx>>(
+                        getDev(view),
+                        byteExtent,
+                        elementsPerThread,
+                        false,
+                        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted));
+                return
+                    createTaskKernel<AccOmp5<TDim,Idx>>(
+                            workDiv,
+                            MemSetKernel(),
+                            byte,
+                            reinterpret_cast<std::uint8_t*>(alpaka::getPtrNative(view)),
                             byteExtent,
-                            elementsPerThread,
-                            false,
-                            alpaka::GridBlockExtentSubDivRestrictions::Unrestricted));
-                    return
-                        createTaskKernel<AccOmp5<TDim,Idx>>(
-                                workDiv,
-                                view::MemSetKernel(),
-                                byte,
-                                reinterpret_cast<std::uint8_t*>(alpaka::view::getPtrNative(view)),
-                                byteExtent,
-                                pitch
-                            );
-                }
-            };
-        }
+                            pitch
+                        );
+            }
+        };
     }
 }
 

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -47,942 +47,937 @@
 
 namespace alpaka
 {
-    namespace view
+    namespace detail
     {
-        namespace detail
+        using vec3D = alpaka::Vec<alpaka::DimInt<3u>, size_t>;
+        using vec2D = alpaka::Vec<alpaka::DimInt<2u>, size_t>;
+
+        ///! copy 3D memory
+        ///
+        /// It is required to start  `height * depth` HIP/CUDA blocks.
+        /// The kernel loops over the memory rows.
+        template<typename T>
+        __global__ void hipMemcpy3DEmulatedKernelD2D(
+            char * dstPtr, vec2D const dstPitch,
+            char const * srcPtr, vec2D const srcPitch, vec3D const extent
+        )
         {
-            using vec3D = alpaka::Vec<alpaka::DimInt<3u>, size_t>;
-            using vec2D = alpaka::Vec<alpaka::DimInt<2u>, size_t>;
+            constexpr size_t X = 2;
+            constexpr size_t Y = 1;
+            constexpr size_t Z = 0;
 
-            ///! copy 3D memory
-            ///
-            /// It is required to start  `height * depth` HIP/CUDA blocks.
-            /// The kernel loops over the memory rows.
-            template<typename T>
-            __global__ void hipMemcpy3DEmulatedKernelD2D(
-                char * dstPtr, vec2D const dstPitch,
-                char const * srcPtr, vec2D const srcPitch, vec3D const extent
-            )
-            {
-                constexpr size_t X = 2;
-                constexpr size_t Y = 1;
-                constexpr size_t Z = 0;
-
-                // blockDim.[y,z] is always 1 and is not needed for index calculations
-                // gridDim and blockIdx is already in alpaka index order [z,y,x]
+            // blockDim.[y,z] is always 1 and is not needed for index calculations
+            // gridDim and blockIdx is already in alpaka index order [z,y,x]
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                alpaka::Vec<alpaka::DimInt<3u>, uint32_t> const tid(
-                    blockIdx.x,
-                    blockIdx.y,
-                    blockIdx.z * blockDim.x + threadIdx.x);
+            alpaka::Vec<alpaka::DimInt<3u>, uint32_t> const tid(
+                blockIdx.x,
+                blockIdx.y,
+                blockIdx.z * blockDim.x + threadIdx.x);
 
-                size_t const bytePerBlock = sizeof(T) * blockDim.x;
-                size_t const bytePerRow = gridDim.z * bytePerBlock;
+            size_t const bytePerBlock = sizeof(T) * blockDim.x;
+            size_t const bytePerRow = gridDim.z * bytePerBlock;
 #else
-                alpaka::Vec<alpaka::DimInt<3u>, uint32_t> const tid(
-                    hipBlockIdx_x,
-                    hipBlockIdx_y,
-                    hipBlockIdx_z * hipBlockDim_x + hipThreadIdx_x);
+            alpaka::Vec<alpaka::DimInt<3u>, uint32_t> const tid(
+                hipBlockIdx_x,
+                hipBlockIdx_y,
+                hipBlockIdx_z * hipBlockDim_x + hipThreadIdx_x);
 
-                size_t const bytePerBlock = sizeof(T) * hipBlockDim_x;
-                size_t const bytePerRow = hipGridDim_z * bytePerBlock;
+            size_t const bytePerBlock = sizeof(T) * hipBlockDim_x;
+            size_t const bytePerRow = hipGridDim_z * bytePerBlock;
 #endif
 
-                size_t const peelLoopSteps = extent[X] / bytePerRow;
-                bool const needRemainder = (extent[X] % bytePerRow) != 0;
+            size_t const peelLoopSteps = extent[X] / bytePerRow;
+            bool const needRemainder = (extent[X] % bytePerRow) != 0;
 
-                dstPtr += tid[Z] * dstPitch[Z] + tid[Y] * dstPitch[Y];
-                srcPtr += tid[Z] * srcPitch[Z] + tid[Y] * srcPitch[Y];
+            dstPtr += tid[Z] * dstPitch[Z] + tid[Y] * dstPitch[Y];
+            srcPtr += tid[Z] * srcPitch[Z] + tid[Y] * srcPitch[Y];
 
-                for(size_t idx = 0; idx < peelLoopSteps; ++idx)
+            for(size_t idx = 0; idx < peelLoopSteps; ++idx)
+            {
+                size_t const byteOffsetX = idx * bytePerRow + tid[X] * sizeof(T);
+                auto dst = reinterpret_cast<T *>(dstPtr + byteOffsetX);
+                auto src = reinterpret_cast<T const *>(srcPtr + byteOffsetX);
+                    *dst = *src;
+            }
+            if(needRemainder)
+            {
+                size_t const byteOffsetX = peelLoopSteps * bytePerRow + tid[X] * sizeof(T);
+                if(byteOffsetX < extent[X])
                 {
-                    size_t const byteOffsetX = idx * bytePerRow + tid[X] * sizeof(T);
                     auto dst = reinterpret_cast<T *>(dstPtr + byteOffsetX);
                     auto src = reinterpret_cast<T const *>(srcPtr + byteOffsetX);
-                        *dst = *src;
-                }
-                if(needRemainder)
-                {
-                    size_t const byteOffsetX = peelLoopSteps * bytePerRow + tid[X] * sizeof(T);
-                    if(byteOffsetX < extent[X])
-                    {
-                        auto dst = reinterpret_cast<T *>(dstPtr + byteOffsetX);
-                        auto src = reinterpret_cast<T const *>(srcPtr + byteOffsetX);
-                        *dst = *src;
-                    }
+                    *dst = *src;
                 }
             }
+        }
 
-            inline size_t divUp(size_t const & x, size_t const & y)
+        inline size_t divUp(size_t const & x, size_t const & y)
+        {
+            return (x + y - 1u) / y;
+        }
+
+        inline auto memcpy3DEmulatedD2DAsync(ALPAKA_API_PREFIX(Memcpy3DParms) const * const p, ALPAKA_API_PREFIX(Stream_t) stream)
+        {
+            using dim3Value_t = std::remove_reference_t<decltype(std::declval<dim3>().x)>;
+            // extent[2] is in byte
+            vec3D const extent(p->extent.depth, p->extent.height, p->extent.width);
+            // pitch in bytes
+            vec2D const dstPitch(p->dstPtr.pitch * p->dstPtr.ysize,p->dstPtr.pitch);
+            vec2D const srcPitch(p->srcPtr.pitch * p->srcPtr.ysize,p->srcPtr.pitch);
+            // offset[2] is in byte
+            vec3D const dstOffset(p->dstPos.z,p->dstPos.y,p->dstPos.x);
+            vec3D const srcOffset(p->srcPos.z,p->srcPos.y,p->srcPos.x);
+
+            char const * srcPtr =
+                    reinterpret_cast<char const *>(p->srcPtr.ptr) + srcOffset[0] * srcPitch[0] + srcOffset[1] * srcPitch[1] + srcOffset[2];
+            char * dstPtr =
+                    reinterpret_cast<char *>(p->dstPtr.ptr) + dstOffset[0] * dstPitch[0] + dstOffset[1] * dstPitch[1] + dstOffset[2];
+
+            bool const use4Byte = (reinterpret_cast<uintptr_t>(srcPtr) % 4u) == 0u && (reinterpret_cast<uintptr_t>(dstPtr) % 4u) == 0u && (extent[2] % 4u) == 0u;
+
+            if(use4Byte)
             {
-                return (x + y - 1u) / y;
+                dim3 block(static_cast<dim3Value_t>(std::min(divUp(extent[2], 4u), size_t(256u))));
+                // use alpaka index order [z,y,x] because x is by default 1
+                dim3 grid(static_cast<dim3Value_t>(extent[0]),  static_cast<dim3Value_t>(extent[1]), 1u);
+                // for less than 100 blocks increase the number of blocks used to copy a row to
+                // increase the utilization of the device
+                if(grid.x * grid.y < 100)
+                {
+                    grid.z = static_cast<dim3Value_t>(divUp(divUp(extent[2], 4u), block.x));
+                }
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+                hipMemcpy3DEmulatedKernelD2D<int><<<
+                    grid, block, 0, stream>>>(
+                        dstPtr, dstPitch, srcPtr, srcPitch, extent);
+#else
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(hipMemcpy3DEmulatedKernelD2D<int>),
+                    grid, block, 0, stream,
+                    dstPtr, dstPitch, srcPtr, srcPitch, extent);
+#endif
             }
-
-            inline auto memcpy3DEmulatedD2DAsync(ALPAKA_API_PREFIX(Memcpy3DParms) const * const p, ALPAKA_API_PREFIX(Stream_t) stream)
+            else
             {
-                using dim3Value_t = std::remove_reference_t<decltype(std::declval<dim3>().x)>;
-                // extent[2] is in byte
-                vec3D const extent(p->extent.depth, p->extent.height, p->extent.width);
-                // pitch in bytes
-                vec2D const dstPitch(p->dstPtr.pitch * p->dstPtr.ysize,p->dstPtr.pitch);
-                vec2D const srcPitch(p->srcPtr.pitch * p->srcPtr.ysize,p->srcPtr.pitch);
-                // offset[2] is in byte
-                vec3D const dstOffset(p->dstPos.z,p->dstPos.y,p->dstPos.x);
-                vec3D const srcOffset(p->srcPos.z,p->srcPos.y,p->srcPos.x);
-
-                char const * srcPtr =
-                        reinterpret_cast<char const *>(p->srcPtr.ptr) + srcOffset[0] * srcPitch[0] + srcOffset[1] * srcPitch[1] + srcOffset[2];
-                char * dstPtr =
-                        reinterpret_cast<char *>(p->dstPtr.ptr) + dstOffset[0] * dstPitch[0] + dstOffset[1] * dstPitch[1] + dstOffset[2];
-
-                bool const use4Byte = (reinterpret_cast<uintptr_t>(srcPtr) % 4u) == 0u && (reinterpret_cast<uintptr_t>(dstPtr) % 4u) == 0u && (extent[2] % 4u) == 0u;
-
-                if(use4Byte)
+                dim3 block(static_cast<dim3Value_t>(std::min(extent[2], size_t(256u))));
+                // use alpaka index order [z,y,x] because x is by default 1
+                dim3 grid(static_cast<dim3Value_t>(extent[0]), static_cast<dim3Value_t>(extent[1]), 1u);
+                // for less than 100 blocks increase the number of blocks used to copy a row to
+                // increase the utilization of the device
+                if(grid.x * grid.y < 100)
                 {
-                    dim3 block(static_cast<dim3Value_t>(std::min(divUp(extent[2], 4u), size_t(256u))));
-                    // use alpaka index order [z,y,x] because x is by default 1
-                    dim3 grid(static_cast<dim3Value_t>(extent[0]),  static_cast<dim3Value_t>(extent[1]), 1u);
-                    // for less than 100 blocks increase the number of blocks used to copy a row to
-                    // increase the utilization of the device
-                    if(grid.x * grid.y < 100)
-                    {
-                        grid.z = static_cast<dim3Value_t>(divUp(divUp(extent[2], 4u), block.x));
-                    }
-
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                    hipMemcpy3DEmulatedKernelD2D<int><<<
-                        grid, block, 0, stream>>>(
-                            dstPtr, dstPitch, srcPtr, srcPitch, extent);
-#else
-                    hipLaunchKernelGGL(
-                        HIP_KERNEL_NAME(hipMemcpy3DEmulatedKernelD2D<int>),
-                        grid, block, 0, stream,
-                        dstPtr, dstPitch, srcPtr, srcPitch, extent);
-#endif
+                    grid.z = static_cast<dim3Value_t>(divUp(extent[2], block.x));
                 }
-                else
-                {
-                    dim3 block(static_cast<dim3Value_t>(std::min(extent[2], size_t(256u))));
-                    // use alpaka index order [z,y,x] because x is by default 1
-                    dim3 grid(static_cast<dim3Value_t>(extent[0]), static_cast<dim3Value_t>(extent[1]), 1u);
-                    // for less than 100 blocks increase the number of blocks used to copy a row to
-                    // increase the utilization of the device
-                    if(grid.x * grid.y < 100)
-                    {
-                        grid.z = static_cast<dim3Value_t>(divUp(extent[2], block.x));
-                    }
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                    hipMemcpy3DEmulatedKernelD2D<char><<<
-                        grid, block, 0, stream>>>(
-                            dstPtr, dstPitch, srcPtr, srcPitch, extent);
-#else
-                    hipLaunchKernelGGL(
-                        HIP_KERNEL_NAME(hipMemcpy3DEmulatedKernelD2D<char>),
-                        grid, block, 0, stream,
+                hipMemcpy3DEmulatedKernelD2D<char><<<
+                    grid, block, 0, stream>>>(
                         dstPtr, dstPitch, srcPtr, srcPitch, extent);
+#else
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(hipMemcpy3DEmulatedKernelD2D<char>),
+                    grid, block, 0, stream,
+                    dstPtr, dstPitch, srcPtr, srcPitch, extent);
 #endif
-                }
-                return ALPAKA_API_PREFIX(GetLastError)();
-            };
+            }
+            return ALPAKA_API_PREFIX(GetLastError)();
+        };
 
-            //-----------------------------------------------------------------------------
-            //! Not being able to enable peer access does not prevent such device to device memory copies.
-            //! However, those copies may be slower because the memory is copied via the CPU.
-            inline auto enablePeerAccessIfPossible(
-                const int & devSrc,
-                const int & devDst)
-            -> void
-            {
-                ALPAKA_ASSERT(devSrc != devDst);
+        //-----------------------------------------------------------------------------
+        //! Not being able to enable peer access does not prevent such device to device memory copies.
+        //! However, those copies may be slower because the memory is copied via the CPU.
+        inline auto enablePeerAccessIfPossible(
+            const int & devSrc,
+            const int & devDst)
+        -> void
+        {
+            ALPAKA_ASSERT(devSrc != devDst);
 
 #if BOOST_COMP_CLANG
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wexit-time-destructors"
 #endif
-                static std::set<std::pair<int, int>> alreadyCheckedPeerAccessDevices;
+            static std::set<std::pair<int, int>> alreadyCheckedPeerAccessDevices;
 #if BOOST_COMP_CLANG
 #pragma clang diagnostic pop
 #endif
-                auto const devicePair = std::make_pair(devSrc, devDst);
+            auto const devicePair = std::make_pair(devSrc, devDst);
 
-                if(alreadyCheckedPeerAccessDevices.find(devicePair) == alreadyCheckedPeerAccessDevices.end())
-                {
-                    alreadyCheckedPeerAccessDevices.insert(devicePair);
+            if(alreadyCheckedPeerAccessDevices.find(devicePair) == alreadyCheckedPeerAccessDevices.end())
+            {
+                alreadyCheckedPeerAccessDevices.insert(devicePair);
 
-                    int canAccessPeer = 0;
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(DeviceCanAccessPeer)(&canAccessPeer, devSrc, devDst));
+                int canAccessPeer = 0;
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(DeviceCanAccessPeer)(&canAccessPeer, devSrc, devDst));
 
-                    if(!canAccessPeer) {
+                if(!canAccessPeer) {
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    std::cout << __func__
-                        << " Direct peer access between given GPUs is not possible!"
-                        << " src=" << devSrc
-                        << " dst=" << devDst
-                        << std::endl;
+                std::cout << __func__
+                    << " Direct peer access between given GPUs is not possible!"
+                    << " src=" << devSrc
+                    << " dst=" << devDst
+                    << std::endl;
 #endif
-                        return;
-                    }
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(devSrc));
+                    return;
+                }
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(devSrc));
 
-                    // NOTE: "until access is explicitly disabled using cudaDeviceDisablePeerAccess() or either device is reset using cudaDeviceReset()."
-                    // We do not remove a device from the enabled device pairs on cudaDeviceReset.
-                    // Note that access granted by this call is unidirectional and that in order to access memory on the current device from peerDevice, a separate symmetric call to cudaDeviceEnablePeerAccess() is required.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(DeviceEnablePeerAccess)(devDst, 0));
+                // NOTE: "until access is explicitly disabled using cudaDeviceDisablePeerAccess() or either device is reset using cudaDeviceReset()."
+                // We do not remove a device from the enabled device pairs on cudaDeviceReset.
+                // Note that access granted by this call is unidirectional and that in order to access memory on the current device from peerDevice, a separate symmetric call to cudaDeviceEnablePeerAccess() is required.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(DeviceEnablePeerAccess)(devDst, 0));
+            }
+        }
+
+        //#############################################################################
+        //! The CUDA/HIP memory copy trait.
+        template<
+            typename TDim,
+            typename TViewDst,
+            typename TViewSrc,
+            typename TExtent>
+        struct TaskCopyUniformCudaHip;
+
+        //#############################################################################
+        //! The 1D CUDA/HIP memory copy trait.
+        template<
+            typename TViewDst,
+            typename TViewSrc,
+            typename TExtent>
+        struct TaskCopyUniformCudaHip<
+            DimInt<1>,
+            TViewDst,
+            TViewSrc,
+            TExtent>
+        {
+            using MemcpyKind = ALPAKA_API_PREFIX(MemcpyKind);
+
+            static_assert(
+                !std::is_const<TViewDst>::value,
+                "The destination view can not be const!");
+
+            static_assert(
+                Dim<TViewDst>::value == Dim<TViewSrc>::value,
+                "The source and the destination view are required to have the same dimensionality!");
+            static_assert(
+                Dim<TViewDst>::value == Dim<TExtent>::value,
+                "The views and the extent are required to have the same dimensionality!");
+            // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
+            static_assert(
+                std::is_same<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>::value,
+                "The source and the destination view are required to have the same element type!");
+
+            using Idx = Idx<TExtent>;
+
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST TaskCopyUniformCudaHip(
+                TViewDst & viewDst,
+                TViewSrc const & viewSrc,
+                TExtent const & extent,
+                MemcpyKind const & uniformMemCpyKind,
+                int const & iDstDevice,
+                int const & iSrcDevice) :
+                    m_uniformMemCpyKind(uniformMemCpyKind),
+                    m_iDstDevice(iDstDevice),
+                    m_iSrcDevice(iSrcDevice),
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                    m_extentWidth(extent::getWidth(extent)),
+                    m_dstWidth(static_cast<Idx>(extent::getWidth(viewDst))),
+                    m_srcWidth(static_cast<Idx>(extent::getWidth(viewSrc))),
+#endif
+                    m_extentWidthBytes(extent::getWidth(extent) * static_cast<Idx>(sizeof(Elem<TViewDst>))),
+                    m_dstMemNative(reinterpret_cast<void *>(getPtrNative(viewDst))),
+                    m_srcMemNative(reinterpret_cast<void const *>(getPtrNative(viewSrc)))
+            {
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                ALPAKA_ASSERT(m_extentWidth <= m_dstWidth);
+                ALPAKA_ASSERT(m_extentWidth <= m_srcWidth);
+#endif
+            }
+
+            //-----------------------------------------------------------------------------
+            template<
+                typename TQueue
+            >
+            auto enqueue(TQueue & queue) const
+            -> void
+            {
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                printDebug();
+#endif
+                if(m_extentWidthBytes == 0)
+                {
+                    return;
+                }
+
+                auto const & uniformCudaHipMemCpyKind(m_uniformMemCpyKind);
+
+                if(m_iDstDevice == m_iSrcDevice)
+                {
+                    // Set the current device.
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(SetDevice)(
+                            m_iDstDevice));
+                    // Initiate the memory copy.
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(MemcpyAsync)(
+                            m_dstMemNative,
+                            m_srcMemNative,
+                            static_cast<std::size_t>(m_extentWidthBytes),
+                            uniformCudaHipMemCpyKind,
+                            queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                }
+                else
+                {
+                    alpaka::detail::enablePeerAccessIfPossible(m_iSrcDevice, m_iDstDevice);
+
+                    // Initiate the memory copy.
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(MemcpyPeerAsync)(
+                            m_dstMemNative,
+                            m_iDstDevice,
+                            m_srcMemNative,
+                            m_iSrcDevice,
+                            static_cast<std::size_t>(m_extentWidthBytes),
+                            queue.m_spQueueImpl->m_UniformCudaHipQueue));
                 }
             }
 
-            //#############################################################################
-            //! The CUDA/HIP memory copy trait.
-            template<
-                typename TDim,
-                typename TViewDst,
-                typename TViewSrc,
-                typename TExtent>
-            struct TaskCopyUniformCudaHip;
-
-            //#############################################################################
-            //! The 1D CUDA/HIP memory copy trait.
-            template<
-                typename TViewDst,
-                typename TViewSrc,
-                typename TExtent>
-            struct TaskCopyUniformCudaHip<
-                DimInt<1>,
-                TViewDst,
-                TViewSrc,
-                TExtent>
+        private:
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST auto printDebug() const
+            -> void
             {
-                using MemcpyKind = ALPAKA_API_PREFIX(MemcpyKind);
+                std::cout << __func__
+                    << " ddev: " << m_iDstDevice
+                    << " ew: " << m_extentWidth
+                    << " ewb: " << m_extentWidthBytes
+                    << " dw: " << m_dstWidth
+                    << " dptr: " << m_dstMemNative
+                    << " sdev: " << m_iSrcDevice
+                    << " sw: " << m_srcWidth
+                    << " sptr: " << m_srcMemNative
+                    << std::endl;
+            }
+#endif
 
-                static_assert(
-                    !std::is_const<TViewDst>::value,
-                    "The destination view can not be const!");
-
-                static_assert(
-                    Dim<TViewDst>::value == Dim<TViewSrc>::value,
-                    "The source and the destination view are required to have the same dimensionality!");
-                static_assert(
-                    Dim<TViewDst>::value == Dim<TExtent>::value,
-                    "The views and the extent are required to have the same dimensionality!");
-                // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
-                static_assert(
-                    std::is_same<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>::value,
-                    "The source and the destination view are required to have the same element type!");
-
-                using Idx = Idx<TExtent>;
-
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST TaskCopyUniformCudaHip(
-                    TViewDst & viewDst,
-                    TViewSrc const & viewSrc,
-                    TExtent const & extent,
-                    MemcpyKind const & uniformMemCpyKind,
-                    int const & iDstDevice,
-                    int const & iSrcDevice) :
-                        m_uniformMemCpyKind(uniformMemCpyKind),
-                        m_iDstDevice(iDstDevice),
-                        m_iSrcDevice(iSrcDevice),
+            MemcpyKind m_uniformMemCpyKind;
+            int m_iDstDevice;
+            int m_iSrcDevice;
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                        m_extentWidth(extent::getWidth(extent)),
-                        m_dstWidth(static_cast<Idx>(extent::getWidth(viewDst))),
-                        m_srcWidth(static_cast<Idx>(extent::getWidth(viewSrc))),
+            Idx m_extentWidth;
+            Idx m_dstWidth;
+            Idx m_srcWidth;
 #endif
-                        m_extentWidthBytes(extent::getWidth(extent) * static_cast<Idx>(sizeof(Elem<TViewDst>))),
-                        m_dstMemNative(reinterpret_cast<void *>(view::getPtrNative(viewDst))),
-                        m_srcMemNative(reinterpret_cast<void const *>(view::getPtrNative(viewSrc)))
-                {
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    ALPAKA_ASSERT(m_extentWidth <= m_dstWidth);
-                    ALPAKA_ASSERT(m_extentWidth <= m_srcWidth);
-#endif
-                }
-
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TQueue
-                >
-                auto enqueue(TQueue & queue) const
-                -> void
-                {
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    printDebug();
-#endif
-                    if(m_extentWidthBytes == 0)
-                    {
-                        return;
-                    }
-
-                    auto const & uniformCudaHipMemCpyKind(m_uniformMemCpyKind);
-
-                    if(m_iDstDevice == m_iSrcDevice)
-                    {
-                        // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            ALPAKA_API_PREFIX(SetDevice)(
-                                m_iDstDevice));
-                        // Initiate the memory copy.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            ALPAKA_API_PREFIX(MemcpyAsync)(
-                                m_dstMemNative,
-                                m_srcMemNative,
-                                static_cast<std::size_t>(m_extentWidthBytes),
-                                uniformCudaHipMemCpyKind,
-                                queue.m_spQueueImpl->m_UniformCudaHipQueue));
-                    }
-                    else
-                    {
-                        alpaka::view::detail::enablePeerAccessIfPossible(m_iSrcDevice, m_iDstDevice);
-
-                        // Initiate the memory copy.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            ALPAKA_API_PREFIX(MemcpyPeerAsync)(
-                                m_dstMemNative,
-                                m_iDstDevice,
-                                m_srcMemNative,
-                                m_iSrcDevice,
-                                static_cast<std::size_t>(m_extentWidthBytes),
-                                queue.m_spQueueImpl->m_UniformCudaHipQueue));
-                    }
-                }
-
-            private:
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST auto printDebug() const
-                -> void
-                {
-                    std::cout << __func__
-                        << " ddev: " << m_iDstDevice
-                        << " ew: " << m_extentWidth
-                        << " ewb: " << m_extentWidthBytes
-                        << " dw: " << m_dstWidth
-                        << " dptr: " << m_dstMemNative
-                        << " sdev: " << m_iSrcDevice
-                        << " sw: " << m_srcWidth
-                        << " sptr: " << m_srcMemNative
-                        << std::endl;
-                }
-#endif
-
-                MemcpyKind m_uniformMemCpyKind;
-                int m_iDstDevice;
-                int m_iSrcDevice;
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                Idx m_extentWidth;
-                Idx m_dstWidth;
-                Idx m_srcWidth;
-#endif
-                Idx m_extentWidthBytes;
-                void * m_dstMemNative;
-                void const * m_srcMemNative;
-            };
-            //#############################################################################
-            //! The 2D CUDA/HIP memory copy trait.
-            template<
-                typename TViewDst,
-                typename TViewSrc,
-                typename TExtent>
-            struct TaskCopyUniformCudaHip<
-                DimInt<2>,
-                TViewDst,
-                TViewSrc,
-                TExtent>
-            {
-                using MemcpyKind = ALPAKA_API_PREFIX(MemcpyKind);
-
-                static_assert(
-                    !std::is_const<TViewDst>::value,
-                    "The destination view can not be const!");
-
-                static_assert(
-                    Dim<TViewDst>::value == Dim<TViewSrc>::value,
-                    "The source and the destination view are required to have the same dimensionality!");
-                static_assert(
-                    Dim<TViewDst>::value == Dim<TExtent>::value,
-                    "The views and the extent are required to have the same dimensionality!");
-                // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
-                static_assert(
-                    std::is_same<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>::value,
-                    "The source and the destination view are required to have the same element type!");
-
-                using Idx = Idx<TExtent>;
-
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST TaskCopyUniformCudaHip(
-                    TViewDst & viewDst,
-                    TViewSrc const & viewSrc,
-                    TExtent const & extent,
-                    MemcpyKind const & uniformMemcpyKind,
-                    int const & iDstDevice,
-                    int const & iSrcDevice) :
-                        m_uniformMemCpyKind(uniformMemcpyKind),
-                        m_iDstDevice(iDstDevice),
-                        m_iSrcDevice(iSrcDevice),
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                        m_extentWidth(extent::getWidth(extent)),
-#endif
-                        m_extentWidthBytes(extent::getWidth(extent) * static_cast<Idx>(sizeof(Elem<TViewDst>))),
-                        m_dstWidth(static_cast<Idx>(extent::getWidth(viewDst))),      // required for 3D peer copy
-                        m_srcWidth(static_cast<Idx>(extent::getWidth(viewSrc))),      // required for 3D peer copy
-
-                        m_extentHeight(extent::getHeight(extent)),
-                        m_dstHeight(static_cast<Idx>(extent::getHeight(viewDst))),    // required for 3D peer copy
-                        m_srcHeight(static_cast<Idx>(extent::getHeight(viewSrc))),    // required for 3D peer copy
-
-                        m_dstpitchBytesX(static_cast<Idx>(view::getPitchBytes<Dim<TViewDst>::value - 1u>(viewDst))),
-                        m_srcpitchBytesX(static_cast<Idx>(view::getPitchBytes<Dim<TViewSrc>::value - 1u>(viewSrc))),
-                        m_dstPitchBytesY(static_cast<Idx>(view::getPitchBytes<Dim<TViewDst>::value - (2u % Dim<TViewDst>::value)>(viewDst))),
-                        m_srcPitchBytesY(static_cast<Idx>(view::getPitchBytes<Dim<TViewSrc>::value - (2u % Dim<TViewDst>::value)>(viewSrc))),
-
-                        m_dstMemNative(reinterpret_cast<void *>(view::getPtrNative(viewDst))),
-                        m_srcMemNative(reinterpret_cast<void const *>(view::getPtrNative(viewSrc)))
-                {
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    ALPAKA_ASSERT(m_extentWidth <= m_dstWidth);
-                    ALPAKA_ASSERT(m_extentHeight <= m_dstHeight);
-                    ALPAKA_ASSERT(m_extentWidth <= m_srcWidth);
-                    ALPAKA_ASSERT(m_extentHeight <= m_srcHeight);
-                    ALPAKA_ASSERT(m_extentWidthBytes <= m_dstpitchBytesX);
-                    ALPAKA_ASSERT(m_extentWidthBytes <= m_srcpitchBytesX);
-#endif
-                }
-
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TQueue
-                >
-                auto enqueue(TQueue & queue) const
-                -> void
-                {
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    printDebug();
-#endif
-                    // This is not only an optimization but also prevents a division by zero.
-                    if(m_extentWidthBytes == 0 || m_extentHeight == 0)
-                    {
-                        return;
-                    }
-
-                    if(m_iDstDevice == m_iSrcDevice)
-                    {
-                        // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            ALPAKA_API_PREFIX(SetDevice)(
-                                m_iDstDevice));
-                        // Initiate the memory copy.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            ALPAKA_API_PREFIX(Memcpy2DAsync)(
-                                m_dstMemNative,
-                                static_cast<std::size_t>(m_dstpitchBytesX),
-                                m_srcMemNative,
-                                static_cast<std::size_t>(m_srcpitchBytesX),
-                                static_cast<std::size_t>(m_extentWidthBytes),
-                                static_cast<std::size_t>(m_extentHeight),
-                                m_uniformMemCpyKind,
-                                queue.m_spQueueImpl->m_UniformCudaHipQueue));
-                    }
-                    else
-                    {
-                        alpaka::view::detail::enablePeerAccessIfPossible(m_iSrcDevice, m_iDstDevice);
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                        // There is no cudaMemcpy2DPeerAsync, therefore we use cudaMemcpy3DPeerAsync.
-                        // Create the struct describing the copy.
-                        ALPAKA_API_PREFIX(Memcpy3DPeerParms) const memCpy3DPeerParms(
-                            buildCudaMemcpy3DPeerParms());
-                        // Initiate the memory copy.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            cudaMemcpy3DPeerAsync(
-                                &memCpy3DPeerParms,
-                                queue.m_spQueueImpl->m_UniformCudaHipQueue));
-#endif
-                    }
-                }
-
-            private:
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST auto buildCudaMemcpy3DPeerParms() const
-                -> cudaMemcpy3DPeerParms
-                {
-                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
-
-                    // Fill CUDA parameter structure.
-                    cudaMemcpy3DPeerParms cudaMemCpy3DPeerParms;
-                    cudaMemCpy3DPeerParms.dstArray = nullptr;  // Either dstArray or dstPtr.
-                    cudaMemCpy3DPeerParms.dstDevice = m_iDstDevice;
-                    cudaMemCpy3DPeerParms.dstPos = make_cudaPos(0, 0, 0);  // Optional. Offset in bytes.
-                    cudaMemCpy3DPeerParms.dstPtr =
-                        make_cudaPitchedPtr(
-                            m_dstMemNative,
-                            static_cast<std::size_t>(m_dstpitchBytesX),
-                            static_cast<std::size_t>(m_dstWidth),
-                            static_cast<std::size_t>(m_dstPitchBytesY / m_dstpitchBytesX));
-                    cudaMemCpy3DPeerParms.extent =
-                        make_cudaExtent(
-                            static_cast<std::size_t>(m_extentWidthBytes),
-                            static_cast<std::size_t>(m_extentHeight),
-                            static_cast<std::size_t>(1u));
-                    cudaMemCpy3DPeerParms.srcArray = nullptr;  // Either srcArray or srcPtr.
-                    cudaMemCpy3DPeerParms.srcDevice = m_iSrcDevice;
-                    cudaMemCpy3DPeerParms.srcPos = make_cudaPos(0, 0, 0);  // Optional. Offset in bytes.
-                    cudaMemCpy3DPeerParms.srcPtr =
-                        make_cudaPitchedPtr(
-                            const_cast<void *>(m_srcMemNative),
-                            static_cast<std::size_t>(m_srcpitchBytesX),
-                            static_cast<std::size_t>(m_srcWidth),
-                            static_cast<std::size_t>(m_srcPitchBytesY / m_srcpitchBytesX));
-
-                    return cudaMemCpy3DPeerParms;
-                }
-#endif
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST auto printDebug() const
-                -> void
-                {
-                    std::cout << __func__
-                        << " ew: " << m_extentWidth
-                        << " eh: " << m_extentHeight
-                        << " ewb: " << m_extentWidthBytes
-                        << " ddev: " << m_iDstDevice
-                        << " dw: " << m_dstWidth
-                        << " dh: " << m_dstHeight
-                        << " dptr: " << m_dstMemNative
-                        << " dpitchb: " << m_dstpitchBytesX
-                        << " sdev: " << m_iSrcDevice
-                        << " sw: " << m_srcWidth
-                        << " sh: " << m_srcHeight
-                        << " sptr: " << m_srcMemNative
-                        << " spitchb: " << m_srcpitchBytesX
-                        << std::endl;
-                }
-#endif
-
-                MemcpyKind m_uniformMemCpyKind;
-                int m_iDstDevice;
-                int m_iSrcDevice;
-
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                Idx m_extentWidth;
-#endif
-                Idx m_extentWidthBytes;
-                Idx m_dstWidth;          // required for 3D peer copy
-                Idx m_srcWidth;          // required for 3D peer copy
-
-                Idx m_extentHeight;
-                Idx m_dstHeight;         // required for 3D peer copy
-                Idx m_srcHeight;         // required for 3D peer copy
-
-                Idx m_dstpitchBytesX;
-                Idx m_srcpitchBytesX;
-                Idx m_dstPitchBytesY;
-                Idx m_srcPitchBytesY;
-
-
-                void * m_dstMemNative;
-                void const * m_srcMemNative;
-            };
-            //#############################################################################
-            //! The 3D CUDA/HIP memory copy trait.
-            template<
-                typename TViewDst,
-                typename TViewSrc,
-                typename TExtent>
-            struct TaskCopyUniformCudaHip<
-                DimInt<3>,
-                TViewDst,
-                TViewSrc,
-                TExtent>
-            {
-                using MemcpyKind = ALPAKA_API_PREFIX(MemcpyKind);
-
-                static_assert(
-                    !std::is_const<TViewDst>::value,
-                    "The destination view can not be const!");
-
-                static_assert(
-                    Dim<TViewDst>::value == Dim<TViewSrc>::value,
-                    "The source and the destination view are required to have the same dimensionality!");
-                static_assert(
-                    Dim<TViewDst>::value == Dim<TExtent>::value,
-                    "The views and the extent are required to have the same dimensionality!");
-                // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
-                static_assert(
-                    std::is_same<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>::value,
-                    "The source and the destination view are required to have the same element type!");
-
-                using Idx = Idx<TExtent>;
-
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST TaskCopyUniformCudaHip(
-                    TViewDst & viewDst,
-                    TViewSrc const & viewSrc,
-                    TExtent const & extent,
-                    MemcpyKind const & uniformMemcpyKind,
-                    int const & iDstDevice,
-                    int const & iSrcDevice) :
-                        m_uniformMemCpyKind(uniformMemcpyKind),
-                        m_iDstDevice(iDstDevice),
-                        m_iSrcDevice(iSrcDevice),
-
-                        m_extentWidth(extent::getWidth(extent)),
-                        m_extentWidthBytes(m_extentWidth * static_cast<Idx>(sizeof(Elem<TViewDst>))),
-                        m_dstWidth(static_cast<Idx>(extent::getWidth(viewDst))),
-                        m_srcWidth(static_cast<Idx>(extent::getWidth(viewSrc))),
-
-                        m_extentHeight(extent::getHeight(extent)),
-                        m_dstHeight(static_cast<Idx>(extent::getHeight(viewDst))),
-                        m_srcHeight(static_cast<Idx>(extent::getHeight(viewSrc))),
-
-                        m_extentDepth(extent::getDepth(extent)),
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                        m_dstDepth(static_cast<Idx>(extent::getDepth(viewDst))),
-                        m_srcDepth(static_cast<Idx>(extent::getDepth(viewSrc))),
-#endif
-                        m_dstpitchBytesX(static_cast<Idx>(view::getPitchBytes<Dim<TViewDst>::value - 1u>(viewDst))),
-                        m_srcpitchBytesX(static_cast<Idx>(view::getPitchBytes<Dim<TViewSrc>::value - 1u>(viewSrc))),
-                        m_dstPitchBytesY(static_cast<Idx>(view::getPitchBytes<Dim<TViewDst>::value - (2u % Dim<TViewDst>::value)>(viewDst))),
-                        m_srcPitchBytesY(static_cast<Idx>(view::getPitchBytes<Dim<TViewSrc>::value - (2u % Dim<TViewDst>::value)>(viewSrc))),
-
-
-                        m_dstMemNative(reinterpret_cast<void *>(view::getPtrNative(viewDst))),
-                        m_srcMemNative(reinterpret_cast<void const *>(view::getPtrNative(viewSrc)))
-                {
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    ALPAKA_ASSERT(m_extentWidth <= m_dstWidth);
-                    ALPAKA_ASSERT(m_extentHeight <= m_dstHeight);
-                    ALPAKA_ASSERT(m_extentDepth <= m_dstDepth);
-                    ALPAKA_ASSERT(m_extentWidth <= m_srcWidth);
-                    ALPAKA_ASSERT(m_extentHeight <= m_srcHeight);
-                    ALPAKA_ASSERT(m_extentDepth <= m_srcDepth);
-                    ALPAKA_ASSERT(m_extentWidthBytes <= m_dstpitchBytesX);
-                    ALPAKA_ASSERT(m_extentWidthBytes <= m_srcpitchBytesX);
-#endif
-                }
-
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TQueue
-                >
-                auto enqueue(TQueue & queue) const
-                -> void
-                {
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                    printDebug();
-#endif
-                    // This is not only an optimization but also prevents a division by zero.
-                    if(m_extentWidthBytes == 0 || m_extentHeight == 0 || m_extentDepth == 0)
-                    {
-                        return;
-                    }
-
-                    if(m_iDstDevice == m_iSrcDevice)
-                    {
-                        // Create the struct describing the copy.
-                        ALPAKA_API_PREFIX(Memcpy3DParms) const uniformCudaHipMemCpy3DParms(
-                            buildUniformCudaHipMemcpy3DParms());
-                        // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            ALPAKA_API_PREFIX(SetDevice)(
-                                m_iDstDevice));
-#if defined(ALPAKA_EMU_MEMCPY3D_ENABLED)
-                        auto isDevice2DeviceCopy = m_uniformMemCpyKind == ALPAKA_API_PREFIX(MemcpyDeviceToDevice);
-                        // contiguous memory can be copied by a single 1D memory copy
-                        auto isContiguousMemory = uniformCudaHipMemCpy3DParms.extent.width == uniformCudaHipMemCpy3DParms.dstPtr.pitch &&
-                                uniformCudaHipMemCpy3DParms.extent.width == uniformCudaHipMemCpy3DParms.srcPtr.pitch;
-                        if(isDevice2DeviceCopy && !isContiguousMemory)
-                        {
-                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                                memcpy3DEmulatedD2DAsync(
-                                    &uniformCudaHipMemCpy3DParms,
-                                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
-                        }
-                        else
-#endif
-                        {
-                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                                ALPAKA_API_PREFIX(Memcpy3DAsync)(
-                                    &uniformCudaHipMemCpy3DParms,
-                                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
-                        }
-                    }
-                    else
-                    {
-                        alpaka::view::detail::enablePeerAccessIfPossible(m_iSrcDevice, m_iDstDevice);
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                        // Create the struct describing the copy.
-                        cudaMemcpy3DPeerParms const cudaMemCpy3DPeerParms(
-                            buildCudaMemcpy3DPeerParms());
-                        // Initiate the memory copy.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            cudaMemcpy3DPeerAsync(
-                                &cudaMemCpy3DPeerParms,
-                                queue.m_spQueueImpl->m_UniformCudaHipQueue));
-#endif
-                    }
-                }
-
-            private:
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST auto buildUniformCudaHipMemcpy3DParms() const
-                -> ALPAKA_API_PREFIX(Memcpy3DParms)
-                {
-                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
-
-                    // Fill CUDA/HIP parameter structure.
-                    ALPAKA_API_PREFIX(Memcpy3DParms) memCpy3DParms;
-                    memCpy3DParms.srcArray = nullptr;  // Either srcArray or srcPtr.
-                    memCpy3DParms.srcPos = ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(Pos))(0, 0, 0);  // Optional. Offset in bytes.
-                    memCpy3DParms.srcPtr =
-                        ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(PitchedPtr))(
-                            const_cast<void *>(m_srcMemNative),
-                            static_cast<std::size_t>(m_srcpitchBytesX),
-                            static_cast<std::size_t>(m_srcWidth),
-                            static_cast<std::size_t>(m_srcPitchBytesY/m_srcpitchBytesX));
-                    memCpy3DParms.dstArray = nullptr;  // Either dstArray or dstPtr.
-                    memCpy3DParms.dstPos = ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(Pos))(0, 0, 0);  // Optional. Offset in bytes.
-                    memCpy3DParms.dstPtr =
-                        ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(PitchedPtr))(
-                            m_dstMemNative,
-                            static_cast<std::size_t>(m_dstpitchBytesX),
-                            static_cast<std::size_t>(m_dstWidth),
-                            static_cast<std::size_t>(m_dstPitchBytesY / m_dstpitchBytesX));
-                    memCpy3DParms.extent =
-                        ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(Extent))(
-                            static_cast<std::size_t>(m_extentWidthBytes),
-                            static_cast<std::size_t>(m_extentHeight),
-                            static_cast<std::size_t>(m_extentDepth));
-#if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && defined(__HIP_PLATFORM_NVCC__)
-                    memCpy3DParms.kind = hipMemcpyKindToCudaMemcpyKind(m_uniformMemCpyKind);
-#else
-                    memCpy3DParms.kind = m_uniformMemCpyKind;
-#endif
-                    return memCpy3DParms;
-                }
-
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST auto buildCudaMemcpy3DPeerParms() const
-                -> cudaMemcpy3DPeerParms
-                {
-                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
-
-                    // Fill CUDA parameter structure.
-                    cudaMemcpy3DPeerParms cudaMemCpy3DPeerParms;
-                    cudaMemCpy3DPeerParms.dstArray = nullptr;  // Either dstArray or dstPtr.
-                    cudaMemCpy3DPeerParms.dstDevice = m_iDstDevice;
-                    cudaMemCpy3DPeerParms.dstPos = make_cudaPos(0, 0, 0);  // Optional. Offset in bytes.
-                    cudaMemCpy3DPeerParms.dstPtr =
-                        make_cudaPitchedPtr(
-                            m_dstMemNative,
-                            static_cast<std::size_t>(m_dstpitchBytesX),
-                            static_cast<std::size_t>(m_dstWidth),
-                            static_cast<std::size_t>(m_dstPitchBytesY/m_dstpitchBytesX));
-                    cudaMemCpy3DPeerParms.extent =
-                        make_cudaExtent(
-                            static_cast<std::size_t>(m_extentWidthBytes),
-                            static_cast<std::size_t>(m_extentHeight),
-                            static_cast<std::size_t>(m_extentDepth));
-                    cudaMemCpy3DPeerParms.srcArray = nullptr;  // Either srcArray or srcPtr.
-                    cudaMemCpy3DPeerParms.srcDevice = m_iSrcDevice;
-                    cudaMemCpy3DPeerParms.srcPos = make_cudaPos(0, 0, 0);  // Optional. Offset in bytes.
-                    cudaMemCpy3DPeerParms.srcPtr =
-                        make_cudaPitchedPtr(
-                            const_cast<void *>(m_srcMemNative),
-                            static_cast<std::size_t>(m_srcpitchBytesX),
-                            static_cast<std::size_t>(m_srcWidth),
-                            static_cast<std::size_t>(m_srcPitchBytesY / m_srcpitchBytesX));
-
-                    return cudaMemCpy3DPeerParms;
-                }
-#endif
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST auto printDebug() const
-                -> void
-                {
-                    std::cout << __func__
-                        << " ew: " << m_extentWidth
-                        << " eh: " << m_extentHeight
-                        << " ed: " << m_extentDepth
-                        << " ewb: " << m_extentWidthBytes
-                        << " ddev: " << m_iDstDevice
-                        << " dw: " << m_dstWidth
-                        << " dh: " << m_dstHeight
-                        << " dd: " << m_dstDepth
-                        << " dptr: " << m_dstMemNative
-                        << " dpitchb: " << m_dstpitchBytesX
-                        << " sdev: " << m_iSrcDevice
-                        << " sw: " << m_srcWidth
-                        << " sh: " << m_srcHeight
-                        << " sd: " << m_srcDepth
-                        << " sptr: " << m_srcMemNative
-                        << " spitchb: " << m_srcpitchBytesX
-                        << std::endl;
-                }
-#endif
-                MemcpyKind m_uniformMemCpyKind;
-                int m_iDstDevice;
-                int m_iSrcDevice;
-
-                Idx m_extentWidth;
-                Idx m_extentWidthBytes;
-                Idx m_dstWidth;
-                Idx m_srcWidth;
-
-                Idx m_extentHeight;
-                Idx m_dstHeight;
-                Idx m_srcHeight;
-
-                Idx m_extentDepth;
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                Idx m_dstDepth;
-                Idx m_srcDepth;
-#endif
-                Idx m_dstpitchBytesX;
-                Idx m_srcpitchBytesX;
-                Idx m_dstPitchBytesY;
-                Idx m_srcPitchBytesY;
-
-                void * m_dstMemNative;
-                void const * m_srcMemNative;
-            };
-        }
-
-        //-----------------------------------------------------------------------------
-        // Trait specializations for CreateTaskCopy.
-        namespace traits
+            Idx m_extentWidthBytes;
+            void * m_dstMemNative;
+            void const * m_srcMemNative;
+        };
+        //#############################################################################
+        //! The 2D CUDA/HIP memory copy trait.
+        template<
+            typename TViewDst,
+            typename TViewSrc,
+            typename TExtent>
+        struct TaskCopyUniformCudaHip<
+            DimInt<2>,
+            TViewDst,
+            TViewSrc,
+            TExtent>
         {
-            //#############################################################################
-            //! The CUDA/HIP to CPU memory copy trait specialization.
-            template<
-                typename TDim>
-            struct CreateTaskCopy<
-                TDim,
-                DevCpu,
-                DevUniformCudaHipRt>
+            using MemcpyKind = ALPAKA_API_PREFIX(MemcpyKind);
+
+            static_assert(
+                !std::is_const<TViewDst>::value,
+                "The destination view can not be const!");
+
+            static_assert(
+                Dim<TViewDst>::value == Dim<TViewSrc>::value,
+                "The source and the destination view are required to have the same dimensionality!");
+            static_assert(
+                Dim<TViewDst>::value == Dim<TExtent>::value,
+                "The views and the extent are required to have the same dimensionality!");
+            // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
+            static_assert(
+                std::is_same<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>::value,
+                "The source and the destination view are required to have the same element type!");
+
+            using Idx = Idx<TExtent>;
+
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST TaskCopyUniformCudaHip(
+                TViewDst & viewDst,
+                TViewSrc const & viewSrc,
+                TExtent const & extent,
+                MemcpyKind const & uniformMemcpyKind,
+                int const & iDstDevice,
+                int const & iSrcDevice) :
+                    m_uniformMemCpyKind(uniformMemcpyKind),
+                    m_iDstDevice(iDstDevice),
+                    m_iSrcDevice(iSrcDevice),
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                    m_extentWidth(extent::getWidth(extent)),
+#endif
+                    m_extentWidthBytes(extent::getWidth(extent) * static_cast<Idx>(sizeof(Elem<TViewDst>))),
+                    m_dstWidth(static_cast<Idx>(extent::getWidth(viewDst))),      // required for 3D peer copy
+                    m_srcWidth(static_cast<Idx>(extent::getWidth(viewSrc))),      // required for 3D peer copy
+
+                    m_extentHeight(extent::getHeight(extent)),
+                    m_dstHeight(static_cast<Idx>(extent::getHeight(viewDst))),    // required for 3D peer copy
+                    m_srcHeight(static_cast<Idx>(extent::getHeight(viewSrc))),    // required for 3D peer copy
+
+                    m_dstpitchBytesX(static_cast<Idx>(getPitchBytes<Dim<TViewDst>::value - 1u>(viewDst))),
+                    m_srcpitchBytesX(static_cast<Idx>(getPitchBytes<Dim<TViewSrc>::value - 1u>(viewSrc))),
+                    m_dstPitchBytesY(static_cast<Idx>(getPitchBytes<Dim<TViewDst>::value - (2u % Dim<TViewDst>::value)>(viewDst))),
+                    m_srcPitchBytesY(static_cast<Idx>(getPitchBytes<Dim<TViewSrc>::value - (2u % Dim<TViewDst>::value)>(viewSrc))),
+
+                    m_dstMemNative(reinterpret_cast<void *>(getPtrNative(viewDst))),
+                    m_srcMemNative(reinterpret_cast<void const *>(getPtrNative(viewSrc)))
             {
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TExtent,
-                    typename TViewSrc,
-                    typename TViewDst>
-                ALPAKA_FN_HOST static auto createTaskCopy(
-                    TViewDst & viewDst,
-                    TViewSrc const & viewSrc,
-                    TExtent const & extent)
-                -> view::detail::TaskCopyUniformCudaHip<
-                    TDim,
-                    TViewDst,
-                    TViewSrc,
-                    TExtent>
-                {
-                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                ALPAKA_ASSERT(m_extentWidth <= m_dstWidth);
+                ALPAKA_ASSERT(m_extentHeight <= m_dstHeight);
+                ALPAKA_ASSERT(m_extentWidth <= m_srcWidth);
+                ALPAKA_ASSERT(m_extentHeight <= m_srcHeight);
+                ALPAKA_ASSERT(m_extentWidthBytes <= m_dstpitchBytesX);
+                ALPAKA_ASSERT(m_extentWidthBytes <= m_srcpitchBytesX);
+#endif
+            }
 
-                    auto const iDevice(
-                        getDev(viewSrc).m_iDevice);
-
-                    return
-                        view::detail::TaskCopyUniformCudaHip<
-                            TDim,
-                            TViewDst,
-                            TViewSrc,
-                            TExtent>(
-                                viewDst,
-                                viewSrc,
-                                extent,
-                                ALPAKA_API_PREFIX(MemcpyDeviceToHost),
-                                iDevice,
-                                iDevice);
-                }
-            };
-            //#############################################################################
-            //! The CPU to CUDA/HIP memory copy trait specialization.
+            //-----------------------------------------------------------------------------
             template<
-                typename TDim>
-            struct CreateTaskCopy<
-                TDim,
-                DevUniformCudaHipRt,
-                DevCpu>
+                typename TQueue
+            >
+            auto enqueue(TQueue & queue) const
+            -> void
             {
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TExtent,
-                    typename TViewSrc,
-                    typename TViewDst>
-                ALPAKA_FN_HOST static auto createTaskCopy(
-                    TViewDst & viewDst,
-                    TViewSrc const & viewSrc,
-                    TExtent const & extent)
-                -> view::detail::TaskCopyUniformCudaHip<
-                    TDim,
-                    TViewDst,
-                    TViewSrc,
-                    TExtent>
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                printDebug();
+#endif
+                // This is not only an optimization but also prevents a division by zero.
+                if(m_extentWidthBytes == 0 || m_extentHeight == 0)
                 {
-                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
-
-                    auto const iDevice(
-                        getDev(viewDst).m_iDevice);
-
-                    return
-                        view::detail::TaskCopyUniformCudaHip<
-                            TDim,
-                            TViewDst,
-                            TViewSrc,
-                            TExtent>(
-                                viewDst,
-                                viewSrc,
-                                extent,
-                                ALPAKA_API_PREFIX(MemcpyHostToDevice),
-                                iDevice,
-                                iDevice);
+                    return;
                 }
-            };
-            //#############################################################################
-            //! The CUDA/HIP to CUDA/HIP memory copy trait specialization.
+
+                if(m_iDstDevice == m_iSrcDevice)
+                {
+                    // Set the current device.
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(SetDevice)(
+                            m_iDstDevice));
+                    // Initiate the memory copy.
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(Memcpy2DAsync)(
+                            m_dstMemNative,
+                            static_cast<std::size_t>(m_dstpitchBytesX),
+                            m_srcMemNative,
+                            static_cast<std::size_t>(m_srcpitchBytesX),
+                            static_cast<std::size_t>(m_extentWidthBytes),
+                            static_cast<std::size_t>(m_extentHeight),
+                            m_uniformMemCpyKind,
+                            queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                }
+                else
+                {
+                    alpaka::detail::enablePeerAccessIfPossible(m_iSrcDevice, m_iDstDevice);
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+                    // There is no cudaMemcpy2DPeerAsync, therefore we use cudaMemcpy3DPeerAsync.
+                    // Create the struct describing the copy.
+                    ALPAKA_API_PREFIX(Memcpy3DPeerParms) const memCpy3DPeerParms(
+                        buildCudaMemcpy3DPeerParms());
+                    // Initiate the memory copy.
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        cudaMemcpy3DPeerAsync(
+                            &memCpy3DPeerParms,
+                            queue.m_spQueueImpl->m_UniformCudaHipQueue));
+#endif
+                }
+            }
+
+        private:
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST auto buildCudaMemcpy3DPeerParms() const
+            -> cudaMemcpy3DPeerParms
+            {
+                ALPAKA_DEBUG_FULL_LOG_SCOPE;
+
+                // Fill CUDA parameter structure.
+                cudaMemcpy3DPeerParms cudaMemCpy3DPeerParms;
+                cudaMemCpy3DPeerParms.dstArray = nullptr;  // Either dstArray or dstPtr.
+                cudaMemCpy3DPeerParms.dstDevice = m_iDstDevice;
+                cudaMemCpy3DPeerParms.dstPos = make_cudaPos(0, 0, 0);  // Optional. Offset in bytes.
+                cudaMemCpy3DPeerParms.dstPtr =
+                    make_cudaPitchedPtr(
+                        m_dstMemNative,
+                        static_cast<std::size_t>(m_dstpitchBytesX),
+                        static_cast<std::size_t>(m_dstWidth),
+                        static_cast<std::size_t>(m_dstPitchBytesY / m_dstpitchBytesX));
+                cudaMemCpy3DPeerParms.extent =
+                    make_cudaExtent(
+                        static_cast<std::size_t>(m_extentWidthBytes),
+                        static_cast<std::size_t>(m_extentHeight),
+                        static_cast<std::size_t>(1u));
+                cudaMemCpy3DPeerParms.srcArray = nullptr;  // Either srcArray or srcPtr.
+                cudaMemCpy3DPeerParms.srcDevice = m_iSrcDevice;
+                cudaMemCpy3DPeerParms.srcPos = make_cudaPos(0, 0, 0);  // Optional. Offset in bytes.
+                cudaMemCpy3DPeerParms.srcPtr =
+                    make_cudaPitchedPtr(
+                        const_cast<void *>(m_srcMemNative),
+                        static_cast<std::size_t>(m_srcpitchBytesX),
+                        static_cast<std::size_t>(m_srcWidth),
+                        static_cast<std::size_t>(m_srcPitchBytesY / m_srcpitchBytesX));
+
+                return cudaMemCpy3DPeerParms;
+            }
+#endif
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST auto printDebug() const
+            -> void
+            {
+                std::cout << __func__
+                    << " ew: " << m_extentWidth
+                    << " eh: " << m_extentHeight
+                    << " ewb: " << m_extentWidthBytes
+                    << " ddev: " << m_iDstDevice
+                    << " dw: " << m_dstWidth
+                    << " dh: " << m_dstHeight
+                    << " dptr: " << m_dstMemNative
+                    << " dpitchb: " << m_dstpitchBytesX
+                    << " sdev: " << m_iSrcDevice
+                    << " sw: " << m_srcWidth
+                    << " sh: " << m_srcHeight
+                    << " sptr: " << m_srcMemNative
+                    << " spitchb: " << m_srcpitchBytesX
+                    << std::endl;
+            }
+#endif
+
+            MemcpyKind m_uniformMemCpyKind;
+            int m_iDstDevice;
+            int m_iSrcDevice;
+
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+            Idx m_extentWidth;
+#endif
+            Idx m_extentWidthBytes;
+            Idx m_dstWidth;          // required for 3D peer copy
+            Idx m_srcWidth;          // required for 3D peer copy
+
+            Idx m_extentHeight;
+            Idx m_dstHeight;         // required for 3D peer copy
+            Idx m_srcHeight;         // required for 3D peer copy
+
+            Idx m_dstpitchBytesX;
+            Idx m_srcpitchBytesX;
+            Idx m_dstPitchBytesY;
+            Idx m_srcPitchBytesY;
+
+
+            void * m_dstMemNative;
+            void const * m_srcMemNative;
+        };
+        //#############################################################################
+        //! The 3D CUDA/HIP memory copy trait.
+        template<
+            typename TViewDst,
+            typename TViewSrc,
+            typename TExtent>
+        struct TaskCopyUniformCudaHip<
+            DimInt<3>,
+            TViewDst,
+            TViewSrc,
+            TExtent>
+        {
+            using MemcpyKind = ALPAKA_API_PREFIX(MemcpyKind);
+
+            static_assert(
+                !std::is_const<TViewDst>::value,
+                "The destination view can not be const!");
+
+            static_assert(
+                Dim<TViewDst>::value == Dim<TViewSrc>::value,
+                "The source and the destination view are required to have the same dimensionality!");
+            static_assert(
+                Dim<TViewDst>::value == Dim<TExtent>::value,
+                "The views and the extent are required to have the same dimensionality!");
+            // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
+            static_assert(
+                std::is_same<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>::value,
+                "The source and the destination view are required to have the same element type!");
+
+            using Idx = Idx<TExtent>;
+
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST TaskCopyUniformCudaHip(
+                TViewDst & viewDst,
+                TViewSrc const & viewSrc,
+                TExtent const & extent,
+                MemcpyKind const & uniformMemcpyKind,
+                int const & iDstDevice,
+                int const & iSrcDevice) :
+                    m_uniformMemCpyKind(uniformMemcpyKind),
+                    m_iDstDevice(iDstDevice),
+                    m_iSrcDevice(iSrcDevice),
+
+                    m_extentWidth(extent::getWidth(extent)),
+                    m_extentWidthBytes(m_extentWidth * static_cast<Idx>(sizeof(Elem<TViewDst>))),
+                    m_dstWidth(static_cast<Idx>(extent::getWidth(viewDst))),
+                    m_srcWidth(static_cast<Idx>(extent::getWidth(viewSrc))),
+
+                    m_extentHeight(extent::getHeight(extent)),
+                    m_dstHeight(static_cast<Idx>(extent::getHeight(viewDst))),
+                    m_srcHeight(static_cast<Idx>(extent::getHeight(viewSrc))),
+
+                    m_extentDepth(extent::getDepth(extent)),
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                    m_dstDepth(static_cast<Idx>(extent::getDepth(viewDst))),
+                    m_srcDepth(static_cast<Idx>(extent::getDepth(viewSrc))),
+#endif
+                    m_dstpitchBytesX(static_cast<Idx>(getPitchBytes<Dim<TViewDst>::value - 1u>(viewDst))),
+                    m_srcpitchBytesX(static_cast<Idx>(getPitchBytes<Dim<TViewSrc>::value - 1u>(viewSrc))),
+                    m_dstPitchBytesY(static_cast<Idx>(getPitchBytes<Dim<TViewDst>::value - (2u % Dim<TViewDst>::value)>(viewDst))),
+                    m_srcPitchBytesY(static_cast<Idx>(getPitchBytes<Dim<TViewSrc>::value - (2u % Dim<TViewDst>::value)>(viewSrc))),
+
+
+                    m_dstMemNative(reinterpret_cast<void *>(getPtrNative(viewDst))),
+                    m_srcMemNative(reinterpret_cast<void const *>(getPtrNative(viewSrc)))
+            {
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                ALPAKA_ASSERT(m_extentWidth <= m_dstWidth);
+                ALPAKA_ASSERT(m_extentHeight <= m_dstHeight);
+                ALPAKA_ASSERT(m_extentDepth <= m_dstDepth);
+                ALPAKA_ASSERT(m_extentWidth <= m_srcWidth);
+                ALPAKA_ASSERT(m_extentHeight <= m_srcHeight);
+                ALPAKA_ASSERT(m_extentDepth <= m_srcDepth);
+                ALPAKA_ASSERT(m_extentWidthBytes <= m_dstpitchBytesX);
+                ALPAKA_ASSERT(m_extentWidthBytes <= m_srcpitchBytesX);
+#endif
+            }
+
+            //-----------------------------------------------------------------------------
             template<
-                typename TDim>
-            struct CreateTaskCopy<
-                TDim,
-                DevUniformCudaHipRt,
-                DevUniformCudaHipRt>
+                typename TQueue
+            >
+            auto enqueue(TQueue & queue) const
+            -> void
             {
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TExtent,
-                    typename TViewSrc,
-                    typename TViewDst>
-                ALPAKA_FN_HOST static auto createTaskCopy(
-                    TViewDst & viewDst,
-                    TViewSrc const & viewSrc,
-                    TExtent const & extent)
-                -> view::detail::TaskCopyUniformCudaHip<
-                    TDim,
-                    TViewDst,
-                    TViewSrc,
-                    TExtent>
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                printDebug();
+#endif
+                // This is not only an optimization but also prevents a division by zero.
+                if(m_extentWidthBytes == 0 || m_extentHeight == 0 || m_extentDepth == 0)
                 {
-                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
-
-                    return
-                        view::detail::TaskCopyUniformCudaHip<
-                            TDim,
-                            TViewDst,
-                            TViewSrc,
-                            TExtent>(
-                                viewDst,
-                                viewSrc,
-                                extent,
-                                ALPAKA_API_PREFIX(MemcpyDeviceToDevice),
-                                getDev(viewDst).m_iDevice,
-                                getDev(viewSrc).m_iDevice);
+                    return;
                 }
-            };
-        }
+
+                if(m_iDstDevice == m_iSrcDevice)
+                {
+                    // Create the struct describing the copy.
+                    ALPAKA_API_PREFIX(Memcpy3DParms) const uniformCudaHipMemCpy3DParms(
+                        buildUniformCudaHipMemcpy3DParms());
+                    // Set the current device.
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(SetDevice)(
+                            m_iDstDevice));
+#if defined(ALPAKA_EMU_MEMCPY3D_ENABLED)
+                    auto isDevice2DeviceCopy = m_uniformMemCpyKind == ALPAKA_API_PREFIX(MemcpyDeviceToDevice);
+                    // contiguous memory can be copied by a single 1D memory copy
+                    auto isContiguousMemory = uniformCudaHipMemCpy3DParms.extent.width == uniformCudaHipMemCpy3DParms.dstPtr.pitch &&
+                            uniformCudaHipMemCpy3DParms.extent.width == uniformCudaHipMemCpy3DParms.srcPtr.pitch;
+                    if(isDevice2DeviceCopy && !isContiguousMemory)
+                    {
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                            memcpy3DEmulatedD2DAsync(
+                                &uniformCudaHipMemCpy3DParms,
+                                queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    }
+                    else
+#endif
+                    {
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                            ALPAKA_API_PREFIX(Memcpy3DAsync)(
+                                &uniformCudaHipMemCpy3DParms,
+                                queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    }
+                }
+                else
+                {
+                    alpaka::detail::enablePeerAccessIfPossible(m_iSrcDevice, m_iDstDevice);
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+                    // Create the struct describing the copy.
+                    cudaMemcpy3DPeerParms const cudaMemCpy3DPeerParms(
+                        buildCudaMemcpy3DPeerParms());
+                    // Initiate the memory copy.
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        cudaMemcpy3DPeerAsync(
+                            &cudaMemCpy3DPeerParms,
+                            queue.m_spQueueImpl->m_UniformCudaHipQueue));
+#endif
+                }
+            }
+
+        private:
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST auto buildUniformCudaHipMemcpy3DParms() const
+            -> ALPAKA_API_PREFIX(Memcpy3DParms)
+            {
+                ALPAKA_DEBUG_FULL_LOG_SCOPE;
+
+                // Fill CUDA/HIP parameter structure.
+                ALPAKA_API_PREFIX(Memcpy3DParms) memCpy3DParms;
+                memCpy3DParms.srcArray = nullptr;  // Either srcArray or srcPtr.
+                memCpy3DParms.srcPos = ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(Pos))(0, 0, 0);  // Optional. Offset in bytes.
+                memCpy3DParms.srcPtr =
+                    ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(PitchedPtr))(
+                        const_cast<void *>(m_srcMemNative),
+                        static_cast<std::size_t>(m_srcpitchBytesX),
+                        static_cast<std::size_t>(m_srcWidth),
+                        static_cast<std::size_t>(m_srcPitchBytesY/m_srcpitchBytesX));
+                memCpy3DParms.dstArray = nullptr;  // Either dstArray or dstPtr.
+                memCpy3DParms.dstPos = ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(Pos))(0, 0, 0);  // Optional. Offset in bytes.
+                memCpy3DParms.dstPtr =
+                    ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(PitchedPtr))(
+                        m_dstMemNative,
+                        static_cast<std::size_t>(m_dstpitchBytesX),
+                        static_cast<std::size_t>(m_dstWidth),
+                        static_cast<std::size_t>(m_dstPitchBytesY / m_dstpitchBytesX));
+                memCpy3DParms.extent =
+                    ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(Extent))(
+                        static_cast<std::size_t>(m_extentWidthBytes),
+                        static_cast<std::size_t>(m_extentHeight),
+                        static_cast<std::size_t>(m_extentDepth));
+#if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && defined(__HIP_PLATFORM_NVCC__)
+                memCpy3DParms.kind = hipMemcpyKindToCudaMemcpyKind(m_uniformMemCpyKind);
+#else
+                memCpy3DParms.kind = m_uniformMemCpyKind;
+#endif
+                return memCpy3DParms;
+            }
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST auto buildCudaMemcpy3DPeerParms() const
+            -> cudaMemcpy3DPeerParms
+            {
+                ALPAKA_DEBUG_FULL_LOG_SCOPE;
+
+                // Fill CUDA parameter structure.
+                cudaMemcpy3DPeerParms cudaMemCpy3DPeerParms;
+                cudaMemCpy3DPeerParms.dstArray = nullptr;  // Either dstArray or dstPtr.
+                cudaMemCpy3DPeerParms.dstDevice = m_iDstDevice;
+                cudaMemCpy3DPeerParms.dstPos = make_cudaPos(0, 0, 0);  // Optional. Offset in bytes.
+                cudaMemCpy3DPeerParms.dstPtr =
+                    make_cudaPitchedPtr(
+                        m_dstMemNative,
+                        static_cast<std::size_t>(m_dstpitchBytesX),
+                        static_cast<std::size_t>(m_dstWidth),
+                        static_cast<std::size_t>(m_dstPitchBytesY/m_dstpitchBytesX));
+                cudaMemCpy3DPeerParms.extent =
+                    make_cudaExtent(
+                        static_cast<std::size_t>(m_extentWidthBytes),
+                        static_cast<std::size_t>(m_extentHeight),
+                        static_cast<std::size_t>(m_extentDepth));
+                cudaMemCpy3DPeerParms.srcArray = nullptr;  // Either srcArray or srcPtr.
+                cudaMemCpy3DPeerParms.srcDevice = m_iSrcDevice;
+                cudaMemCpy3DPeerParms.srcPos = make_cudaPos(0, 0, 0);  // Optional. Offset in bytes.
+                cudaMemCpy3DPeerParms.srcPtr =
+                    make_cudaPitchedPtr(
+                        const_cast<void *>(m_srcMemNative),
+                        static_cast<std::size_t>(m_srcpitchBytesX),
+                        static_cast<std::size_t>(m_srcWidth),
+                        static_cast<std::size_t>(m_srcPitchBytesY / m_srcpitchBytesX));
+
+                return cudaMemCpy3DPeerParms;
+            }
+#endif
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST auto printDebug() const
+            -> void
+            {
+                std::cout << __func__
+                    << " ew: " << m_extentWidth
+                    << " eh: " << m_extentHeight
+                    << " ed: " << m_extentDepth
+                    << " ewb: " << m_extentWidthBytes
+                    << " ddev: " << m_iDstDevice
+                    << " dw: " << m_dstWidth
+                    << " dh: " << m_dstHeight
+                    << " dd: " << m_dstDepth
+                    << " dptr: " << m_dstMemNative
+                    << " dpitchb: " << m_dstpitchBytesX
+                    << " sdev: " << m_iSrcDevice
+                    << " sw: " << m_srcWidth
+                    << " sh: " << m_srcHeight
+                    << " sd: " << m_srcDepth
+                    << " sptr: " << m_srcMemNative
+                    << " spitchb: " << m_srcpitchBytesX
+                    << std::endl;
+            }
+#endif
+            MemcpyKind m_uniformMemCpyKind;
+            int m_iDstDevice;
+            int m_iSrcDevice;
+
+            Idx m_extentWidth;
+            Idx m_extentWidthBytes;
+            Idx m_dstWidth;
+            Idx m_srcWidth;
+
+            Idx m_extentHeight;
+            Idx m_dstHeight;
+            Idx m_srcHeight;
+
+            Idx m_extentDepth;
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+            Idx m_dstDepth;
+            Idx m_srcDepth;
+#endif
+            Idx m_dstpitchBytesX;
+            Idx m_srcpitchBytesX;
+            Idx m_dstPitchBytesY;
+            Idx m_srcPitchBytesY;
+
+            void * m_dstMemNative;
+            void const * m_srcMemNative;
+        };
     }
+
+    //-----------------------------------------------------------------------------
+    // Trait specializations for CreateTaskCopy.
     namespace traits
     {
+        //#############################################################################
+        //! The CUDA/HIP to CPU memory copy trait specialization.
+        template<
+            typename TDim>
+        struct CreateTaskCopy<
+            TDim,
+            DevCpu,
+            DevUniformCudaHipRt>
+        {
+            //-----------------------------------------------------------------------------
+            template<
+                typename TExtent,
+                typename TViewSrc,
+                typename TViewDst>
+            ALPAKA_FN_HOST static auto createTaskCopy(
+                TViewDst & viewDst,
+                TViewSrc const & viewSrc,
+                TExtent const & extent)
+            -> alpaka::detail::TaskCopyUniformCudaHip<
+                TDim,
+                TViewDst,
+                TViewSrc,
+                TExtent>
+            {
+                ALPAKA_DEBUG_FULL_LOG_SCOPE;
+
+                auto const iDevice(
+                    getDev(viewSrc).m_iDevice);
+
+                return
+                    alpaka::detail::TaskCopyUniformCudaHip<
+                        TDim,
+                        TViewDst,
+                        TViewSrc,
+                        TExtent>(
+                            viewDst,
+                            viewSrc,
+                            extent,
+                            ALPAKA_API_PREFIX(MemcpyDeviceToHost),
+                            iDevice,
+                            iDevice);
+            }
+        };
+        //#############################################################################
+        //! The CPU to CUDA/HIP memory copy trait specialization.
+        template<
+            typename TDim>
+        struct CreateTaskCopy<
+            TDim,
+            DevUniformCudaHipRt,
+            DevCpu>
+        {
+            //-----------------------------------------------------------------------------
+            template<
+                typename TExtent,
+                typename TViewSrc,
+                typename TViewDst>
+            ALPAKA_FN_HOST static auto createTaskCopy(
+                TViewDst & viewDst,
+                TViewSrc const & viewSrc,
+                TExtent const & extent)
+            -> alpaka::detail::TaskCopyUniformCudaHip<
+                TDim,
+                TViewDst,
+                TViewSrc,
+                TExtent>
+            {
+                ALPAKA_DEBUG_FULL_LOG_SCOPE;
+
+                auto const iDevice(
+                    getDev(viewDst).m_iDevice);
+
+                return
+                    alpaka::detail::TaskCopyUniformCudaHip<
+                        TDim,
+                        TViewDst,
+                        TViewSrc,
+                        TExtent>(
+                            viewDst,
+                            viewSrc,
+                            extent,
+                            ALPAKA_API_PREFIX(MemcpyHostToDevice),
+                            iDevice,
+                            iDevice);
+            }
+        };
+        //#############################################################################
+        //! The CUDA/HIP to CUDA/HIP memory copy trait specialization.
+        template<
+            typename TDim>
+        struct CreateTaskCopy<
+            TDim,
+            DevUniformCudaHipRt,
+            DevUniformCudaHipRt>
+        {
+            //-----------------------------------------------------------------------------
+            template<
+                typename TExtent,
+                typename TViewSrc,
+                typename TViewDst>
+            ALPAKA_FN_HOST static auto createTaskCopy(
+                TViewDst & viewDst,
+                TViewSrc const & viewSrc,
+                TExtent const & extent)
+            -> alpaka::detail::TaskCopyUniformCudaHip<
+                TDim,
+                TViewDst,
+                TViewSrc,
+                TExtent>
+            {
+                ALPAKA_DEBUG_FULL_LOG_SCOPE;
+
+                return
+                    alpaka::detail::TaskCopyUniformCudaHip<
+                        TDim,
+                        TViewDst,
+                        TViewSrc,
+                        TExtent>(
+                            viewDst,
+                            viewSrc,
+                            extent,
+                            ALPAKA_API_PREFIX(MemcpyDeviceToDevice),
+                            getDev(viewDst).m_iDevice,
+                            getDev(viewSrc).m_iDevice);
+            }
+        };
+
         //#############################################################################
         //! The CUDA/HIP non-blocking device queue 1D copy enqueue trait specialization.
         template<
@@ -991,12 +986,12 @@ namespace alpaka
             typename TViewDst>
         struct Enqueue<
             QueueUniformCudaHipRtNonBlocking,
-            view::detail::TaskCopyUniformCudaHip<DimInt<1u>, TViewDst, TViewSrc, TExtent>>
+            alpaka::detail::TaskCopyUniformCudaHip<DimInt<1u>, TViewDst, TViewSrc, TExtent>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtNonBlocking & queue,
-                view::detail::TaskCopyUniformCudaHip<DimInt<1u>, TViewDst, TViewSrc, TExtent> const & task)
+                alpaka::detail::TaskCopyUniformCudaHip<DimInt<1u>, TViewDst, TViewSrc, TExtent> const & task)
             -> void
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -1012,12 +1007,12 @@ namespace alpaka
             typename TViewDst>
         struct Enqueue<
             QueueUniformCudaHipRtBlocking,
-            view::detail::TaskCopyUniformCudaHip<DimInt<1u>, TViewDst, TViewSrc, TExtent>>
+            alpaka::detail::TaskCopyUniformCudaHip<DimInt<1u>, TViewDst, TViewSrc, TExtent>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtBlocking & queue,
-                view::detail::TaskCopyUniformCudaHip<DimInt<1u>, TViewDst, TViewSrc, TExtent> const & task)
+                alpaka::detail::TaskCopyUniformCudaHip<DimInt<1u>, TViewDst, TViewSrc, TExtent> const & task)
             -> void
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -1037,12 +1032,12 @@ namespace alpaka
             typename TViewDst>
         struct Enqueue<
             QueueUniformCudaHipRtNonBlocking,
-            view::detail::TaskCopyUniformCudaHip<DimInt<2u>, TViewDst, TViewSrc, TExtent>>
+            alpaka::detail::TaskCopyUniformCudaHip<DimInt<2u>, TViewDst, TViewSrc, TExtent>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtNonBlocking & queue,
-                view::detail::TaskCopyUniformCudaHip<DimInt<2u>, TViewDst, TViewSrc, TExtent> const & task)
+                alpaka::detail::TaskCopyUniformCudaHip<DimInt<2u>, TViewDst, TViewSrc, TExtent> const & task)
             -> void
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -1058,12 +1053,12 @@ namespace alpaka
             typename TViewDst>
         struct Enqueue<
             QueueUniformCudaHipRtBlocking,
-            view::detail::TaskCopyUniformCudaHip<DimInt<2u>, TViewDst, TViewSrc, TExtent>>
+            alpaka::detail::TaskCopyUniformCudaHip<DimInt<2u>, TViewDst, TViewSrc, TExtent>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtBlocking & queue,
-                view::detail::TaskCopyUniformCudaHip<DimInt<2u>, TViewDst, TViewSrc, TExtent> const & task)
+                alpaka::detail::TaskCopyUniformCudaHip<DimInt<2u>, TViewDst, TViewSrc, TExtent> const & task)
             -> void
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -1083,12 +1078,12 @@ namespace alpaka
             typename TViewDst>
         struct Enqueue<
             QueueUniformCudaHipRtNonBlocking,
-            view::detail::TaskCopyUniformCudaHip<DimInt<3u>, TViewDst, TViewSrc, TExtent>>
+            alpaka::detail::TaskCopyUniformCudaHip<DimInt<3u>, TViewDst, TViewSrc, TExtent>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtNonBlocking & queue,
-                view::detail::TaskCopyUniformCudaHip<DimInt<3u>, TViewDst, TViewSrc, TExtent> const & task)
+                alpaka::detail::TaskCopyUniformCudaHip<DimInt<3u>, TViewDst, TViewSrc, TExtent> const & task)
             -> void
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -1104,12 +1099,12 @@ namespace alpaka
             typename TViewDst>
         struct Enqueue<
             QueueUniformCudaHipRtBlocking,
-            view::detail::TaskCopyUniformCudaHip<DimInt<3u>, TViewDst, TViewSrc, TExtent>>
+            alpaka::detail::TaskCopyUniformCudaHip<DimInt<3u>, TViewDst, TViewSrc, TExtent>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtBlocking & queue,
-                view::detail::TaskCopyUniformCudaHip<DimInt<3u>, TViewDst, TViewSrc, TExtent> const & task)
+                alpaka::detail::TaskCopyUniformCudaHip<DimInt<3u>, TViewDst, TViewSrc, TExtent> const & task)
             -> void
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -848,14 +848,14 @@ namespace alpaka
     }
 
     //-----------------------------------------------------------------------------
-    // Trait specializations for CreateTaskCopy.
+    // Trait specializations for CreateTaskMemcpy.
     namespace traits
     {
         //#############################################################################
         //! The CUDA/HIP to CPU memory copy trait specialization.
         template<
             typename TDim>
-        struct CreateTaskCopy<
+        struct CreateTaskMemcpy<
             TDim,
             DevCpu,
             DevUniformCudaHipRt>
@@ -865,7 +865,7 @@ namespace alpaka
                 typename TExtent,
                 typename TViewSrc,
                 typename TViewDst>
-            ALPAKA_FN_HOST static auto createTaskCopy(
+            ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst & viewDst,
                 TViewSrc const & viewSrc,
                 TExtent const & extent)
@@ -898,7 +898,7 @@ namespace alpaka
         //! The CPU to CUDA/HIP memory copy trait specialization.
         template<
             typename TDim>
-        struct CreateTaskCopy<
+        struct CreateTaskMemcpy<
             TDim,
             DevUniformCudaHipRt,
             DevCpu>
@@ -908,7 +908,7 @@ namespace alpaka
                 typename TExtent,
                 typename TViewSrc,
                 typename TViewDst>
-            ALPAKA_FN_HOST static auto createTaskCopy(
+            ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst & viewDst,
                 TViewSrc const & viewSrc,
                 TExtent const & extent)
@@ -941,7 +941,7 @@ namespace alpaka
         //! The CUDA/HIP to CUDA/HIP memory copy trait specialization.
         template<
             typename TDim>
-        struct CreateTaskCopy<
+        struct CreateTaskMemcpy<
             TDim,
             DevUniformCudaHipRt,
             DevUniformCudaHipRt>
@@ -951,7 +951,7 @@ namespace alpaka
                 typename TExtent,
                 typename TViewSrc,
                 typename TViewDst>
-            ALPAKA_FN_HOST static auto createTaskCopy(
+            ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst & viewDst,
                 TViewSrc const & viewSrc,
                 TExtent const & extent)

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -40,324 +40,315 @@
 namespace alpaka
 {
     class DevUniformCudaHipRt;
-}
 
-namespace alpaka
-{
-    namespace view
+    namespace detail
     {
-        namespace detail
+        //#############################################################################
+        //! The CUDA/HIP memory set task base.
+        template<
+            typename TDim,
+            typename TView,
+            typename TExtent>
+        struct TaskSetUniformCudaHipBase
         {
-            //#############################################################################
-            //! The CUDA/HIP memory set task base.
-            template<
-                typename TDim,
-                typename TView,
-                typename TExtent>
-            struct TaskSetUniformCudaHipBase
+            //-----------------------------------------------------------------------------
+            TaskSetUniformCudaHipBase(
+                TView & view,
+                std::uint8_t const & byte,
+                TExtent const & extent) :
+                    m_view(view),
+                    m_byte(byte),
+                    m_extent(extent),
+                    m_iDevice(getDev(view).m_iDevice)
             {
-                //-----------------------------------------------------------------------------
-                TaskSetUniformCudaHipBase(
-                    TView & view,
-                    std::uint8_t const & byte,
-                    TExtent const & extent) :
-                        m_view(view),
-                        m_byte(byte),
-                        m_extent(extent),
-                        m_iDevice(getDev(view).m_iDevice)
-                {
-                    static_assert(
-                        !std::is_const<TView>::value,
-                        "The destination view can not be const!");
+                static_assert(
+                    !std::is_const<TView>::value,
+                    "The destination view can not be const!");
 
-                    static_assert(
-                        Dim<TView>::value == Dim<TExtent>::value,
-                        "The destination view and the extent are required to have the same dimensionality!");
-                }
+                static_assert(
+                    Dim<TView>::value == Dim<TExtent>::value,
+                    "The destination view and the extent are required to have the same dimensionality!");
+            }
 
-            protected:
-                TView & m_view;
-                std::uint8_t const m_byte;
-                TExtent const m_extent;
-                std::int32_t const m_iDevice;
-            };
+        protected:
+            TView & m_view;
+            std::uint8_t const m_byte;
+            TExtent const m_extent;
+            std::int32_t const m_iDevice;
+        };
 
-            //#############################################################################
-            //! The CUDA/HIP memory set task.
-            template<
-                typename TDim,
-                typename TView,
-                typename TExtent>
-            struct TaskSetUniformCudaHip;
+        //#############################################################################
+        //! The CUDA/HIP memory set task.
+        template<
+            typename TDim,
+            typename TView,
+            typename TExtent>
+        struct TaskSetUniformCudaHip;
 
-            //#############################################################################
-            //! The 1D CUDA/HIP memory set task.
-            template<
-                typename TView,
-                typename TExtent>
-            struct TaskSetUniformCudaHip<
-                DimInt<1>,
-                TView,
-                TExtent>
-                : public TaskSetUniformCudaHipBase<DimInt<1>, TView, TExtent>
-            {
-                //-----------------------------------------------------------------------------
-                TaskSetUniformCudaHip(
-                    TView & view,
-                    std::uint8_t const & byte,
-                    TExtent const & extent) :
-                        TaskSetUniformCudaHipBase<DimInt<1>, TView, TExtent>(view, byte, extent)
-                {
-                }
-
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TQueue
-                >
-                auto enqueue(TQueue & queue) const
-                -> void
-                {
-                    static_assert(
-                        Dim<TView>::value == 1u,
-                        "The destination buffer is required to be 1-dimensional for this specialization!");
-                    static_assert(
-                        Dim<TView>::value == Dim<TExtent>::value,
-                        "The destination buffer and the extent are required to have the same dimensionality!");
-
-                    using Idx = Idx<TExtent>;
-
-                    auto & view(this->m_view);
-                    auto const & extent(this->m_extent);
-
-                    auto const extentWidth(extent::getWidth(extent));
-
-                    if(extentWidth == 0)
-                    {
-                        return;
-                    }
-
-                    auto const extentWidthBytes(extentWidth * static_cast<Idx>(sizeof(Elem<TView>)));
-#if !defined(NDEBUG)
-                    auto const dstWidth(extent::getWidth(view));
-#endif
-                    auto const dstNativePtr(reinterpret_cast<void *>(view::getPtrNative(view)));
-                    ALPAKA_ASSERT(extentWidth <= dstWidth);
-
-                    // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        ALPAKA_API_PREFIX(SetDevice)(
-                            this->m_iDevice));
-                    // Initiate the memory set.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        ALPAKA_API_PREFIX(MemsetAsync)(
-                            dstNativePtr,
-                            static_cast<int>(this->m_byte),
-                            static_cast<size_t>(extentWidthBytes),
-                            queue.m_spQueueImpl->m_UniformCudaHipQueue));
-                }
-            };
-            //#############################################################################
-            //! The 2D CUDA/HIP memory set task.
-            template<
-                typename TView,
-                typename TExtent>
-            struct TaskSetUniformCudaHip<
-                DimInt<2>,
-                TView,
-                TExtent>
-                : public TaskSetUniformCudaHipBase<DimInt<2>, TView, TExtent>
-            {
-                //-----------------------------------------------------------------------------
-                TaskSetUniformCudaHip(
-                    TView & view,
-                    std::uint8_t const & byte,
-                    TExtent const & extent) :
-                        TaskSetUniformCudaHipBase<DimInt<2>, TView, TExtent>(view, byte, extent)
-                {
-                }
-
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TQueue
-                >
-                auto enqueue(TQueue & queue) const
-                -> void
-                {
-                    static_assert(
-                        Dim<TView>::value == 2u,
-                        "The destination buffer is required to be 2-dimensional for this specialization!");
-                    static_assert(
-                        Dim<TView>::value == Dim<TExtent>::value,
-                        "The destination buffer and the extent are required to have the same dimensionality!");
-
-                    using Idx = Idx<TExtent>;
-
-                    auto & view(this->m_view);
-                    auto const & extent(this->m_extent);
-
-                    auto const extentWidth(extent::getWidth(extent));
-                    auto const extentHeight(extent::getHeight(extent));
-
-                    if(extentWidth == 0 || extentHeight == 0)
-                    {
-                        return;
-                    }
-
-                    auto const extentWidthBytes(extentWidth * static_cast<Idx>(sizeof(Elem<TView>)));
-
-#if !defined(NDEBUG)
-                    auto const dstWidth(extent::getWidth(view));
-                    auto const dstHeight(extent::getHeight(view));
-#endif
-                    auto const dstPitchBytesX(view::getPitchBytes<Dim<TView>::value - 1u>(view));
-                    auto const dstNativePtr(reinterpret_cast<void *>(view::getPtrNative(view)));
-                    ALPAKA_ASSERT(extentWidth <= dstWidth);
-                    ALPAKA_ASSERT(extentHeight <= dstHeight);
-
-                    // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        ALPAKA_API_PREFIX(SetDevice)(
-                            this->m_iDevice));
-                    // Initiate the memory set.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        ALPAKA_API_PREFIX(Memset2DAsync)(
-                            dstNativePtr,
-                            static_cast<size_t>(dstPitchBytesX),
-                            static_cast<int>(this->m_byte),
-                            static_cast<size_t>(extentWidthBytes),
-                            static_cast<size_t>(extentHeight),
-                            queue.m_spQueueImpl->m_UniformCudaHipQueue));
-                }
-            };
-            //#############################################################################
-            //! The 3D CUDA/HIP memory set task.
-            template<
-                typename TView,
-                typename TExtent>
-            struct TaskSetUniformCudaHip<
-                DimInt<3>,
-                TView,
-                TExtent>
-                : public TaskSetUniformCudaHipBase<DimInt<3>, TView, TExtent>
-            {
-                //-----------------------------------------------------------------------------
-                TaskSetUniformCudaHip(
-                    TView & view,
-                    std::uint8_t const & byte,
-                    TExtent const & extent) :
-                        TaskSetUniformCudaHipBase<DimInt<3>, TView, TExtent>(view, byte, extent)
-                {
-                }
-
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TQueue
-                >
-                auto enqueue(TQueue & queue) const
-                -> void
-                {
-                    static_assert(
-                        Dim<TView>::value == 3u,
-                        "The destination buffer is required to be 3-dimensional for this specialization!");
-                    static_assert(
-                        Dim<TView>::value == Dim<TExtent>::value,
-                        "The destination buffer and the extent are required to have the same dimensionality!");
-
-                    using Elem = alpaka::Elem<TView>;
-                    using Idx = Idx<TExtent>;
-
-                    auto & view(this->m_view);
-                    auto const & extent(this->m_extent);
-
-                    auto const extentWidth(extent::getWidth(extent));
-                    auto const extentHeight(extent::getHeight(extent));
-                    auto const extentDepth(extent::getDepth(extent));
-
-                    // This is not only an optimization but also prevents a division by zero.
-                    if(extentWidth == 0 || extentHeight == 0 || extentDepth == 0)
-                    {
-                        return;
-                    }
-
-                    auto const dstWidth(extent::getWidth(view));
-#if !defined(NDEBUG)
-                    auto const dstHeight(extent::getHeight(view));
-                    auto const dstDepth(extent::getDepth(view));
-#endif
-                    auto const dstPitchBytesX(view::getPitchBytes<Dim<TView>::value - 1u>(view));
-                    auto const dstPitchBytesY(view::getPitchBytes<Dim<TView>::value - (2u % Dim<TView>::value)>(view));
-                    auto const dstNativePtr(reinterpret_cast<void *>(view::getPtrNative(view)));
-                    ALPAKA_ASSERT(extentWidth <= dstWidth);
-                    ALPAKA_ASSERT(extentHeight <= dstHeight);
-                    ALPAKA_ASSERT(extentDepth <= dstDepth);
-
-                    // Fill CUDA parameter structures.
-                    ALPAKA_API_PREFIX(PitchedPtr) const pitchedPtrVal(
-                        ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(PitchedPtr))(
-                            dstNativePtr,
-                            static_cast<size_t>(dstPitchBytesX),
-                            static_cast<size_t>(dstWidth * static_cast<Idx>(sizeof(Elem))),
-                            static_cast<size_t>(dstPitchBytesY / dstPitchBytesX)));
-
-                    ALPAKA_API_PREFIX(Extent) const extentVal(
-                        ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(Extent))(
-                            static_cast<size_t>(extentWidth * static_cast<Idx>(sizeof(Elem))),
-                            static_cast<size_t>(extentHeight),
-                            static_cast<size_t>(extentDepth)));
-
-                    // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        ALPAKA_API_PREFIX(SetDevice)(
-                            this->m_iDevice));
-                    // Initiate the memory set.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        ALPAKA_API_PREFIX(Memset3DAsync)(
-                            pitchedPtrVal,
-                            static_cast<int>(this->m_byte),
-                            extentVal,
-                            queue.m_spQueueImpl->m_UniformCudaHipQueue));
-                }
-            };
-        }
-
-        namespace traits
+        //#############################################################################
+        //! The 1D CUDA/HIP memory set task.
+        template<
+            typename TView,
+            typename TExtent>
+        struct TaskSetUniformCudaHip<
+            DimInt<1>,
+            TView,
+            TExtent>
+            : public TaskSetUniformCudaHipBase<DimInt<1>, TView, TExtent>
         {
-            //#############################################################################
-            //! The CUDA device memory set trait specialization.
-            template<
-                typename TDim>
-            struct CreateTaskSet<
-                TDim,
-                DevUniformCudaHipRt>
+            //-----------------------------------------------------------------------------
+            TaskSetUniformCudaHip(
+                TView & view,
+                std::uint8_t const & byte,
+                TExtent const & extent) :
+                    TaskSetUniformCudaHipBase<DimInt<1>, TView, TExtent>(view, byte, extent)
             {
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TExtent,
-                    typename TView>
-                ALPAKA_FN_HOST static auto createTaskSet(
-                    TView & view,
-                    std::uint8_t const & byte,
-                    TExtent const & extent)
-                -> view::detail::TaskSetUniformCudaHip<
-                    TDim,
-                    TView,
-                    TExtent>
+            }
+
+            //-----------------------------------------------------------------------------
+            template<
+                typename TQueue
+            >
+            auto enqueue(TQueue & queue) const
+            -> void
+            {
+                static_assert(
+                    Dim<TView>::value == 1u,
+                    "The destination buffer is required to be 1-dimensional for this specialization!");
+                static_assert(
+                    Dim<TView>::value == Dim<TExtent>::value,
+                    "The destination buffer and the extent are required to have the same dimensionality!");
+
+                using Idx = Idx<TExtent>;
+
+                auto & view(this->m_view);
+                auto const & extent(this->m_extent);
+
+                auto const extentWidth(extent::getWidth(extent));
+
+                if(extentWidth == 0)
                 {
-                    return
-                        view::detail::TaskSetUniformCudaHip<
-                            TDim,
-                            TView,
-                            TExtent>(
-                                view,
-                                byte,
-                                extent);
+                    return;
                 }
-            };
-        }
+
+                auto const extentWidthBytes(extentWidth * static_cast<Idx>(sizeof(Elem<TView>)));
+#if !defined(NDEBUG)
+                auto const dstWidth(extent::getWidth(view));
+#endif
+                auto const dstNativePtr(reinterpret_cast<void *>(getPtrNative(view)));
+                ALPAKA_ASSERT(extentWidth <= dstWidth);
+
+                // Set the current device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(SetDevice)(
+                        this->m_iDevice));
+                // Initiate the memory set.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(MemsetAsync)(
+                        dstNativePtr,
+                        static_cast<int>(this->m_byte),
+                        static_cast<size_t>(extentWidthBytes),
+                        queue.m_spQueueImpl->m_UniformCudaHipQueue));
+            }
+        };
+        //#############################################################################
+        //! The 2D CUDA/HIP memory set task.
+        template<
+            typename TView,
+            typename TExtent>
+        struct TaskSetUniformCudaHip<
+            DimInt<2>,
+            TView,
+            TExtent>
+            : public TaskSetUniformCudaHipBase<DimInt<2>, TView, TExtent>
+        {
+            //-----------------------------------------------------------------------------
+            TaskSetUniformCudaHip(
+                TView & view,
+                std::uint8_t const & byte,
+                TExtent const & extent) :
+                    TaskSetUniformCudaHipBase<DimInt<2>, TView, TExtent>(view, byte, extent)
+            {
+            }
+
+            //-----------------------------------------------------------------------------
+            template<
+                typename TQueue
+            >
+            auto enqueue(TQueue & queue) const
+            -> void
+            {
+                static_assert(
+                    Dim<TView>::value == 2u,
+                    "The destination buffer is required to be 2-dimensional for this specialization!");
+                static_assert(
+                    Dim<TView>::value == Dim<TExtent>::value,
+                    "The destination buffer and the extent are required to have the same dimensionality!");
+
+                using Idx = Idx<TExtent>;
+
+                auto & view(this->m_view);
+                auto const & extent(this->m_extent);
+
+                auto const extentWidth(extent::getWidth(extent));
+                auto const extentHeight(extent::getHeight(extent));
+
+                if(extentWidth == 0 || extentHeight == 0)
+                {
+                    return;
+                }
+
+                auto const extentWidthBytes(extentWidth * static_cast<Idx>(sizeof(Elem<TView>)));
+
+#if !defined(NDEBUG)
+                auto const dstWidth(extent::getWidth(view));
+                auto const dstHeight(extent::getHeight(view));
+#endif
+                auto const dstPitchBytesX(getPitchBytes<Dim<TView>::value - 1u>(view));
+                auto const dstNativePtr(reinterpret_cast<void *>(getPtrNative(view)));
+                ALPAKA_ASSERT(extentWidth <= dstWidth);
+                ALPAKA_ASSERT(extentHeight <= dstHeight);
+
+                // Set the current device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(SetDevice)(
+                        this->m_iDevice));
+                // Initiate the memory set.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(Memset2DAsync)(
+                        dstNativePtr,
+                        static_cast<size_t>(dstPitchBytesX),
+                        static_cast<int>(this->m_byte),
+                        static_cast<size_t>(extentWidthBytes),
+                        static_cast<size_t>(extentHeight),
+                        queue.m_spQueueImpl->m_UniformCudaHipQueue));
+            }
+        };
+        //#############################################################################
+        //! The 3D CUDA/HIP memory set task.
+        template<
+            typename TView,
+            typename TExtent>
+        struct TaskSetUniformCudaHip<
+            DimInt<3>,
+            TView,
+            TExtent>
+            : public TaskSetUniformCudaHipBase<DimInt<3>, TView, TExtent>
+        {
+            //-----------------------------------------------------------------------------
+            TaskSetUniformCudaHip(
+                TView & view,
+                std::uint8_t const & byte,
+                TExtent const & extent) :
+                    TaskSetUniformCudaHipBase<DimInt<3>, TView, TExtent>(view, byte, extent)
+            {
+            }
+
+            //-----------------------------------------------------------------------------
+            template<
+                typename TQueue
+            >
+            auto enqueue(TQueue & queue) const
+            -> void
+            {
+                static_assert(
+                    Dim<TView>::value == 3u,
+                    "The destination buffer is required to be 3-dimensional for this specialization!");
+                static_assert(
+                    Dim<TView>::value == Dim<TExtent>::value,
+                    "The destination buffer and the extent are required to have the same dimensionality!");
+
+                using Elem = alpaka::Elem<TView>;
+                using Idx = Idx<TExtent>;
+
+                auto & view(this->m_view);
+                auto const & extent(this->m_extent);
+
+                auto const extentWidth(extent::getWidth(extent));
+                auto const extentHeight(extent::getHeight(extent));
+                auto const extentDepth(extent::getDepth(extent));
+
+                // This is not only an optimization but also prevents a division by zero.
+                if(extentWidth == 0 || extentHeight == 0 || extentDepth == 0)
+                {
+                    return;
+                }
+
+                auto const dstWidth(extent::getWidth(view));
+#if !defined(NDEBUG)
+                auto const dstHeight(extent::getHeight(view));
+                auto const dstDepth(extent::getDepth(view));
+#endif
+                auto const dstPitchBytesX(getPitchBytes<Dim<TView>::value - 1u>(view));
+                auto const dstPitchBytesY(getPitchBytes<Dim<TView>::value - (2u % Dim<TView>::value)>(view));
+                auto const dstNativePtr(reinterpret_cast<void *>(getPtrNative(view)));
+                ALPAKA_ASSERT(extentWidth <= dstWidth);
+                ALPAKA_ASSERT(extentHeight <= dstHeight);
+                ALPAKA_ASSERT(extentDepth <= dstDepth);
+
+                // Fill CUDA parameter structures.
+                ALPAKA_API_PREFIX(PitchedPtr) const pitchedPtrVal(
+                    ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(PitchedPtr))(
+                        dstNativePtr,
+                        static_cast<size_t>(dstPitchBytesX),
+                        static_cast<size_t>(dstWidth * static_cast<Idx>(sizeof(Elem))),
+                        static_cast<size_t>(dstPitchBytesY / dstPitchBytesX)));
+
+                ALPAKA_API_PREFIX(Extent) const extentVal(
+                    ALPAKA_PP_CONCAT(make_,ALPAKA_API_PREFIX(Extent))(
+                        static_cast<size_t>(extentWidth * static_cast<Idx>(sizeof(Elem))),
+                        static_cast<size_t>(extentHeight),
+                        static_cast<size_t>(extentDepth)));
+
+                // Set the current device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(SetDevice)(
+                        this->m_iDevice));
+                // Initiate the memory set.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(Memset3DAsync)(
+                        pitchedPtrVal,
+                        static_cast<int>(this->m_byte),
+                        extentVal,
+                        queue.m_spQueueImpl->m_UniformCudaHipQueue));
+            }
+        };
     }
 
     namespace traits
     {
+        //#############################################################################
+        //! The CUDA device memory set trait specialization.
+        template<
+            typename TDim>
+        struct CreateTaskSet<
+            TDim,
+            DevUniformCudaHipRt>
+        {
+            //-----------------------------------------------------------------------------
+            template<
+                typename TExtent,
+                typename TView>
+            ALPAKA_FN_HOST static auto createTaskSet(
+                TView & view,
+                std::uint8_t const & byte,
+                TExtent const & extent)
+            -> alpaka::detail::TaskSetUniformCudaHip<
+                TDim,
+                TView,
+                TExtent>
+            {
+                return
+                    alpaka::detail::TaskSetUniformCudaHip<
+                        TDim,
+                        TView,
+                        TExtent>(
+                            view,
+                            byte,
+                            extent);
+            }
+        };
+
         //#############################################################################
         //! The CUDA non-blocking device queue 1D set enqueue trait specialization.
         template<
@@ -365,12 +356,12 @@ namespace alpaka
             typename TExtent>
         struct Enqueue<
             QueueUniformCudaHipRtNonBlocking,
-            view::detail::TaskSetUniformCudaHip<DimInt<1u>, TView, TExtent>>
+            alpaka::detail::TaskSetUniformCudaHip<DimInt<1u>, TView, TExtent>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtNonBlocking & queue,
-                view::detail::TaskSetUniformCudaHip<DimInt<1u>, TView, TExtent> const & task)
+                alpaka::detail::TaskSetUniformCudaHip<DimInt<1u>, TView, TExtent> const & task)
             -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -385,12 +376,12 @@ namespace alpaka
             typename TExtent>
         struct Enqueue<
             QueueUniformCudaHipRtBlocking,
-            view::detail::TaskSetUniformCudaHip<DimInt<1u>, TView, TExtent>>
+            alpaka::detail::TaskSetUniformCudaHip<DimInt<1u>, TView, TExtent>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtBlocking & queue,
-                view::detail::TaskSetUniformCudaHip<DimInt<1u>, TView, TExtent> const & task)
+                alpaka::detail::TaskSetUniformCudaHip<DimInt<1u>, TView, TExtent> const & task)
             -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -407,12 +398,12 @@ namespace alpaka
             typename TExtent>
         struct Enqueue<
             QueueUniformCudaHipRtNonBlocking,
-            view::detail::TaskSetUniformCudaHip<DimInt<2u>, TView, TExtent>>
+            alpaka::detail::TaskSetUniformCudaHip<DimInt<2u>, TView, TExtent>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtNonBlocking & queue,
-                view::detail::TaskSetUniformCudaHip<DimInt<2u>, TView, TExtent> const & task)
+                alpaka::detail::TaskSetUniformCudaHip<DimInt<2u>, TView, TExtent> const & task)
             -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -427,12 +418,12 @@ namespace alpaka
             typename TExtent>
         struct Enqueue<
             QueueUniformCudaHipRtBlocking,
-            view::detail::TaskSetUniformCudaHip<DimInt<2u>, TView, TExtent>>
+            alpaka::detail::TaskSetUniformCudaHip<DimInt<2u>, TView, TExtent>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtBlocking & queue,
-                view::detail::TaskSetUniformCudaHip<DimInt<2u>, TView, TExtent> const & task)
+                alpaka::detail::TaskSetUniformCudaHip<DimInt<2u>, TView, TExtent> const & task)
             -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -449,12 +440,12 @@ namespace alpaka
             typename TExtent>
         struct Enqueue<
             QueueUniformCudaHipRtNonBlocking,
-            view::detail::TaskSetUniformCudaHip<DimInt<3u>, TView, TExtent>>
+            alpaka::detail::TaskSetUniformCudaHip<DimInt<3u>, TView, TExtent>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtNonBlocking & queue,
-                view::detail::TaskSetUniformCudaHip<DimInt<3u>, TView, TExtent> const & task)
+                alpaka::detail::TaskSetUniformCudaHip<DimInt<3u>, TView, TExtent> const & task)
             -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -469,12 +460,12 @@ namespace alpaka
             typename TExtent>
         struct Enqueue<
             QueueUniformCudaHipRtBlocking,
-            view::detail::TaskSetUniformCudaHip<DimInt<3u>, TView, TExtent>>
+            alpaka::detail::TaskSetUniformCudaHip<DimInt<3u>, TView, TExtent>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtBlocking & queue,
-                view::detail::TaskSetUniformCudaHip<DimInt<3u>, TView, TExtent> const & task)
+                alpaka::detail::TaskSetUniformCudaHip<DimInt<3u>, TView, TExtent> const & task)
             -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -321,7 +321,7 @@ namespace alpaka
         //! The CUDA device memory set trait specialization.
         template<
             typename TDim>
-        struct CreateTaskSet<
+        struct CreateTaskMemset<
             TDim,
             DevUniformCudaHipRt>
         {
@@ -329,7 +329,7 @@ namespace alpaka
             template<
                 typename TExtent,
                 typename TView>
-            ALPAKA_FN_HOST static auto createTaskSet(
+            ALPAKA_FN_HOST static auto createTaskMemset(
                 TView & view,
                 std::uint8_t const & byte,
                 TExtent const & extent)

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -27,547 +27,542 @@
 namespace alpaka
 {
     //-----------------------------------------------------------------------------
-    //! The view specifics.
-    namespace view
+    //! The view traits.
+    namespace traits
     {
-        //-----------------------------------------------------------------------------
-        //! The view traits.
-        namespace traits
+        //#############################################################################
+        //! The native pointer get trait.
+        template<
+            typename TView,
+            typename TSfinae = void>
+        struct GetPtrNative;
+
+        //#############################################################################
+        //! The pointer on device get trait.
+        template<
+            typename TView,
+            typename TDev,
+            typename TSfinae = void>
+        struct GetPtrDev;
+
+        namespace detail
         {
             //#############################################################################
-            //! The native pointer get trait.
-            template<
-                typename TView,
-                typename TSfinae = void>
-            struct GetPtrNative;
-
-            //#############################################################################
-            //! The pointer on device get trait.
-            template<
-                typename TView,
-                typename TDev,
-                typename TSfinae = void>
-            struct GetPtrDev;
-
-            namespace detail
-            {
-                //#############################################################################
-                template<
-                    typename TIdx,
-                    typename TView,
-                    typename TSfinae = void>
-                struct GetPitchBytesDefault;
-            }
-
-            //#############################################################################
-            //! The pitch in bytes.
-            //! This is the distance in bytes in the linear memory between two consecutive elements in the next higher dimension (TIdx-1).
-            //!
-            //! The default implementation uses the extent to calculate the pitch.
             template<
                 typename TIdx,
                 typename TView,
                 typename TSfinae = void>
-            struct GetPitchBytes
+            struct GetPitchBytesDefault;
+        }
+
+        //#############################################################################
+        //! The pitch in bytes.
+        //! This is the distance in bytes in the linear memory between two consecutive elements in the next higher dimension (TIdx-1).
+        //!
+        //! The default implementation uses the extent to calculate the pitch.
+        template<
+            typename TIdx,
+            typename TView,
+            typename TSfinae = void>
+        struct GetPitchBytes
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPitchBytes(
+                TView const & view)
+            -> Idx<TView>
+            {
+                return detail::GetPitchBytesDefault<TIdx, TView>::getPitchBytesDefault(view);
+            }
+        };
+
+        namespace detail
+        {
+            //#############################################################################
+            template<
+                typename TIdx,
+                typename TView>
+            struct GetPitchBytesDefault<
+                TIdx,
+                TView,
+                std::enable_if_t<TIdx::value < (Dim<TView>::value - 1)>>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPitchBytes(
+                ALPAKA_FN_HOST static auto getPitchBytesDefault(
                     TView const & view)
                 -> Idx<TView>
                 {
-                    return detail::GetPitchBytesDefault<TIdx, TView>::getPitchBytesDefault(view);
+                    return
+                        extent::getExtent<TIdx::value>(view)
+                        * GetPitchBytes<DimInt<TIdx::value+1>, TView>::getPitchBytes(view);
                 }
             };
-
-            namespace detail
-            {
-                //#############################################################################
-                template<
-                    typename TIdx,
-                    typename TView>
-                struct GetPitchBytesDefault<
-                    TIdx,
-                    TView,
-                    std::enable_if_t<TIdx::value < (Dim<TView>::value - 1)>>
-                {
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getPitchBytesDefault(
-                        TView const & view)
-                    -> Idx<TView>
-                    {
-                        return
-                            extent::getExtent<TIdx::value>(view)
-                            * GetPitchBytes<DimInt<TIdx::value+1>, TView>::getPitchBytes(view);
-                    }
-                };
-                //#############################################################################
-                template<
-                    typename TView>
-                struct GetPitchBytesDefault<
-                    DimInt<Dim<TView>::value - 1u>,
-                    TView>
-                {
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getPitchBytesDefault(
-                        TView const & view)
-                    -> Idx<TView>
-                    {
-                        return
-                            extent::getExtent<Dim<TView>::value - 1u>(view)
-                            * sizeof(Elem<TView>);
-                    }
-                };
-                //#############################################################################
-                template<
-                    typename TView>
-                struct GetPitchBytesDefault<
-                    DimInt<Dim<TView>::value>,
-                    TView>
-                {
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getPitchBytesDefault(
-                        TView const &)
-                    -> Idx<TView>
-                    {
-                        return
-                            sizeof(Elem<TView>);
-                    }
-                };
-            }
-
             //#############################################################################
-            //! The memory set task trait.
-            //!
-            //! Fills the view with data.
-            template<
-                typename TDim,
-                typename TDev,
-                typename TSfinae = void>
-            struct CreateTaskSet;
-
-            //#############################################################################
-            //! The memory copy task trait.
-            //!
-            //! Copies memory from one view into another view possibly on a different device.
-            template<
-                typename TDim,
-                typename TDevDst,
-                typename TDevSrc,
-                typename TSfinae = void>
-            struct CreateTaskCopy;
-
-            //#############################################################################
-            //! The static device memory view creation trait.
-            template<
-                typename TDev,
-                typename TSfinae = void>
-            struct CreateStaticDevMemView;
-        }
-
-        //-----------------------------------------------------------------------------
-        //! Gets the native pointer of the memory view.
-        //!
-        //! \param view The memory view.
-        //! \return The native pointer.
-        template<
-            typename TView>
-        ALPAKA_FN_HOST auto getPtrNative(
-            TView const & view)
-        -> Elem<TView> const *
-        {
-            return
-                traits::GetPtrNative<
-                    TView>
-                ::getPtrNative(
-                    view);
-        }
-        //-----------------------------------------------------------------------------
-        //! Gets the native pointer of the memory view.
-        //!
-        //! \param view The memory view.
-        //! \return The native pointer.
-        template<
-            typename TView>
-        ALPAKA_FN_HOST auto getPtrNative(
-            TView & view)
-        -> Elem<TView> *
-        {
-            return
-                traits::GetPtrNative<
-                    TView>
-                ::getPtrNative(
-                    view);
-        }
-
-        //-----------------------------------------------------------------------------
-        //! Gets the pointer to the view on the given device.
-        //!
-        //! \param view The memory view.
-        //! \param dev The device.
-        //! \return The pointer on the device.
-        template<
-            typename TView,
-            typename TDev>
-        ALPAKA_FN_HOST auto getPtrDev(
-            TView const & view,
-            TDev const & dev)
-        -> Elem<TView> const *
-        {
-            return
-                traits::GetPtrDev<
-                    TView,
-                    TDev>
-                ::getPtrDev(
-                    view,
-                    dev);
-        }
-        //-----------------------------------------------------------------------------
-        //! Gets the pointer to the view on the given device.
-        //!
-        //! \param view The memory view.
-        //! \param dev The device.
-        //! \return The pointer on the device.
-        template<
-            typename TView,
-            typename TDev>
-        ALPAKA_FN_HOST auto getPtrDev(
-            TView & view,
-            TDev const & dev)
-        -> Elem<TView> *
-        {
-            return
-                traits::GetPtrDev<
-                    TView,
-                    TDev>
-                ::getPtrDev(
-                    view,
-                    dev);
-        }
-
-        //-----------------------------------------------------------------------------
-        //! \return The pitch in bytes. This is the distance in bytes between two consecutive elements in the given dimension.
-        ALPAKA_NO_HOST_ACC_WARNING
-        template<
-            std::size_t Tidx,
-            typename TView>
-        ALPAKA_FN_HOST_ACC
-        auto getPitchBytes(
-            TView const & view)
-        -> Idx<TView>
-        {
-            return
-                traits::GetPitchBytes<
-                    DimInt<Tidx>,
-                    TView>
-                ::getPitchBytes(
-                    view);
-        }
-
-        //-----------------------------------------------------------------------------
-        //! Create a memory set task.
-        //!
-        //! \param view The memory view to fill.
-        //! \param byte Value to set for each element of the specified view.
-        //! \param extent The extent of the view to fill.
-        template<
-            typename TExtent,
-            typename TView>
-        ALPAKA_FN_HOST auto createTaskSet(
-            TView & view,
-            std::uint8_t const & byte,
-            TExtent const & extent)
-        {
-            static_assert(
-                Dim<TView>::value == Dim<TExtent>::value,
-                "The view and the extent are required to have the same dimensionality!");
-
-            return
-                traits::CreateTaskSet<
-                    Dim<TView>,
-                    Dev<TView>>
-                ::createTaskSet(
-                    view,
-                    byte,
-                    extent);
-        }
-
-        //-----------------------------------------------------------------------------
-        //! Sets the memory to the given value.
-        //!
-        //! \param queue The queue to enqueue the view fill task into.
-        //! \param view The memory view to fill.
-        //! \param byte Value to set for each element of the specified view.
-        //! \param extent The extent of the view to fill.
-        template<
-            typename TExtent,
-            typename TView,
-            typename TQueue>
-        ALPAKA_FN_HOST auto set(
-            TQueue & queue,
-            TView & view,
-            std::uint8_t const & byte,
-            TExtent const & extent)
-        -> void
-        {
-            enqueue(
-                queue,
-                view::createTaskSet(
-                    view,
-                    byte,
-                    extent));
-        }
-
-        //-----------------------------------------------------------------------------
-        //! Creates a memory copy task.
-        //!
-        //! \param viewDst The destination memory view.
-        //! \param viewSrc The source memory view.
-        //! \param extent The extent of the view to copy.
-        template<
-            typename TExtent,
-            typename TViewSrc,
-            typename TViewDst>
-        ALPAKA_FN_HOST auto createTaskCopy(
-            TViewDst & viewDst,
-            TViewSrc const & viewSrc,
-            TExtent const & extent)
-        {
-            static_assert(
-                Dim<TViewDst>::value == Dim<TViewSrc>::value,
-                "The source and the destination view are required to have the same dimensionality!");
-            static_assert(
-                Dim<TViewDst>::value == Dim<TExtent>::value,
-                "The destination view and the extent are required to have the same dimensionality!");
-            static_assert(
-                std::is_same<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>::value,
-                "The source and the destination view are required to have the same element type!");
-
-            return
-                traits::CreateTaskCopy<
-                    Dim<TViewDst>,
-                    Dev<TViewDst>,
-                    Dev<TViewSrc>>
-                ::createTaskCopy(
-                    viewDst,
-                    viewSrc,
-                    extent);
-        }
-
-        //-----------------------------------------------------------------------------
-        //! Copies memory possibly between different memory spaces.
-        //!
-        //! \param queue The queue to enqueue the view copy task into.
-        //! \param viewDst The destination memory view.
-        //! \param viewSrc The source memory view.
-        //! \param extent The extent of the view to copy.
-        template<
-            typename TExtent,
-            typename TViewSrc,
-            typename TViewDst,
-            typename TQueue>
-        ALPAKA_FN_HOST auto copy(
-            TQueue & queue,
-            TViewDst & viewDst,
-            TViewSrc const & viewSrc,
-            TExtent const & extent)
-        -> void
-        {
-            enqueue(
-                queue,
-                view::createTaskCopy(
-                    viewDst,
-                    viewSrc,
-                    extent));
-        }
-
-        namespace detail
-        {
-            //-----------------------------------------------------------------------------
-            template<
-                typename TDim,
-                typename TView>
-            struct Print
-            {
-                ALPAKA_FN_HOST static auto print(
-                    TView const & view,
-                    Elem<TView> const * const ptr,
-                    Vec<Dim<TView>, Idx<TView>> const & extent,
-                    std::ostream & os,
-                    std::string const & elementSeparator,
-                    std::string const & rowSeparator,
-                    std::string const & rowPrefix,
-                    std::string const & rowSuffix)
-                -> void
-                {
-                    os << rowPrefix;
-
-                    auto const pitch(view::getPitchBytes<TDim::value+1u>(view));
-                    auto const lastIdx(extent[TDim::value]-1u);
-                    for(auto i(decltype(lastIdx)(0)); i<=lastIdx ;++i)
-                    {
-                        Print<
-                            DimInt<TDim::value+1u>,
-                            TView>
-                        ::print(
-                            view,
-                            reinterpret_cast<Elem<TView> const *>(reinterpret_cast<std::uint8_t const *>(ptr)+i*pitch),
-                            extent,
-                            os,
-                            elementSeparator,
-                            rowSeparator,
-                            rowPrefix,
-                            rowSuffix);
-
-                        // While we are not at the end of a row, add the row separator.
-                        if(i != lastIdx)
-                        {
-                            os << rowSeparator;
-                        }
-                    }
-
-                    os << rowSuffix;
-                }
-            };
-            //-----------------------------------------------------------------------------
             template<
                 typename TView>
-            struct Print<
-                DimInt<Dim<TView>::value-1u>,
+            struct GetPitchBytesDefault<
+                DimInt<Dim<TView>::value - 1u>,
                 TView>
-            {
-                ALPAKA_FN_HOST static auto print(
-                    TView const & view,
-                    Elem<TView> const * const ptr,
-                    Vec<Dim<TView>, Idx<TView>> const & extent,
-                    std::ostream & os,
-                    std::string const & elementSeparator,
-                    std::string const & rowSeparator,
-                    std::string const & rowPrefix,
-                    std::string const & rowSuffix)
-                -> void
-                {
-                    alpaka::ignore_unused(view);
-                    alpaka::ignore_unused(rowSeparator);
-
-                    os << rowPrefix;
-
-                    auto const lastIdx(extent[Dim<TView>::value-1u]-1u);
-                    for(auto i(decltype(lastIdx)(0)); i<=lastIdx ;++i)
-                    {
-                        // Add the current element.
-                        os << *(ptr+i);
-
-                        // While we are not at the end of a line, add the element separator.
-                        if(i != lastIdx)
-                        {
-                            os << elementSeparator;
-                        }
-                    }
-
-                    os << rowSuffix;
-                }
-            };
-        }
-        //-----------------------------------------------------------------------------
-        //! Prints the content of the view to the given queue.
-        // \TODO: Add precision flag.
-        // \TODO: Add column alignment flag.
-        template<
-            typename TView>
-        ALPAKA_FN_HOST auto print(
-            TView const & view,
-            std::ostream & os,
-            std::string const & elementSeparator = ", ",
-            std::string const & rowSeparator = "\n",
-            std::string const & rowPrefix = "[",
-            std::string const & rowSuffix = "]")
-        -> void
-        {
-            detail::Print<
-                DimInt<0u>,
-                TView>
-            ::print(
-                view,
-                view::getPtrNative(view),
-                extent::getExtentVec(view),
-                os,
-                elementSeparator,
-                rowSeparator,
-                rowPrefix,
-                rowSuffix);
-        }
-
-        namespace detail
-        {
-            //#############################################################################
-            //! A class with a create method that returns the pitch for each index.
-            template<
-                std::size_t Tidx>
-            struct CreatePitchBytes
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_NO_HOST_ACC_WARNING
-                template<
-                    typename TPitch>
-                ALPAKA_FN_HOST_ACC
-                static auto create(
-                    TPitch const & pitch)
-                -> Idx<TPitch>
+                ALPAKA_FN_HOST static auto getPitchBytesDefault(
+                    TView const & view)
+                -> Idx<TView>
                 {
-                    return view::getPitchBytes<Tidx>(pitch);
+                    return
+                        extent::getExtent<Dim<TView>::value - 1u>(view)
+                        * sizeof(Elem<TView>);
+                }
+            };
+            //#############################################################################
+            template<
+                typename TView>
+            struct GetPitchBytesDefault<
+                DimInt<Dim<TView>::value>,
+                TView>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto getPitchBytesDefault(
+                    TView const &)
+                -> Idx<TView>
+                {
+                    return
+                        sizeof(Elem<TView>);
                 }
             };
         }
-        //-----------------------------------------------------------------------------
-        //! \return The pitch vector.
-        template<
-            typename TPitch>
-        auto getPitchBytesVec(
-            TPitch const & pitch = TPitch())
-        -> Vec<Dim<TPitch>, Idx<TPitch>>
-        {
-            return
-                createVecFromIndexedFn<
-                    Dim<TPitch>,
-                    detail::CreatePitchBytes>(
-                        pitch);
-        }
-        //-----------------------------------------------------------------------------
-        //! \return The pitch but only the last N elements.
+
+        //#############################################################################
+        //! The memory set task trait.
+        //!
+        //! Fills the view with data.
         template<
             typename TDim,
-            typename TPitch>
-        ALPAKA_FN_HOST auto getPitchBytesVecEnd(
-            TPitch const & pitch = TPitch())
-        -> Vec<TDim, Idx<TPitch>>
-        {
-            using IdxOffset = std::integral_constant<std::intmax_t, static_cast<std::intmax_t>(Dim<TPitch>::value) - static_cast<std::intmax_t>(TDim::value)>;
-            return
-                createVecFromIndexedFnOffset<
-                    TDim,
-                    detail::CreatePitchBytes,
-                    IdxOffset>(
-                        pitch);
-        }
-
-        //-----------------------------------------------------------------------------
-        //! \return A view to static device memory.
-        template<
-            typename TElem,
             typename TDev,
-            typename TExtent>
-        auto createStaticDevMemView(
-            TElem * pMem,
-            TDev const & dev,
-            TExtent const & extent)
+            typename TSfinae = void>
+        struct CreateTaskSet;
+
+        //#############################################################################
+        //! The memory copy task trait.
+        //!
+        //! Copies memory from one view into another view possibly on a different device.
+        template<
+            typename TDim,
+            typename TDevDst,
+            typename TDevSrc,
+            typename TSfinae = void>
+        struct CreateTaskCopy;
+
+        //#############################################################################
+        //! The static device memory view creation trait.
+        template<
+            typename TDev,
+            typename TSfinae = void>
+        struct CreateStaticDevMemView;
+    }
+
+    //-----------------------------------------------------------------------------
+    //! Gets the native pointer of the memory view.
+    //!
+    //! \param view The memory view.
+    //! \return The native pointer.
+    template<
+        typename TView>
+    ALPAKA_FN_HOST auto getPtrNative(
+        TView const & view)
+    -> Elem<TView> const *
+    {
+        return
+            traits::GetPtrNative<
+                TView>
+            ::getPtrNative(
+                view);
+    }
+    //-----------------------------------------------------------------------------
+    //! Gets the native pointer of the memory view.
+    //!
+    //! \param view The memory view.
+    //! \return The native pointer.
+    template<
+        typename TView>
+    ALPAKA_FN_HOST auto getPtrNative(
+        TView & view)
+    -> Elem<TView> *
+    {
+        return
+            traits::GetPtrNative<
+                TView>
+            ::getPtrNative(
+                view);
+    }
+
+    //-----------------------------------------------------------------------------
+    //! Gets the pointer to the view on the given device.
+    //!
+    //! \param view The memory view.
+    //! \param dev The device.
+    //! \return The pointer on the device.
+    template<
+        typename TView,
+        typename TDev>
+    ALPAKA_FN_HOST auto getPtrDev(
+        TView const & view,
+        TDev const & dev)
+    -> Elem<TView> const *
+    {
+        return
+            traits::GetPtrDev<
+                TView,
+                TDev>
+            ::getPtrDev(
+                view,
+                dev);
+    }
+    //-----------------------------------------------------------------------------
+    //! Gets the pointer to the view on the given device.
+    //!
+    //! \param view The memory view.
+    //! \param dev The device.
+    //! \return The pointer on the device.
+    template<
+        typename TView,
+        typename TDev>
+    ALPAKA_FN_HOST auto getPtrDev(
+        TView & view,
+        TDev const & dev)
+    -> Elem<TView> *
+    {
+        return
+            traits::GetPtrDev<
+                TView,
+                TDev>
+            ::getPtrDev(
+                view,
+                dev);
+    }
+
+    //-----------------------------------------------------------------------------
+    //! \return The pitch in bytes. This is the distance in bytes between two consecutive elements in the given dimension.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<
+        std::size_t Tidx,
+        typename TView>
+    ALPAKA_FN_HOST_ACC
+    auto getPitchBytes(
+        TView const & view)
+    -> Idx<TView>
+    {
+        return
+            traits::GetPitchBytes<
+                DimInt<Tidx>,
+                TView>
+            ::getPitchBytes(
+                view);
+    }
+
+    //-----------------------------------------------------------------------------
+    //! Create a memory set task.
+    //!
+    //! \param view The memory view to fill.
+    //! \param byte Value to set for each element of the specified view.
+    //! \param extent The extent of the view to fill.
+    template<
+        typename TExtent,
+        typename TView>
+    ALPAKA_FN_HOST auto createTaskSet(
+        TView & view,
+        std::uint8_t const & byte,
+        TExtent const & extent)
+    {
+        static_assert(
+            Dim<TView>::value == Dim<TExtent>::value,
+            "The view and the extent are required to have the same dimensionality!");
+
+        return
+            traits::CreateTaskSet<
+                Dim<TView>,
+                Dev<TView>>
+            ::createTaskSet(
+                view,
+                byte,
+                extent);
+    }
+
+    //-----------------------------------------------------------------------------
+    //! Sets the memory to the given value.
+    //!
+    //! \param queue The queue to enqueue the view fill task into.
+    //! \param view The memory view to fill.
+    //! \param byte Value to set for each element of the specified view.
+    //! \param extent The extent of the view to fill.
+    template<
+        typename TExtent,
+        typename TView,
+        typename TQueue>
+    ALPAKA_FN_HOST auto set(
+        TQueue & queue,
+        TView & view,
+        std::uint8_t const & byte,
+        TExtent const & extent)
+    -> void
+    {
+        enqueue(
+            queue,
+            createTaskSet(
+                view,
+                byte,
+                extent));
+    }
+
+    //-----------------------------------------------------------------------------
+    //! Creates a memory copy task.
+    //!
+    //! \param viewDst The destination memory view.
+    //! \param viewSrc The source memory view.
+    //! \param extent The extent of the view to copy.
+    template<
+        typename TExtent,
+        typename TViewSrc,
+        typename TViewDst>
+    ALPAKA_FN_HOST auto createTaskCopy(
+        TViewDst & viewDst,
+        TViewSrc const & viewSrc,
+        TExtent const & extent)
+    {
+        static_assert(
+            Dim<TViewDst>::value == Dim<TViewSrc>::value,
+            "The source and the destination view are required to have the same dimensionality!");
+        static_assert(
+            Dim<TViewDst>::value == Dim<TExtent>::value,
+            "The destination view and the extent are required to have the same dimensionality!");
+        static_assert(
+            std::is_same<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>::value,
+            "The source and the destination view are required to have the same element type!");
+
+        return
+            traits::CreateTaskCopy<
+                Dim<TViewDst>,
+                Dev<TViewDst>,
+                Dev<TViewSrc>>
+            ::createTaskCopy(
+                viewDst,
+                viewSrc,
+                extent);
+    }
+
+    //-----------------------------------------------------------------------------
+    //! Copies memory possibly between different memory spaces.
+    //!
+    //! \param queue The queue to enqueue the view copy task into.
+    //! \param viewDst The destination memory view.
+    //! \param viewSrc The source memory view.
+    //! \param extent The extent of the view to copy.
+    template<
+        typename TExtent,
+        typename TViewSrc,
+        typename TViewDst,
+        typename TQueue>
+    ALPAKA_FN_HOST auto copy(
+        TQueue & queue,
+        TViewDst & viewDst,
+        TViewSrc const & viewSrc,
+        TExtent const & extent)
+    -> void
+    {
+        enqueue(
+            queue,
+            createTaskCopy(
+                viewDst,
+                viewSrc,
+                extent));
+    }
+
+    namespace detail
+    {
+        //-----------------------------------------------------------------------------
+        template<
+            typename TDim,
+            typename TView>
+        struct Print
         {
-            return
-                traits::CreateStaticDevMemView<
-                    TDev>
-                ::createStaticDevMemView(
-                    pMem,
-                    dev,
-                    extent);
-        }
+            ALPAKA_FN_HOST static auto print(
+                TView const & view,
+                Elem<TView> const * const ptr,
+                Vec<Dim<TView>, Idx<TView>> const & extent,
+                std::ostream & os,
+                std::string const & elementSeparator,
+                std::string const & rowSeparator,
+                std::string const & rowPrefix,
+                std::string const & rowSuffix)
+            -> void
+            {
+                os << rowPrefix;
+
+                auto const pitch(getPitchBytes<TDim::value+1u>(view));
+                auto const lastIdx(extent[TDim::value]-1u);
+                for(auto i(decltype(lastIdx)(0)); i<=lastIdx ;++i)
+                {
+                    Print<
+                        DimInt<TDim::value+1u>,
+                        TView>
+                    ::print(
+                        view,
+                        reinterpret_cast<Elem<TView> const *>(reinterpret_cast<std::uint8_t const *>(ptr)+i*pitch),
+                        extent,
+                        os,
+                        elementSeparator,
+                        rowSeparator,
+                        rowPrefix,
+                        rowSuffix);
+
+                    // While we are not at the end of a row, add the row separator.
+                    if(i != lastIdx)
+                    {
+                        os << rowSeparator;
+                    }
+                }
+
+                os << rowSuffix;
+            }
+        };
+        //-----------------------------------------------------------------------------
+        template<
+            typename TView>
+        struct Print<
+            DimInt<Dim<TView>::value-1u>,
+            TView>
+        {
+            ALPAKA_FN_HOST static auto print(
+                TView const & view,
+                Elem<TView> const * const ptr,
+                Vec<Dim<TView>, Idx<TView>> const & extent,
+                std::ostream & os,
+                std::string const & elementSeparator,
+                std::string const & rowSeparator,
+                std::string const & rowPrefix,
+                std::string const & rowSuffix)
+            -> void
+            {
+                alpaka::ignore_unused(view);
+                alpaka::ignore_unused(rowSeparator);
+
+                os << rowPrefix;
+
+                auto const lastIdx(extent[Dim<TView>::value-1u]-1u);
+                for(auto i(decltype(lastIdx)(0)); i<=lastIdx ;++i)
+                {
+                    // Add the current element.
+                    os << *(ptr+i);
+
+                    // While we are not at the end of a line, add the element separator.
+                    if(i != lastIdx)
+                    {
+                        os << elementSeparator;
+                    }
+                }
+
+                os << rowSuffix;
+            }
+        };
+    }
+    //-----------------------------------------------------------------------------
+    //! Prints the content of the view to the given queue.
+    // \TODO: Add precision flag.
+    // \TODO: Add column alignment flag.
+    template<
+        typename TView>
+    ALPAKA_FN_HOST auto print(
+        TView const & view,
+        std::ostream & os,
+        std::string const & elementSeparator = ", ",
+        std::string const & rowSeparator = "\n",
+        std::string const & rowPrefix = "[",
+        std::string const & rowSuffix = "]")
+    -> void
+    {
+        detail::Print<
+            DimInt<0u>,
+            TView>
+        ::print(
+            view,
+            getPtrNative(view),
+            extent::getExtentVec(view),
+            os,
+            elementSeparator,
+            rowSeparator,
+            rowPrefix,
+            rowSuffix);
+    }
+
+    namespace detail
+    {
+        //#############################################################################
+        //! A class with a create method that returns the pitch for each index.
+        template<
+            std::size_t Tidx>
+        struct CreatePitchBytes
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_NO_HOST_ACC_WARNING
+            template<
+                typename TPitch>
+            ALPAKA_FN_HOST_ACC
+            static auto create(
+                TPitch const & pitch)
+            -> Idx<TPitch>
+            {
+                return getPitchBytes<Tidx>(pitch);
+            }
+        };
+    }
+    //-----------------------------------------------------------------------------
+    //! \return The pitch vector.
+    template<
+        typename TPitch>
+    auto getPitchBytesVec(
+        TPitch const & pitch = TPitch())
+    -> Vec<Dim<TPitch>, Idx<TPitch>>
+    {
+        return
+            createVecFromIndexedFn<
+                Dim<TPitch>,
+                detail::CreatePitchBytes>(
+                    pitch);
+    }
+    //-----------------------------------------------------------------------------
+    //! \return The pitch but only the last N elements.
+    template<
+        typename TDim,
+        typename TPitch>
+    ALPAKA_FN_HOST auto getPitchBytesVecEnd(
+        TPitch const & pitch = TPitch())
+    -> Vec<TDim, Idx<TPitch>>
+    {
+        using IdxOffset = std::integral_constant<std::intmax_t, static_cast<std::intmax_t>(Dim<TPitch>::value) - static_cast<std::intmax_t>(TDim::value)>;
+        return
+            createVecFromIndexedFnOffset<
+                TDim,
+                detail::CreatePitchBytes,
+                IdxOffset>(
+                    pitch);
+    }
+
+    //-----------------------------------------------------------------------------
+    //! \return A view to static device memory.
+    template<
+        typename TElem,
+        typename TDev,
+        typename TExtent>
+    auto createStaticDevMemView(
+        TElem * pMem,
+        TDev const & dev,
+        TExtent const & extent)
+    {
+        return
+            traits::CreateStaticDevMemView<
+                TDev>
+            ::createStaticDevMemView(
+                pMem,
+                dev,
+                extent);
     }
 }

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -139,7 +139,7 @@ namespace alpaka
             typename TDim,
             typename TDev,
             typename TSfinae = void>
-        struct CreateTaskSet;
+        struct CreateTaskMemset;
 
         //#############################################################################
         //! The memory copy task trait.
@@ -150,7 +150,7 @@ namespace alpaka
             typename TDevDst,
             typename TDevSrc,
             typename TSfinae = void>
-        struct CreateTaskCopy;
+        struct CreateTaskMemcpy;
 
         //#############################################################################
         //! The static device memory view creation trait.
@@ -268,7 +268,7 @@ namespace alpaka
     template<
         typename TExtent,
         typename TView>
-    ALPAKA_FN_HOST auto createTaskSet(
+    ALPAKA_FN_HOST auto createTaskMemset(
         TView & view,
         std::uint8_t const & byte,
         TExtent const & extent)
@@ -278,10 +278,10 @@ namespace alpaka
             "The view and the extent are required to have the same dimensionality!");
 
         return
-            traits::CreateTaskSet<
+            traits::CreateTaskMemset<
                 Dim<TView>,
                 Dev<TView>>
-            ::createTaskSet(
+            ::createTaskMemset(
                 view,
                 byte,
                 extent);
@@ -298,7 +298,7 @@ namespace alpaka
         typename TExtent,
         typename TView,
         typename TQueue>
-    ALPAKA_FN_HOST auto set(
+    ALPAKA_FN_HOST auto memset(
         TQueue & queue,
         TView & view,
         std::uint8_t const & byte,
@@ -307,7 +307,7 @@ namespace alpaka
     {
         enqueue(
             queue,
-            createTaskSet(
+            createTaskMemset(
                 view,
                 byte,
                 extent));
@@ -323,7 +323,7 @@ namespace alpaka
         typename TExtent,
         typename TViewSrc,
         typename TViewDst>
-    ALPAKA_FN_HOST auto createTaskCopy(
+    ALPAKA_FN_HOST auto createTaskMemcpy(
         TViewDst & viewDst,
         TViewSrc const & viewSrc,
         TExtent const & extent)
@@ -339,11 +339,11 @@ namespace alpaka
             "The source and the destination view are required to have the same element type!");
 
         return
-            traits::CreateTaskCopy<
+            traits::CreateTaskMemcpy<
                 Dim<TViewDst>,
                 Dev<TViewDst>,
                 Dev<TViewSrc>>
-            ::createTaskCopy(
+            ::createTaskMemcpy(
                 viewDst,
                 viewSrc,
                 extent);
@@ -361,7 +361,7 @@ namespace alpaka
         typename TViewSrc,
         typename TViewDst,
         typename TQueue>
-    ALPAKA_FN_HOST auto copy(
+    ALPAKA_FN_HOST auto memcpy(
         TQueue & queue,
         TViewDst & viewDst,
         TViewSrc const & viewSrc,
@@ -370,7 +370,7 @@ namespace alpaka
     {
         enqueue(
             queue,
-            createTaskCopy(
+            createTaskMemcpy(
                 viewDst,
                 viewSrc,
                 extent));

--- a/include/alpaka/mem/view/ViewCompileTimeArray.hpp
+++ b/include/alpaka/mem/view/ViewCompileTimeArray.hpp
@@ -106,62 +106,57 @@ namespace alpaka
             };
         }
     }
-    namespace view
-    {
-        namespace traits
-        {
-            //#############################################################################
-            //! The fixed idx array native pointer get trait specialization.
-            template<
-                typename TFixedSizeArray>
-            struct GetPtrNative<
-                TFixedSizeArray,
-                std::enable_if_t<
-                    std::is_array<TFixedSizeArray>::value>>
-            {
-                using TElem = std::remove_all_extent_t<TFixedSizeArray>;
-
-                //-----------------------------------------------------------------------------
-                static auto getPtrNative(
-                    TFixedSizeArray const & view)
-                -> TElem const *
-                {
-                    return view;
-                }
-                //-----------------------------------------------------------------------------
-                static auto getPtrNative(
-                    TFixedSizeArray & view)
-                -> TElem *
-                {
-                    return view;
-                }
-            };
-
-            //#############################################################################
-            //! The fixed idx array pitch get trait specialization.
-            template<
-                typename TFixedSizeArray>
-            struct GetPitchBytes<
-                DimInt<std::rank<TFixedSizeArray>::value - 1u>,
-                TFixedSizeArray,
-                std::enable_if_t<
-                    std::is_array<TFixedSizeArray>::value
-                    && (std::extent<TFixedSizeArray, std::rank<TFixedSizeArray>::value - 1u>::value > 0u)>>
-            {
-                using TElem = std::remove_all_extent_t<TFixedSizeArray>;
-
-                //-----------------------------------------------------------------------------
-                static constexpr auto getPitchBytes(
-                    TFixedSizeArray const &)
-                -> Idx<TFixedSizeArray>
-                {
-                    return sizeof(TElem) * std::extent<TFixedSizeArray, std::rank<TFixedSizeArray>::value - 1u>::value;
-                }
-            };
-        }
-    }
     namespace traits
     {
+        //#############################################################################
+        //! The fixed idx array native pointer get trait specialization.
+        template<
+            typename TFixedSizeArray>
+        struct GetPtrNative<
+            TFixedSizeArray,
+            std::enable_if_t<
+                std::is_array<TFixedSizeArray>::value>>
+        {
+            using TElem = std::remove_all_extent_t<TFixedSizeArray>;
+
+            //-----------------------------------------------------------------------------
+            static auto getPtrNative(
+                TFixedSizeArray const & view)
+            -> TElem const *
+            {
+                return view;
+            }
+            //-----------------------------------------------------------------------------
+            static auto getPtrNative(
+                TFixedSizeArray & view)
+            -> TElem *
+            {
+                return view;
+            }
+        };
+
+        //#############################################################################
+        //! The fixed idx array pitch get trait specialization.
+        template<
+            typename TFixedSizeArray>
+        struct GetPitchBytes<
+            DimInt<std::rank<TFixedSizeArray>::value - 1u>,
+            TFixedSizeArray,
+            std::enable_if_t<
+                std::is_array<TFixedSizeArray>::value
+                && (std::extent<TFixedSizeArray, std::rank<TFixedSizeArray>::value - 1u>::value > 0u)>>
+        {
+            using TElem = std::remove_all_extent_t<TFixedSizeArray>;
+
+            //-----------------------------------------------------------------------------
+            static constexpr auto getPitchBytes(
+                TFixedSizeArray const &)
+            -> Idx<TFixedSizeArray>
+            {
+                return sizeof(TElem) * std::extent<TFixedSizeArray, std::rank<TFixedSizeArray>::value - 1u>::value;
+            }
+        };
+
         //#############################################################################
         //! The fixed idx array offset get trait specialization.
         template<

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -20,102 +20,99 @@
 
 namespace alpaka
 {
-    namespace view
+    //#############################################################################
+    //! The memory view to wrap plain pointers.
+    template<
+        typename TDev,
+        typename TElem,
+        typename TDim,
+        typename TIdx>
+    class ViewPlainPtr final
     {
-        //#############################################################################
-        //! The memory view to wrap plain pointers.
+        static_assert(
+            !std::is_const<TIdx>::value,
+            "The idx type of the view can not be const!");
+
+        using Dev = alpaka::Dev<TDev>;
+    public:
+        //-----------------------------------------------------------------------------
         template<
-            typename TDev,
-            typename TElem,
-            typename TDim,
-            typename TIdx>
-        class ViewPlainPtr final
-        {
-            static_assert(
-                !std::is_const<TIdx>::value,
-                "The idx type of the view can not be const!");
+            typename TExtent>
+        ALPAKA_FN_HOST ViewPlainPtr(
+            TElem * pMem,
+            Dev const & dev,
+            TExtent const & extent = TExtent()) :
+                m_pMem(pMem),
+                m_dev(dev),
+                m_extentElements(extent::getExtentVecEnd<TDim>(extent)),
+                m_pitchBytes(calculatePitchesFromExtents(m_extentElements))
+        {}
 
-            using Dev = alpaka::Dev<TDev>;
-        public:
-            //-----------------------------------------------------------------------------
-            template<
-                typename TExtent>
-            ALPAKA_FN_HOST ViewPlainPtr(
-                TElem * pMem,
-                Dev const & dev,
-                TExtent const & extent = TExtent()) :
-                    m_pMem(pMem),
-                    m_dev(dev),
-                    m_extentElements(extent::getExtentVecEnd<TDim>(extent)),
-                    m_pitchBytes(calculatePitchesFromExtents(m_extentElements))
-            {}
-
-            //-----------------------------------------------------------------------------
-            template<
-                typename TExtent,
-                typename TPitch>
-            ALPAKA_FN_HOST ViewPlainPtr(
-                TElem * pMem,
-                Dev const dev,
-                TExtent const & extent,
-                TPitch const & pitchBytes) :
-                    m_pMem(pMem),
-                    m_dev(dev),
-                    m_extentElements(extent::getExtentVecEnd<TDim>(extent)),
-                    m_pitchBytes(
-                        subVecEnd<TDim>(
-                            static_cast<
-                                Vec<TDim, TIdx> >(pitchBytes)
-                        )
+        //-----------------------------------------------------------------------------
+        template<
+            typename TExtent,
+            typename TPitch>
+        ALPAKA_FN_HOST ViewPlainPtr(
+            TElem * pMem,
+            Dev const dev,
+            TExtent const & extent,
+            TPitch const & pitchBytes) :
+                m_pMem(pMem),
+                m_dev(dev),
+                m_extentElements(extent::getExtentVecEnd<TDim>(extent)),
+                m_pitchBytes(
+                    subVecEnd<TDim>(
+                        static_cast<
+                            Vec<TDim, TIdx> >(pitchBytes)
                     )
-            {}
+                )
+        {}
 
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST
-            ViewPlainPtr(ViewPlainPtr const &) = default;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST
-            ViewPlainPtr(ViewPlainPtr && other) noexcept :
-                    m_pMem(other.m_pMem),
-                    m_dev(other.m_dev),
-                    m_extentElements(other.m_extentElements),
-                    m_pitchBytes(other.m_pitchBytes)
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST
+        ViewPlainPtr(ViewPlainPtr const &) = default;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST
+        ViewPlainPtr(ViewPlainPtr && other) noexcept :
+                m_pMem(other.m_pMem),
+                m_dev(other.m_dev),
+                m_extentElements(other.m_extentElements),
+                m_pitchBytes(other.m_pitchBytes)
+        {
+        }
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST
+        auto operator=(ViewPlainPtr const &) -> ViewPlainPtr & = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST
+        auto operator=(ViewPlainPtr &&) -> ViewPlainPtr & = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST ~ViewPlainPtr() = default;
+
+    private:
+        //-----------------------------------------------------------------------------
+        //! Calculate the pitches purely from the extents.
+        template<
+            typename TExtent>
+        ALPAKA_FN_HOST static auto calculatePitchesFromExtents(
+            TExtent const & extent)
+        -> Vec<TDim, TIdx>
+        {
+            Vec<TDim, TIdx> pitchBytes(Vec<TDim, TIdx>::all(0));
+            pitchBytes[TDim::value - 1u] = extent[TDim::value - 1u] * static_cast<TIdx>(sizeof(TElem));
+            for(TIdx i = TDim::value - 1u; i > static_cast<TIdx>(0u); --i)
             {
+                pitchBytes[i-1] = extent[i-1] * pitchBytes[i];
             }
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST
-            auto operator=(ViewPlainPtr const &) -> ViewPlainPtr & = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST
-            auto operator=(ViewPlainPtr &&) -> ViewPlainPtr & = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST ~ViewPlainPtr() = default;
+            return pitchBytes;
+        }
 
-        private:
-            //-----------------------------------------------------------------------------
-            //! Calculate the pitches purely from the extents.
-            template<
-                typename TExtent>
-            ALPAKA_FN_HOST static auto calculatePitchesFromExtents(
-                TExtent const & extent)
-            -> Vec<TDim, TIdx>
-            {
-                Vec<TDim, TIdx> pitchBytes(Vec<TDim, TIdx>::all(0));
-                pitchBytes[TDim::value - 1u] = extent[TDim::value - 1u] * static_cast<TIdx>(sizeof(TElem));
-                for(TIdx i = TDim::value - 1u; i > static_cast<TIdx>(0u); --i)
-                {
-                    pitchBytes[i-1] = extent[i-1] * pitchBytes[i];
-                }
-                return pitchBytes;
-            }
-
-        public:
-            TElem * const m_pMem;
-            Dev const m_dev;
-            Vec<TDim, TIdx> const m_extentElements;
-            Vec<TDim, TIdx> const m_pitchBytes;
-        };
-    }
+    public:
+        TElem * const m_pMem;
+        Dev const m_dev;
+        Vec<TDim, TIdx> const m_extentElements;
+        Vec<TDim, TIdx> const m_pitchBytes;
+    };
 
     //-----------------------------------------------------------------------------
     // Trait specializations for ViewPlainPtr.
@@ -129,7 +126,7 @@ namespace alpaka
             typename TDim,
             typename TIdx>
         struct DevType<
-            view::ViewPlainPtr<TDev, TElem, TDim, TIdx>>
+            ViewPlainPtr<TDev, TElem, TDim, TIdx>>
         {
             using type = alpaka::Dev<TDev>;
         };
@@ -142,10 +139,10 @@ namespace alpaka
             typename TDim,
             typename TIdx>
         struct GetDev<
-            view::ViewPlainPtr<TDev, TElem, TDim, TIdx>>
+            ViewPlainPtr<TDev, TElem, TDim, TIdx>>
         {
             static auto getDev(
-                view::ViewPlainPtr<TDev, TElem, TDim, TIdx> const & view)
+                ViewPlainPtr<TDev, TElem, TDim, TIdx> const & view)
                 -> alpaka::Dev<TDev>
             {
                 return view.m_dev;
@@ -160,7 +157,7 @@ namespace alpaka
             typename TDim,
             typename TIdx>
         struct DimType<
-            view::ViewPlainPtr<TDev, TElem, TDim, TIdx>>
+            ViewPlainPtr<TDev, TElem, TDim, TIdx>>
         {
             using type = TDim;
         };
@@ -173,7 +170,7 @@ namespace alpaka
             typename TDim,
             typename TIdx>
         struct ElemType<
-            view::ViewPlainPtr<TDev, TElem, TDim, TIdx>>
+            ViewPlainPtr<TDev, TElem, TDim, TIdx>>
         {
             using type = TElem;
         };
@@ -192,13 +189,13 @@ namespace alpaka
                 typename TIdx>
             struct GetExtent<
                 TIdxIntegralConst,
-                view::ViewPlainPtr<TDev, TElem, TDim, TIdx>,
+                ViewPlainPtr<TDev, TElem, TDim, TIdx>,
                 std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC
                 static auto getExtent(
-                    view::ViewPlainPtr<TDev, TElem, TDim, TIdx> const & extent)
+                    ViewPlainPtr<TDev, TElem, TDim, TIdx> const & extent)
                 -> TIdx
                 {
                     return extent.m_extentElements[TIdxIntegralConst::value];
@@ -206,166 +203,162 @@ namespace alpaka
             };
         }
     }
-    namespace view
+
+    namespace traits
     {
-        namespace traits
+        //#############################################################################
+        //! The ViewPlainPtr native pointer get trait specialization.
+        template<
+            typename TDev,
+            typename TElem,
+            typename TDim,
+            typename TIdx>
+        struct GetPtrNative<
+            ViewPlainPtr<TDev, TElem, TDim, TIdx>>
         {
-            //#############################################################################
-            //! The ViewPlainPtr native pointer get trait specialization.
-            template<
-                typename TDev,
-                typename TElem,
-                typename TDim,
-                typename TIdx>
-            struct GetPtrNative<
-                view::ViewPlainPtr<TDev, TElem, TDim, TIdx>>
+            static auto getPtrNative(
+                ViewPlainPtr<TDev, TElem, TDim, TIdx> const & view)
+            -> TElem const *
             {
-                static auto getPtrNative(
-                    view::ViewPlainPtr<TDev, TElem, TDim, TIdx> const & view)
-                -> TElem const *
-                {
-                    return view.m_pMem;
-                }
-                static auto getPtrNative(
-                    view::ViewPlainPtr<TDev, TElem, TDim, TIdx> & view)
-                -> TElem *
-                {
-                    return view.m_pMem;
-                }
-            };
+                return view.m_pMem;
+            }
+            static auto getPtrNative(
+                ViewPlainPtr<TDev, TElem, TDim, TIdx> & view)
+            -> TElem *
+            {
+                return view.m_pMem;
+            }
+        };
 
-            //#############################################################################
-            //! The ViewPlainPtr memory pitch get trait specialization.
-            template<
-                typename TIdxIntegralConst,
-                typename TDev,
-                typename TElem,
-                typename TDim,
-                typename TIdx>
-            struct GetPitchBytes<
-                TIdxIntegralConst,
-                view::ViewPlainPtr<TDev, TElem, TDim, TIdx>,
-                std::enable_if_t<TIdxIntegralConst::value < TDim::value>>
+        //#############################################################################
+        //! The ViewPlainPtr memory pitch get trait specialization.
+        template<
+            typename TIdxIntegralConst,
+            typename TDev,
+            typename TElem,
+            typename TDim,
+            typename TIdx>
+        struct GetPitchBytes<
+            TIdxIntegralConst,
+            ViewPlainPtr<TDev, TElem, TDim, TIdx>,
+            std::enable_if_t<TIdxIntegralConst::value < TDim::value>>
+        {
+            ALPAKA_FN_HOST static auto getPitchBytes(
+                ViewPlainPtr<TDev, TElem, TDim, TIdx> const & view)
+            -> TIdx
             {
-                ALPAKA_FN_HOST static auto getPitchBytes(
-                    view::ViewPlainPtr<TDev, TElem, TDim, TIdx> const & view)
-                -> TIdx
-                {
-                    return view.m_pitchBytes[TIdxIntegralConst::value];
-                }
-            };
+                return view.m_pitchBytes[TIdxIntegralConst::value];
+            }
+        };
 
-            //#############################################################################
-            //! The CPU device CreateStaticDevMemView trait specialization.
-            template<>
-            struct CreateStaticDevMemView<
-                DevCpu>
+        //#############################################################################
+        //! The CPU device CreateStaticDevMemView trait specialization.
+        template<>
+        struct CreateStaticDevMemView<
+            DevCpu>
+        {
+            //-----------------------------------------------------------------------------
+            template<
+                typename TElem,
+                typename TExtent>
+            static auto createStaticDevMemView(
+                TElem * pMem,
+                DevCpu const & dev,
+                TExtent const & extent)
             {
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TElem,
-                    typename TExtent>
-                static auto createStaticDevMemView(
-                    TElem * pMem,
-                    DevCpu const & dev,
-                    TExtent const & extent)
-                {
-                    return
-                        alpaka::view::ViewPlainPtr<
-                            DevCpu,
-                            TElem,
-                            alpaka::Dim<TExtent>,
-                            alpaka::Idx<TExtent>>(
-                                pMem,
-                                dev,
-                                extent);
-                }
-            };
+                return
+                    alpaka::ViewPlainPtr<
+                        DevCpu,
+                        TElem,
+                        alpaka::Dim<TExtent>,
+                        alpaka::Idx<TExtent>>(
+                            pMem,
+                            dev,
+                            extent);
+            }
+        };
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-            //#############################################################################
-            //! The CUDA/HIP RT device CreateStaticDevMemView trait specialization.
-            template<>
-            struct CreateStaticDevMemView<
-                DevUniformCudaHipRt>
+        //#############################################################################
+        //! The CUDA/HIP RT device CreateStaticDevMemView trait specialization.
+        template<>
+        struct CreateStaticDevMemView<
+            DevUniformCudaHipRt>
+        {
+            //-----------------------------------------------------------------------------
+            template<
+                typename TElem,
+                typename TExtent>
+            static auto createStaticDevMemView(
+                TElem * pMem,
+                DevUniformCudaHipRt const & dev,
+                TExtent const & extent)
             {
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TElem,
-                    typename TExtent>
-                static auto createStaticDevMemView(
-                    TElem * pMem,
-                    DevUniformCudaHipRt const & dev,
-                    TExtent const & extent)
-                {
-                    TElem* pMemAcc(nullptr);
+                TElem* pMemAcc(nullptr);
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        cudaGetSymbolAddress(
-                            reinterpret_cast<void **>(&pMemAcc),
-                            *pMem));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    cudaGetSymbolAddress(
+                        reinterpret_cast<void **>(&pMemAcc),
+                        *pMem));
 #else
 #ifdef __HIP_PLATFORM_NVCC__
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipCUDAErrorTohipError(
-                        cudaGetSymbolAddress(
-                            reinterpret_cast<void **>(&pMemAcc),
-                            *pMem)));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipCUDAErrorTohipError(
+                    cudaGetSymbolAddress(
+                        reinterpret_cast<void **>(&pMemAcc),
+                        *pMem)));
 #else
-                    // FIXME: still does not work in HIP(clang) (results in hipErrorNotFound)
-                    // HIP_SYMBOL(X) not useful because it only does #X on HIP(clang), while &X on HIP(NVCC)
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        hipGetSymbolAddress(
-                            reinterpret_cast<void **>(&pMemAcc),
-                            pMem));
+                // FIXME: still does not work in HIP(clang) (results in hipErrorNotFound)
+                // HIP_SYMBOL(X) not useful because it only does #X on HIP(clang), while &X on HIP(NVCC)
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    hipGetSymbolAddress(
+                        reinterpret_cast<void **>(&pMemAcc),
+                        pMem));
 #endif
 #endif
-                    return
-                        alpaka::view::ViewPlainPtr<
-                            DevUniformCudaHipRt,
-                            TElem,
-                            alpaka::Dim<TExtent>,
-                            alpaka::Idx<TExtent>>(
-                                pMemAcc,
-                                dev,
-                                extent);
-                }
-            };
+                return
+                    alpaka::ViewPlainPtr<
+                        DevUniformCudaHipRt,
+                        TElem,
+                        alpaka::Dim<TExtent>,
+                        alpaka::Idx<TExtent>>(
+                            pMemAcc,
+                            dev,
+                            extent);
+            }
+        };
 #endif
 
 #ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-            //#############################################################################
-            //! The Omp5 device CreateStaticDevMemView trait specialization.
-            //! \todo What ist this for? Does this exist in OMP5?
-            template<>
-            struct CreateStaticDevMemView<
-                DevOmp5>
+        //#############################################################################
+        //! The Omp5 device CreateStaticDevMemView trait specialization.
+        //! \todo What ist this for? Does this exist in OMP5?
+        template<>
+        struct CreateStaticDevMemView<
+            DevOmp5>
+        {
+            //-----------------------------------------------------------------------------
+            template<
+                typename TElem,
+                typename TExtent>
+            static auto createStaticDevMemView(
+                TElem * pMem,
+                DevOmp5 const & dev,
+                TExtent const & extent)
             {
-                //-----------------------------------------------------------------------------
-                template<
-                    typename TElem,
-                    typename TExtent>
-                static auto createStaticDevMemView(
-                    TElem * pMem,
-                    DevOmp5 const & dev,
-                    TExtent const & extent)
-                {
-                    return
-                        alpaka::view::ViewPlainPtr<
-                            DevOmp5,
-                            TElem,
-                            alpaka::Dim<TExtent>,
-                            alpaka::Idx<TExtent>>(
-                                pMem,
-                                dev,
-                                extent);
-                }
-            };
+                return
+                    alpaka::ViewPlainPtr<
+                        DevOmp5,
+                        TElem,
+                        alpaka::Dim<TExtent>,
+                        alpaka::Idx<TExtent>>(
+                            pMem,
+                            dev,
+                            extent);
+            }
+        };
 #endif
-        }
-    }
-    namespace traits
-    {
+
         //#############################################################################
         //! The ViewPlainPtr offset get trait specialization.
         template<
@@ -376,13 +369,13 @@ namespace alpaka
             typename TIdx>
         struct GetOffset<
             TIdxIntegralConst,
-            view::ViewPlainPtr<TDev, TElem, TDim, TIdx>>
+            ViewPlainPtr<TDev, TElem, TDim, TIdx>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST_ACC
             static auto getOffset(
-                view::ViewPlainPtr<TDev, TElem, TDim, TIdx> const &)
+                ViewPlainPtr<TDev, TElem, TDim, TIdx> const &)
             -> TIdx
             {
                 return 0u;
@@ -397,7 +390,7 @@ namespace alpaka
             typename TDim,
             typename TIdx>
         struct IdxType<
-            view::ViewPlainPtr<TDev, TElem, TDim, TIdx>>
+            ViewPlainPtr<TDev, TElem, TDim, TIdx>>
         {
             using type = TIdx;
         };

--- a/include/alpaka/mem/view/ViewStdArray.hpp
+++ b/include/alpaka/mem/view/ViewStdArray.hpp
@@ -96,55 +96,51 @@ namespace alpaka
             };
         }
     }
-    namespace view
-    {
-        namespace traits
-        {
-            //#############################################################################
-            //! The std::array native pointer get trait specialization.
-            template<
-                typename TElem,
-                std::size_t Tsize>
-            struct GetPtrNative<
-                std::array<TElem, Tsize>>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrNative(
-                    std::array<TElem, Tsize> const & view)
-                -> TElem const *
-                {
-                    return view.data();
-                }
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrNative(
-                    std::array<TElem, Tsize> & view)
-                -> TElem *
-                {
-                    return view.data();
-                }
-            };
 
-            //#############################################################################
-            //! The std::array pitch get trait specialization.
-            template<
-                typename TElem,
-                std::size_t Tsize>
-            struct GetPitchBytes<
-                DimInt<0u>,
-                std::array<TElem, Tsize>>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPitchBytes(
-                    std::array<TElem, Tsize> const & pitch)
-                -> Idx<std::array<TElem, Tsize>>
-                {
-                    return sizeof(TElem) * pitch.size();
-                }
-            };
-        }
-    }
     namespace traits
     {
+        //#############################################################################
+        //! The std::array native pointer get trait specialization.
+        template<
+            typename TElem,
+            std::size_t Tsize>
+        struct GetPtrNative<
+            std::array<TElem, Tsize>>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrNative(
+                std::array<TElem, Tsize> const & view)
+            -> TElem const *
+            {
+                return view.data();
+            }
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrNative(
+                std::array<TElem, Tsize> & view)
+            -> TElem *
+            {
+                return view.data();
+            }
+        };
+
+        //#############################################################################
+        //! The std::array pitch get trait specialization.
+        template<
+            typename TElem,
+            std::size_t Tsize>
+        struct GetPitchBytes<
+            DimInt<0u>,
+            std::array<TElem, Tsize>>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPitchBytes(
+                std::array<TElem, Tsize> const & pitch)
+            -> Idx<std::array<TElem, Tsize>>
+            {
+                return sizeof(TElem) * pitch.size();
+            }
+        };
+
         //#############################################################################
         //! The std::array offset get trait specialization.
         template<

--- a/include/alpaka/mem/view/ViewStdVector.hpp
+++ b/include/alpaka/mem/view/ViewStdVector.hpp
@@ -95,55 +95,50 @@ namespace alpaka
             };
         }
     }
-    namespace view
-    {
-        namespace traits
-        {
-            //#############################################################################
-            //! The std::vector native pointer get trait specialization.
-            template<
-                typename TElem,
-                typename TAllocator>
-            struct GetPtrNative<
-                std::vector<TElem, TAllocator>>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrNative(
-                    std::vector<TElem, TAllocator> const & view)
-                -> TElem const *
-                {
-                    return view.data();
-                }
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrNative(
-                    std::vector<TElem, TAllocator> & view)
-                -> TElem *
-                {
-                    return view.data();
-                }
-            };
-
-            //#############################################################################
-            //! The std::vector pitch get trait specialization.
-            template<
-                typename TElem,
-                typename TAllocator>
-            struct GetPitchBytes<
-                DimInt<0u>,
-                std::vector<TElem, TAllocator>>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPitchBytes(
-                    std::vector<TElem, TAllocator> const & pitch)
-                -> Idx<std::vector<TElem, TAllocator>>
-                {
-                    return sizeof(TElem) * pitch.size();
-                }
-            };
-        }
-    }
     namespace traits
     {
+        //#############################################################################
+        //! The std::vector native pointer get trait specialization.
+        template<
+            typename TElem,
+            typename TAllocator>
+        struct GetPtrNative<
+            std::vector<TElem, TAllocator>>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrNative(
+                std::vector<TElem, TAllocator> const & view)
+            -> TElem const *
+            {
+                return view.data();
+            }
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrNative(
+                std::vector<TElem, TAllocator> & view)
+            -> TElem *
+            {
+                return view.data();
+            }
+        };
+
+        //#############################################################################
+        //! The std::vector pitch get trait specialization.
+        template<
+            typename TElem,
+            typename TAllocator>
+        struct GetPitchBytes<
+            DimInt<0u>,
+            std::vector<TElem, TAllocator>>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPitchBytes(
+                std::vector<TElem, TAllocator> const & pitch)
+            -> Idx<std::vector<TElem, TAllocator>>
+            {
+                return sizeof(TElem) * pitch.size();
+            }
+        };
+
         //#############################################################################
         //! The std::vector offset get trait specialization.
         template<

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -27,157 +27,154 @@
 
 namespace alpaka
 {
-    namespace view
+    //#############################################################################
+    //! A sub-view to a view.
+    template<
+        typename TDev,
+        typename TElem,
+        typename TDim,
+        typename TIdx>
+    class ViewSubView
     {
-        //#############################################################################
-        //! A sub-view to a view.
+        static_assert(
+            !std::is_const<TIdx>::value,
+            "The idx type of the view can not be const!");
+
+        using Dev = alpaka::Dev<TDev>;
+
+    public:
+        //-----------------------------------------------------------------------------
+        //! Constructor.
+        //! \param view The view this view is a sub-view of.
+        //! \param extentElements The extent in elements.
+        //! \param relativeOffsetsElements The offsets in elements.
         template<
-            typename TDev,
-            typename TElem,
-            typename TDim,
-            typename TIdx>
-        class ViewSubView
+            typename TView,
+            typename TOffsets,
+            typename TExtent>
+        ViewSubView(
+            TView const & view,
+            TExtent const & extentElements,
+            TOffsets const & relativeOffsetsElements = TOffsets()) :
+                m_viewParentView(
+                    getPtrNative(view),
+                    getDev(view),
+                    extent::getExtentVec(view),
+                    getPitchBytesVec(view)),
+                m_extentElements(extent::getExtentVec(extentElements)),
+                m_offsetsElements(getOffsetVec(relativeOffsetsElements))
         {
+            ALPAKA_DEBUG_FULL_LOG_SCOPE;
+
             static_assert(
-                !std::is_const<TIdx>::value,
-                "The idx type of the view can not be const!");
+                std::is_same<Dev, alpaka::Dev<TView>>::value,
+                "The dev type of TView and the Dev template parameter have to be identical!");
 
-            using Dev = alpaka::Dev<TDev>;
+            static_assert(
+                std::is_same<TIdx, Idx<TView>>::value,
+                "The idx type of TView and the TIdx template parameter have to be identical!");
+            static_assert(
+                std::is_same<TIdx, Idx<TExtent>>::value,
+                "The idx type of TExtent and the TIdx template parameter have to be identical!");
+            static_assert(
+                std::is_same<TIdx, Idx<TOffsets>>::value,
+                "The idx type of TOffsets and the TIdx template parameter have to be identical!");
 
-        public:
-            //-----------------------------------------------------------------------------
-            //! Constructor.
-            //! \param view The view this view is a sub-view of.
-            //! \param extentElements The extent in elements.
-            //! \param relativeOffsetsElements The offsets in elements.
-            template<
-                typename TView,
-                typename TOffsets,
-                typename TExtent>
-            ViewSubView(
-                TView const & view,
-                TExtent const & extentElements,
-                TOffsets const & relativeOffsetsElements = TOffsets()) :
-                    m_viewParentView(
-                        view::getPtrNative(view),
-                        getDev(view),
-                        extent::getExtentVec(view),
-                        view::getPitchBytesVec(view)),
-                    m_extentElements(extent::getExtentVec(extentElements)),
-                    m_offsetsElements(getOffsetVec(relativeOffsetsElements))
-            {
-                ALPAKA_DEBUG_FULL_LOG_SCOPE;
+            static_assert(
+                std::is_same<TDim, Dim<TView>>::value,
+                "The dim type of TView and the TDim template parameter have to be identical!");
+            static_assert(
+                std::is_same<TDim, Dim<TExtent>>::value,
+                "The dim type of TExtent and the TDim template parameter have to be identical!");
+            static_assert(
+                std::is_same<TDim, Dim<TOffsets>>::value,
+                "The dim type of TOffsets and the TDim template parameter have to be identical!");
 
-                static_assert(
-                    std::is_same<Dev, alpaka::Dev<TView>>::value,
-                    "The dev type of TView and the Dev template parameter have to be identical!");
+            ALPAKA_ASSERT(((m_offsetsElements + m_extentElements) <= extent::getExtentVec(view)).foldrAll(std::logical_and<bool>()));
+        }
+        //-----------------------------------------------------------------------------
+        //! Constructor.
+        //! \param view The view this view is a sub-view of.
+        //! \param extentElements The extent in elements.
+        //! \param relativeOffsetsElements The offsets in elements.
+        template<
+            typename TView,
+            typename TOffsets,
+            typename TExtent>
+        ViewSubView(
+            TView & view,
+            TExtent const & extentElements,
+            TOffsets const & relativeOffsetsElements = TOffsets()) :
+                m_viewParentView(
+                    getPtrNative(view),
+                    getDev(view),
+                    extent::getExtentVec(view),
+                    getPitchBytesVec(view)),
+                m_extentElements(extent::getExtentVec(extentElements)),
+                m_offsetsElements(getOffsetVec(relativeOffsetsElements))
+        {
+            ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                static_assert(
-                    std::is_same<TIdx, Idx<TView>>::value,
-                    "The idx type of TView and the TIdx template parameter have to be identical!");
-                static_assert(
-                    std::is_same<TIdx, Idx<TExtent>>::value,
-                    "The idx type of TExtent and the TIdx template parameter have to be identical!");
-                static_assert(
-                    std::is_same<TIdx, Idx<TOffsets>>::value,
-                    "The idx type of TOffsets and the TIdx template parameter have to be identical!");
+            static_assert(
+                std::is_same<Dev, alpaka::Dev<TView>>::value,
+                "The dev type of TView and the Dev template parameter have to be identical!");
 
-                static_assert(
-                    std::is_same<TDim, Dim<TView>>::value,
-                    "The dim type of TView and the TDim template parameter have to be identical!");
-                static_assert(
-                    std::is_same<TDim, Dim<TExtent>>::value,
-                    "The dim type of TExtent and the TDim template parameter have to be identical!");
-                static_assert(
-                    std::is_same<TDim, Dim<TOffsets>>::value,
-                    "The dim type of TOffsets and the TDim template parameter have to be identical!");
+            static_assert(
+                std::is_same<TIdx, Idx<TView>>::value,
+                "The idx type of TView and the TIdx template parameter have to be identical!");
+            static_assert(
+                std::is_same<TIdx, Idx<TExtent>>::value,
+                "The idx type of TExtent and the TIdx template parameter have to be identical!");
+            static_assert(
+                std::is_same<TIdx, Idx<TOffsets>>::value,
+                "The idx type of TOffsets and the TIdx template parameter have to be identical!");
 
-                ALPAKA_ASSERT(((m_offsetsElements + m_extentElements) <= extent::getExtentVec(view)).foldrAll(std::logical_and<bool>()));
-            }
-            //-----------------------------------------------------------------------------
-            //! Constructor.
-            //! \param view The view this view is a sub-view of.
-            //! \param extentElements The extent in elements.
-            //! \param relativeOffsetsElements The offsets in elements.
-            template<
-                typename TView,
-                typename TOffsets,
-                typename TExtent>
-            ViewSubView(
-                TView & view,
-                TExtent const & extentElements,
-                TOffsets const & relativeOffsetsElements = TOffsets()) :
-                    m_viewParentView(
-                        view::getPtrNative(view),
-                        getDev(view),
-                        extent::getExtentVec(view),
-                        view::getPitchBytesVec(view)),
-                    m_extentElements(extent::getExtentVec(extentElements)),
-                    m_offsetsElements(getOffsetVec(relativeOffsetsElements))
-            {
-                ALPAKA_DEBUG_FULL_LOG_SCOPE;
+            static_assert(
+                std::is_same<TDim, Dim<TView>>::value,
+                "The dim type of TView and the TDim template parameter have to be identical!");
+            static_assert(
+                std::is_same<TDim, Dim<TExtent>>::value,
+                "The dim type of TExtent and the TDim template parameter have to be identical!");
+            static_assert(
+                std::is_same<TDim, Dim<TOffsets>>::value,
+                "The dim type of TOffsets and the TDim template parameter have to be identical!");
 
-                static_assert(
-                    std::is_same<Dev, alpaka::Dev<TView>>::value,
-                    "The dev type of TView and the Dev template parameter have to be identical!");
+            ALPAKA_ASSERT(((m_offsetsElements + m_extentElements) <= extent::getExtentVec(view)).foldrAll(std::logical_and<bool>()));
+        }
 
-                static_assert(
-                    std::is_same<TIdx, Idx<TView>>::value,
-                    "The idx type of TView and the TIdx template parameter have to be identical!");
-                static_assert(
-                    std::is_same<TIdx, Idx<TExtent>>::value,
-                    "The idx type of TExtent and the TIdx template parameter have to be identical!");
-                static_assert(
-                    std::is_same<TIdx, Idx<TOffsets>>::value,
-                    "The idx type of TOffsets and the TIdx template parameter have to be identical!");
+        //-----------------------------------------------------------------------------
+        //! \param view The view this view is a sub-view of.
+        template<
+            typename TView>
+        explicit ViewSubView(
+            TView const & view) :
+                ViewSubView(
+                    view,
+                    view,
+                    Vec<TDim, TIdx>::all(0))
+        {
+            ALPAKA_DEBUG_FULL_LOG_SCOPE;
+        }
 
-                static_assert(
-                    std::is_same<TDim, Dim<TView>>::value,
-                    "The dim type of TView and the TDim template parameter have to be identical!");
-                static_assert(
-                    std::is_same<TDim, Dim<TExtent>>::value,
-                    "The dim type of TExtent and the TDim template parameter have to be identical!");
-                static_assert(
-                    std::is_same<TDim, Dim<TOffsets>>::value,
-                    "The dim type of TOffsets and the TDim template parameter have to be identical!");
+        //-----------------------------------------------------------------------------
+        //! \param view The view this view is a sub-view of.
+        template<
+            typename TView>
+        explicit ViewSubView(
+            TView & view) :
+                ViewSubView(
+                    view,
+                    view,
+                    Vec<TDim, TIdx>::all(0))
+        {
+            ALPAKA_DEBUG_FULL_LOG_SCOPE;
+        }
 
-                ALPAKA_ASSERT(((m_offsetsElements + m_extentElements) <= extent::getExtentVec(view)).foldrAll(std::logical_and<bool>()));
-            }
-
-            //-----------------------------------------------------------------------------
-            //! \param view The view this view is a sub-view of.
-            template<
-                typename TView>
-            explicit ViewSubView(
-                TView const & view) :
-                    ViewSubView(
-                        view,
-                        view,
-                        Vec<TDim, TIdx>::all(0))
-            {
-                ALPAKA_DEBUG_FULL_LOG_SCOPE;
-            }
-
-            //-----------------------------------------------------------------------------
-            //! \param view The view this view is a sub-view of.
-            template<
-                typename TView>
-            explicit ViewSubView(
-                TView & view) :
-                    ViewSubView(
-                        view,
-                        view,
-                        Vec<TDim, TIdx>::all(0))
-            {
-                ALPAKA_DEBUG_FULL_LOG_SCOPE;
-            }
-
-        public:
-            view::ViewPlainPtr<Dev, TElem, TDim, TIdx> m_viewParentView; // This wraps the parent view.
-            Vec<TDim, TIdx> m_extentElements;     // The extent of this view.
-            Vec<TDim, TIdx> m_offsetsElements;    // The offset relative to the parent view.
-        };
-    }
+    public:
+        ViewPlainPtr<Dev, TElem, TDim, TIdx> m_viewParentView; // This wraps the parent view.
+        Vec<TDim, TIdx> m_extentElements;     // The extent of this view.
+        Vec<TDim, TIdx> m_offsetsElements;    // The offset relative to the parent view.
+    };
 
     //-----------------------------------------------------------------------------
     // Trait specializations for ViewSubView.
@@ -191,7 +188,7 @@ namespace alpaka
             typename TDev,
             typename TIdx>
         struct DevType<
-            view::ViewSubView<TDev, TElem, TDim, TIdx>>
+            ViewSubView<TDev, TElem, TDim, TIdx>>
         {
             using type = alpaka::Dev<TDev>;
         };
@@ -204,11 +201,11 @@ namespace alpaka
             typename TDev,
             typename TIdx>
         struct GetDev<
-            view::ViewSubView<TDev, TElem, TDim, TIdx>>
+            ViewSubView<TDev, TElem, TDim, TIdx>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDev(
-                view::ViewSubView<TDev, TElem, TDim, TIdx> const & view)
+                ViewSubView<TDev, TElem, TDim, TIdx> const & view)
             -> alpaka::Dev<TDev>
             {
                 return
@@ -225,7 +222,7 @@ namespace alpaka
             typename TDev,
             typename TIdx>
         struct DimType<
-            view::ViewSubView<TDev, TElem, TDim, TIdx>>
+            ViewSubView<TDev, TElem, TDim, TIdx>>
         {
             using type = TDim;
         };
@@ -238,7 +235,7 @@ namespace alpaka
             typename TDev,
             typename TIdx>
         struct ElemType<
-            view::ViewSubView<TDev, TElem, TDim, TIdx>>
+            ViewSubView<TDev, TElem, TDim, TIdx>>
         {
             using type = TElem;
         };
@@ -257,12 +254,12 @@ namespace alpaka
                 typename TIdx>
             struct GetExtent<
                 TIdxIntegralConst,
-                view::ViewSubView<TDev, TElem, TDim, TIdx>,
+                ViewSubView<TDev, TElem, TDim, TIdx>,
                 std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getExtent(
-                    view::ViewSubView<TDev, TElem, TDim, TIdx> const & extent)
+                    ViewSubView<TDev, TElem, TDim, TIdx> const & extent)
                 -> TIdx
                 {
                     return extent.m_extentElements[TIdxIntegralConst::value];
@@ -270,114 +267,109 @@ namespace alpaka
             };
         }
     }
-    namespace view
+    namespace traits
     {
-        namespace traits
-        {
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align" // "cast from 'std::uint8_t*' to 'TElem*' increases required alignment of target type"
 #endif
-            //#############################################################################
-            //! The ViewSubView native pointer get trait specialization.
-            template<
-                typename TElem,
-                typename TDim,
-                typename TDev,
-                typename TIdx>
-            struct GetPtrNative<
-                view::ViewSubView<TDev, TElem, TDim, TIdx>>
+        //#############################################################################
+        //! The ViewSubView native pointer get trait specialization.
+        template<
+            typename TElem,
+            typename TDim,
+            typename TDev,
+            typename TIdx>
+        struct GetPtrNative<
+            ViewSubView<TDev, TElem, TDim, TIdx>>
+        {
+        private:
+            using IdxSequence = std::make_index_sequence<TDim::value>;
+        public:
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrNative(
+                ViewSubView<TDev, TElem, TDim, TIdx> const & view)
+            -> TElem const *
             {
-            private:
-                using IdxSequence = std::make_index_sequence<TDim::value>;
-            public:
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrNative(
-                    view::ViewSubView<TDev, TElem, TDim, TIdx> const & view)
-                -> TElem const *
-                {
-                    // \TODO: pre-calculate this pointer for faster execution.
-                    return
-                        reinterpret_cast<TElem const *>(
-                            reinterpret_cast<std::uint8_t const *>(view::getPtrNative(view.m_viewParentView))
-                            + pitchedOffsetBytes(view, IdxSequence()));
-                }
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPtrNative(
-                    view::ViewSubView<TDev, TElem, TDim, TIdx> & view)
-                -> TElem *
-                {
-                    // \TODO: pre-calculate this pointer for faster execution.
-                    return
-                        reinterpret_cast<TElem *>(
-                            reinterpret_cast<std::uint8_t *>(view::getPtrNative(view.m_viewParentView))
-                            + pitchedOffsetBytes(view, IdxSequence()));
-                }
+                // \TODO: pre-calculate this pointer for faster execution.
+                return
+                    reinterpret_cast<TElem const *>(
+                        reinterpret_cast<std::uint8_t const *>(alpaka::getPtrNative(view.m_viewParentView))
+                        + pitchedOffsetBytes(view, IdxSequence()));
+            }
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPtrNative(
+                ViewSubView<TDev, TElem, TDim, TIdx> & view)
+            -> TElem *
+            {
+                // \TODO: pre-calculate this pointer for faster execution.
+                return
+                    reinterpret_cast<TElem *>(
+                        reinterpret_cast<std::uint8_t *>(alpaka::getPtrNative(view.m_viewParentView))
+                        + pitchedOffsetBytes(view, IdxSequence()));
+            }
 
-            private:
-                //-----------------------------------------------------------------------------
-                //! For a 3D vector this calculates:
-                //!
-                //! getOffset<0u>(view) * view::getPitchBytes<1u>(view)
-                //! + getOffset<1u>(view) * view::getPitchBytes<2u>(view)
-                //! + getOffset<2u>(view) * view::getPitchBytes<3u>(view)
-                //! while view::getPitchBytes<3u>(view) is equivalent to sizeof(TElem)
-                template<
-                    typename TView,
-                    std::size_t... TIndices>
-                ALPAKA_FN_HOST static auto pitchedOffsetBytes(
-                    TView const & view,
-                    std::index_sequence<TIndices...> const &)
-                -> TIdx
-                {
-                    return
-                        meta::foldr(
-                            std::plus<TIdx>(),
-                            pitchedOffsetBytesDim<TIndices>(view)...);
-                }
-                //-----------------------------------------------------------------------------
-                template<
-                    std::size_t Tidx,
-                    typename TView>
-                ALPAKA_FN_HOST static auto pitchedOffsetBytesDim(
-                    TView const & view)
-                -> TIdx
-                {
-                    return
-                        getOffset<Tidx>(view)
-                        * view::getPitchBytes<Tidx + 1u>(view);
-                }
-            };
+        private:
+            //-----------------------------------------------------------------------------
+            //! For a 3D vector this calculates:
+            //!
+            //! getOffset<0u>(view) * getPitchBytes<1u>(view)
+            //! + getOffset<1u>(view) * getPitchBytes<2u>(view)
+            //! + getOffset<2u>(view) * getPitchBytes<3u>(view)
+            //! while getPitchBytes<3u>(view) is equivalent to sizeof(TElem)
+            template<
+                typename TView,
+                std::size_t... TIndices>
+            ALPAKA_FN_HOST static auto pitchedOffsetBytes(
+                TView const & view,
+                std::index_sequence<TIndices...> const &)
+            -> TIdx
+            {
+                return
+                    meta::foldr(
+                        std::plus<TIdx>(),
+                        pitchedOffsetBytesDim<TIndices>(view)...);
+            }
+            //-----------------------------------------------------------------------------
+            template<
+                std::size_t Tidx,
+                typename TView>
+            ALPAKA_FN_HOST static auto pitchedOffsetBytesDim(
+                TView const & view)
+            -> TIdx
+            {
+                return
+                    getOffset<Tidx>(view)
+                    * getPitchBytes<Tidx + 1u>(view);
+            }
+        };
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic pop
 #endif
 
-            //#############################################################################
-            //! The ViewSubView pitch get trait specialization.
-            template<
-                typename TIdxIntegralConst,
-                typename TDev,
-                typename TElem,
-                typename TDim,
-                typename TIdx>
-            struct GetPitchBytes<
-                TIdxIntegralConst,
-                view::ViewSubView<TDev, TElem, TDim, TIdx>>
+        //#############################################################################
+        //! The ViewSubView pitch get trait specialization.
+        template<
+            typename TIdxIntegralConst,
+            typename TDev,
+            typename TElem,
+            typename TDim,
+            typename TIdx>
+        struct GetPitchBytes<
+            TIdxIntegralConst,
+            ViewSubView<TDev, TElem, TDim, TIdx>>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getPitchBytes(
+                ViewSubView<TDev, TElem, TDim, TIdx> const & view)
+            -> TIdx
             {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getPitchBytes(
-                    view::ViewSubView<TDev, TElem, TDim, TIdx> const & view)
-                -> TIdx
-                {
-                    return
-                        view::getPitchBytes<TIdxIntegralConst::value>(
-                            view.m_viewParentView);
-                }
-            };
-        }
-    }
-    namespace traits
-    {
+                return
+                    alpaka::getPitchBytes<TIdxIntegralConst::value>(
+                        view.m_viewParentView);
+            }
+        };
+
         //#############################################################################
         //! The ViewSubView x offset get trait specialization.
         template<
@@ -388,12 +380,12 @@ namespace alpaka
             typename TIdx>
         struct GetOffset<
             TIdxIntegralConst,
-            view::ViewSubView<TDev, TElem, TDim, TIdx>,
+            ViewSubView<TDev, TElem, TDim, TIdx>,
             std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
         {
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getOffset(
-                view::ViewSubView<TDev, TElem, TDim, TIdx> const & offset)
+                ViewSubView<TDev, TElem, TDim, TIdx> const & offset)
             -> TIdx
             {
                 return offset.m_offsetsElements[TIdxIntegralConst::value];
@@ -408,7 +400,7 @@ namespace alpaka
             typename TDev,
             typename TIdx>
         struct IdxType<
-            view::ViewSubView<TDev, TElem, TDim, TIdx>>
+            ViewSubView<TDev, TElem, TDim, TIdx>>
         {
             using type = TIdx;
         };

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -729,7 +729,7 @@ namespace alpaka
                 return
                     createVecFromIndexedFn<
                         TDim,
-                        detail::CreateCast>(
+                        alpaka::detail::CreateCast>(
                             TSizeNew(),
                             vec);
             }
@@ -861,7 +861,7 @@ namespace alpaka
                 return
                     createVecFromIndexedFn<
                         DimInt<TDimL::value + TDimR::value>,
-                        detail::CreateConcat>(
+                        alpaka::detail::CreateConcat>(
                             vecL,
                             vecR);
             }

--- a/test/common/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/test/common/include/alpaka/test/KernelExecutionFixture.hpp
@@ -69,7 +69,7 @@ namespace alpaka
             {
                 // Allocate the result value
                 auto bufAccResult(alpaka::allocBuf<bool, Idx>(m_devAcc, static_cast<Idx>(1u)));
-                alpaka::set(
+                alpaka::memset(
                     m_queue,
                     bufAccResult,
                     static_cast<std::uint8_t>(true),
@@ -84,7 +84,7 @@ namespace alpaka
 
                 // Copy the result value to the host
                 auto bufHostResult(alpaka::allocBuf<bool, Idx>(m_devHost, static_cast<Idx>(1u)));
-                alpaka::copy(m_queue, bufHostResult, bufAccResult, bufAccResult);
+                alpaka::memcpy(m_queue, bufHostResult, bufAccResult, bufAccResult);
                 alpaka::wait(m_queue);
 
                 auto const result(*alpaka::getPtrNative(bufHostResult));

--- a/test/common/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/test/common/include/alpaka/test/KernelExecutionFixture.hpp
@@ -69,7 +69,7 @@ namespace alpaka
             {
                 // Allocate the result value
                 auto bufAccResult(alpaka::allocBuf<bool, Idx>(m_devAcc, static_cast<Idx>(1u)));
-                alpaka::view::set(
+                alpaka::set(
                     m_queue,
                     bufAccResult,
                     static_cast<std::uint8_t>(true),
@@ -79,15 +79,15 @@ namespace alpaka
                     m_queue,
                     m_workDiv,
                     kernelFnObj,
-                    alpaka::view::getPtrNative(bufAccResult),
+                    alpaka::getPtrNative(bufAccResult),
                     std::forward<TArgs>(args)...);
 
                 // Copy the result value to the host
                 auto bufHostResult(alpaka::allocBuf<bool, Idx>(m_devHost, static_cast<Idx>(1u)));
-                alpaka::view::copy(m_queue, bufHostResult, bufAccResult, bufAccResult);
+                alpaka::copy(m_queue, bufHostResult, bufAccResult, bufAccResult);
                 alpaka::wait(m_queue);
 
-                auto const result(*alpaka::view::getPtrNative(bufHostResult));
+                auto const result(*alpaka::getPtrNative(bufHostResult));
 
                 return result;
             }

--- a/test/common/include/alpaka/test/mem/view/Iterator.hpp
+++ b/test/common/include/alpaka/test/mem/view/Iterator.hpp
@@ -21,212 +21,207 @@ namespace alpaka
     {
         //-----------------------------------------------------------------------------
         //!
-        namespace view
+        namespace traits
         {
-            //-----------------------------------------------------------------------------
-            //!
-            namespace traits
-            {
-                //#############################################################################
-                // \tparam T Type to conditionally make const.
-                // \tparam TSource Type to mimic the constness of.
-                template<
-                    typename T,
-                    typename TSource>
-                using MimicConst = std::conditional_t<
-                    std::is_const<TSource>::value,
-                    std::add_const_t<T>,
-                    std::remove_const_t<T>>;
+            //#############################################################################
+            // \tparam T Type to conditionally make const.
+            // \tparam TSource Type to mimic the constness of.
+            template<
+                typename T,
+                typename TSource>
+            using MimicConst = std::conditional_t<
+                std::is_const<TSource>::value,
+                std::add_const_t<T>,
+                std::remove_const_t<T>>;
 
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align" // "cast from 'Byte*' to 'Elem*' increases required alignment of target type"
 #endif
-                //#############################################################################
-                template<
-                    typename TView,
-                    typename TSfinae = void>
-                class IteratorView
+            //#############################################################################
+            template<
+                typename TView,
+                typename TSfinae = void>
+            class IteratorView
+            {
+                using TViewDecayed = std::decay_t<TView>;
+                using Dim = alpaka::Dim<TViewDecayed>;
+                using Idx = alpaka::Idx<TViewDecayed>;
+                using Elem = MimicConst<alpaka::Elem<TViewDecayed>, TView>;
+
+            public:
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST IteratorView(
+                    TView & view,
+                    Idx const idx) :
+                        m_nativePtr(alpaka::getPtrNative(view)),
+                        m_currentIdx(idx),
+                        m_extents(alpaka::extent::getExtentVec(view)),
+                        m_pitchBytes(alpaka::getPitchBytesVec(view))
+                {}
+
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST IteratorView(
+                    TView & view) :
+                        IteratorView(view, 0)
+                {}
+
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST_ACC auto operator++()
+                -> IteratorView&
                 {
-                    using TViewDecayed = std::decay_t<TView>;
-                    using Dim = alpaka::Dim<TViewDecayed>;
-                    using Idx = alpaka::Idx<TViewDecayed>;
-                    using Elem = MimicConst<alpaka::Elem<TViewDecayed>, TView>;
+                    ++m_currentIdx;
+                    return *this;
+                }
 
-                public:
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST IteratorView(
-                        TView & view,
-                        Idx const idx) :
-                            m_nativePtr(alpaka::view::getPtrNative(view)),
-                            m_currentIdx(idx),
-                            m_extents(alpaka::extent::getExtentVec(view)),
-                            m_pitchBytes(alpaka::view::getPitchBytesVec(view))
-                    {}
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST_ACC auto operator--()
+                -> IteratorView&
+                {
+                    --m_currentIdx;
+                    return *this;
+                }
 
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST IteratorView(
-                        TView & view) :
-                            IteratorView(view, 0)
-                    {}
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST_ACC auto operator++(
+                    int)
+                -> IteratorView
+                {
+                    IteratorView iterCopy = *this;
+                    m_currentIdx++;
+                    return iterCopy;
+                }
 
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST_ACC auto operator++()
-                    -> IteratorView&
-                    {
-                        ++m_currentIdx;
-                        return *this;
-                    }
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST_ACC auto operator--(
+                    int)
+                -> IteratorView
+                {
+                    IteratorView iterCopy = *this;
+                    m_currentIdx--;
+                    return iterCopy;
+                }
 
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST_ACC auto operator--()
-                    -> IteratorView&
-                    {
-                        --m_currentIdx;
-                        return *this;
-                    }
+                //-----------------------------------------------------------------------------
+                template<typename TIter>
+                ALPAKA_FN_HOST_ACC auto operator==(
+                    TIter &other) const
+                -> bool
+                {
+                    return m_currentIdx == other.m_currentIdx;
+                }
 
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST_ACC auto operator++(
-                        int)
-                    -> IteratorView
-                    {
-                        IteratorView iterCopy = *this;
-                        m_currentIdx++;
-                        return iterCopy;
-                    }
+                //-----------------------------------------------------------------------------
+                template<typename TIter>
+                ALPAKA_FN_HOST_ACC auto operator!=(
+                    TIter &other) const
+                -> bool
+                {
+                    return m_currentIdx != other.m_currentIdx;
+                }
 
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST_ACC auto operator--(
-                        int)
-                    -> IteratorView
-                    {
-                        IteratorView iterCopy = *this;
-                        m_currentIdx--;
-                        return iterCopy;
-                    }
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST_ACC auto operator*() const
+                -> Elem &
+                {
+                    using Dim1 = alpaka::DimInt<1>;
+                    using DimMin1 = alpaka::DimInt<Dim::value - 1u>;
 
-                    //-----------------------------------------------------------------------------
-                    template<typename TIter>
-                    ALPAKA_FN_HOST_ACC auto operator==(
-                        TIter &other) const
-                    -> bool
-                    {
-                        return m_currentIdx == other.m_currentIdx;
-                    }
+                    Vec<Dim1, Idx> const currentIdxDim1{m_currentIdx};
+                    Vec<Dim, Idx> const currentIdxDimx(alpaka::mapIdx<Dim::value>(currentIdxDim1, m_extents));
 
-                    //-----------------------------------------------------------------------------
-                    template<typename TIter>
-                    ALPAKA_FN_HOST_ACC auto operator!=(
-                        TIter &other) const
-                    -> bool
-                    {
-                        return m_currentIdx != other.m_currentIdx;
-                    }
+                    // [pz, py, px] -> [py, px]
+                    auto const pitchWithoutOutermost(subVecEnd<DimMin1>(m_pitchBytes));
+                    // [ElemSize]
+                    Vec<Dim1, Idx> const elementSizeVec(static_cast<Idx>(sizeof(Elem)));
+                    // [py, px] ++ [ElemSize] -> [py, px, ElemSize]
+                    Vec<Dim, Idx> const dstPitchBytes(concatVec(pitchWithoutOutermost, elementSizeVec));
+                    // [py, px, ElemSize] [z, y, x] -> [py*z, px*y, ElemSize*x]
+                    auto const dimensionalOffsetsInByte(currentIdxDimx * dstPitchBytes);
+                    // sum{[py*z, px*y, ElemSize*x]} -> offset in byte
+                    auto const offsetInByte(dimensionalOffsetsInByte.foldrAll(std::plus<Idx>()));
 
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST_ACC auto operator*() const
-                    -> Elem &
-                    {
-                        using Dim1 = alpaka::DimInt<1>;
-                        using DimMin1 = alpaka::DimInt<Dim::value - 1u>;
-
-                        Vec<Dim1, Idx> const currentIdxDim1{m_currentIdx};
-                        Vec<Dim, Idx> const currentIdxDimx(alpaka::mapIdx<Dim::value>(currentIdxDim1, m_extents));
-
-                        // [pz, py, px] -> [py, px]
-                        auto const pitchWithoutOutermost(subVecEnd<DimMin1>(m_pitchBytes));
-                        // [ElemSize]
-                        Vec<Dim1, Idx> const elementSizeVec(static_cast<Idx>(sizeof(Elem)));
-                        // [py, px] ++ [ElemSize] -> [py, px, ElemSize]
-                        Vec<Dim, Idx> const dstPitchBytes(concatVec(pitchWithoutOutermost, elementSizeVec));
-                        // [py, px, ElemSize] [z, y, x] -> [py*z, px*y, ElemSize*x]
-                        auto const dimensionalOffsetsInByte(currentIdxDimx * dstPitchBytes);
-                        // sum{[py*z, px*y, ElemSize*x]} -> offset in byte
-                        auto const offsetInByte(dimensionalOffsetsInByte.foldrAll(std::plus<Idx>()));
-
-                        using Byte = MimicConst<std::uint8_t, Elem>;
-                        Byte* ptr(reinterpret_cast<Byte*>(m_nativePtr) + offsetInByte);
+                    using Byte = MimicConst<std::uint8_t, Elem>;
+                    Byte* ptr(reinterpret_cast<Byte*>(m_nativePtr) + offsetInByte);
 
 #if 0
-                        std::cout
-                            << " i1: " << currentIdxDim1
-                            << " in: " << currentIdxDimx
-                            << " dpb: " << dstPitchBytes
-                            << " offb: " << offsetInByte
-                            << " ptr: " << reinterpret_cast<void const *>(ptr)
-                            << " v: " << *reinterpret_cast<Elem *>(ptr)
-                            << std::endl;
+                    std::cout
+                        << " i1: " << currentIdxDim1
+                        << " in: " << currentIdxDimx
+                        << " dpb: " << dstPitchBytes
+                        << " offb: " << offsetInByte
+                        << " ptr: " << reinterpret_cast<void const *>(ptr)
+                        << " v: " << *reinterpret_cast<Elem *>(ptr)
+                        << std::endl;
 #endif
-                        return *reinterpret_cast<Elem *>(ptr);
-                    }
+                    return *reinterpret_cast<Elem *>(ptr);
+                }
 
-                private:
-                    Elem * const m_nativePtr;
-                    Idx m_currentIdx;
-                    Vec<Dim, Idx> const m_extents;
-                    Vec<Dim, Idx> const m_pitchBytes;
-                };
+            private:
+                Elem * const m_nativePtr;
+                Idx m_currentIdx;
+                Vec<Dim, Idx> const m_extents;
+                Vec<Dim, Idx> const m_pitchBytes;
+            };
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic pop
 #endif
 
-                //#############################################################################
-                template<
-                    typename TView,
-                    typename TSfinae = void>
-                struct Begin
+            //#############################################################################
+            template<
+                typename TView,
+                typename TSfinae = void>
+            struct Begin
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto begin(
+                    TView & view)
+                -> IteratorView<TView>
                 {
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto begin(
-                        TView & view)
-                    -> IteratorView<TView>
-                    {
-                        return IteratorView<TView>(view);
-                    }
-                };
-
-                //#############################################################################
-                template<
-                    typename TView,
-                    typename TSfinae = void>
-                struct End
-                {
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto end(
-                        TView & view)
-                    -> IteratorView<TView>
-                    {
-                        auto extents = alpaka::extent::getExtentVec(view);
-                        return IteratorView<TView>(view, extents.prod());
-                    }
-                };
-            }
+                    return IteratorView<TView>(view);
+                }
+            };
 
             //#############################################################################
             template<
-                typename TView>
-            using Iterator = traits::IteratorView<TView>;
-
-            //-----------------------------------------------------------------------------
-            template<
-                typename TView>
-            ALPAKA_FN_HOST auto begin(
-                TView & view)
-            -> Iterator<TView>
+                typename TView,
+                typename TSfinae = void>
+            struct End
             {
-                return traits::Begin<TView>::begin(view);
-            }
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto end(
+                    TView & view)
+                -> IteratorView<TView>
+                {
+                    auto extents = alpaka::extent::getExtentVec(view);
+                    return IteratorView<TView>(view, extents.prod());
+                }
+            };
+        }
 
-            //-----------------------------------------------------------------------------
-            template<
-                typename TView>
-            ALPAKA_FN_HOST auto end(
-                TView & view)
-            -> Iterator<TView>
-            {
-                return traits::End<TView>::end(view);
-            }
+        //#############################################################################
+        template<
+            typename TView>
+        using Iterator = traits::IteratorView<TView>;
+
+        //-----------------------------------------------------------------------------
+        template<
+            typename TView>
+        ALPAKA_FN_HOST auto begin(
+            TView & view)
+        -> Iterator<TView>
+        {
+            return traits::Begin<TView>::begin(view);
+        }
+
+        //-----------------------------------------------------------------------------
+        template<
+            typename TView>
+        ALPAKA_FN_HOST auto end(
+            TView & view)
+        -> Iterator<TView>
+        {
+            return traits::End<TView>::end(view);
         }
     }
 }

--- a/test/common/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/test/common/include/alpaka/test/mem/view/ViewTest.hpp
@@ -299,7 +299,7 @@ namespace alpaka
             ViewPlainPtr plainBuf(v.data(), devHost, extent);
 
             // Copy the generated content into the given view.
-            alpaka::copy(queue, view, plainBuf, extent);
+            alpaka::memcpy(queue, view, plainBuf, extent);
 
             alpaka::wait(queue);
         }
@@ -333,7 +333,7 @@ namespace alpaka
             // alpaka::set
             {
                 std::uint8_t const byte(static_cast<uint8_t>(42u));
-                alpaka::set(queue, view, byte, extent);
+                alpaka::memset(queue, view, byte, extent);
                 alpaka::wait(queue);
                 verifyBytesSet<TAcc>(view, byte);
             }
@@ -351,7 +351,7 @@ namespace alpaka
                 {
                     auto srcBufAcc(alpaka::allocBuf<Elem, Idx>(devAcc, extent));
                     iotaFillView(queue, srcBufAcc);
-                    alpaka::copy(queue, view, srcBufAcc, extent);
+                    alpaka::memcpy(queue, view, srcBufAcc, extent);
                     alpaka::wait(queue);
                     verifyViewsEqual<TAcc>(view, srcBufAcc);
                 }
@@ -360,7 +360,7 @@ namespace alpaka
                 // alpaka::copy from given view
                 {
                     auto dstBufAcc(alpaka::allocBuf<Elem, Idx>(devAcc, extent));
-                    alpaka::copy(queue, dstBufAcc, view, extent);
+                    alpaka::memcpy(queue, dstBufAcc, view, extent);
                     alpaka::wait(queue);
                     verifyViewsEqual<TAcc>(dstBufAcc, view);
                 }

--- a/test/common/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/test/common/include/alpaka/test/mem/view/ViewTest.hpp
@@ -27,346 +27,342 @@ namespace alpaka
     namespace test
     {
         //-----------------------------------------------------------------------------
-        namespace view
+        template<
+            typename TElem,
+            typename TDim,
+            typename TIdx,
+            typename TDev,
+            typename TView>
+        ALPAKA_FN_HOST auto testViewImmutable(
+            TView const & view,
+            TDev const & dev,
+            alpaka::Vec<TDim, TIdx> const & extent,
+            alpaka::Vec<TDim, TIdx> const & offset)
+        -> void
         {
             //-----------------------------------------------------------------------------
-            template<
-                typename TElem,
-                typename TDim,
-                typename TIdx,
-                typename TDev,
-                typename TView>
-            ALPAKA_FN_HOST auto testViewImmutable(
-                TView const & view,
-                TDev const & dev,
-                alpaka::Vec<TDim, TIdx> const & extent,
-                alpaka::Vec<TDim, TIdx> const & offset)
-            -> void
+            // alpaka::traits::DevType
             {
-                //-----------------------------------------------------------------------------
-                // alpaka::traits::DevType
+                static_assert(
+                    std::is_same<alpaka::Dev<TView>, TDev>::value,
+                    "The device type of the view has to be equal to the specified one.");
+            }
+
+            //-----------------------------------------------------------------------------
+            // alpaka::traits::GetDev
+            {
+                REQUIRE(
+                    dev == alpaka::getDev(view));
+            }
+
+            //-----------------------------------------------------------------------------
+            // alpaka::traits::DimType
+            {
+                static_assert(
+                    alpaka::Dim<TView>::value == TDim::value,
+                    "The dimensionality of the view has to be equal to the specified one.");
+            }
+
+            //-----------------------------------------------------------------------------
+            // alpaka::traits::ElemType
+            {
+                static_assert(
+                    std::is_same<alpaka::Elem<TView>, TElem>::value,
+                    "The element type of the view has to be equal to the specified one.");
+            }
+
+            //-----------------------------------------------------------------------------
+            // alpaka::extent::traits::GetExtent
+            {
+                REQUIRE(
+                    extent ==
+                    alpaka::extent::getExtentVec(view));
+            }
+
+            //-----------------------------------------------------------------------------
+            // alpaka::traits::GetPitchBytes
+            {
+                // The pitches have to be at least as large as the values we calculate here.
+                auto pitchMinimum(alpaka::Vec<alpaka::DimInt<TDim::value + 1u>, TIdx>::ones());
+                // Initialize the pitch between two elements of the X dimension ...
+                pitchMinimum[TDim::value] = sizeof(TElem);
+                // ... and fill all the other dimensions.
+                for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
                 {
-                    static_assert(
-                        std::is_same<alpaka::Dev<TView>, TDev>::value,
-                        "The device type of the view has to be equal to the specified one.");
+                    pitchMinimum[i-1] = extent[i-1] * pitchMinimum[i];
                 }
 
-                //-----------------------------------------------------------------------------
-                // alpaka::traits::GetDev
+                auto const pitchView(alpaka::getPitchBytesVec(view));
+
+                for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
                 {
                     REQUIRE(
-                        dev == alpaka::getDev(view));
-                }
-
-                //-----------------------------------------------------------------------------
-                // alpaka::traits::DimType
-                {
-                    static_assert(
-                        alpaka::Dim<TView>::value == TDim::value,
-                        "The dimensionality of the view has to be equal to the specified one.");
-                }
-
-                //-----------------------------------------------------------------------------
-                // alpaka::traits::ElemType
-                {
-                    static_assert(
-                        std::is_same<alpaka::Elem<TView>, TElem>::value,
-                        "The element type of the view has to be equal to the specified one.");
-                }
-
-                //-----------------------------------------------------------------------------
-                // alpaka::extent::traits::GetExtent
-                {
-                    REQUIRE(
-                        extent ==
-                        alpaka::extent::getExtentVec(view));
-                }
-
-                //-----------------------------------------------------------------------------
-                // alpaka::view::traits::GetPitchBytes
-                {
-                    // The pitches have to be at least as large as the values we calculate here.
-                    auto pitchMinimum(alpaka::Vec<alpaka::DimInt<TDim::value + 1u>, TIdx>::ones());
-                    // Initialize the pitch between two elements of the X dimension ...
-                    pitchMinimum[TDim::value] = sizeof(TElem);
-                    // ... and fill all the other dimensions.
-                    for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
-                    {
-                        pitchMinimum[i-1] = extent[i-1] * pitchMinimum[i];
-                    }
-
-                    auto const pitchView(alpaka::view::getPitchBytesVec(view));
-
-                    for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
-                    {
-                        REQUIRE(
-                            pitchView[i-1] >=
-                            pitchMinimum[i-1]);
-                    }
-                }
-
-                //-----------------------------------------------------------------------------
-                // alpaka::view::traits::GetPtrNative
-                {
-                    // The view is a const& so the pointer has to point to a const value.
-                    using NativePtr = decltype(alpaka::view::getPtrNative(view));
-                    static_assert(
-                        std::is_pointer<NativePtr>::value,
-                        "The value returned by getPtrNative has to be a pointer.");
-                    static_assert(
-                        std::is_const<std::remove_pointer_t<NativePtr>>::value,
-                        "The value returned by getPtrNative has to be const when the view is const.");
-
-                    if(alpaka::extent::getExtentProduct(view) != static_cast<TIdx>(0u))
-                    {
-                        // The pointer is only required to be non-null when the extent is > 0.
-                        TElem const * const invalidPtr(nullptr);
-                        REQUIRE(
-                            invalidPtr !=
-                            alpaka::view::getPtrNative(view));
-                    }
-                    else
-                    {
-                        // When the extent is 0, the pointer is undefined but it should still be possible get it.
-                        alpaka::view::getPtrNative(view);
-                    }
-                }
-
-                //-----------------------------------------------------------------------------
-                // alpaka::traits::GetOffset
-                {
-                    REQUIRE(
-                        offset ==
-                        alpaka::getOffsetVec(view));
-                }
-
-                //-----------------------------------------------------------------------------
-                // alpaka::traits::IdxType
-                {
-                    static_assert(
-                        std::is_same<alpaka::Idx<TView>, TIdx>::value,
-                        "The idx type of the view has to be equal to the specified one.");
+                        pitchView[i-1] >=
+                        pitchMinimum[i-1]);
                 }
             }
 
-            //#############################################################################
-            //! Compares element-wise that all bytes are set to the same value.
-            struct VerifyBytesSetKernel
-            {
-                ALPAKA_NO_HOST_ACC_WARNING
-                template<
-                    typename TAcc,
-                    typename TIter>
-                ALPAKA_FN_ACC void operator()(
-                    TAcc const & acc,
-                    bool * success,
-                    TIter const & begin,
-                    TIter const & end,
-                    std::uint8_t const & byte) const
-                {
-                    alpaka::ignore_unused(acc);
-
-                    constexpr auto elemSizeInByte = sizeof(decltype(*begin));
-                    for(auto it = begin; it != end; ++it)
-                    {
-                        auto const& elem = *it;
-                        auto const pBytes = reinterpret_cast<std::uint8_t const *>(&elem);
-                        for(std::size_t i = 0u; i < elemSizeInByte; ++i)
-                        {
-                            ALPAKA_CHECK(*success, pBytes[i] == byte);
-                        }
-                    }
-                }
-            };
             //-----------------------------------------------------------------------------
+            // alpaka::traits::GetPtrNative
+            {
+                // The view is a const& so the pointer has to point to a const value.
+                using NativePtr = decltype(alpaka::getPtrNative(view));
+                static_assert(
+                    std::is_pointer<NativePtr>::value,
+                    "The value returned by getPtrNative has to be a pointer.");
+                static_assert(
+                    std::is_const<std::remove_pointer_t<NativePtr>>::value,
+                    "The value returned by getPtrNative has to be const when the view is const.");
+
+                if(alpaka::extent::getExtentProduct(view) != static_cast<TIdx>(0u))
+                {
+                    // The pointer is only required to be non-null when the extent is > 0.
+                    TElem const * const invalidPtr(nullptr);
+                    REQUIRE(
+                        invalidPtr !=
+                        alpaka::getPtrNative(view));
+                }
+                else
+                {
+                    // When the extent is 0, the pointer is undefined but it should still be possible get it.
+                    alpaka::getPtrNative(view);
+                }
+            }
+
+            //-----------------------------------------------------------------------------
+            // alpaka::traits::GetOffset
+            {
+                REQUIRE(
+                    offset ==
+                    alpaka::getOffsetVec(view));
+            }
+
+            //-----------------------------------------------------------------------------
+            // alpaka::traits::IdxType
+            {
+                static_assert(
+                    std::is_same<alpaka::Idx<TView>, TIdx>::value,
+                    "The idx type of the view has to be equal to the specified one.");
+            }
+        }
+
+        //#############################################################################
+        //! Compares element-wise that all bytes are set to the same value.
+        struct VerifyBytesSetKernel
+        {
+            ALPAKA_NO_HOST_ACC_WARNING
             template<
                 typename TAcc,
-                typename TView>
-            ALPAKA_FN_HOST auto verifyBytesSet(
-                TView const & view,
-                std::uint8_t const & byte)
-            -> void
+                typename TIter>
+            ALPAKA_FN_ACC void operator()(
+                TAcc const & acc,
+                bool * success,
+                TIter const & begin,
+                TIter const & end,
+                std::uint8_t const & byte) const
             {
-                using Dim = alpaka::Dim<TView>;
-                using Idx = alpaka::Idx<TView>;
+                alpaka::ignore_unused(acc);
 
-                alpaka::test::KernelExecutionFixture<TAcc> fixture(
-                    alpaka::Vec<Dim, Idx>::ones());
-
-                VerifyBytesSetKernel verifyBytesSet;
-
-                REQUIRE(
-                    fixture(
-                        verifyBytesSet,
-                        alpaka::test::view::begin(view),
-                        alpaka::test::view::end(view),
-                        byte));
+                constexpr auto elemSizeInByte = sizeof(decltype(*begin));
+                for(auto it = begin; it != end; ++it)
+                {
+                    auto const& elem = *it;
+                    auto const pBytes = reinterpret_cast<std::uint8_t const *>(&elem);
+                    for(std::size_t i = 0u; i < elemSizeInByte; ++i)
+                    {
+                        ALPAKA_CHECK(*success, pBytes[i] == byte);
+                    }
+                }
             }
+        };
+        //-----------------------------------------------------------------------------
+        template<
+            typename TAcc,
+            typename TView>
+        ALPAKA_FN_HOST auto verifyBytesSet(
+            TView const & view,
+            std::uint8_t const & byte)
+        -> void
+        {
+            using Dim = alpaka::Dim<TView>;
+            using Idx = alpaka::Idx<TView>;
 
-            //#############################################################################
-            //! Compares iterators element-wise
+            alpaka::test::KernelExecutionFixture<TAcc> fixture(
+                alpaka::Vec<Dim, Idx>::ones());
+
+            VerifyBytesSetKernel verifyBytesSet;
+
+            REQUIRE(
+                fixture(
+                    verifyBytesSet,
+                    alpaka::test::begin(view),
+                    alpaka::test::end(view),
+                    byte));
+        }
+
+        //#############################################################################
+        //! Compares iterators element-wise
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wfloat-equal"  // "comparing floating point with == or != is unsafe"
 #endif
-            struct VerifyViewsEqualKernel
+        struct VerifyViewsEqualKernel
+        {
+            ALPAKA_NO_HOST_ACC_WARNING
+            template<
+                typename TAcc,
+                typename TIterA,
+                typename TIterB>
+            ALPAKA_FN_ACC void operator()(
+                TAcc const & acc,
+                bool * success,
+                TIterA beginA,
+                TIterA const & endA,
+                TIterB beginB) const
             {
-                ALPAKA_NO_HOST_ACC_WARNING
-                template<
-                    typename TAcc,
-                    typename TIterA,
-                    typename TIterB>
-                ALPAKA_FN_ACC void operator()(
-                    TAcc const & acc,
-                    bool * success,
-                    TIterA beginA,
-                    TIterA const & endA,
-                    TIterB beginB) const
-                {
-                    alpaka::ignore_unused(acc);
+                alpaka::ignore_unused(acc);
 
-                    for(; beginA != endA; ++beginA, ++beginB)
-                    {
+                for(; beginA != endA; ++beginA, ++beginB)
+                {
 #if BOOST_COMP_CLANG
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wfloat-equal" // "comparing floating point with == or != is unsafe"
 #endif
-                        ALPAKA_CHECK(*success, *beginA == *beginB);
+                    ALPAKA_CHECK(*success, *beginA == *beginB);
 #if BOOST_COMP_CLANG
 #pragma clang diagnostic pop
 #endif
-                    }
                 }
-            };
+            }
+        };
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic pop
 #endif
 
+        //-----------------------------------------------------------------------------
+        template<
+            typename TAcc,
+            typename TViewB,
+            typename TViewA>
+        ALPAKA_FN_HOST auto verifyViewsEqual(
+            TViewA const & viewA,
+            TViewB const & viewB)
+        -> void
+        {
+            using DimA = alpaka::Dim<TViewA>;
+            using DimB = alpaka::Dim<TViewB>;
+            static_assert(DimA::value == DimB::value, "viewA and viewB are required to have identical Dim");
+            using IdxA = alpaka::Idx<TViewA>;
+            using IdxB = alpaka::Idx<TViewB>;
+            static_assert(std::is_same<IdxA, IdxB>::value, "viewA and viewB are required to have identical Idx");
+
+            alpaka::test::KernelExecutionFixture<TAcc> fixture(
+                alpaka::Vec<DimA, IdxA>::ones());
+
+            VerifyViewsEqualKernel verifyViewsEqualKernel;
+
+            REQUIRE(
+                fixture(
+                    verifyViewsEqualKernel,
+                    alpaka::test::begin(viewA),
+                    alpaka::test::end(viewA),
+                    alpaka::test::begin(viewB)));
+        }
+
+        //-----------------------------------------------------------------------------
+        //! Fills the given view with increasing values starting at 0.
+        template<
+            typename TView,
+            typename TQueue>
+        ALPAKA_FN_HOST auto iotaFillView(
+            TQueue & queue,
+            TView & view)
+        -> void
+        {
+            using Dim = alpaka::Dim<TView>;
+            using Idx = alpaka::Idx<TView>;
+
+            using DevHost = alpaka::DevCpu;
+            using PltfHost = alpaka::Pltf<DevHost>;
+
+            using Elem = alpaka::Elem<TView>;
+
+            using ViewPlainPtr = alpaka::ViewPlainPtr<DevHost, Elem, Dim, Idx>;
+
+            DevHost const devHost(alpaka::getDevByIdx<PltfHost>(0));
+
+            auto const extent(alpaka::extent::getExtentVec(view));
+
+            // Init buf with increasing values
+            std::vector<Elem> v(static_cast<std::size_t>(extent.prod()), static_cast<Elem>(0));
+            std::iota(v.begin(), v.end(), static_cast<Elem>(0));
+            ViewPlainPtr plainBuf(v.data(), devHost, extent);
+
+            // Copy the generated content into the given view.
+            alpaka::copy(queue, view, plainBuf, extent);
+
+            alpaka::wait(queue);
+        }
+
+        //-----------------------------------------------------------------------------
+        template<
+            typename TAcc,
+            typename TView,
+            typename TQueue>
+        ALPAKA_FN_HOST auto testViewMutable(
+            TQueue & queue,
+            TView & view)
+        -> void
+        {
             //-----------------------------------------------------------------------------
-            template<
-                typename TAcc,
-                typename TViewB,
-                typename TViewA>
-            ALPAKA_FN_HOST auto verifyViewsEqual(
-                TViewA const & viewA,
-                TViewB const & viewB)
-            -> void
+            // alpaka::traits::GetPtrNative
             {
-                using DimA = alpaka::Dim<TViewA>;
-                using DimB = alpaka::Dim<TViewB>;
-                static_assert(DimA::value == DimB::value, "viewA and viewB are required to have identical Dim");
-                using IdxA = alpaka::Idx<TViewA>;
-                using IdxB = alpaka::Idx<TViewB>;
-                static_assert(std::is_same<IdxA, IdxB>::value, "viewA and viewB are required to have identical Idx");
+                // The view is a non-const so the pointer has to point to a non-const value.
+                using NativePtr = decltype(alpaka::getPtrNative(view));
+                static_assert(
+                    std::is_pointer<NativePtr>::value,
+                    "The value returned by getPtrNative has to be a pointer.");
+                static_assert(
+                    !std::is_const<std::remove_pointer_t<NativePtr>>::value,
+                    "The value returned by getPtrNative has to be non-const when the view is non-const.");
+            }
 
-                alpaka::test::KernelExecutionFixture<TAcc> fixture(
-                    alpaka::Vec<DimA, IdxA>::ones());
+            auto const extent(alpaka::extent::getExtentVec(view));
 
-                VerifyViewsEqualKernel verifyViewsEqualKernel;
-
-                REQUIRE(
-                    fixture(
-                        verifyViewsEqualKernel,
-                        alpaka::test::view::begin(viewA),
-                        alpaka::test::view::end(viewA),
-                        alpaka::test::view::begin(viewB)));
+            //-----------------------------------------------------------------------------
+            // alpaka::set
+            {
+                std::uint8_t const byte(static_cast<uint8_t>(42u));
+                alpaka::set(queue, view, byte, extent);
+                alpaka::wait(queue);
+                verifyBytesSet<TAcc>(view, byte);
             }
 
             //-----------------------------------------------------------------------------
-            //! Fills the given view with increasing values starting at 0.
-            template<
-                typename TView,
-                typename TQueue>
-            ALPAKA_FN_HOST auto iotaFillView(
-                TQueue & queue,
-                TView & view)
-            -> void
+            // alpaka::copy
             {
-                using Dim = alpaka::Dim<TView>;
+                using Elem = alpaka::Elem<TView>;
                 using Idx = alpaka::Idx<TView>;
 
-                using DevHost = alpaka::DevCpu;
-                using PltfHost = alpaka::Pltf<DevHost>;
-
-                using Elem = alpaka::Elem<TView>;
-
-                using ViewPlainPtr = alpaka::view::ViewPlainPtr<DevHost, Elem, Dim, Idx>;
-
-                DevHost const devHost(alpaka::getDevByIdx<PltfHost>(0));
-
-                auto const extent(alpaka::extent::getExtentVec(view));
-
-                // Init buf with increasing values
-                std::vector<Elem> v(static_cast<std::size_t>(extent.prod()), static_cast<Elem>(0));
-                std::iota(v.begin(), v.end(), static_cast<Elem>(0));
-                ViewPlainPtr plainBuf(v.data(), devHost, extent);
-
-                // Copy the generated content into the given view.
-                alpaka::view::copy(queue, view, plainBuf, extent);
-
-                alpaka::wait(queue);
-            }
-
-            //-----------------------------------------------------------------------------
-            template<
-                typename TAcc,
-                typename TView,
-                typename TQueue>
-            ALPAKA_FN_HOST auto testViewMutable(
-                TQueue & queue,
-                TView & view)
-            -> void
-            {
-                //-----------------------------------------------------------------------------
-                // alpaka::view::traits::GetPtrNative
-                {
-                    // The view is a non-const so the pointer has to point to a non-const value.
-                    using NativePtr = decltype(alpaka::view::getPtrNative(view));
-                    static_assert(
-                        std::is_pointer<NativePtr>::value,
-                        "The value returned by getPtrNative has to be a pointer.");
-                    static_assert(
-                        !std::is_const<std::remove_pointer_t<NativePtr>>::value,
-                        "The value returned by getPtrNative has to be non-const when the view is non-const.");
-                }
-
-                auto const extent(alpaka::extent::getExtentVec(view));
+                auto const devAcc = alpaka::getDev(view);
 
                 //-----------------------------------------------------------------------------
-                // alpaka::view::set
+                // alpaka::copy into given view
                 {
-                    std::uint8_t const byte(static_cast<uint8_t>(42u));
-                    alpaka::view::set(queue, view, byte, extent);
+                    auto srcBufAcc(alpaka::allocBuf<Elem, Idx>(devAcc, extent));
+                    iotaFillView(queue, srcBufAcc);
+                    alpaka::copy(queue, view, srcBufAcc, extent);
                     alpaka::wait(queue);
-                    verifyBytesSet<TAcc>(view, byte);
+                    verifyViewsEqual<TAcc>(view, srcBufAcc);
                 }
 
                 //-----------------------------------------------------------------------------
-                // alpaka::view::copy
+                // alpaka::copy from given view
                 {
-                    using Elem = alpaka::Elem<TView>;
-                    using Idx = alpaka::Idx<TView>;
-
-                    auto const devAcc = alpaka::getDev(view);
-
-                    //-----------------------------------------------------------------------------
-                    // alpaka::view::copy into given view
-                    {
-                        auto srcBufAcc(alpaka::allocBuf<Elem, Idx>(devAcc, extent));
-                        iotaFillView(queue, srcBufAcc);
-                        alpaka::view::copy(queue, view, srcBufAcc, extent);
-                        alpaka::wait(queue);
-                        verifyViewsEqual<TAcc>(view, srcBufAcc);
-                    }
-
-                    //-----------------------------------------------------------------------------
-                    // alpaka::view::copy from given view
-                    {
-                        auto dstBufAcc(alpaka::allocBuf<Elem, Idx>(devAcc, extent));
-                        alpaka::view::copy(queue, dstBufAcc, view, extent);
-                        alpaka::wait(queue);
-                        verifyViewsEqual<TAcc>(dstBufAcc, view);
-                    }
+                    auto dstBufAcc(alpaka::allocBuf<Elem, Idx>(devAcc, extent));
+                    alpaka::copy(queue, dstBufAcc, view, extent);
+                    alpaka::wait(queue);
+                    verifyViewsEqual<TAcc>(dstBufAcc, view);
                 }
             }
         }

--- a/test/integ/axpy/src/axpy.cpp
+++ b/test/integ/axpy/src/axpy.cpp
@@ -133,9 +133,9 @@ TEMPLATE_LIST_TEST_CASE( "axpy", "[axpy]", TestAccs)
     auto memBufHostX(alpaka::allocBuf<Val, Idx>(devHost, extent));
     auto memBufHostOrigY(alpaka::allocBuf<Val, Idx>(devHost, extent));
     auto memBufHostY(alpaka::allocBuf<Val, Idx>(devHost, extent));
-    Val * const pBufHostX = alpaka::view::getPtrNative(memBufHostX);
-    Val * const pBufHostOrigY = alpaka::view::getPtrNative(memBufHostOrigY);
-    Val * const pBufHostY = alpaka::view::getPtrNative(memBufHostY);
+    Val * const pBufHostX = alpaka::getPtrNative(memBufHostX);
+    Val * const pBufHostOrigY = alpaka::getPtrNative(memBufHostOrigY);
+    Val * const pBufHostY = alpaka::getPtrNative(memBufHostY);
 
     // random generator for uniformly distributed numbers in [0,1)
     // keep in mind, this can generate different values on different platforms
@@ -156,10 +156,10 @@ TEMPLATE_LIST_TEST_CASE( "axpy", "[axpy]", TestAccs)
     std::cout << __func__
         << " alpha: " << alpha << std::endl;
     std::cout << __func__ << " X_host: ";
-    alpaka::view::print(memBufHostX, std::cout);
+    alpaka::print(memBufHostX, std::cout);
     std::cout << std::endl;
     std::cout << __func__ << " Y_host: ";
-    alpaka::view::print(memBufHostOrigY, std::cout);
+    alpaka::print(memBufHostOrigY, std::cout);
     std::cout << std::endl;
 #endif
 
@@ -168,17 +168,17 @@ TEMPLATE_LIST_TEST_CASE( "axpy", "[axpy]", TestAccs)
     auto memBufAccY(alpaka::allocBuf<Val, Idx>(devAcc, extent));
 
     // Copy Host -> Acc.
-    alpaka::view::copy(queue, memBufAccX, memBufHostX, extent);
-    alpaka::view::copy(queue, memBufAccY, memBufHostOrigY, extent);
+    alpaka::copy(queue, memBufAccX, memBufHostX, extent);
+    alpaka::copy(queue, memBufAccY, memBufHostOrigY, extent);
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
     alpaka::wait(queue);
 
     std::cout << __func__ << " X_Dev: ";
-    alpaka::view::print(memBufHostX, std::cout);
+    alpaka::print(memBufHostX, std::cout);
     std::cout << std::endl;
     std::cout << __func__ << " Y_Dev: ";
-    alpaka::view::print(memBufHostX, std::cout);
+    alpaka::print(memBufHostX, std::cout);
     std::cout << std::endl;
 #endif
 
@@ -188,8 +188,8 @@ TEMPLATE_LIST_TEST_CASE( "axpy", "[axpy]", TestAccs)
         kernel,
         numElements,
         alpha,
-        alpaka::view::getPtrNative(memBufAccX),
-        alpaka::view::getPtrNative(memBufAccY)));
+        alpaka::getPtrNative(memBufAccX),
+        alpaka::getPtrNative(memBufAccY)));
 
     // Profile the kernel execution.
     std::cout << "Execution time: "
@@ -200,7 +200,7 @@ TEMPLATE_LIST_TEST_CASE( "axpy", "[axpy]", TestAccs)
         << std::endl;
 
     // Copy back the result.
-    alpaka::view::copy(queue, memBufHostY, memBufAccY, extent);
+    alpaka::copy(queue, memBufHostY, memBufAccY, extent);
 
     // Wait for the queue to finish the memory operation.
     alpaka::wait(queue);

--- a/test/integ/axpy/src/axpy.cpp
+++ b/test/integ/axpy/src/axpy.cpp
@@ -168,8 +168,8 @@ TEMPLATE_LIST_TEST_CASE( "axpy", "[axpy]", TestAccs)
     auto memBufAccY(alpaka::allocBuf<Val, Idx>(devAcc, extent));
 
     // Copy Host -> Acc.
-    alpaka::copy(queue, memBufAccX, memBufHostX, extent);
-    alpaka::copy(queue, memBufAccY, memBufHostOrigY, extent);
+    alpaka::memcpy(queue, memBufAccX, memBufHostX, extent);
+    alpaka::memcpy(queue, memBufAccY, memBufHostOrigY, extent);
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
     alpaka::wait(queue);
@@ -200,7 +200,7 @@ TEMPLATE_LIST_TEST_CASE( "axpy", "[axpy]", TestAccs)
         << std::endl;
 
     // Copy back the result.
-    alpaka::copy(queue, memBufHostY, memBufAccY, extent);
+    alpaka::memcpy(queue, memBufHostY, memBufAccY, extent);
 
     // Wait for the queue to finish the memory operation.
     alpaka::wait(queue);

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -250,7 +250,7 @@ auto writeTgaColorImage(
     ALPAKA_ASSERT(bufWidthColors >= 1);
     auto const bufHeightColors(alpaka::extent::getHeight(bufRgba));
     ALPAKA_ASSERT(bufHeightColors >= 1);
-    auto const bufPitchBytes(alpaka::view::getPitchBytes<alpaka::Dim<TBuf>::value - 1u>(bufRgba));
+    auto const bufPitchBytes(alpaka::getPitchBytes<alpaka::Dim<TBuf>::value - 1u>(bufRgba));
     ALPAKA_ASSERT(bufPitchBytes >= bufWidthBytes);
 
     std::ofstream ofs(
@@ -282,7 +282,7 @@ auto writeTgaColorImage(
     ofs.put(0x20);                      // Image Descriptor Byte.
 
     // Write the data.
-    char const * pData(reinterpret_cast<char const *>(alpaka::view::getPtrNative(bufRgba)));
+    char const * pData(reinterpret_cast<char const *>(alpaka::getPtrNative(bufRgba)));
     // If there is no padding, we can directly write the whole buffer data ...
     if(bufPitchBytes == bufWidthBytes)
     {
@@ -378,16 +378,16 @@ TEMPLATE_LIST_TEST_CASE( "mandelbrot", "[mandelbrot]", TestAccs)
         alpaka::allocBuf<Val, Idx>(devAcc, extent));
 
     // Copy Host -> Acc.
-    alpaka::view::copy(queue, bufColorAcc, bufColorHost, extent);
+    alpaka::copy(queue, bufColorAcc, bufColorHost, extent);
 
     // Create the kernel execution task.
     auto const taskKernel(alpaka::createTaskKernel<Acc>(
         workDiv,
         kernel,
-        alpaka::view::getPtrNative(bufColorAcc),
+        alpaka::getPtrNative(bufColorAcc),
         numRows,
         numCols,
-        alpaka::view::getPitchBytes<1u>(bufColorAcc),
+        alpaka::getPitchBytes<1u>(bufColorAcc),
         fMinR,
         fMaxR,
         fMinI,
@@ -403,7 +403,7 @@ TEMPLATE_LIST_TEST_CASE( "mandelbrot", "[mandelbrot]", TestAccs)
         << std::endl;
 
     // Copy back the result.
-    alpaka::view::copy(queue, bufColorHost, bufColorAcc, extent);
+    alpaka::copy(queue, bufColorHost, bufColorAcc, extent);
 
     // Wait for the queue to finish the memory operation.
     alpaka::wait(queue);

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -378,7 +378,7 @@ TEMPLATE_LIST_TEST_CASE( "mandelbrot", "[mandelbrot]", TestAccs)
         alpaka::allocBuf<Val, Idx>(devAcc, extent));
 
     // Copy Host -> Acc.
-    alpaka::copy(queue, bufColorAcc, bufColorHost, extent);
+    alpaka::memcpy(queue, bufColorAcc, bufColorHost, extent);
 
     // Create the kernel execution task.
     auto const taskKernel(alpaka::createTaskKernel<Acc>(
@@ -403,7 +403,7 @@ TEMPLATE_LIST_TEST_CASE( "mandelbrot", "[mandelbrot]", TestAccs)
         << std::endl;
 
     // Copy back the result.
-    alpaka::copy(queue, bufColorHost, bufColorAcc, extent);
+    alpaka::memcpy(queue, bufColorHost, bufColorAcc, extent);
 
     // Wait for the queue to finish the memory operation.
     alpaka::wait(queue);

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -288,7 +288,7 @@ TEMPLATE_LIST_TEST_CASE( "matMul", "[matMul]", TestAccs)
 
     // Allocate C and set it to zero.
     auto bufCHost(alpaka::allocBuf<Val, Idx>(devHost, extentC));
-    alpaka::set(queueHost, bufCHost, 0u, extentC);
+    alpaka::memset(queueHost, bufCHost, 0u, extentC);
 
     // Allocate the buffers on the accelerator.
     auto bufAAcc(alpaka::allocBuf<Val, Idx>(devAcc, extentA));
@@ -296,10 +296,10 @@ TEMPLATE_LIST_TEST_CASE( "matMul", "[matMul]", TestAccs)
     auto bufCAcc(alpaka::allocBuf<Val, Idx>(devAcc, extentC));
 
     // Copy Host -> Acc.
-    alpaka::copy(queueAcc, bufAAcc, bufAHost, extentA);
-    alpaka::copy(queueAcc, bufBAcc, bufBHost, extentB);
+    alpaka::memcpy(queueAcc, bufAAcc, bufAHost, extentA);
+    alpaka::memcpy(queueAcc, bufBAcc, bufBHost, extentB);
     alpaka::wait(queueHost);
-    alpaka::copy(queueAcc, bufCAcc, bufCHost, extentC);
+    alpaka::memcpy(queueAcc, bufCAcc, bufCHost, extentC);
 
     // Create the kernel execution task.
     auto const taskKernel(alpaka::createTaskKernel<Acc>(
@@ -326,7 +326,7 @@ TEMPLATE_LIST_TEST_CASE( "matMul", "[matMul]", TestAccs)
         << std::endl;
 
     // Copy back the result.
-    alpaka::copy(queueAcc, bufCHost, bufCAcc, extentC);
+    alpaka::memcpy(queueAcc, bufCHost, bufCAcc, extentC);
 
     // Wait for the queue to finish the memory operation.
     alpaka::wait(queueAcc);

--- a/test/integ/separableCompilation/src/main.cpp
+++ b/test/integ/separableCompilation/src/main.cpp
@@ -140,8 +140,8 @@ TEMPLATE_LIST_TEST_CASE( "separableCompilation", "[separableCompilation]", TestA
     auto memBufAccC(alpaka::allocBuf<Val, Idx>(devAcc, extent));
 
     // Copy Host -> Acc.
-    alpaka::copy(queueAcc, memBufAccA, memBufHostA, extent);
-    alpaka::copy(queueAcc, memBufAccB, memBufHostB, extent);
+    alpaka::memcpy(queueAcc, memBufAccA, memBufHostA, extent);
+    alpaka::memcpy(queueAcc, memBufAccB, memBufHostB, extent);
 
     // Create the executor task.
     auto const taskKernel(alpaka::createTaskKernel<Acc>(
@@ -161,7 +161,7 @@ TEMPLATE_LIST_TEST_CASE( "separableCompilation", "[separableCompilation]", TestA
         << std::endl;
 
     // Copy back the result.
-    alpaka::copy(queueAcc, memBufHostC, memBufAccC, extent);
+    alpaka::memcpy(queueAcc, memBufHostC, memBufAccC, extent);
     alpaka::wait(queueAcc);
 
     bool resultCorrect(true);

--- a/test/integ/separableCompilation/src/main.cpp
+++ b/test/integ/separableCompilation/src/main.cpp
@@ -130,8 +130,8 @@ TEMPLATE_LIST_TEST_CASE( "separableCompilation", "[separableCompilation]", TestA
     // Initialize the host input vectors
     for (Idx i(0); i < numElements; ++i)
     {
-        alpaka::view::getPtrNative(memBufHostA)[i] = static_cast<Val>(rand()) / static_cast<Val>(RAND_MAX);
-        alpaka::view::getPtrNative(memBufHostB)[i] = static_cast<Val>(rand()) / static_cast<Val>(RAND_MAX);
+        alpaka::getPtrNative(memBufHostA)[i] = static_cast<Val>(rand()) / static_cast<Val>(RAND_MAX);
+        alpaka::getPtrNative(memBufHostB)[i] = static_cast<Val>(rand()) / static_cast<Val>(RAND_MAX);
     }
 
     // Allocate the buffers on the accelerator.
@@ -140,16 +140,16 @@ TEMPLATE_LIST_TEST_CASE( "separableCompilation", "[separableCompilation]", TestA
     auto memBufAccC(alpaka::allocBuf<Val, Idx>(devAcc, extent));
 
     // Copy Host -> Acc.
-    alpaka::view::copy(queueAcc, memBufAccA, memBufHostA, extent);
-    alpaka::view::copy(queueAcc, memBufAccB, memBufHostB, extent);
+    alpaka::copy(queueAcc, memBufAccA, memBufHostA, extent);
+    alpaka::copy(queueAcc, memBufAccB, memBufHostB, extent);
 
     // Create the executor task.
     auto const taskKernel(alpaka::createTaskKernel<Acc>(
         workDiv,
         kernel,
-        alpaka::view::getPtrNative(memBufAccA),
-        alpaka::view::getPtrNative(memBufAccB),
-        alpaka::view::getPtrNative(memBufAccC),
+        alpaka::getPtrNative(memBufAccA),
+        alpaka::getPtrNative(memBufAccB),
+        alpaka::getPtrNative(memBufAccC),
         numElements));
 
     // Profile the kernel execution.
@@ -161,17 +161,17 @@ TEMPLATE_LIST_TEST_CASE( "separableCompilation", "[separableCompilation]", TestA
         << std::endl;
 
     // Copy back the result.
-    alpaka::view::copy(queueAcc, memBufHostC, memBufAccC, extent);
+    alpaka::copy(queueAcc, memBufHostC, memBufAccC, extent);
     alpaka::wait(queueAcc);
 
     bool resultCorrect(true);
-    auto const pHostData(alpaka::view::getPtrNative(memBufHostC));
+    auto const pHostData(alpaka::getPtrNative(memBufHostC));
     for(Idx i(0u);
         i < numElements;
         ++i)
     {
         auto const & val(pHostData[i]);
-        auto const correctResult(std::sqrt(alpaka::view::getPtrNative(memBufHostA)[i]) + std::sqrt(alpaka::view::getPtrNative(memBufHostB)[i]));
+        auto const correctResult(std::sqrt(alpaka::getPtrNative(memBufHostA)[i]) + std::sqrt(alpaka::getPtrNative(memBufHostB)[i]));
         auto const absDiff = (val - correctResult);
         if( absDiff > std::numeric_limits<Val>::epsilon() )
         {

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -189,13 +189,13 @@ TEMPLATE_LIST_TEST_CASE( "sharedMem", "[sharedMem]", TestAccs)
     // Allocate accelerator buffers and copy.
     Idx const resultElemCount(gridBlocksCount);
     auto blockRetValsAcc(alpaka::allocBuf<Val, Idx>(devAcc, resultElemCount));
-    alpaka::view::copy(queue, blockRetValsAcc, blockRetVals, resultElemCount);
+    alpaka::copy(queue, blockRetValsAcc, blockRetVals, resultElemCount);
 
     // Create the kernel execution task.
     auto const taskKernel(alpaka::createTaskKernel<Acc>(
         workDiv,
         kernel,
-        alpaka::view::getPtrNative(blockRetValsAcc)));
+        alpaka::getPtrNative(blockRetValsAcc)));
 
     // Profile the kernel execution.
     std::cout << "Execution time: "
@@ -206,7 +206,7 @@ TEMPLATE_LIST_TEST_CASE( "sharedMem", "[sharedMem]", TestAccs)
         << std::endl;
 
     // Copy back the result.
-    alpaka::view::copy(queue, blockRetVals, blockRetValsAcc, resultElemCount);
+    alpaka::copy(queue, blockRetVals, blockRetValsAcc, resultElemCount);
 
     // Wait for the queue to finish the memory operation.
     alpaka::wait(queue);

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -189,7 +189,7 @@ TEMPLATE_LIST_TEST_CASE( "sharedMem", "[sharedMem]", TestAccs)
     // Allocate accelerator buffers and copy.
     Idx const resultElemCount(gridBlocksCount);
     auto blockRetValsAcc(alpaka::allocBuf<Val, Idx>(devAcc, resultElemCount));
-    alpaka::copy(queue, blockRetValsAcc, blockRetVals, resultElemCount);
+    alpaka::memcpy(queue, blockRetValsAcc, blockRetVals, resultElemCount);
 
     // Create the kernel execution task.
     auto const taskKernel(alpaka::createTaskKernel<Acc>(
@@ -206,7 +206,7 @@ TEMPLATE_LIST_TEST_CASE( "sharedMem", "[sharedMem]", TestAccs)
         << std::endl;
 
     // Copy back the result.
-    alpaka::copy(queue, blockRetVals, blockRetValsAcc, resultElemCount);
+    alpaka::memcpy(queue, blockRetVals, blockRetValsAcc, resultElemCount);
 
     // Wait for the queue to finish the memory operation.
     alpaka::wait(queue);

--- a/test/unit/idx/src/MapIdxPitchBytes.cpp
+++ b/test/unit/idx/src/MapIdxPitchBytes.cpp
@@ -32,13 +32,13 @@ TEMPLATE_LIST_TEST_CASE( "mapIdxPitchBytes", "[idx]", alpaka::test::TestDims)
     using Dev = alpaka::Dev<Acc>;
     using Elem = std::uint8_t;
     auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
-    alpaka::view::ViewPlainPtr<Dev, Elem, Dim, Idx> parentView( nullptr, devAcc, extentNd );
+    alpaka::ViewPlainPtr<Dev, Elem, Dim, Idx> parentView( nullptr, devAcc, extentNd );
 
     auto const offset(Vec::all(4u));
     auto const extent(Vec::all(4u));
     auto const idxNd(Vec::all(2u));
-    alpaka::view::ViewSubView<Dev, Elem, Dim, Idx> view( parentView, extent, offset );
-    auto pitch = alpaka::view::getPitchBytesVec(view);
+    alpaka::ViewSubView<Dev, Elem, Dim, Idx> view( parentView, extent, offset );
+    auto pitch = alpaka::getPitchBytesVec(view);
 
     auto const idx1d(alpaka::mapIdxPitchBytes<1u>(idxNd, pitch));
     auto const idx1dDelta(alpaka::mapIdx<1u>(idxNd+offset, extentNd)

--- a/test/unit/math/src/Buffer.hpp
+++ b/test/unit/math/src/Buffer.hpp
@@ -85,15 +85,15 @@ struct Buffer
         {
             alpaka::allocBuf<TData, Idx>(devAcc, Tcapacity)
         },
-        pHostBuffer{ alpaka::view::getPtrNative( hostBuffer ) },
-        pDevBuffer{ alpaka::view::getPtrNative( devBuffer ) }
+        pHostBuffer{ alpaka::getPtrNative( hostBuffer ) },
+        pDevBuffer{ alpaka::getPtrNative( devBuffer ) }
     {}
 
     // Copy Host -> Acc.
     template< typename Queue >
     auto copyToDevice( Queue queue ) -> void
     {
-        alpaka::view::copy(
+        alpaka::copy(
             queue,
             devBuffer,
             hostBuffer,
@@ -105,7 +105,7 @@ struct Buffer
     template< typename Queue >
     auto copyFromDevice( Queue queue ) -> void
     {
-        alpaka::view::copy(
+        alpaka::copy(
             queue,
             hostBuffer,
             devBuffer,

--- a/test/unit/math/src/Buffer.hpp
+++ b/test/unit/math/src/Buffer.hpp
@@ -93,7 +93,7 @@ struct Buffer
     template< typename Queue >
     auto copyToDevice( Queue queue ) -> void
     {
-        alpaka::copy(
+        alpaka::memcpy(
             queue,
             devBuffer,
             hostBuffer,
@@ -105,7 +105,7 @@ struct Buffer
     template< typename Queue >
     auto copyFromDevice( Queue queue ) -> void
     {
-        alpaka::copy(
+        alpaka::memcpy(
             queue,
             hostBuffer,
             devBuffer,

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -43,7 +43,7 @@ static auto testBufferMutable(
 
     //-----------------------------------------------------------------------------
     auto const offset(alpaka::Vec<Dim, Idx>::zeros());
-    alpaka::test::view::testViewImmutable<
+    alpaka::test::testViewImmutable<
         Elem>(
             buf,
             dev,
@@ -51,7 +51,7 @@ static auto testBufferMutable(
             offset);
 
     //-----------------------------------------------------------------------------
-    alpaka::test::view::testViewMutable<
+    alpaka::test::testViewMutable<
         TAcc>(
             queue,
             buf);
@@ -108,7 +108,7 @@ static auto testBufferImmutable(
 
     //-----------------------------------------------------------------------------
     auto const offset(alpaka::Vec<Dim, Idx>::zeros());
-    alpaka::test::view::testViewImmutable<
+    alpaka::test::testViewImmutable<
         Elem>(
             buf,
             dev,

--- a/test/unit/mem/copy/src/BufSlicing.cpp
+++ b/test/unit/mem/copy/src/BufSlicing.cpp
@@ -117,7 +117,7 @@ struct TestContainer
         Vec extents
     ) -> void
     {
-        alpaka::copy(
+        alpaka::memcpy(
             devQueue,
             bufAcc,
             bufHost,
@@ -132,7 +132,7 @@ struct TestContainer
         Vec extents
     ) -> void
     {
-        alpaka::copy(
+        alpaka::memcpy(
             devQueue,
             bufHost,
             bufAcc,
@@ -155,7 +155,7 @@ struct TestContainer
             offsets
         );
         // Copy the subView into a new buffer.
-        alpaka::copy(
+        alpaka::memcpy(
             devQueue,
             slicedBuffer,
             subView,

--- a/test/unit/mem/copy/src/BufSlicing.cpp
+++ b/test/unit/mem/copy/src/BufSlicing.cpp
@@ -52,7 +52,7 @@ struct TestContainer
         TIdx
     >;
 
-    using SubView = alpaka::view::ViewSubView<
+    using SubView = alpaka::ViewSubView<
         DevAcc,
         TData,
         TDim,
@@ -87,7 +87,7 @@ struct TestContainer
             ));
         if(indexed)
         {
-            TData *const ptr = alpaka::view::getPtrNative(bufHost);
+            TData *const ptr = alpaka::getPtrNative(bufHost);
             for(TIdx i(0);i < extents.prod();++i)
             {
                 ptr[i] = static_cast<TData>(i);
@@ -117,7 +117,7 @@ struct TestContainer
         Vec extents
     ) -> void
     {
-        alpaka::view::copy(
+        alpaka::copy(
             devQueue,
             bufAcc,
             bufHost,
@@ -132,7 +132,7 @@ struct TestContainer
         Vec extents
     ) -> void
     {
-        alpaka::view::copy(
+        alpaka::copy(
             devQueue,
             bufHost,
             bufAcc,
@@ -155,7 +155,7 @@ struct TestContainer
             offsets
         );
         // Copy the subView into a new buffer.
-        alpaka::view::copy(
+        alpaka::copy(
             devQueue,
             slicedBuffer,
             subView,
@@ -171,8 +171,8 @@ struct TestContainer
         Vec const & extents
     ) const
     {
-        TData const *const ptrA = alpaka::view::getPtrNative(bufferA);
-        TData const *const ptrB = alpaka::view::getPtrNative(bufferB);
+        TData const *const ptrA = alpaka::getPtrNative(bufferA);
+        TData const *const ptrB = alpaka::getPtrNative(bufferB);
         for(TIdx i(0);i < extents.prod();++i)
         {
             INFO("Dim: " << TDim::value)
@@ -278,7 +278,7 @@ TEMPLATE_LIST_TEST_CASE("memBufSlicingTest",
         extentsSubView,
         false
     );
-    Data *ptrNative = alpaka::view::getPtrNative(correctResults);
+    Data *ptrNative = alpaka::getPtrNative(correctResults);
     using Dim1 = alpaka::DimInt<1u>;
 
     for(Idx i(0);i < extentsSubView.prod();++i)

--- a/test/unit/mem/p2p/src/P2P.cpp
+++ b/test/unit/mem/p2p/src/P2P.cpp
@@ -50,10 +50,10 @@ static auto testP2P(
 
     //-----------------------------------------------------------------------------
     std::uint8_t const byte(static_cast<uint8_t>(42u));
-    alpaka::set(queue0, buf0, byte, extent);
+    alpaka::memset(queue0, buf0, byte, extent);
 
     //-----------------------------------------------------------------------------
-    alpaka::copy(queue0, buf1, buf0, extent);
+    alpaka::memcpy(queue0, buf1, buf0, extent);
     alpaka::wait(queue0);
     alpaka::test::verifyBytesSet<TAcc>(buf1, byte);
 }

--- a/test/unit/mem/p2p/src/P2P.cpp
+++ b/test/unit/mem/p2p/src/P2P.cpp
@@ -50,12 +50,12 @@ static auto testP2P(
 
     //-----------------------------------------------------------------------------
     std::uint8_t const byte(static_cast<uint8_t>(42u));
-    alpaka::view::set(queue0, buf0, byte, extent);
+    alpaka::set(queue0, buf0, byte, extent);
 
     //-----------------------------------------------------------------------------
-    alpaka::view::copy(queue0, buf1, buf0, extent);
+    alpaka::copy(queue0, buf1, buf0, extent);
     alpaka::wait(queue0);
-    alpaka::test::view::verifyBytesSet<TAcc>(buf1, byte);
+    alpaka::test::verifyBytesSet<TAcc>(buf1, byte);
 }
 
 //-----------------------------------------------------------------------------

--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -30,8 +30,6 @@ namespace alpaka
 {
 namespace test
 {
-namespace view
-{
     //-----------------------------------------------------------------------------
     template<
         typename TAcc,
@@ -40,14 +38,14 @@ namespace view
         typename TDim,
         typename TIdx>
     auto testViewPlainPtrImmutable(
-        alpaka::view::ViewPlainPtr<TDev, TElem, TDim, TIdx> const & view,
+        alpaka::ViewPlainPtr<TDev, TElem, TDim, TIdx> const & view,
         TDev const & dev,
         alpaka::Vec<TDim, TIdx> const & extentView,
         alpaka::Vec<TDim, TIdx> const & offsetView)
     -> void
     {
         //-----------------------------------------------------------------------------
-        alpaka::test::view::testViewImmutable<
+        alpaka::test::testViewImmutable<
             TElem>(
                 view,
                 dev,
@@ -63,7 +61,7 @@ namespace view
         typename TDim,
         typename TIdx>
     auto testViewPlainPtrMutable(
-        alpaka::view::ViewPlainPtr<TDev, TElem, TDim, TIdx> & view,
+        alpaka::ViewPlainPtr<TDev, TElem, TDim, TIdx> & view,
         TDev const & dev,
         alpaka::Vec<TDim, TIdx> const & extentView,
         alpaka::Vec<TDim, TIdx> const & offsetView)
@@ -80,7 +78,7 @@ namespace view
         using Queue = alpaka::test::DefaultQueue<TDev>;
         Queue queue(dev);
         //-----------------------------------------------------------------------------
-        alpaka::test::view::testViewMutable<
+        alpaka::test::testViewMutable<
             TAcc>(
                 queue,
                 view);
@@ -98,7 +96,7 @@ namespace view
 
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
-        using View = alpaka::view::ViewPlainPtr<Dev, TElem, Dim, Idx>;
+        using View = alpaka::ViewPlainPtr<Dev, TElem, Dim, Idx>;
 
         Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
@@ -108,12 +106,12 @@ namespace view
         auto const extentView(extentBuf);
         auto const offsetView(alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0)));
         View view(
-            alpaka::view::getPtrNative(buf),
+            alpaka::getPtrNative(buf),
             alpaka::getDev(buf),
             alpaka::extent::getExtentVec(buf),
-            alpaka::view::getPitchBytesVec(buf));
+            alpaka::getPitchBytesVec(buf));
 
-        alpaka::test::view::testViewPlainPtrMutable<TAcc>(view, dev, extentView, offsetView);
+        alpaka::test::testViewPlainPtrMutable<TAcc>(view, dev, extentView, offsetView);
     }
 
     //-----------------------------------------------------------------------------
@@ -128,7 +126,7 @@ namespace view
 
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
-        using View = alpaka::view::ViewPlainPtr<Dev, TElem, Dim, Idx>;
+        using View = alpaka::ViewPlainPtr<Dev, TElem, Dim, Idx>;
 
         Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
@@ -138,12 +136,12 @@ namespace view
         auto const extentView(extentBuf);
         auto const offsetView(alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0)));
         View const view(
-            alpaka::view::getPtrNative(buf),
+            alpaka::getPtrNative(buf),
             alpaka::getDev(buf),
             alpaka::extent::getExtentVec(buf),
-            alpaka::view::getPitchBytesVec(buf));
+            alpaka::getPitchBytesVec(buf));
 
-        alpaka::test::view::testViewPlainPtrImmutable<TAcc>(view, dev, extentView, offsetView);
+        alpaka::test::testViewPlainPtrImmutable<TAcc>(view, dev, extentView, offsetView);
     }
 
     //-----------------------------------------------------------------------------
@@ -158,7 +156,7 @@ namespace view
 
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
-        using View = alpaka::view::ViewPlainPtr<Dev, TElem, Dim, Idx>;
+        using View = alpaka::ViewPlainPtr<Dev, TElem, Dim, Idx>;
 
         Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
@@ -166,10 +164,10 @@ namespace view
         auto buf(alpaka::allocBuf<TElem, Idx>(dev, extentBuf));
 
         View view(
-            alpaka::view::getPtrNative(buf),
+            alpaka::getPtrNative(buf),
             alpaka::getDev(buf),
             alpaka::extent::getExtentVec(buf),
-            alpaka::view::getPitchBytesVec(buf));
+            alpaka::getPitchBytesVec(buf));
 
         // copy-constructor
         View viewCopy(view);
@@ -179,7 +177,6 @@ namespace view
     }
 }
 }
-}
 #if BOOST_COMP_GNUC
     #pragma GCC diagnostic pop
 #endif
@@ -187,17 +184,17 @@ namespace view
 //-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE( "viewPlainPtrTest", "[memView]", alpaka::test::TestAccs)
 {
-    alpaka::test::view::testViewPlainPtr<TestType, float>();
+    alpaka::test::testViewPlainPtr<TestType, float>();
 }
 
 //-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE( "viewPlainPtrConstTest", "[memView]", alpaka::test::TestAccs)
 {
-    alpaka::test::view::testViewPlainPtrConst<TestType, float>();
+    alpaka::test::testViewPlainPtrConst<TestType, float>();
 }
 
 //-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE( "viewPlainPtrOperatorTest", "[memView]", alpaka::test::TestAccs)
 {
-    alpaka::test::view::testViewPlainPtrOperators<TestType, float>();
+    alpaka::test::testViewPlainPtrOperators<TestType, float>();
 }

--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -84,14 +84,14 @@ TEMPLATE_LIST_TEST_CASE( "staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestA
     // initialized static constant device memory
     {
         auto const viewConstantMemInitialized(
-            alpaka::view::createStaticDevMemView(
+            alpaka::createStaticDevMemView(
                 &g_constantMemory2DInitialized[0u][0u],
                 devAcc,
                 extent));
 
         REQUIRE(fixture(
             kernel,
-            alpaka::view::getPtrNative(viewConstantMemInitialized)));
+            alpaka::getPtrNative(viewConstantMemInitialized)));
     }
     //-----------------------------------------------------------------------------
     // uninitialized static constant device memory
@@ -103,20 +103,20 @@ TEMPLATE_LIST_TEST_CASE( "staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestA
         QueueAcc queueAcc(devAcc);
 
         std::vector<Elem> const data{0u, 1u, 2u, 3u, 4u, 5u};
-        alpaka::view::ViewPlainPtr<decltype(devHost), const Elem, Dim, Idx> bufHost(data.data(), devHost, extent);
+        alpaka::ViewPlainPtr<decltype(devHost), const Elem, Dim, Idx> bufHost(data.data(), devHost, extent);
 
         auto viewConstantMemUninitialized(
-            alpaka::view::createStaticDevMemView(
+            alpaka::createStaticDevMemView(
                 &g_constantMemory2DUninitialized[0u][0u],
                 devAcc,
                 extent));
 
-        alpaka::view::copy(queueAcc, viewConstantMemUninitialized, bufHost, extent);
+        alpaka::copy(queueAcc, viewConstantMemUninitialized, bufHost, extent);
         alpaka::wait(queueAcc);
 
         REQUIRE(fixture(
             kernel,
-            alpaka::view::getPtrNative(viewConstantMemUninitialized)));
+            alpaka::getPtrNative(viewConstantMemUninitialized)));
     }
 #endif
 }
@@ -157,7 +157,7 @@ TEMPLATE_LIST_TEST_CASE( "staticDeviceMemoryConstant", "[viewStaticAccMem]", Tes
     // initialized static global device memory
     {
         auto const viewGlobalMemInitialized(
-            alpaka::view::createStaticDevMemView(
+            alpaka::createStaticDevMemView(
                 &g_globalMemory2DInitialized[0u][0u],
                 devAcc,
                 extent));
@@ -165,7 +165,7 @@ TEMPLATE_LIST_TEST_CASE( "staticDeviceMemoryConstant", "[viewStaticAccMem]", Tes
         REQUIRE(
             fixture(
                 kernel,
-                alpaka::view::getPtrNative(viewGlobalMemInitialized)));
+                alpaka::getPtrNative(viewGlobalMemInitialized)));
     }
 
     //-----------------------------------------------------------------------------
@@ -178,21 +178,21 @@ TEMPLATE_LIST_TEST_CASE( "staticDeviceMemoryConstant", "[viewStaticAccMem]", Tes
         QueueAcc queueAcc(devAcc);
 
         std::vector<Elem> const data{0u, 1u, 2u, 3u, 4u, 5u};
-        alpaka::view::ViewPlainPtr<decltype(devHost), const Elem, Dim, Idx> bufHost(data.data(), devHost, extent);
+        alpaka::ViewPlainPtr<decltype(devHost), const Elem, Dim, Idx> bufHost(data.data(), devHost, extent);
 
         auto viewGlobalMemUninitialized(
-            alpaka::view::createStaticDevMemView(
+            alpaka::createStaticDevMemView(
                 &g_globalMemory2DUninitialized[0u][0u],
                 devAcc,
                 extent));
 
-        alpaka::view::copy(queueAcc, viewGlobalMemUninitialized, bufHost, extent);
+        alpaka::copy(queueAcc, viewGlobalMemUninitialized, bufHost, extent);
         alpaka::wait(queueAcc);
 
         REQUIRE(
             fixture(
                 kernel,
-                alpaka::view::getPtrNative(viewGlobalMemUninitialized)));
+                alpaka::getPtrNative(viewGlobalMemUninitialized)));
     }
 #endif
 }

--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -111,7 +111,7 @@ TEMPLATE_LIST_TEST_CASE( "staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestA
                 devAcc,
                 extent));
 
-        alpaka::copy(queueAcc, viewConstantMemUninitialized, bufHost, extent);
+        alpaka::memcpy(queueAcc, viewConstantMemUninitialized, bufHost, extent);
         alpaka::wait(queueAcc);
 
         REQUIRE(fixture(
@@ -186,7 +186,7 @@ TEMPLATE_LIST_TEST_CASE( "staticDeviceMemoryConstant", "[viewStaticAccMem]", Tes
                 devAcc,
                 extent));
 
-        alpaka::copy(queueAcc, viewGlobalMemUninitialized, bufHost, extent);
+        alpaka::memcpy(queueAcc, viewGlobalMemUninitialized, bufHost, extent);
         alpaka::wait(queueAcc);
 
         REQUIRE(

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -30,8 +30,6 @@ namespace alpaka
 {
 namespace test
 {
-namespace view
-{
     //-----------------------------------------------------------------------------
     template<
         typename TAcc,
@@ -41,7 +39,7 @@ namespace view
         typename TIdx,
         typename TBuf>
     auto testViewSubViewImmutable(
-        alpaka::view::ViewSubView<TDev, TElem, TDim, TIdx> const & view,
+        alpaka::ViewSubView<TDev, TElem, TDim, TIdx> const & view,
         TBuf & buf,
         TDev const & dev,
         alpaka::Vec<TDim, TIdx> const & extentView,
@@ -49,7 +47,7 @@ namespace view
     -> void
     {
         //-----------------------------------------------------------------------------
-        alpaka::test::view::testViewImmutable<
+        alpaka::test::testViewImmutable<
             TElem>(
                 view,
                 dev,
@@ -57,11 +55,11 @@ namespace view
                 offsetView);
 
         //-----------------------------------------------------------------------------
-        // alpaka::view::traits::GetPitchBytes
+        // alpaka::traits::GetPitchBytes
         // The pitch of the view has to be identical to the pitch of the underlying buffer in all dimensions.
         {
-            auto const pitchBuf(alpaka::view::getPitchBytesVec(buf));
-            auto const pitchView(alpaka::view::getPitchBytesVec(view));
+            auto const pitchBuf(alpaka::getPitchBytesVec(buf));
+            auto const pitchView(alpaka::getPitchBytesVec(view));
 
             for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
             {
@@ -72,13 +70,13 @@ namespace view
         }
 
         //-----------------------------------------------------------------------------
-        // alpaka::view::traits::GetPtrNative
+        // alpaka::traits::GetPtrNative
         // The native pointer has to be exactly the value we calculate here.
         {
             auto viewPtrNative(
                 reinterpret_cast<std::uint8_t *>(
-                    alpaka::view::getPtrNative(buf)));
-            auto const pitchBuf(alpaka::view::getPitchBytesVec(buf));
+                    alpaka::getPtrNative(buf)));
+            auto const pitchBuf(alpaka::getPitchBytesVec(buf));
             for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
             {
                 auto const pitch = (i < static_cast<TIdx>(TDim::value)) ? pitchBuf[i] : static_cast<TIdx>(sizeof(TElem));
@@ -86,7 +84,7 @@ namespace view
             }
             REQUIRE(
                 reinterpret_cast<TElem *>(viewPtrNative) ==
-                alpaka::view::getPtrNative(view));
+                alpaka::getPtrNative(view));
         }
     }
 
@@ -99,7 +97,7 @@ namespace view
         typename TIdx,
         typename TBuf>
     auto testViewSubViewMutable(
-        alpaka::view::ViewSubView<TDev, TElem, TDim, TIdx> & view,
+        alpaka::ViewSubView<TDev, TElem, TDim, TIdx> & view,
         TBuf & buf,
         TDev const & dev,
         alpaka::Vec<TDim, TIdx> const & extentView,
@@ -118,7 +116,7 @@ namespace view
         using Queue = alpaka::test::DefaultQueue<TDev>;
         Queue queue(dev);
         //-----------------------------------------------------------------------------
-        alpaka::test::view::testViewMutable<
+        alpaka::test::testViewMutable<
             TAcc>(
                 queue,
                 view);
@@ -136,7 +134,7 @@ namespace view
 
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
-        using View = alpaka::view::ViewSubView<Dev, TElem, Dim, Idx>;
+        using View = alpaka::ViewSubView<Dev, TElem, Dim, Idx>;
 
         Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
@@ -147,7 +145,7 @@ namespace view
         auto const offsetView(alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0)));
         View view(buf);
 
-        alpaka::test::view::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
+        alpaka::test::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
     }
 
     //-----------------------------------------------------------------------------
@@ -162,7 +160,7 @@ namespace view
 
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
-        using View = alpaka::view::ViewSubView<Dev, TElem, Dim, Idx>;
+        using View = alpaka::ViewSubView<Dev, TElem, Dim, Idx>;
 
         Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
@@ -173,7 +171,7 @@ namespace view
         auto const offsetView(alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>());
         View view(buf, extentView, offsetView);
 
-        alpaka::test::view::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
+        alpaka::test::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
     }
 
     //-----------------------------------------------------------------------------
@@ -188,7 +186,7 @@ namespace view
 
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
-        using View = alpaka::view::ViewSubView<Dev, TElem, Dim, Idx>;
+        using View = alpaka::ViewSubView<Dev, TElem, Dim, Idx>;
 
         Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
@@ -199,9 +197,8 @@ namespace view
         auto const offsetView(alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>());
         View const view(buf, extentView, offsetView);
 
-        alpaka::test::view::testViewSubViewImmutable<TAcc>(view, buf, dev, extentView, offsetView);
+        alpaka::test::testViewSubViewImmutable<TAcc>(view, buf, dev, extentView, offsetView);
     }
-}
 }
 }
 #if BOOST_COMP_GNUC
@@ -211,17 +208,17 @@ namespace view
 //-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE( "viewSubViewNoOffsetTest", "[memView]", alpaka::test::TestAccs)
 {
-    alpaka::test::view::testViewSubViewNoOffset<TestType, float>();
+    alpaka::test::testViewSubViewNoOffset<TestType, float>();
 }
 
 //-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE( "viewSubViewOffsetTest", "[memView]", alpaka::test::TestAccs)
 {
-    alpaka::test::view::testViewSubViewOffset<TestType, float>();
+    alpaka::test::testViewSubViewOffset<TestType, float>();
 }
 
 //-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE( "viewSubViewOffsetConstTest", "[memView]", alpaka::test::TestAccs)
 {
-    alpaka::test::view::testViewSubViewOffsetConst<TestType, float>();
+    alpaka::test::testViewSubViewOffsetConst<TestType, float>();
 }

--- a/test/unit/queue/src/CollectiveQueue.cpp
+++ b/test/unit/queue/src/CollectiveQueue.cpp
@@ -119,7 +119,7 @@ TEST_CASE("TestCollectiveMemcpy", "[queue]")
     {
         int threadId = omp_get_thread_num();
 
-        using View = alpaka::view::ViewPlainPtr<Dev, int, Dim, Idx>;
+        using View = alpaka::ViewPlainPtr<Dev, int, Dim, Idx>;
 
         View dst(
             results.data() + threadId,
@@ -138,7 +138,7 @@ TEST_CASE("TestCollectiveMemcpy", "[queue]")
         std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
 
         // only one thread will perform this memcpy
-        alpaka::view::copy(queue, dst, src, Vec(static_cast<Idx>(1u)));
+        alpaka::copy(queue, dst, src, Vec(static_cast<Idx>(1u)));
 
         alpaka::wait(queue);
     }

--- a/test/unit/queue/src/CollectiveQueue.cpp
+++ b/test/unit/queue/src/CollectiveQueue.cpp
@@ -138,7 +138,7 @@ TEST_CASE("TestCollectiveMemcpy", "[queue]")
         std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
 
         // only one thread will perform this memcpy
-        alpaka::copy(queue, dst, src, Vec(static_cast<Idx>(1u)));
+        alpaka::memcpy(queue, dst, src, Vec(static_cast<Idx>(1u)));
 
         alpaka::wait(queue);
     }


### PR DESCRIPTION
See #1034

Also renames these functions, since their names are now too generic when residing in the `alpaka` namespace:

* `alpaka::copy` to `alpaka::memcpy`
* `alpaka::set` to `alpaka::memset`