### PR TITLE
Remove namespace alpaka::block and some inner namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - renamed function `alpaka::view::set` to `alpaka::memset`
 - renamed function `alpaka::view::copy` to `alpaka::memcpy`
 - removed namespace `alpaka::view`
+- removed namespace `alpaka::block::st`
+- removed namespace `alpaka::block::dyn`
+- renamed namespace `alpaka::block::op` to `alpaka::blockOp`
+- removed namespace `alpaka::block`
 
 ## [0.5.0] - 2020-06-26
 ### Compatibility Changes:

--- a/example/reduce/src/kernel.hpp
+++ b/example/reduce/src/kernel.hpp
@@ -80,7 +80,7 @@ struct ReduceKernel
                                   TFunc func) const -> void
     {
         auto &sdata(
-            alpaka::block::st::allocVar<cheapArray<T, TBlockSize>,
+            alpaka::block::allocVar<cheapArray<T, TBlockSize>,
                                                 __COUNTER__>(acc));
 
         const uint32_t blockIndex(static_cast<uint32_t>(

--- a/example/reduce/src/kernel.hpp
+++ b/example/reduce/src/kernel.hpp
@@ -80,7 +80,7 @@ struct ReduceKernel
                                   TFunc func) const -> void
     {
         auto &sdata(
-            alpaka::block::allocVar<cheapArray<T, TBlockSize>,
+            alpaka::allocVar<cheapArray<T, TBlockSize>,
                                                 __COUNTER__>(acc));
 
         const uint32_t blockIndex(static_cast<uint32_t>(
@@ -125,7 +125,7 @@ struct ReduceKernel
         if (threadIndex < n)
             sdata[threadIndex] = result;
 
-        alpaka::block::syncBlockThreads(acc);
+        alpaka::syncBlockThreads(acc);
 
         // --------
         // Level 2: block + warp reduce, reading from shared memory
@@ -155,7 +155,7 @@ struct ReduceKernel
                     func(sdata[threadIndex],
                          sdata[threadIndex + currentBlockSizeUp]);
 
-            alpaka::block::syncBlockThreads(acc);
+            alpaka::syncBlockThreads(acc);
         }
 
         // store block result to gmem

--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -74,9 +74,9 @@ namespace alpaka
             AtomicNoOp         // thread atomics
         >,
         public math::MathStdLib,
-        public block::BlockSharedMemDynAlignedAlloc,
-        public block::BlockSharedMemStMasterSync,
-        public block::BlockSyncBarrierFiber<TIdx>,
+        public BlockSharedMemDynAlignedAlloc,
+        public BlockSharedMemStMasterSync,
+        public BlockSyncBarrierFiber<TIdx>,
         public IntrinsicCpu,
         public rand::RandStdLib,
         public TimeStdLib,
@@ -109,11 +109,11 @@ namespace alpaka
                     AtomicNoOp         // atomics between threads
                 >(),
                 math::MathStdLib(),
-                block::BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
-                block::BlockSharedMemStMasterSync(
-                    [this](){block::syncBlockThreads(*this);},
+                BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
+                BlockSharedMemStMasterSync(
+                    [this](){syncBlockThreads(*this);},
                     [this](){return (m_masterFiberId == boost::this_fiber::get_id());}),
-                block::BlockSyncBarrierFiber<TIdx>(
+                BlockSyncBarrierFiber<TIdx>(
                     getWorkDiv<Block, Threads>(workDiv).prod()),
                 rand::RandStdLib(),
                 TimeStdLib(),

--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -74,8 +74,8 @@ namespace alpaka
             AtomicNoOp         // thread atomics
         >,
         public math::MathStdLib,
-        public block::dyn::BlockSharedMemDynAlignedAlloc,
-        public block::st::BlockSharedMemStMasterSync,
+        public block::BlockSharedMemDynAlignedAlloc,
+        public block::BlockSharedMemStMasterSync,
         public block::BlockSyncBarrierFiber<TIdx>,
         public IntrinsicCpu,
         public rand::RandStdLib,
@@ -109,8 +109,8 @@ namespace alpaka
                     AtomicNoOp         // atomics between threads
                 >(),
                 math::MathStdLib(),
-                block::dyn::BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
-                block::st::BlockSharedMemStMasterSync(
+                block::BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
+                block::BlockSharedMemStMasterSync(
                     [this](){block::syncBlockThreads(*this);},
                     [this](){return (m_masterFiberId == boost::this_fiber::get_id());}),
                 block::BlockSyncBarrierFiber<TIdx>(

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -75,8 +75,8 @@ namespace alpaka
             AtomicNoOp           // thread atomics
         >,
         public math::MathStdLib,
-        public block::dyn::BlockSharedMemDynMember<>,
-        public block::st::BlockSharedMemStMember<>,
+        public block::BlockSharedMemDynMember<>,
+        public block::BlockSharedMemStMember<>,
         public block::BlockSyncNoOp,
         public IntrinsicCpu,
         public rand::RandStdLib,
@@ -110,8 +110,8 @@ namespace alpaka
                     AtomicNoOp        // atomics between threads
                 >(),
                 math::MathStdLib(),
-                block::dyn::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
-                block::st::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
+                block::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
+                block::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
                 block::BlockSyncNoOp(),
                 rand::RandStdLib(),
                 TimeOmp(),

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -75,9 +75,9 @@ namespace alpaka
             AtomicNoOp           // thread atomics
         >,
         public math::MathStdLib,
-        public block::BlockSharedMemDynMember<>,
-        public block::BlockSharedMemStMember<>,
-        public block::BlockSyncNoOp,
+        public BlockSharedMemDynMember<>,
+        public BlockSharedMemStMember<>,
+        public BlockSyncNoOp,
         public IntrinsicCpu,
         public rand::RandStdLib,
         public TimeOmp,
@@ -110,9 +110,9 @@ namespace alpaka
                     AtomicNoOp        // atomics between threads
                 >(),
                 math::MathStdLib(),
-                block::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
-                block::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
-                block::BlockSyncNoOp(),
+                BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
+                BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
+                BlockSyncNoOp(),
                 rand::RandStdLib(),
                 TimeOmp(),
                 m_gridBlockIdx(Vec<TDim, TIdx>::zeros())

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -76,8 +76,8 @@ namespace alpaka
             AtomicOmpBuiltIn     // thread atomics
         >,
         public math::MathStdLib,
-        public block::dyn::BlockSharedMemDynAlignedAlloc,
-        public block::st::BlockSharedMemStMasterSync,
+        public block::BlockSharedMemDynAlignedAlloc,
+        public block::BlockSharedMemStMasterSync,
         public block::BlockSyncBarrierOmp,
         public IntrinsicCpu,
         public rand::RandStdLib,
@@ -111,8 +111,8 @@ namespace alpaka
                     AtomicOmpBuiltIn  // atomics between threads
                 >(),
                 math::MathStdLib(),
-                block::dyn::BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
-                block::st::BlockSharedMemStMasterSync(
+                block::BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
+                block::BlockSharedMemStMasterSync(
                     [this](){block::syncBlockThreads(*this);},
                     [](){return (::omp_get_thread_num() == 0);}),
                 block::BlockSyncBarrierOmp(),

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -76,9 +76,9 @@ namespace alpaka
             AtomicOmpBuiltIn     // thread atomics
         >,
         public math::MathStdLib,
-        public block::BlockSharedMemDynAlignedAlloc,
-        public block::BlockSharedMemStMasterSync,
-        public block::BlockSyncBarrierOmp,
+        public BlockSharedMemDynAlignedAlloc,
+        public BlockSharedMemStMasterSync,
+        public BlockSyncBarrierOmp,
         public IntrinsicCpu,
         public rand::RandStdLib,
         public TimeOmp,
@@ -111,11 +111,11 @@ namespace alpaka
                     AtomicOmpBuiltIn  // atomics between threads
                 >(),
                 math::MathStdLib(),
-                block::BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
-                block::BlockSharedMemStMasterSync(
-                    [this](){block::syncBlockThreads(*this);},
+                BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
+                BlockSharedMemStMasterSync(
+                    [this](){syncBlockThreads(*this);},
                     [](){return (::omp_get_thread_num() == 0);}),
-                block::BlockSyncBarrierOmp(),
+                BlockSyncBarrierOmp(),
                 rand::RandStdLib(),
                 TimeOmp(),
                 m_gridBlockIdx(Vec<TDim, TIdx>::zeros())

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -69,9 +69,9 @@ namespace alpaka
             AtomicNoOp         // thread atomics
         >,
         public math::MathStdLib,
-        public block::BlockSharedMemDynMember<>,
-        public block::BlockSharedMemStMember<>,
-        public block::BlockSyncNoOp,
+        public BlockSharedMemDynMember<>,
+        public BlockSharedMemStMember<>,
+        public BlockSyncNoOp,
         public IntrinsicCpu,
         public rand::RandStdLib,
         public TimeStdLib,
@@ -104,9 +104,9 @@ namespace alpaka
                     AtomicNoOp         // atomics between threads
                 >(),
                 math::MathStdLib(),
-                block::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
-                block::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
-                block::BlockSyncNoOp(),
+                BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
+                BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
+                BlockSyncNoOp(),
                 rand::RandStdLib(),
                 TimeStdLib(),
                 m_gridBlockIdx(Vec<TDim, TIdx>::zeros())

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -69,8 +69,8 @@ namespace alpaka
             AtomicNoOp         // thread atomics
         >,
         public math::MathStdLib,
-        public block::dyn::BlockSharedMemDynMember<>,
-        public block::st::BlockSharedMemStMember<>,
+        public block::BlockSharedMemDynMember<>,
+        public block::BlockSharedMemStMember<>,
         public block::BlockSyncNoOp,
         public IntrinsicCpu,
         public rand::RandStdLib,
@@ -104,8 +104,8 @@ namespace alpaka
                     AtomicNoOp         // atomics between threads
                 >(),
                 math::MathStdLib(),
-                block::dyn::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
-                block::st::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
+                block::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
+                block::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
                 block::BlockSyncNoOp(),
                 rand::RandStdLib(),
                 TimeStdLib(),

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -66,9 +66,9 @@ namespace alpaka
             AtomicNoOp         // thread atomics
         >,
         public math::MathStdLib,
-        public block::BlockSharedMemDynMember<>,
-        public block::BlockSharedMemStMember<>,
-        public block::BlockSyncNoOp,
+        public BlockSharedMemDynMember<>,
+        public BlockSharedMemStMember<>,
+        public BlockSyncNoOp,
         public IntrinsicCpu,
         public rand::RandStdLib,
         public TimeStdLib,
@@ -101,9 +101,9 @@ namespace alpaka
                     AtomicNoOp         // atomics between threads
                 >(),
                 math::MathStdLib(),
-                block::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
-                block::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
-                block::BlockSyncNoOp(),
+                BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
+                BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
+                BlockSyncNoOp(),
                 rand::RandStdLib(),
                 TimeStdLib(),
                 m_gridBlockIdx(Vec<TDim, TIdx>::zeros())

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -66,8 +66,8 @@ namespace alpaka
             AtomicNoOp         // thread atomics
         >,
         public math::MathStdLib,
-        public block::dyn::BlockSharedMemDynMember<>,
-        public block::st::BlockSharedMemStMember<>,
+        public block::BlockSharedMemDynMember<>,
+        public block::BlockSharedMemStMember<>,
         public block::BlockSyncNoOp,
         public IntrinsicCpu,
         public rand::RandStdLib,
@@ -101,8 +101,8 @@ namespace alpaka
                     AtomicNoOp         // atomics between threads
                 >(),
                 math::MathStdLib(),
-                block::dyn::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
-                block::st::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
+                block::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
+                block::BlockSharedMemStMember<>(staticMemBegin(), staticMemCapacity()),
                 block::BlockSyncNoOp(),
                 rand::RandStdLib(),
                 TimeStdLib(),

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -71,9 +71,9 @@ namespace alpaka
             AtomicStdLibLock<16>  // thread atomics
         >,
         public math::MathStdLib,
-        public block::BlockSharedMemDynAlignedAlloc,
-        public block::BlockSharedMemStMasterSync,
-        public block::BlockSyncBarrierThread<TIdx>,
+        public BlockSharedMemDynAlignedAlloc,
+        public BlockSharedMemStMasterSync,
+        public BlockSyncBarrierThread<TIdx>,
         public IntrinsicCpu,
         public rand::RandStdLib,
         public TimeStdLib,
@@ -106,11 +106,11 @@ namespace alpaka
                     AtomicStdLibLock<16>  // atomics between threads
                 >(),
                 math::MathStdLib(),
-                block::BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
-                block::BlockSharedMemStMasterSync(
-                    [this](){block::syncBlockThreads(*this);},
+                BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
+                BlockSharedMemStMasterSync(
+                    [this](){syncBlockThreads(*this);},
                     [this](){return (m_idMasterThread == std::this_thread::get_id());}),
-                block::BlockSyncBarrierThread<TIdx>(
+                BlockSyncBarrierThread<TIdx>(
                     getWorkDiv<Block, Threads>(workDiv).prod()),
                 rand::RandStdLib(),
                 TimeStdLib(),

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -71,8 +71,8 @@ namespace alpaka
             AtomicStdLibLock<16>  // thread atomics
         >,
         public math::MathStdLib,
-        public block::dyn::BlockSharedMemDynAlignedAlloc,
-        public block::st::BlockSharedMemStMasterSync,
+        public block::BlockSharedMemDynAlignedAlloc,
+        public block::BlockSharedMemStMasterSync,
         public block::BlockSyncBarrierThread<TIdx>,
         public IntrinsicCpu,
         public rand::RandStdLib,
@@ -106,8 +106,8 @@ namespace alpaka
                     AtomicStdLibLock<16>  // atomics between threads
                 >(),
                 math::MathStdLib(),
-                block::dyn::BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
-                block::st::BlockSharedMemStMasterSync(
+                block::BlockSharedMemDynAlignedAlloc(blockSharedMemDynSizeBytes),
+                block::BlockSharedMemStMasterSync(
                     [this](){block::syncBlockThreads(*this);},
                     [this](){return (m_idMasterThread == std::this_thread::get_id());}),
                 block::BlockSyncBarrierThread<TIdx>(

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -77,8 +77,8 @@ namespace alpaka
             AtomicUniformCudaHipBuiltIn  // thread atomics
         >,
         public math::MathUniformCudaHipBuiltIn,
-        public block::dyn::BlockSharedMemDynUniformCudaHipBuiltIn,
-        public block::st::BlockSharedMemStUniformCudaHipBuiltIn,
+        public block::BlockSharedMemDynUniformCudaHipBuiltIn,
+        public block::BlockSharedMemStUniformCudaHipBuiltIn,
         public block::BlockSyncUniformCudaHipBuiltIn,
         public IntrinsicUniformCudaHipBuiltIn,
         public rand::RandUniformCudaHipRand,
@@ -100,8 +100,8 @@ namespace alpaka
                     AtomicUniformCudaHipBuiltIn  // atomics between threads
                 >(),
                 math::MathUniformCudaHipBuiltIn(),
-                block::dyn::BlockSharedMemDynUniformCudaHipBuiltIn(),
-                block::st::BlockSharedMemStUniformCudaHipBuiltIn(),
+                block::BlockSharedMemDynUniformCudaHipBuiltIn(),
+                block::BlockSharedMemStUniformCudaHipBuiltIn(),
                 block::BlockSyncUniformCudaHipBuiltIn(),
                 rand::RandUniformCudaHipRand(),
                 TimeUniformCudaHipBuiltIn()

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -77,9 +77,9 @@ namespace alpaka
             AtomicUniformCudaHipBuiltIn  // thread atomics
         >,
         public math::MathUniformCudaHipBuiltIn,
-        public block::BlockSharedMemDynUniformCudaHipBuiltIn,
-        public block::BlockSharedMemStUniformCudaHipBuiltIn,
-        public block::BlockSyncUniformCudaHipBuiltIn,
+        public BlockSharedMemDynUniformCudaHipBuiltIn,
+        public BlockSharedMemStUniformCudaHipBuiltIn,
+        public BlockSyncUniformCudaHipBuiltIn,
         public IntrinsicUniformCudaHipBuiltIn,
         public rand::RandUniformCudaHipRand,
         public TimeUniformCudaHipBuiltIn,
@@ -100,9 +100,9 @@ namespace alpaka
                     AtomicUniformCudaHipBuiltIn  // atomics between threads
                 >(),
                 math::MathUniformCudaHipBuiltIn(),
-                block::BlockSharedMemDynUniformCudaHipBuiltIn(),
-                block::BlockSharedMemStUniformCudaHipBuiltIn(),
-                block::BlockSyncUniformCudaHipBuiltIn(),
+                BlockSharedMemDynUniformCudaHipBuiltIn(),
+                BlockSharedMemStUniformCudaHipBuiltIn(),
+                BlockSyncUniformCudaHipBuiltIn(),
                 rand::RandUniformCudaHipRand(),
                 TimeUniformCudaHipBuiltIn()
         {}

--- a/include/alpaka/acc/AccOmp5.hpp
+++ b/include/alpaka/acc/AccOmp5.hpp
@@ -72,9 +72,9 @@ namespace alpaka
             AtomicOmpBuiltIn     // thread atomics
         >,
         public math::MathStdLib,
-        public block::BlockSharedMemDynMember<>,
-        public block::BlockSharedMemStOmp5,
-        public block::BlockSyncBarrierOmp,
+        public BlockSharedMemDynMember<>,
+        public BlockSharedMemStOmp5,
+        public BlockSyncBarrierOmp,
         // cannot determine which intrinsics are safe to use (depends on target), using fallback
         public IntrinsicFallback,
         public rand::RandStdLib,
@@ -109,10 +109,10 @@ namespace alpaka
                     AtomicOmpBuiltIn  // atomics between threads
                 >(),
                 math::MathStdLib(),
-                block::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
+                BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
                 //! \TODO can with some TMP determine the amount of statically alloced smem from the kernelFuncObj?
-                block::BlockSharedMemStOmp5(staticMemBegin(), staticMemCapacity()),
-                block::BlockSyncBarrierOmp(),
+                BlockSharedMemStOmp5(staticMemBegin(), staticMemCapacity()),
+                BlockSyncBarrierOmp(),
                 rand::RandStdLib(),
                 TimeOmp()
         {}

--- a/include/alpaka/acc/AccOmp5.hpp
+++ b/include/alpaka/acc/AccOmp5.hpp
@@ -72,8 +72,8 @@ namespace alpaka
             AtomicOmpBuiltIn     // thread atomics
         >,
         public math::MathStdLib,
-        public block::dyn::BlockSharedMemDynMember<>,
-        public block::st::BlockSharedMemStOmp5,
+        public block::BlockSharedMemDynMember<>,
+        public block::BlockSharedMemStOmp5,
         public block::BlockSyncBarrierOmp,
         // cannot determine which intrinsics are safe to use (depends on target), using fallback
         public IntrinsicFallback,
@@ -109,9 +109,9 @@ namespace alpaka
                     AtomicOmpBuiltIn  // atomics between threads
                 >(),
                 math::MathStdLib(),
-                block::dyn::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
+                block::BlockSharedMemDynMember<>(blockSharedMemDynSizeBytes),
                 //! \TODO can with some TMP determine the amount of statically alloced smem from the kernelFuncObj?
-                block::st::BlockSharedMemStOmp5(staticMemBegin(), staticMemCapacity()),
+                block::BlockSharedMemStOmp5(staticMemBegin(), staticMemCapacity()),
                 block::BlockSyncBarrierOmp(),
                 rand::RandStdLib(),
                 TimeOmp()

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynAlignedAlloc.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynAlignedAlloc.hpp
@@ -20,70 +20,67 @@
 
 namespace alpaka
 {
-    namespace block
+    //#############################################################################
+    //! The block shared dynamic memory allocator without synchronization.
+    class BlockSharedMemDynAlignedAlloc : public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynAlignedAlloc>
     {
-        //#############################################################################
-        //! The block shared dynamic memory allocator without synchronization.
-        class BlockSharedMemDynAlignedAlloc : public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynAlignedAlloc>
+    public:
+        //-----------------------------------------------------------------------------
+        BlockSharedMemDynAlignedAlloc(
+            std::size_t const & blockSharedMemDynSizeBytes)
         {
-        public:
-            //-----------------------------------------------------------------------------
-            BlockSharedMemDynAlignedAlloc(
-                std::size_t const & blockSharedMemDynSizeBytes)
+            if(blockSharedMemDynSizeBytes > 0u)
             {
-                if(blockSharedMemDynSizeBytes > 0u)
-                {
-                    m_blockSharedMemDyn.reset(
-                        reinterpret_cast<uint8_t *>(
-                            core::alignedAlloc(core::vectorization::defaultAlignment, blockSharedMemDynSizeBytes)));
-                }
+                m_blockSharedMemDyn.reset(
+                    reinterpret_cast<uint8_t *>(
+                        core::alignedAlloc(core::vectorization::defaultAlignment, blockSharedMemDynSizeBytes)));
             }
-            //-----------------------------------------------------------------------------
-            BlockSharedMemDynAlignedAlloc(BlockSharedMemDynAlignedAlloc const &) = delete;
-            //-----------------------------------------------------------------------------
-            BlockSharedMemDynAlignedAlloc(BlockSharedMemDynAlignedAlloc &&) = delete;
-            //-----------------------------------------------------------------------------
-            auto operator=(BlockSharedMemDynAlignedAlloc const &) -> BlockSharedMemDynAlignedAlloc & = delete;
-            //-----------------------------------------------------------------------------
-            auto operator=(BlockSharedMemDynAlignedAlloc &&) -> BlockSharedMemDynAlignedAlloc & = delete;
-            //-----------------------------------------------------------------------------
-            /*virtual*/ ~BlockSharedMemDynAlignedAlloc() = default;
+        }
+        //-----------------------------------------------------------------------------
+        BlockSharedMemDynAlignedAlloc(BlockSharedMemDynAlignedAlloc const &) = delete;
+        //-----------------------------------------------------------------------------
+        BlockSharedMemDynAlignedAlloc(BlockSharedMemDynAlignedAlloc &&) = delete;
+        //-----------------------------------------------------------------------------
+        auto operator=(BlockSharedMemDynAlignedAlloc const &) -> BlockSharedMemDynAlignedAlloc & = delete;
+        //-----------------------------------------------------------------------------
+        auto operator=(BlockSharedMemDynAlignedAlloc &&) -> BlockSharedMemDynAlignedAlloc & = delete;
+        //-----------------------------------------------------------------------------
+        /*virtual*/ ~BlockSharedMemDynAlignedAlloc() = default;
 
-        public:
-            std::unique_ptr<
-                uint8_t,
-                core::AlignedDelete> mutable
-                    m_blockSharedMemDyn;  //!< Block shared dynamic memory.
-        };
+    public:
+        std::unique_ptr<
+            uint8_t,
+            core::AlignedDelete> mutable
+                m_blockSharedMemDyn;  //!< Block shared dynamic memory.
+    };
 
-        namespace traits
-        {
+    namespace traits
+    {
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
 #endif
-            //#############################################################################
-            template<
-                typename T>
-            struct GetMem<
-                T,
-                BlockSharedMemDynAlignedAlloc>
+        //#############################################################################
+        template<
+            typename T>
+        struct GetMem<
+            T,
+            BlockSharedMemDynAlignedAlloc>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto getMem(
+                BlockSharedMemDynAlignedAlloc const & blockSharedMemDyn)
+            -> T *
             {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto getMem(
-                    block::BlockSharedMemDynAlignedAlloc const & blockSharedMemDyn)
-                -> T *
-                {
-                    static_assert(
-                        core::vectorization::defaultAlignment >= alignof(T),
-                        "Unable to get block shared dynamic memory for types with alignment higher than defaultAlignment!");
+                static_assert(
+                    core::vectorization::defaultAlignment >= alignof(T),
+                    "Unable to get block shared dynamic memory for types with alignment higher than defaultAlignment!");
 
-                    return reinterpret_cast<T*>(blockSharedMemDyn.m_blockSharedMemDyn.get());
-                }
-            };
+                return reinterpret_cast<T*>(blockSharedMemDyn.m_blockSharedMemDyn.get());
+            }
+        };
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic pop
 #endif
-        }
     }
 }

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynAlignedAlloc.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynAlignedAlloc.hpp
@@ -22,71 +22,68 @@ namespace alpaka
 {
     namespace block
     {
-        namespace dyn
+        //#############################################################################
+        //! The block shared dynamic memory allocator without synchronization.
+        class BlockSharedMemDynAlignedAlloc : public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynAlignedAlloc>
         {
-            //#############################################################################
-            //! The block shared dynamic memory allocator without synchronization.
-            class BlockSharedMemDynAlignedAlloc : public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynAlignedAlloc>
+        public:
+            //-----------------------------------------------------------------------------
+            BlockSharedMemDynAlignedAlloc(
+                std::size_t const & blockSharedMemDynSizeBytes)
             {
-            public:
-                //-----------------------------------------------------------------------------
-                BlockSharedMemDynAlignedAlloc(
-                    std::size_t const & blockSharedMemDynSizeBytes)
+                if(blockSharedMemDynSizeBytes > 0u)
                 {
-                    if(blockSharedMemDynSizeBytes > 0u)
-                    {
-                        m_blockSharedMemDyn.reset(
-                            reinterpret_cast<uint8_t *>(
-                                core::alignedAlloc(core::vectorization::defaultAlignment, blockSharedMemDynSizeBytes)));
-                    }
+                    m_blockSharedMemDyn.reset(
+                        reinterpret_cast<uint8_t *>(
+                            core::alignedAlloc(core::vectorization::defaultAlignment, blockSharedMemDynSizeBytes)));
                 }
-                //-----------------------------------------------------------------------------
-                BlockSharedMemDynAlignedAlloc(BlockSharedMemDynAlignedAlloc const &) = delete;
-                //-----------------------------------------------------------------------------
-                BlockSharedMemDynAlignedAlloc(BlockSharedMemDynAlignedAlloc &&) = delete;
-                //-----------------------------------------------------------------------------
-                auto operator=(BlockSharedMemDynAlignedAlloc const &) -> BlockSharedMemDynAlignedAlloc & = delete;
-                //-----------------------------------------------------------------------------
-                auto operator=(BlockSharedMemDynAlignedAlloc &&) -> BlockSharedMemDynAlignedAlloc & = delete;
-                //-----------------------------------------------------------------------------
-                /*virtual*/ ~BlockSharedMemDynAlignedAlloc() = default;
+            }
+            //-----------------------------------------------------------------------------
+            BlockSharedMemDynAlignedAlloc(BlockSharedMemDynAlignedAlloc const &) = delete;
+            //-----------------------------------------------------------------------------
+            BlockSharedMemDynAlignedAlloc(BlockSharedMemDynAlignedAlloc &&) = delete;
+            //-----------------------------------------------------------------------------
+            auto operator=(BlockSharedMemDynAlignedAlloc const &) -> BlockSharedMemDynAlignedAlloc & = delete;
+            //-----------------------------------------------------------------------------
+            auto operator=(BlockSharedMemDynAlignedAlloc &&) -> BlockSharedMemDynAlignedAlloc & = delete;
+            //-----------------------------------------------------------------------------
+            /*virtual*/ ~BlockSharedMemDynAlignedAlloc() = default;
 
-            public:
-                std::unique_ptr<
-                    uint8_t,
-                    core::AlignedDelete> mutable
-                        m_blockSharedMemDyn;  //!< Block shared dynamic memory.
-            };
+        public:
+            std::unique_ptr<
+                uint8_t,
+                core::AlignedDelete> mutable
+                    m_blockSharedMemDyn;  //!< Block shared dynamic memory.
+        };
 
-            namespace traits
-            {
+        namespace traits
+        {
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
 #endif
-                //#############################################################################
-                template<
-                    typename T>
-                struct GetMem<
-                    T,
-                    BlockSharedMemDynAlignedAlloc>
+            //#############################################################################
+            template<
+                typename T>
+            struct GetMem<
+                T,
+                BlockSharedMemDynAlignedAlloc>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto getMem(
+                    block::BlockSharedMemDynAlignedAlloc const & blockSharedMemDyn)
+                -> T *
                 {
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getMem(
-                        block::dyn::BlockSharedMemDynAlignedAlloc const & blockSharedMemDyn)
-                    -> T *
-                    {
-                        static_assert(
-                            core::vectorization::defaultAlignment >= alignof(T),
-                            "Unable to get block shared dynamic memory for types with alignment higher than defaultAlignment!");
+                    static_assert(
+                        core::vectorization::defaultAlignment >= alignof(T),
+                        "Unable to get block shared dynamic memory for types with alignment higher than defaultAlignment!");
 
-                        return reinterpret_cast<T*>(blockSharedMemDyn.m_blockSharedMemDyn.get());
-                    }
-                };
+                    return reinterpret_cast<T*>(blockSharedMemDyn.m_blockSharedMemDyn.get());
+                }
+            };
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic pop
 #endif
-            }
         }
     }
 }

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -24,112 +24,109 @@ namespace alpaka
 {
     namespace block
     {
-        namespace dyn
+        namespace detail
         {
-            namespace detail
+            //#############################################################################
+            //! "namespace" for static constexpr members that should be in BlockSharedMemDynMember
+            //! but cannot be because having a static const member breaks GCC 10
+            //! OpenMP target and OpenACC: type not mappable.
+            template<std::size_t TStaticAllocKiB>
+            struct BlockSharedMemDynMemberStatic
             {
-                //#############################################################################
-                //! "namespace" for static constexpr members that should be in BlockSharedMemDynMember
-                //! but cannot be because having a static const member breaks GCC 10
-                //! OpenMP target and OpenACC: type not mappable.
-                template<std::size_t TStaticAllocKiB>
-                struct BlockSharedMemDynMemberStatic
-                {
-                    //! Storage size in bytes
-                    static constexpr std::size_t staticAllocBytes = TStaticAllocKiB<<10;
-                };
-            }
+                //! Storage size in bytes
+                static constexpr std::size_t staticAllocBytes = TStaticAllocKiB<<10;
+            };
+        }
 
 #if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
 #pragma warning(push)
 #pragma warning(disable: 4324)  // warning C4324: structure was padded due to alignment specifier
 #endif
-            //#############################################################################
-            //! Dynamic block shared memory provider using fixed-size
-            //! member array to allocate memory on the stack or in shared
-            //! memory.
-            template<std::size_t TStaticAllocKiB = ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB>
-            class alignas(core::vectorization::defaultAlignment) BlockSharedMemDynMember :
-                public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynMember<TStaticAllocKiB>>
+        //#############################################################################
+        //! Dynamic block shared memory provider using fixed-size
+        //! member array to allocate memory on the stack or in shared
+        //! memory.
+        template<std::size_t TStaticAllocKiB = ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB>
+        class alignas(core::vectorization::defaultAlignment) BlockSharedMemDynMember :
+            public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynMember<TStaticAllocKiB>>
+        {
+        public:
+            //-----------------------------------------------------------------------------
+            BlockSharedMemDynMember(std::size_t sizeBytes)
+                : m_dynPitch((sizeBytes / core::vectorization::defaultAlignment
+                        + (sizeBytes % core::vectorization::defaultAlignment > 0u)) * core::vectorization::defaultAlignment)
             {
-            public:
-                //-----------------------------------------------------------------------------
-                BlockSharedMemDynMember(std::size_t sizeBytes)
-                    : m_dynPitch((sizeBytes / core::vectorization::defaultAlignment
-                            + (sizeBytes % core::vectorization::defaultAlignment > 0u)) * core::vectorization::defaultAlignment)
-                {
 #if (defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (! defined NDEBUG)
-                    ALPAKA_ASSERT(sizeBytes <= staticAllocBytes());
+                ALPAKA_ASSERT(sizeBytes <= staticAllocBytes());
 #endif
-                }
-                //-----------------------------------------------------------------------------
-                BlockSharedMemDynMember(BlockSharedMemDynMember const &) = delete;
-                //-----------------------------------------------------------------------------
-                BlockSharedMemDynMember(BlockSharedMemDynMember &&) = delete;
-                //-----------------------------------------------------------------------------
-                auto operator=(BlockSharedMemDynMember const &) -> BlockSharedMemDynMember & = delete;
-                //-----------------------------------------------------------------------------
-                auto operator=(BlockSharedMemDynMember &&) -> BlockSharedMemDynMember & = delete;
-                //-----------------------------------------------------------------------------
-                /*virtual*/ ~BlockSharedMemDynMember() = default;
+            }
+            //-----------------------------------------------------------------------------
+            BlockSharedMemDynMember(BlockSharedMemDynMember const &) = delete;
+            //-----------------------------------------------------------------------------
+            BlockSharedMemDynMember(BlockSharedMemDynMember &&) = delete;
+            //-----------------------------------------------------------------------------
+            auto operator=(BlockSharedMemDynMember const &) -> BlockSharedMemDynMember & = delete;
+            //-----------------------------------------------------------------------------
+            auto operator=(BlockSharedMemDynMember &&) -> BlockSharedMemDynMember & = delete;
+            //-----------------------------------------------------------------------------
+            /*virtual*/ ~BlockSharedMemDynMember() = default;
 
-                uint8_t* dynMemBegin() const {return m_mem.data();}
+            uint8_t* dynMemBegin() const {return m_mem.data();}
 
-                /*! \return the pointer to the begin of data after the portion allocated as dynamical shared memory.
-                    */
-                uint8_t* staticMemBegin() const
-                {
-                    return m_mem.data() + m_dynPitch;
-                }
+            /*! \return the pointer to the begin of data after the portion allocated as dynamical shared memory.
+                */
+            uint8_t* staticMemBegin() const
+            {
+                return m_mem.data() + m_dynPitch;
+            }
 
-                /*! \return the remaining capacity for static block shared memory.
-                    */
-                std::size_t staticMemCapacity() const
-                {
-                    return staticAllocBytes() - m_dynPitch;
-                }
+            /*! \return the remaining capacity for static block shared memory.
+                */
+            std::size_t staticMemCapacity() const
+            {
+                return staticAllocBytes() - m_dynPitch;
+            }
 
-                //! Storage size in bytes
-                static constexpr std::size_t staticAllocBytes() {return detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes;}
+            //! Storage size in bytes
+            static constexpr std::size_t staticAllocBytes() {return detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes;}
 
-            private:
+        private:
 
-                mutable std::array<uint8_t, detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes> m_mem;
-                std::size_t m_dynPitch;
-            };
+            mutable std::array<uint8_t, detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes> m_mem;
+            std::size_t m_dynPitch;
+        };
 #if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
 #pragma warning(pop)
 #endif
 
-            namespace traits
+        namespace traits
+        {
+            //#############################################################################
+            template<
+                typename T,
+                std::size_t TStaticAllocKiB>
+            struct GetMem<
+                T,
+                BlockSharedMemDynMember<TStaticAllocKiB>>
             {
-                //#############################################################################
-                template<
-                    typename T,
-                    std::size_t TStaticAllocKiB>
-                struct GetMem<
-                    T,
-                    BlockSharedMemDynMember<TStaticAllocKiB>>
-                {
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
 #endif
-                    //-----------------------------------------------------------------------------
-                    static auto getMem(
-                        block::dyn::BlockSharedMemDynMember<TStaticAllocKiB> const &mem)
-                    -> T *
-                    {
-                        static_assert(
-                            core::vectorization::defaultAlignment >= alignof(T),
-                            "Unable to get block shared dynamic memory for types with alignment higher than defaultAlignment!");
-                        return reinterpret_cast<T*>(mem.dynMemBegin());
-                    }
+                //-----------------------------------------------------------------------------
+                static auto getMem(
+                    block::BlockSharedMemDynMember<TStaticAllocKiB> const &mem)
+                -> T *
+                {
+                    static_assert(
+                        core::vectorization::defaultAlignment >= alignof(T),
+                        "Unable to get block shared dynamic memory for types with alignment higher than defaultAlignment!");
+                    return reinterpret_cast<T*>(mem.dynMemBegin());
+                }
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic pop
 #endif
-                };
-            }
+            };
         }
     }
 }

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -22,111 +22,108 @@
 
 namespace alpaka
 {
-    namespace block
+    namespace detail
     {
-        namespace detail
+        //#############################################################################
+        //! "namespace" for static constexpr members that should be in BlockSharedMemDynMember
+        //! but cannot be because having a static const member breaks GCC 10
+        //! OpenMP target and OpenACC: type not mappable.
+        template<std::size_t TStaticAllocKiB>
+        struct BlockSharedMemDynMemberStatic
         {
-            //#############################################################################
-            //! "namespace" for static constexpr members that should be in BlockSharedMemDynMember
-            //! but cannot be because having a static const member breaks GCC 10
-            //! OpenMP target and OpenACC: type not mappable.
-            template<std::size_t TStaticAllocKiB>
-            struct BlockSharedMemDynMemberStatic
-            {
-                //! Storage size in bytes
-                static constexpr std::size_t staticAllocBytes = TStaticAllocKiB<<10;
-            };
-        }
+            //! Storage size in bytes
+            static constexpr std::size_t staticAllocBytes = TStaticAllocKiB<<10;
+        };
+    }
 
 #if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
 #pragma warning(push)
 #pragma warning(disable: 4324)  // warning C4324: structure was padded due to alignment specifier
 #endif
-        //#############################################################################
-        //! Dynamic block shared memory provider using fixed-size
-        //! member array to allocate memory on the stack or in shared
-        //! memory.
-        template<std::size_t TStaticAllocKiB = ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB>
-        class alignas(core::vectorization::defaultAlignment) BlockSharedMemDynMember :
-            public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynMember<TStaticAllocKiB>>
+    //#############################################################################
+    //! Dynamic block shared memory provider using fixed-size
+    //! member array to allocate memory on the stack or in shared
+    //! memory.
+    template<std::size_t TStaticAllocKiB = ALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB>
+    class alignas(core::vectorization::defaultAlignment) BlockSharedMemDynMember :
+        public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynMember<TStaticAllocKiB>>
+    {
+    public:
+        //-----------------------------------------------------------------------------
+        BlockSharedMemDynMember(std::size_t sizeBytes)
+            : m_dynPitch((sizeBytes / core::vectorization::defaultAlignment
+                    + (sizeBytes % core::vectorization::defaultAlignment > 0u)) * core::vectorization::defaultAlignment)
         {
-        public:
-            //-----------------------------------------------------------------------------
-            BlockSharedMemDynMember(std::size_t sizeBytes)
-                : m_dynPitch((sizeBytes / core::vectorization::defaultAlignment
-                        + (sizeBytes % core::vectorization::defaultAlignment > 0u)) * core::vectorization::defaultAlignment)
-            {
 #if (defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (! defined NDEBUG)
-                ALPAKA_ASSERT(sizeBytes <= staticAllocBytes());
+            ALPAKA_ASSERT(sizeBytes <= staticAllocBytes());
 #endif
-            }
-            //-----------------------------------------------------------------------------
-            BlockSharedMemDynMember(BlockSharedMemDynMember const &) = delete;
-            //-----------------------------------------------------------------------------
-            BlockSharedMemDynMember(BlockSharedMemDynMember &&) = delete;
-            //-----------------------------------------------------------------------------
-            auto operator=(BlockSharedMemDynMember const &) -> BlockSharedMemDynMember & = delete;
-            //-----------------------------------------------------------------------------
-            auto operator=(BlockSharedMemDynMember &&) -> BlockSharedMemDynMember & = delete;
-            //-----------------------------------------------------------------------------
-            /*virtual*/ ~BlockSharedMemDynMember() = default;
+        }
+        //-----------------------------------------------------------------------------
+        BlockSharedMemDynMember(BlockSharedMemDynMember const &) = delete;
+        //-----------------------------------------------------------------------------
+        BlockSharedMemDynMember(BlockSharedMemDynMember &&) = delete;
+        //-----------------------------------------------------------------------------
+        auto operator=(BlockSharedMemDynMember const &) -> BlockSharedMemDynMember & = delete;
+        //-----------------------------------------------------------------------------
+        auto operator=(BlockSharedMemDynMember &&) -> BlockSharedMemDynMember & = delete;
+        //-----------------------------------------------------------------------------
+        /*virtual*/ ~BlockSharedMemDynMember() = default;
 
-            uint8_t* dynMemBegin() const {return m_mem.data();}
+        uint8_t* dynMemBegin() const {return m_mem.data();}
 
-            /*! \return the pointer to the begin of data after the portion allocated as dynamical shared memory.
-                */
-            uint8_t* staticMemBegin() const
-            {
-                return m_mem.data() + m_dynPitch;
-            }
+        /*! \return the pointer to the begin of data after the portion allocated as dynamical shared memory.
+            */
+        uint8_t* staticMemBegin() const
+        {
+            return m_mem.data() + m_dynPitch;
+        }
 
-            /*! \return the remaining capacity for static block shared memory.
-                */
-            std::size_t staticMemCapacity() const
-            {
-                return staticAllocBytes() - m_dynPitch;
-            }
+        /*! \return the remaining capacity for static block shared memory.
+            */
+        std::size_t staticMemCapacity() const
+        {
+            return staticAllocBytes() - m_dynPitch;
+        }
 
-            //! Storage size in bytes
-            static constexpr std::size_t staticAllocBytes() {return detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes;}
+        //! Storage size in bytes
+        static constexpr std::size_t staticAllocBytes() {return detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes;}
 
-        private:
+    private:
 
-            mutable std::array<uint8_t, detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes> m_mem;
-            std::size_t m_dynPitch;
-        };
+        mutable std::array<uint8_t, detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes> m_mem;
+        std::size_t m_dynPitch;
+    };
 #if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
 #pragma warning(pop)
 #endif
 
-        namespace traits
+    namespace traits
+    {
+        //#############################################################################
+        template<
+            typename T,
+            std::size_t TStaticAllocKiB>
+        struct GetMem<
+            T,
+            BlockSharedMemDynMember<TStaticAllocKiB>>
         {
-            //#############################################################################
-            template<
-                typename T,
-                std::size_t TStaticAllocKiB>
-            struct GetMem<
-                T,
-                BlockSharedMemDynMember<TStaticAllocKiB>>
-            {
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
 #endif
-                //-----------------------------------------------------------------------------
-                static auto getMem(
-                    block::BlockSharedMemDynMember<TStaticAllocKiB> const &mem)
-                -> T *
-                {
-                    static_assert(
-                        core::vectorization::defaultAlignment >= alignof(T),
-                        "Unable to get block shared dynamic memory for types with alignment higher than defaultAlignment!");
-                    return reinterpret_cast<T*>(mem.dynMemBegin());
-                }
+            //-----------------------------------------------------------------------------
+            static auto getMem(
+                BlockSharedMemDynMember<TStaticAllocKiB> const &mem)
+            -> T *
+            {
+                static_assert(
+                    core::vectorization::defaultAlignment >= alignof(T),
+                    "Unable to get block shared dynamic memory for types with alignment higher than defaultAlignment!");
+                return reinterpret_cast<T*>(mem.dynMemBegin());
+            }
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic pop
 #endif
-            };
-        }
+        };
     }
 }

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynUniformCudaHipBuiltIn.hpp
@@ -29,50 +29,47 @@ namespace alpaka
 {
     namespace block
     {
-        namespace dyn
+        //#############################################################################
+        //! The GPU CUDA/HIP block shared memory allocator.
+        class BlockSharedMemDynUniformCudaHipBuiltIn : public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynUniformCudaHipBuiltIn>
+        {
+        public:
+            //-----------------------------------------------------------------------------
+            BlockSharedMemDynUniformCudaHipBuiltIn() = default;
+            //-----------------------------------------------------------------------------
+            __device__ BlockSharedMemDynUniformCudaHipBuiltIn(BlockSharedMemDynUniformCudaHipBuiltIn const &) = delete;
+            //-----------------------------------------------------------------------------
+            __device__ BlockSharedMemDynUniformCudaHipBuiltIn(BlockSharedMemDynUniformCudaHipBuiltIn &&) = delete;
+            //-----------------------------------------------------------------------------
+            __device__ auto operator=(BlockSharedMemDynUniformCudaHipBuiltIn const &) -> BlockSharedMemDynUniformCudaHipBuiltIn & = delete;
+            //-----------------------------------------------------------------------------
+            __device__ auto operator=(BlockSharedMemDynUniformCudaHipBuiltIn &&) -> BlockSharedMemDynUniformCudaHipBuiltIn & = delete;
+            //-----------------------------------------------------------------------------
+            /*virtual*/ ~BlockSharedMemDynUniformCudaHipBuiltIn() = default;
+        };
+
+        namespace traits
         {
             //#############################################################################
-            //! The GPU CUDA/HIP block shared memory allocator.
-            class BlockSharedMemDynUniformCudaHipBuiltIn : public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynUniformCudaHipBuiltIn>
+            template<
+                typename T>
+            struct GetMem<
+                T,
+                BlockSharedMemDynUniformCudaHipBuiltIn>
             {
-            public:
                 //-----------------------------------------------------------------------------
-                BlockSharedMemDynUniformCudaHipBuiltIn() = default;
-                //-----------------------------------------------------------------------------
-                __device__ BlockSharedMemDynUniformCudaHipBuiltIn(BlockSharedMemDynUniformCudaHipBuiltIn const &) = delete;
-                //-----------------------------------------------------------------------------
-                __device__ BlockSharedMemDynUniformCudaHipBuiltIn(BlockSharedMemDynUniformCudaHipBuiltIn &&) = delete;
-                //-----------------------------------------------------------------------------
-                __device__ auto operator=(BlockSharedMemDynUniformCudaHipBuiltIn const &) -> BlockSharedMemDynUniformCudaHipBuiltIn & = delete;
-                //-----------------------------------------------------------------------------
-                __device__ auto operator=(BlockSharedMemDynUniformCudaHipBuiltIn &&) -> BlockSharedMemDynUniformCudaHipBuiltIn & = delete;
-                //-----------------------------------------------------------------------------
-                /*virtual*/ ~BlockSharedMemDynUniformCudaHipBuiltIn() = default;
-            };
-
-            namespace traits
-            {
-                //#############################################################################
-                template<
-                    typename T>
-                struct GetMem<
-                    T,
-                    BlockSharedMemDynUniformCudaHipBuiltIn>
+                __device__ static auto getMem(
+                    block::BlockSharedMemDynUniformCudaHipBuiltIn const &)
+                -> T *
                 {
-                    //-----------------------------------------------------------------------------
-                    __device__ static auto getMem(
-                        block::dyn::BlockSharedMemDynUniformCudaHipBuiltIn const &)
-                    -> T *
-                    {
-                        // Because unaligned access to variables is not allowed in device code,
-                        // we have to use the widest possible type to have all types aligned correctly.
-                        // See: http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#shared
-                        // http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#vector-types
-                        extern __shared__ float4 shMem[];
-                        return reinterpret_cast<T *>(shMem);
-                    }
-                };
-            }
+                    // Because unaligned access to variables is not allowed in device code,
+                    // we have to use the widest possible type to have all types aligned correctly.
+                    // See: http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#shared
+                    // http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#vector-types
+                    extern __shared__ float4 shMem[];
+                    return reinterpret_cast<T *>(shMem);
+                }
+            };
         }
     }
 }

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynUniformCudaHipBuiltIn.hpp
@@ -27,50 +27,47 @@
 
 namespace alpaka
 {
-    namespace block
+    //#############################################################################
+    //! The GPU CUDA/HIP block shared memory allocator.
+    class BlockSharedMemDynUniformCudaHipBuiltIn : public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynUniformCudaHipBuiltIn>
+    {
+    public:
+        //-----------------------------------------------------------------------------
+        BlockSharedMemDynUniformCudaHipBuiltIn() = default;
+        //-----------------------------------------------------------------------------
+        __device__ BlockSharedMemDynUniformCudaHipBuiltIn(BlockSharedMemDynUniformCudaHipBuiltIn const &) = delete;
+        //-----------------------------------------------------------------------------
+        __device__ BlockSharedMemDynUniformCudaHipBuiltIn(BlockSharedMemDynUniformCudaHipBuiltIn &&) = delete;
+        //-----------------------------------------------------------------------------
+        __device__ auto operator=(BlockSharedMemDynUniformCudaHipBuiltIn const &) -> BlockSharedMemDynUniformCudaHipBuiltIn & = delete;
+        //-----------------------------------------------------------------------------
+        __device__ auto operator=(BlockSharedMemDynUniformCudaHipBuiltIn &&) -> BlockSharedMemDynUniformCudaHipBuiltIn & = delete;
+        //-----------------------------------------------------------------------------
+        /*virtual*/ ~BlockSharedMemDynUniformCudaHipBuiltIn() = default;
+    };
+
+    namespace traits
     {
         //#############################################################################
-        //! The GPU CUDA/HIP block shared memory allocator.
-        class BlockSharedMemDynUniformCudaHipBuiltIn : public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynUniformCudaHipBuiltIn>
+        template<
+            typename T>
+        struct GetMem<
+            T,
+            BlockSharedMemDynUniformCudaHipBuiltIn>
         {
-        public:
             //-----------------------------------------------------------------------------
-            BlockSharedMemDynUniformCudaHipBuiltIn() = default;
-            //-----------------------------------------------------------------------------
-            __device__ BlockSharedMemDynUniformCudaHipBuiltIn(BlockSharedMemDynUniformCudaHipBuiltIn const &) = delete;
-            //-----------------------------------------------------------------------------
-            __device__ BlockSharedMemDynUniformCudaHipBuiltIn(BlockSharedMemDynUniformCudaHipBuiltIn &&) = delete;
-            //-----------------------------------------------------------------------------
-            __device__ auto operator=(BlockSharedMemDynUniformCudaHipBuiltIn const &) -> BlockSharedMemDynUniformCudaHipBuiltIn & = delete;
-            //-----------------------------------------------------------------------------
-            __device__ auto operator=(BlockSharedMemDynUniformCudaHipBuiltIn &&) -> BlockSharedMemDynUniformCudaHipBuiltIn & = delete;
-            //-----------------------------------------------------------------------------
-            /*virtual*/ ~BlockSharedMemDynUniformCudaHipBuiltIn() = default;
-        };
-
-        namespace traits
-        {
-            //#############################################################################
-            template<
-                typename T>
-            struct GetMem<
-                T,
-                BlockSharedMemDynUniformCudaHipBuiltIn>
+            __device__ static auto getMem(
+                BlockSharedMemDynUniformCudaHipBuiltIn const &)
+            -> T *
             {
-                //-----------------------------------------------------------------------------
-                __device__ static auto getMem(
-                    block::BlockSharedMemDynUniformCudaHipBuiltIn const &)
-                -> T *
-                {
-                    // Because unaligned access to variables is not allowed in device code,
-                    // we have to use the widest possible type to have all types aligned correctly.
-                    // See: http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#shared
-                    // http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#vector-types
-                    extern __shared__ float4 shMem[];
-                    return reinterpret_cast<T *>(shMem);
-                }
-            };
-        }
+                // Because unaligned access to variables is not allowed in device code,
+                // we have to use the widest possible type to have all types aligned correctly.
+                // See: http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#shared
+                // http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#vector-types
+                extern __shared__ float4 shMem[];
+                return reinterpret_cast<T *>(shMem);
+            }
+        };
     }
 }
 

--- a/include/alpaka/block/shared/dyn/Traits.hpp
+++ b/include/alpaka/block/shared/dyn/Traits.hpp
@@ -20,47 +20,42 @@ namespace alpaka
     //! The grid block specifics
     namespace block
     {
+        struct ConceptBlockSharedDyn{};
+
         //-----------------------------------------------------------------------------
-        //! The block shared dynamic memory operation specifics.
-        namespace dyn
+        //! The block shared dynamic memory operation traits.
+        namespace traits
         {
-            struct ConceptBlockSharedDyn{};
-
-            //-----------------------------------------------------------------------------
-            //! The block shared dynamic memory operation traits.
-            namespace traits
-            {
-                //#############################################################################
-                //! The block shared dynamic memory get trait.
-                template<
-                    typename T,
-                    typename TBlockSharedMemDyn,
-                    typename TSfinae = void>
-                struct GetMem;
-            }
-
-            //-----------------------------------------------------------------------------
-            //! Returns the pointr to the block shared dynamic memory.
-            //!
-            //! \tparam T The element type.
-            //! \tparam TBlockSharedMemDyn The block shared dynamic memory implementation type.
-            //! \param blockSharedMemDyn The block shared dynamic memory implementation.
-            ALPAKA_NO_HOST_ACC_WARNING
+            //#############################################################################
+            //! The block shared dynamic memory get trait.
             template<
                 typename T,
-                typename TBlockSharedMemDyn>
-            ALPAKA_FN_ACC auto getMem(
-                TBlockSharedMemDyn const & blockSharedMemDyn)
-            -> T *
-            {
-                using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedDyn, TBlockSharedMemDyn>;
-                return
-                    traits::GetMem<
-                        T,
-                        ImplementationBase>
-                    ::getMem(
-                        blockSharedMemDyn);
-            }
+                typename TBlockSharedMemDyn,
+                typename TSfinae = void>
+            struct GetMem;
+        }
+
+        //-----------------------------------------------------------------------------
+        //! Returns the pointr to the block shared dynamic memory.
+        //!
+        //! \tparam T The element type.
+        //! \tparam TBlockSharedMemDyn The block shared dynamic memory implementation type.
+        //! \param blockSharedMemDyn The block shared dynamic memory implementation.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T,
+            typename TBlockSharedMemDyn>
+        ALPAKA_FN_ACC auto getMem(
+            TBlockSharedMemDyn const & blockSharedMemDyn)
+        -> T *
+        {
+            using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedDyn, TBlockSharedMemDyn>;
+            return
+                traits::GetMem<
+                    T,
+                    ImplementationBase>
+                ::getMem(
+                    blockSharedMemDyn);
         }
     }
 }

--- a/include/alpaka/block/shared/dyn/Traits.hpp
+++ b/include/alpaka/block/shared/dyn/Traits.hpp
@@ -16,46 +16,41 @@
 
 namespace alpaka
 {
+    struct ConceptBlockSharedDyn{};
+
     //-----------------------------------------------------------------------------
-    //! The grid block specifics
-    namespace block
+    //! The block shared dynamic memory operation traits.
+    namespace traits
     {
-        struct ConceptBlockSharedDyn{};
-
-        //-----------------------------------------------------------------------------
-        //! The block shared dynamic memory operation traits.
-        namespace traits
-        {
-            //#############################################################################
-            //! The block shared dynamic memory get trait.
-            template<
-                typename T,
-                typename TBlockSharedMemDyn,
-                typename TSfinae = void>
-            struct GetMem;
-        }
-
-        //-----------------------------------------------------------------------------
-        //! Returns the pointr to the block shared dynamic memory.
-        //!
-        //! \tparam T The element type.
-        //! \tparam TBlockSharedMemDyn The block shared dynamic memory implementation type.
-        //! \param blockSharedMemDyn The block shared dynamic memory implementation.
-        ALPAKA_NO_HOST_ACC_WARNING
+        //#############################################################################
+        //! The block shared dynamic memory get trait.
         template<
             typename T,
-            typename TBlockSharedMemDyn>
-        ALPAKA_FN_ACC auto getMem(
-            TBlockSharedMemDyn const & blockSharedMemDyn)
-        -> T *
-        {
-            using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedDyn, TBlockSharedMemDyn>;
-            return
-                traits::GetMem<
-                    T,
-                    ImplementationBase>
-                ::getMem(
-                    blockSharedMemDyn);
-        }
+            typename TBlockSharedMemDyn,
+            typename TSfinae = void>
+        struct GetMem;
+    }
+
+    //-----------------------------------------------------------------------------
+    //! Returns the pointr to the block shared dynamic memory.
+    //!
+    //! \tparam T The element type.
+    //! \tparam TBlockSharedMemDyn The block shared dynamic memory implementation type.
+    //! \param blockSharedMemDyn The block shared dynamic memory implementation.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<
+        typename T,
+        typename TBlockSharedMemDyn>
+    ALPAKA_FN_ACC auto getMem(
+        TBlockSharedMemDyn const & blockSharedMemDyn)
+    -> T *
+    {
+        using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedDyn, TBlockSharedMemDyn>;
+        return
+            traits::GetMem<
+                T,
+                ImplementationBase>
+            ::getMem(
+                blockSharedMemDyn);
     }
 }

--- a/include/alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp
@@ -21,99 +21,96 @@
 
 namespace alpaka
 {
-    namespace block
+    //#############################################################################
+    //! The block shared memory allocator allocating memory with synchronization on the master thread.
+    class BlockSharedMemStMasterSync : public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStMasterSync>
     {
-        //#############################################################################
-        //! The block shared memory allocator allocating memory with synchronization on the master thread.
-        class BlockSharedMemStMasterSync : public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStMasterSync>
-        {
-        public:
-            //-----------------------------------------------------------------------------
-            BlockSharedMemStMasterSync(
-                std::function<void()> fnSync,
-                std::function<bool()> fnIsMasterThread) :
-                    m_syncFn(fnSync),
-                    m_isMasterThreadFn(fnIsMasterThread)
-            {}
-            //-----------------------------------------------------------------------------
-            BlockSharedMemStMasterSync(BlockSharedMemStMasterSync const &) = delete;
-            //-----------------------------------------------------------------------------
-            BlockSharedMemStMasterSync(BlockSharedMemStMasterSync &&) = delete;
-            //-----------------------------------------------------------------------------
-            auto operator=(BlockSharedMemStMasterSync const &) -> BlockSharedMemStMasterSync & = delete;
-            //-----------------------------------------------------------------------------
-            auto operator=(BlockSharedMemStMasterSync &&) -> BlockSharedMemStMasterSync & = delete;
-            //-----------------------------------------------------------------------------
-            /*virtual*/ ~BlockSharedMemStMasterSync() = default;
+    public:
+        //-----------------------------------------------------------------------------
+        BlockSharedMemStMasterSync(
+            std::function<void()> fnSync,
+            std::function<bool()> fnIsMasterThread) :
+                m_syncFn(fnSync),
+                m_isMasterThreadFn(fnIsMasterThread)
+        {}
+        //-----------------------------------------------------------------------------
+        BlockSharedMemStMasterSync(BlockSharedMemStMasterSync const &) = delete;
+        //-----------------------------------------------------------------------------
+        BlockSharedMemStMasterSync(BlockSharedMemStMasterSync &&) = delete;
+        //-----------------------------------------------------------------------------
+        auto operator=(BlockSharedMemStMasterSync const &) -> BlockSharedMemStMasterSync & = delete;
+        //-----------------------------------------------------------------------------
+        auto operator=(BlockSharedMemStMasterSync &&) -> BlockSharedMemStMasterSync & = delete;
+        //-----------------------------------------------------------------------------
+        /*virtual*/ ~BlockSharedMemStMasterSync() = default;
 
-        public:
-            // TODO: We should add the size of the (current) allocation.
-            // This would allow to assert that all parallel function calls request to allocate the same size.
-            std::vector<
-                std::unique_ptr<
-                    uint8_t,
-                    core::AlignedDelete>> mutable
-                m_sharedAllocs;
+    public:
+        // TODO: We should add the size of the (current) allocation.
+        // This would allow to assert that all parallel function calls request to allocate the same size.
+        std::vector<
+            std::unique_ptr<
+                uint8_t,
+                core::AlignedDelete>> mutable
+            m_sharedAllocs;
 
-            std::function<void()> m_syncFn;
-            std::function<bool()> m_isMasterThreadFn;
-        };
+        std::function<void()> m_syncFn;
+        std::function<bool()> m_isMasterThreadFn;
+    };
 
-        namespace traits
-        {
+    namespace traits
+    {
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
 #endif
-            //#############################################################################
-            template<
-                typename T,
-                std::size_t TuniqueId>
-            struct AllocVar<
-                T,
-                TuniqueId,
-                BlockSharedMemStMasterSync>
+        //#############################################################################
+        template<
+            typename T,
+            std::size_t TuniqueId>
+        struct AllocVar<
+            T,
+            TuniqueId,
+            BlockSharedMemStMasterSync>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto allocVar(
+                BlockSharedMemStMasterSync const & blockSharedMemSt)
+            -> T &
             {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto allocVar(
-                    block::BlockSharedMemStMasterSync const & blockSharedMemSt)
-                -> T &
+                constexpr std::size_t alignmentInBytes = std::max(core::vectorization::defaultAlignment, alignof(T));
+
+                // Assure that all threads have executed the return of the last allocBlockSharedArr function (if there was one before).
+                blockSharedMemSt.m_syncFn();
+
+                if(blockSharedMemSt.m_isMasterThreadFn())
                 {
-                    constexpr std::size_t alignmentInBytes = std::max(core::vectorization::defaultAlignment, alignof(T));
-
-                    // Assure that all threads have executed the return of the last allocBlockSharedArr function (if there was one before).
-                    blockSharedMemSt.m_syncFn();
-
-                    if(blockSharedMemSt.m_isMasterThreadFn())
-                    {
-                        blockSharedMemSt.m_sharedAllocs.emplace_back(
-                            reinterpret_cast<uint8_t *>(
-                                core::alignedAlloc(alignmentInBytes, sizeof(T))));
-                    }
-                    blockSharedMemSt.m_syncFn();
-
-                    return
-                        std::ref(
-                            *reinterpret_cast<T*>(
-                                blockSharedMemSt.m_sharedAllocs.back().get()));
+                    blockSharedMemSt.m_sharedAllocs.emplace_back(
+                        reinterpret_cast<uint8_t *>(
+                            core::alignedAlloc(alignmentInBytes, sizeof(T))));
                 }
-            };
+                blockSharedMemSt.m_syncFn();
+
+                return
+                    std::ref(
+                        *reinterpret_cast<T*>(
+                            blockSharedMemSt.m_sharedAllocs.back().get()));
+            }
+        };
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic pop
 #endif
-            //#############################################################################
-            template<>
-            struct FreeMem<
-                BlockSharedMemStMasterSync>
+        //#############################################################################
+        template<>
+        struct FreeMem<
+            BlockSharedMemStMasterSync>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_HOST static auto freeMem(
+                BlockSharedMemStMasterSync const & blockSharedMemSt)
+            -> void
             {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto freeMem(
-                    block::BlockSharedMemStMasterSync const & blockSharedMemSt)
-                -> void
-                {
-                    blockSharedMemSt.m_sharedAllocs.clear();
-                }
-            };
-        }
+                blockSharedMemSt.m_sharedAllocs.clear();
+            }
+        };
     }
 }

--- a/include/alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp
@@ -23,100 +23,97 @@ namespace alpaka
 {
     namespace block
     {
-        namespace st
+        //#############################################################################
+        //! The block shared memory allocator allocating memory with synchronization on the master thread.
+        class BlockSharedMemStMasterSync : public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStMasterSync>
         {
-            //#############################################################################
-            //! The block shared memory allocator allocating memory with synchronization on the master thread.
-            class BlockSharedMemStMasterSync : public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStMasterSync>
-            {
-            public:
-                //-----------------------------------------------------------------------------
-                BlockSharedMemStMasterSync(
-                    std::function<void()> fnSync,
-                    std::function<bool()> fnIsMasterThread) :
-                        m_syncFn(fnSync),
-                        m_isMasterThreadFn(fnIsMasterThread)
-                {}
-                //-----------------------------------------------------------------------------
-                BlockSharedMemStMasterSync(BlockSharedMemStMasterSync const &) = delete;
-                //-----------------------------------------------------------------------------
-                BlockSharedMemStMasterSync(BlockSharedMemStMasterSync &&) = delete;
-                //-----------------------------------------------------------------------------
-                auto operator=(BlockSharedMemStMasterSync const &) -> BlockSharedMemStMasterSync & = delete;
-                //-----------------------------------------------------------------------------
-                auto operator=(BlockSharedMemStMasterSync &&) -> BlockSharedMemStMasterSync & = delete;
-                //-----------------------------------------------------------------------------
-                /*virtual*/ ~BlockSharedMemStMasterSync() = default;
+        public:
+            //-----------------------------------------------------------------------------
+            BlockSharedMemStMasterSync(
+                std::function<void()> fnSync,
+                std::function<bool()> fnIsMasterThread) :
+                    m_syncFn(fnSync),
+                    m_isMasterThreadFn(fnIsMasterThread)
+            {}
+            //-----------------------------------------------------------------------------
+            BlockSharedMemStMasterSync(BlockSharedMemStMasterSync const &) = delete;
+            //-----------------------------------------------------------------------------
+            BlockSharedMemStMasterSync(BlockSharedMemStMasterSync &&) = delete;
+            //-----------------------------------------------------------------------------
+            auto operator=(BlockSharedMemStMasterSync const &) -> BlockSharedMemStMasterSync & = delete;
+            //-----------------------------------------------------------------------------
+            auto operator=(BlockSharedMemStMasterSync &&) -> BlockSharedMemStMasterSync & = delete;
+            //-----------------------------------------------------------------------------
+            /*virtual*/ ~BlockSharedMemStMasterSync() = default;
 
-            public:
-                // TODO: We should add the size of the (current) allocation.
-                // This would allow to assert that all parallel function calls request to allocate the same size.
-                std::vector<
-                    std::unique_ptr<
-                        uint8_t,
-                        core::AlignedDelete>> mutable
-                    m_sharedAllocs;
+        public:
+            // TODO: We should add the size of the (current) allocation.
+            // This would allow to assert that all parallel function calls request to allocate the same size.
+            std::vector<
+                std::unique_ptr<
+                    uint8_t,
+                    core::AlignedDelete>> mutable
+                m_sharedAllocs;
 
-                std::function<void()> m_syncFn;
-                std::function<bool()> m_isMasterThreadFn;
-            };
+            std::function<void()> m_syncFn;
+            std::function<bool()> m_isMasterThreadFn;
+        };
 
-            namespace traits
-            {
+        namespace traits
+        {
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
 #endif
-                //#############################################################################
-                template<
-                    typename T,
-                    std::size_t TuniqueId>
-                struct AllocVar<
-                    T,
-                    TuniqueId,
-                    BlockSharedMemStMasterSync>
+            //#############################################################################
+            template<
+                typename T,
+                std::size_t TuniqueId>
+            struct AllocVar<
+                T,
+                TuniqueId,
+                BlockSharedMemStMasterSync>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto allocVar(
+                    block::BlockSharedMemStMasterSync const & blockSharedMemSt)
+                -> T &
                 {
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto allocVar(
-                        block::st::BlockSharedMemStMasterSync const & blockSharedMemSt)
-                    -> T &
+                    constexpr std::size_t alignmentInBytes = std::max(core::vectorization::defaultAlignment, alignof(T));
+
+                    // Assure that all threads have executed the return of the last allocBlockSharedArr function (if there was one before).
+                    blockSharedMemSt.m_syncFn();
+
+                    if(blockSharedMemSt.m_isMasterThreadFn())
                     {
-                        constexpr std::size_t alignmentInBytes = std::max(core::vectorization::defaultAlignment, alignof(T));
-
-                        // Assure that all threads have executed the return of the last allocBlockSharedArr function (if there was one before).
-                        blockSharedMemSt.m_syncFn();
-
-                        if(blockSharedMemSt.m_isMasterThreadFn())
-                        {
-                            blockSharedMemSt.m_sharedAllocs.emplace_back(
-                                reinterpret_cast<uint8_t *>(
-                                    core::alignedAlloc(alignmentInBytes, sizeof(T))));
-                        }
-                        blockSharedMemSt.m_syncFn();
-
-                        return
-                            std::ref(
-                                *reinterpret_cast<T*>(
-                                    blockSharedMemSt.m_sharedAllocs.back().get()));
+                        blockSharedMemSt.m_sharedAllocs.emplace_back(
+                            reinterpret_cast<uint8_t *>(
+                                core::alignedAlloc(alignmentInBytes, sizeof(T))));
                     }
-                };
+                    blockSharedMemSt.m_syncFn();
+
+                    return
+                        std::ref(
+                            *reinterpret_cast<T*>(
+                                blockSharedMemSt.m_sharedAllocs.back().get()));
+                }
+            };
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic pop
 #endif
-                //#############################################################################
-                template<>
-                struct FreeMem<
-                    BlockSharedMemStMasterSync>
+            //#############################################################################
+            template<>
+            struct FreeMem<
+                BlockSharedMemStMasterSync>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto freeMem(
+                    block::BlockSharedMemStMasterSync const & blockSharedMemSt)
+                -> void
                 {
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto freeMem(
-                        block::st::BlockSharedMemStMasterSync const & blockSharedMemSt)
-                    -> void
-                    {
-                        blockSharedMemSt.m_sharedAllocs.clear();
-                    }
-                };
-            }
+                    blockSharedMemSt.m_sharedAllocs.clear();
+                }
+            };
         }
     }
 }

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -21,133 +21,130 @@ namespace alpaka
 {
     namespace block
     {
-        namespace st
+        namespace detail
         {
-            namespace detail
+            //#############################################################################
+            //! Implementation of static block shared memory provider.
+            template<std::size_t TDataAlignBytes = core::vectorization::defaultAlignment>
+            class BlockSharedMemStMemberImpl
             {
-                //#############################################################################
-                //! Implementation of static block shared memory provider.
-                template<std::size_t TDataAlignBytes = core::vectorization::defaultAlignment>
-                class BlockSharedMemStMemberImpl
-                {
-                public:
-                    //-----------------------------------------------------------------------------
+            public:
+                //-----------------------------------------------------------------------------
 #ifndef NDEBUG
-                    BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t capacity) : m_mem(mem), m_capacity(capacity)
-                    {
+                BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t capacity) : m_mem(mem), m_capacity(capacity)
+                {
 #ifdef ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST
-                        ALPAKA_ASSERT( ( m_mem == nullptr ) == ( m_capacity == 0u ) );
+                    ALPAKA_ASSERT( ( m_mem == nullptr ) == ( m_capacity == 0u ) );
 #endif
-                    }
+                }
 #else
-                    BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t) : m_mem(mem) {}
+                BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t) : m_mem(mem) {}
 #endif
-                    //-----------------------------------------------------------------------------
-                    BlockSharedMemStMemberImpl(BlockSharedMemStMemberImpl const &) = delete;
-                    //-----------------------------------------------------------------------------
-                    BlockSharedMemStMemberImpl(BlockSharedMemStMemberImpl &&) = delete;
-                    //-----------------------------------------------------------------------------
-                    auto operator=(BlockSharedMemStMemberImpl const &) -> BlockSharedMemStMemberImpl & = delete;
-                    //-----------------------------------------------------------------------------
-                    auto operator=(BlockSharedMemStMemberImpl &&) -> BlockSharedMemStMemberImpl & = delete;
-                    //-----------------------------------------------------------------------------
-                    /*virtual*/ ~BlockSharedMemStMemberImpl() = default;
+                //-----------------------------------------------------------------------------
+                BlockSharedMemStMemberImpl(BlockSharedMemStMemberImpl const &) = delete;
+                //-----------------------------------------------------------------------------
+                BlockSharedMemStMemberImpl(BlockSharedMemStMemberImpl &&) = delete;
+                //-----------------------------------------------------------------------------
+                auto operator=(BlockSharedMemStMemberImpl const &) -> BlockSharedMemStMemberImpl & = delete;
+                //-----------------------------------------------------------------------------
+                auto operator=(BlockSharedMemStMemberImpl &&) -> BlockSharedMemStMemberImpl & = delete;
+                //-----------------------------------------------------------------------------
+                /*virtual*/ ~BlockSharedMemStMemberImpl() = default;
 
-                    template <typename T>
-                    void alloc() const
-                    {
-                        m_allocdBytes = allocPitch<T>();
-                        m_allocdBytes += sizeof(T);
+                template <typename T>
+                void alloc() const
+                {
+                    m_allocdBytes = allocPitch<T>();
+                    m_allocdBytes += sizeof(T);
 #if (defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (! defined NDEBUG)
-                        ALPAKA_ASSERT(m_allocdBytes <= m_capacity);
+                    ALPAKA_ASSERT(m_allocdBytes <= m_capacity);
 #endif
-                    }
+                }
 
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
 #endif
-                    template <typename T>
-                    T& getLatestVar() const
-                    {
-                        return *reinterpret_cast<T*>(&m_mem[m_allocdBytes-sizeof(T)]);
-                    }
+                template <typename T>
+                T& getLatestVar() const
+                {
+                    return *reinterpret_cast<T*>(&m_mem[m_allocdBytes-sizeof(T)]);
+                }
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic pop
 #endif
 
-                    void free() const
-                    {
-                        m_allocdBytes = 0u;
-                    }
+                void free() const
+                {
+                    m_allocdBytes = 0u;
+                }
 
-                private:
-                    mutable std::size_t m_allocdBytes = 0;
-                    mutable uint8_t* m_mem;
+            private:
+                mutable std::size_t m_allocdBytes = 0;
+                mutable uint8_t* m_mem;
 #ifndef NDEBUG
-                    const std::size_t m_capacity;
+                const std::size_t m_capacity;
 #endif
 
-                    template<typename T>
-                    std::size_t allocPitch() const
-                    {
-                        static_assert(
-                            core::vectorization::defaultAlignment >= alignof(T),
-                            "Unable to get block shared static memory for types with alignment higher than defaultAlignment!");
-                        constexpr std::size_t align = std::max(TDataAlignBytes, alignof(T));
-                        return (m_allocdBytes/align + (m_allocdBytes%align>0))*align;
-                    }
-                };
-            }
-            //#############################################################################
-            //! Static block shared memory provider using a pointer to
-            //! externally allocated fixed-size memory, likely provided by
-            //! BlockSharedMemDynMember.
-            template<std::size_t TDataAlignBytes = core::vectorization::defaultAlignment>
-            class BlockSharedMemStMember :
-                public detail::BlockSharedMemStMemberImpl<TDataAlignBytes>,
-                public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStMember<TDataAlignBytes>>
-            {
-            public:
-                using detail::BlockSharedMemStMemberImpl<TDataAlignBytes>::BlockSharedMemStMemberImpl;
+                template<typename T>
+                std::size_t allocPitch() const
+                {
+                    static_assert(
+                        core::vectorization::defaultAlignment >= alignof(T),
+                        "Unable to get block shared static memory for types with alignment higher than defaultAlignment!");
+                    constexpr std::size_t align = std::max(TDataAlignBytes, alignof(T));
+                    return (m_allocdBytes/align + (m_allocdBytes%align>0))*align;
+                }
             };
+        }
+        //#############################################################################
+        //! Static block shared memory provider using a pointer to
+        //! externally allocated fixed-size memory, likely provided by
+        //! BlockSharedMemDynMember.
+        template<std::size_t TDataAlignBytes = core::vectorization::defaultAlignment>
+        class BlockSharedMemStMember :
+            public detail::BlockSharedMemStMemberImpl<TDataAlignBytes>,
+            public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStMember<TDataAlignBytes>>
+        {
+        public:
+            using detail::BlockSharedMemStMemberImpl<TDataAlignBytes>::BlockSharedMemStMemberImpl;
+        };
 
-            namespace traits
+        namespace traits
+        {
+            //#############################################################################
+            template<
+                typename T,
+                std::size_t TDataAlignBytes,
+                std::size_t TuniqueId>
+            struct AllocVar<
+                T,
+                TuniqueId,
+                BlockSharedMemStMember<TDataAlignBytes>>
             {
-                //#############################################################################
-                template<
-                    typename T,
-                    std::size_t TDataAlignBytes,
-                    std::size_t TuniqueId>
-                struct AllocVar<
-                    T,
-                    TuniqueId,
-                    BlockSharedMemStMember<TDataAlignBytes>>
+                //-----------------------------------------------------------------------------
+                static auto allocVar(
+                    block::BlockSharedMemStMember<TDataAlignBytes> const &smem)
+                -> T &
                 {
-                    //-----------------------------------------------------------------------------
-                    static auto allocVar(
-                        block::st::BlockSharedMemStMember<TDataAlignBytes> const &smem)
-                    -> T &
-                    {
-                        smem.template alloc<T>();
-                        return smem.template getLatestVar<T>();
-                    }
-                };
-                //#############################################################################
-                template<
-                    std::size_t TDataAlignBytes>
-                struct FreeMem<
-                    BlockSharedMemStMember<TDataAlignBytes>>
+                    smem.template alloc<T>();
+                    return smem.template getLatestVar<T>();
+                }
+            };
+            //#############################################################################
+            template<
+                std::size_t TDataAlignBytes>
+            struct FreeMem<
+                BlockSharedMemStMember<TDataAlignBytes>>
+            {
+                //-----------------------------------------------------------------------------
+                static auto freeMem(
+                    block::BlockSharedMemStMember<TDataAlignBytes> const &mem)
+                -> void
                 {
-                    //-----------------------------------------------------------------------------
-                    static auto freeMem(
-                        block::st::BlockSharedMemStMember<TDataAlignBytes> const &mem)
-                    -> void
-                    {
-                        mem.free();
-                    }
-                };
-            }
+                    mem.free();
+                }
+            };
         }
     }
 }

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -19,132 +19,129 @@
 
 namespace alpaka
 {
-    namespace block
+    namespace detail
     {
-        namespace detail
+        //#############################################################################
+        //! Implementation of static block shared memory provider.
+        template<std::size_t TDataAlignBytes = core::vectorization::defaultAlignment>
+        class BlockSharedMemStMemberImpl
         {
-            //#############################################################################
-            //! Implementation of static block shared memory provider.
-            template<std::size_t TDataAlignBytes = core::vectorization::defaultAlignment>
-            class BlockSharedMemStMemberImpl
-            {
-            public:
-                //-----------------------------------------------------------------------------
+        public:
+            //-----------------------------------------------------------------------------
 #ifndef NDEBUG
-                BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t capacity) : m_mem(mem), m_capacity(capacity)
-                {
+            BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t capacity) : m_mem(mem), m_capacity(capacity)
+            {
 #ifdef ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST
-                    ALPAKA_ASSERT( ( m_mem == nullptr ) == ( m_capacity == 0u ) );
+                ALPAKA_ASSERT( ( m_mem == nullptr ) == ( m_capacity == 0u ) );
 #endif
-                }
+            }
 #else
-                BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t) : m_mem(mem) {}
+            BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t) : m_mem(mem) {}
 #endif
-                //-----------------------------------------------------------------------------
-                BlockSharedMemStMemberImpl(BlockSharedMemStMemberImpl const &) = delete;
-                //-----------------------------------------------------------------------------
-                BlockSharedMemStMemberImpl(BlockSharedMemStMemberImpl &&) = delete;
-                //-----------------------------------------------------------------------------
-                auto operator=(BlockSharedMemStMemberImpl const &) -> BlockSharedMemStMemberImpl & = delete;
-                //-----------------------------------------------------------------------------
-                auto operator=(BlockSharedMemStMemberImpl &&) -> BlockSharedMemStMemberImpl & = delete;
-                //-----------------------------------------------------------------------------
-                /*virtual*/ ~BlockSharedMemStMemberImpl() = default;
+            //-----------------------------------------------------------------------------
+            BlockSharedMemStMemberImpl(BlockSharedMemStMemberImpl const &) = delete;
+            //-----------------------------------------------------------------------------
+            BlockSharedMemStMemberImpl(BlockSharedMemStMemberImpl &&) = delete;
+            //-----------------------------------------------------------------------------
+            auto operator=(BlockSharedMemStMemberImpl const &) -> BlockSharedMemStMemberImpl & = delete;
+            //-----------------------------------------------------------------------------
+            auto operator=(BlockSharedMemStMemberImpl &&) -> BlockSharedMemStMemberImpl & = delete;
+            //-----------------------------------------------------------------------------
+            /*virtual*/ ~BlockSharedMemStMemberImpl() = default;
 
-                template <typename T>
-                void alloc() const
-                {
-                    m_allocdBytes = allocPitch<T>();
-                    m_allocdBytes += sizeof(T);
+            template <typename T>
+            void alloc() const
+            {
+                m_allocdBytes = allocPitch<T>();
+                m_allocdBytes += sizeof(T);
 #if (defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (! defined NDEBUG)
-                    ALPAKA_ASSERT(m_allocdBytes <= m_capacity);
+                ALPAKA_ASSERT(m_allocdBytes <= m_capacity);
 #endif
-                }
+            }
 
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
 #endif
-                template <typename T>
-                T& getLatestVar() const
-                {
-                    return *reinterpret_cast<T*>(&m_mem[m_allocdBytes-sizeof(T)]);
-                }
+            template <typename T>
+            T& getLatestVar() const
+            {
+                return *reinterpret_cast<T*>(&m_mem[m_allocdBytes-sizeof(T)]);
+            }
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic pop
 #endif
 
-                void free() const
-                {
-                    m_allocdBytes = 0u;
-                }
+            void free() const
+            {
+                m_allocdBytes = 0u;
+            }
 
-            private:
-                mutable std::size_t m_allocdBytes = 0;
-                mutable uint8_t* m_mem;
+        private:
+            mutable std::size_t m_allocdBytes = 0;
+            mutable uint8_t* m_mem;
 #ifndef NDEBUG
-                const std::size_t m_capacity;
+            const std::size_t m_capacity;
 #endif
 
-                template<typename T>
-                std::size_t allocPitch() const
-                {
-                    static_assert(
-                        core::vectorization::defaultAlignment >= alignof(T),
-                        "Unable to get block shared static memory for types with alignment higher than defaultAlignment!");
-                    constexpr std::size_t align = std::max(TDataAlignBytes, alignof(T));
-                    return (m_allocdBytes/align + (m_allocdBytes%align>0))*align;
-                }
-            };
-        }
-        //#############################################################################
-        //! Static block shared memory provider using a pointer to
-        //! externally allocated fixed-size memory, likely provided by
-        //! BlockSharedMemDynMember.
-        template<std::size_t TDataAlignBytes = core::vectorization::defaultAlignment>
-        class BlockSharedMemStMember :
-            public detail::BlockSharedMemStMemberImpl<TDataAlignBytes>,
-            public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStMember<TDataAlignBytes>>
-        {
-        public:
-            using detail::BlockSharedMemStMemberImpl<TDataAlignBytes>::BlockSharedMemStMemberImpl;
+            template<typename T>
+            std::size_t allocPitch() const
+            {
+                static_assert(
+                    core::vectorization::defaultAlignment >= alignof(T),
+                    "Unable to get block shared static memory for types with alignment higher than defaultAlignment!");
+                constexpr std::size_t align = std::max(TDataAlignBytes, alignof(T));
+                return (m_allocdBytes/align + (m_allocdBytes%align>0))*align;
+            }
         };
+    }
+    //#############################################################################
+    //! Static block shared memory provider using a pointer to
+    //! externally allocated fixed-size memory, likely provided by
+    //! BlockSharedMemDynMember.
+    template<std::size_t TDataAlignBytes = core::vectorization::defaultAlignment>
+    class BlockSharedMemStMember :
+        public detail::BlockSharedMemStMemberImpl<TDataAlignBytes>,
+        public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStMember<TDataAlignBytes>>
+    {
+    public:
+        using detail::BlockSharedMemStMemberImpl<TDataAlignBytes>::BlockSharedMemStMemberImpl;
+    };
 
-        namespace traits
+    namespace traits
+    {
+        //#############################################################################
+        template<
+            typename T,
+            std::size_t TDataAlignBytes,
+            std::size_t TuniqueId>
+        struct AllocVar<
+            T,
+            TuniqueId,
+            BlockSharedMemStMember<TDataAlignBytes>>
         {
-            //#############################################################################
-            template<
-                typename T,
-                std::size_t TDataAlignBytes,
-                std::size_t TuniqueId>
-            struct AllocVar<
-                T,
-                TuniqueId,
-                BlockSharedMemStMember<TDataAlignBytes>>
+            //-----------------------------------------------------------------------------
+            static auto allocVar(
+                BlockSharedMemStMember<TDataAlignBytes> const &smem)
+            -> T &
             {
-                //-----------------------------------------------------------------------------
-                static auto allocVar(
-                    block::BlockSharedMemStMember<TDataAlignBytes> const &smem)
-                -> T &
-                {
-                    smem.template alloc<T>();
-                    return smem.template getLatestVar<T>();
-                }
-            };
-            //#############################################################################
-            template<
-                std::size_t TDataAlignBytes>
-            struct FreeMem<
-                BlockSharedMemStMember<TDataAlignBytes>>
+                smem.template alloc<T>();
+                return smem.template getLatestVar<T>();
+            }
+        };
+        //#############################################################################
+        template<
+            std::size_t TDataAlignBytes>
+        struct FreeMem<
+            BlockSharedMemStMember<TDataAlignBytes>>
+        {
+            //-----------------------------------------------------------------------------
+            static auto freeMem(
+                BlockSharedMemStMember<TDataAlignBytes> const &mem)
+            -> void
             {
-                //-----------------------------------------------------------------------------
-                static auto freeMem(
-                    block::BlockSharedMemStMember<TDataAlignBytes> const &mem)
-                -> void
-                {
-                    mem.free();
-                }
-            };
-        }
+                mem.free();
+            }
+        };
     }
 }

--- a/include/alpaka/block/shared/st/BlockSharedMemStNoSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStNoSync.hpp
@@ -22,84 +22,81 @@ namespace alpaka
 {
     namespace block
     {
-        namespace st
+        //#############################################################################
+        //! The block shared memory allocator without synchronization.
+        class BlockSharedMemStNoSync : public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStNoSync>
         {
-            //#############################################################################
-            //! The block shared memory allocator without synchronization.
-            class BlockSharedMemStNoSync : public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStNoSync>
-            {
-            public:
-                //-----------------------------------------------------------------------------
-                BlockSharedMemStNoSync() = default;
-                //-----------------------------------------------------------------------------
-                BlockSharedMemStNoSync(BlockSharedMemStNoSync const &) = delete;
-                //-----------------------------------------------------------------------------
-                BlockSharedMemStNoSync(BlockSharedMemStNoSync &&) = delete;
-                //-----------------------------------------------------------------------------
-                auto operator=(BlockSharedMemStNoSync const &) -> BlockSharedMemStNoSync & = delete;
-                //-----------------------------------------------------------------------------
-                auto operator=(BlockSharedMemStNoSync &&) -> BlockSharedMemStNoSync & = delete;
-                //-----------------------------------------------------------------------------
-                /*virtual*/ ~BlockSharedMemStNoSync() = default;
+        public:
+            //-----------------------------------------------------------------------------
+            BlockSharedMemStNoSync() = default;
+            //-----------------------------------------------------------------------------
+            BlockSharedMemStNoSync(BlockSharedMemStNoSync const &) = delete;
+            //-----------------------------------------------------------------------------
+            BlockSharedMemStNoSync(BlockSharedMemStNoSync &&) = delete;
+            //-----------------------------------------------------------------------------
+            auto operator=(BlockSharedMemStNoSync const &) -> BlockSharedMemStNoSync & = delete;
+            //-----------------------------------------------------------------------------
+            auto operator=(BlockSharedMemStNoSync &&) -> BlockSharedMemStNoSync & = delete;
+            //-----------------------------------------------------------------------------
+            /*virtual*/ ~BlockSharedMemStNoSync() = default;
 
-            public:
-                // TODO: We should add the size of the (current) allocation.
-                // This would allow to assert that all parallel function calls request to allocate the same size.
-                std::vector<
-                    std::unique_ptr<
-                        uint8_t,
-                        core::AlignedDelete>> mutable
-                    m_sharedAllocs;
-            };
+        public:
+            // TODO: We should add the size of the (current) allocation.
+            // This would allow to assert that all parallel function calls request to allocate the same size.
+            std::vector<
+                std::unique_ptr<
+                    uint8_t,
+                    core::AlignedDelete>> mutable
+                m_sharedAllocs;
+        };
 
-            namespace traits
-            {
+        namespace traits
+        {
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
 #endif
-                //#############################################################################
-                template<
-                    typename T,
-                    std::size_t TuniqueId>
-                struct AllocVar<
-                    T,
-                    TuniqueId,
-                    BlockSharedMemStNoSync>
+            //#############################################################################
+            template<
+                typename T,
+                std::size_t TuniqueId>
+            struct AllocVar<
+                T,
+                TuniqueId,
+                BlockSharedMemStNoSync>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto allocVar(
+                    block::BlockSharedMemStNoSync const & blockSharedMemSt)
+                -> T &
                 {
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto allocVar(
-                        block::st::BlockSharedMemStNoSync const & blockSharedMemSt)
-                    -> T &
-                    {
-                        constexpr std::size_t alignmentInBytes = std::max(core::vectorization::defaultAlignment, alignof(T));
+                    constexpr std::size_t alignmentInBytes = std::max(core::vectorization::defaultAlignment, alignof(T));
 
-                        blockSharedMemSt.m_sharedAllocs.emplace_back(
-                            reinterpret_cast<uint8_t *>(
-                                core::alignedAlloc(alignmentInBytes, sizeof(T))));
-                        return
-                            std::ref(
-                                *reinterpret_cast<T*>(
-                                    blockSharedMemSt.m_sharedAllocs.back().get()));
-                    }
-                };
+                    blockSharedMemSt.m_sharedAllocs.emplace_back(
+                        reinterpret_cast<uint8_t *>(
+                            core::alignedAlloc(alignmentInBytes, sizeof(T))));
+                    return
+                        std::ref(
+                            *reinterpret_cast<T*>(
+                                blockSharedMemSt.m_sharedAllocs.back().get()));
+                }
+            };
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic pop
 #endif
-                //#############################################################################
-                template<>
-                struct FreeMem<
-                    BlockSharedMemStNoSync>
+            //#############################################################################
+            template<>
+            struct FreeMem<
+                BlockSharedMemStNoSync>
+            {
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto freeMem(
+                    block::BlockSharedMemStNoSync const & blockSharedMemSt)
+                -> void
                 {
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto freeMem(
-                        block::st::BlockSharedMemStNoSync const & blockSharedMemSt)
-                    -> void
-                    {
-                        blockSharedMemSt.m_sharedAllocs.clear();
-                    }
-                };
-            }
+                    blockSharedMemSt.m_sharedAllocs.clear();
+                }
+            };
         }
     }
 }

--- a/include/alpaka/block/shared/st/BlockSharedMemStOmp5.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStOmp5.hpp
@@ -26,54 +26,51 @@ namespace alpaka
 {
     namespace block
     {
-        namespace st
+        //#############################################################################
+        //! The OpenMP 5 block shared memory allocator.
+        class BlockSharedMemStOmp5 :
+            public detail::BlockSharedMemStMemberImpl<4>,
+            public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStOmp5>
+        {
+        public:
+            using BlockSharedMemStMemberImpl<4>::BlockSharedMemStMemberImpl;
+        };
+
+        namespace traits
         {
             //#############################################################################
-            //! The OpenMP 5 block shared memory allocator.
-            class BlockSharedMemStOmp5 :
-                public detail::BlockSharedMemStMemberImpl<4>,
-                public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStOmp5>
+            template<
+                typename T,
+                std::size_t TuniqueId>
+            struct AllocVar<
+                T,
+                TuniqueId,
+                BlockSharedMemStOmp5>
             {
-            public:
-                using BlockSharedMemStMemberImpl<4>::BlockSharedMemStMemberImpl;
+                //-----------------------------------------------------------------------------
+                static auto allocVar(
+                    block::BlockSharedMemStOmp5 const &smem)
+                -> T &
+                {
+                    #pragma omp barrier
+                    smem.alloc<T>();
+                    #pragma omp barrier
+                    return smem.getLatestVar<T>();
+                }
             };
-
-            namespace traits
+            //#############################################################################
+            template<>
+            struct FreeMem<
+                BlockSharedMemStOmp5>
             {
-                //#############################################################################
-                template<
-                    typename T,
-                    std::size_t TuniqueId>
-                struct AllocVar<
-                    T,
-                    TuniqueId,
-                    BlockSharedMemStOmp5>
+                //-----------------------------------------------------------------------------
+                static auto freeMem(
+                    block::BlockSharedMemStOmp5 const &mem)
+                -> void
                 {
-                    //-----------------------------------------------------------------------------
-                    static auto allocVar(
-                        block::st::BlockSharedMemStOmp5 const &smem)
-                    -> T &
-                    {
-                        #pragma omp barrier
-                        smem.alloc<T>();
-                        #pragma omp barrier
-                        return smem.getLatestVar<T>();
-                    }
-                };
-                //#############################################################################
-                template<>
-                struct FreeMem<
-                    BlockSharedMemStOmp5>
-                {
-                    //-----------------------------------------------------------------------------
-                    static auto freeMem(
-                        block::st::BlockSharedMemStOmp5 const &mem)
-                    -> void
-                    {
-                        mem.free();
-                    }
-                };
-            }
+                    mem.free();
+                }
+            };
         }
     }
 }

--- a/include/alpaka/block/shared/st/BlockSharedMemStOmp5.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStOmp5.hpp
@@ -24,54 +24,51 @@
 
 namespace alpaka
 {
-    namespace block
+    //#############################################################################
+    //! The OpenMP 5 block shared memory allocator.
+    class BlockSharedMemStOmp5 :
+        public detail::BlockSharedMemStMemberImpl<4>,
+        public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStOmp5>
+    {
+    public:
+        using BlockSharedMemStMemberImpl<4>::BlockSharedMemStMemberImpl;
+    };
+
+    namespace traits
     {
         //#############################################################################
-        //! The OpenMP 5 block shared memory allocator.
-        class BlockSharedMemStOmp5 :
-            public detail::BlockSharedMemStMemberImpl<4>,
-            public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStOmp5>
+        template<
+            typename T,
+            std::size_t TuniqueId>
+        struct AllocVar<
+            T,
+            TuniqueId,
+            BlockSharedMemStOmp5>
         {
-        public:
-            using BlockSharedMemStMemberImpl<4>::BlockSharedMemStMemberImpl;
+            //-----------------------------------------------------------------------------
+            static auto allocVar(
+                BlockSharedMemStOmp5 const &smem)
+            -> T &
+            {
+                #pragma omp barrier
+                smem.alloc<T>();
+                #pragma omp barrier
+                return smem.getLatestVar<T>();
+            }
         };
-
-        namespace traits
+        //#############################################################################
+        template<>
+        struct FreeMem<
+            BlockSharedMemStOmp5>
         {
-            //#############################################################################
-            template<
-                typename T,
-                std::size_t TuniqueId>
-            struct AllocVar<
-                T,
-                TuniqueId,
-                BlockSharedMemStOmp5>
+            //-----------------------------------------------------------------------------
+            static auto freeMem(
+                BlockSharedMemStOmp5 const &mem)
+            -> void
             {
-                //-----------------------------------------------------------------------------
-                static auto allocVar(
-                    block::BlockSharedMemStOmp5 const &smem)
-                -> T &
-                {
-                    #pragma omp barrier
-                    smem.alloc<T>();
-                    #pragma omp barrier
-                    return smem.getLatestVar<T>();
-                }
-            };
-            //#############################################################################
-            template<>
-            struct FreeMem<
-                BlockSharedMemStOmp5>
-            {
-                //-----------------------------------------------------------------------------
-                static auto freeMem(
-                    block::BlockSharedMemStOmp5 const &mem)
-                -> void
-                {
-                    mem.free();
-                }
-            };
-        }
+                mem.free();
+            }
+        };
     }
 }
 

--- a/include/alpaka/block/shared/st/BlockSharedMemStUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStUniformCudaHipBuiltIn.hpp
@@ -30,68 +30,65 @@ namespace alpaka
 {
     namespace block
     {
-        namespace st
+        //#############################################################################
+        //! The GPU CUDA/HIP block shared memory allocator.
+        class BlockSharedMemStUniformCudaHipBuiltIn : public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStUniformCudaHipBuiltIn>
+        {
+        public:
+            //-----------------------------------------------------------------------------
+            //! Default constructor.
+            BlockSharedMemStUniformCudaHipBuiltIn() = default;
+            //-----------------------------------------------------------------------------
+            //! Copy constructor.
+            __device__ BlockSharedMemStUniformCudaHipBuiltIn(BlockSharedMemStUniformCudaHipBuiltIn const &) = delete;
+            //-----------------------------------------------------------------------------
+            //! Move constructor.
+            __device__ BlockSharedMemStUniformCudaHipBuiltIn(BlockSharedMemStUniformCudaHipBuiltIn &&) = delete;
+            //-----------------------------------------------------------------------------
+            //! Copy assignment operator.
+            __device__ auto operator=(BlockSharedMemStUniformCudaHipBuiltIn const &) -> BlockSharedMemStUniformCudaHipBuiltIn & = delete;
+            //-----------------------------------------------------------------------------
+            //! Move assignment operator.
+            __device__ auto operator=(BlockSharedMemStUniformCudaHipBuiltIn &&) -> BlockSharedMemStUniformCudaHipBuiltIn & = delete;
+            //-----------------------------------------------------------------------------
+            //! Destructor.
+            /*virtual*/ ~BlockSharedMemStUniformCudaHipBuiltIn() = default;
+        };
+
+        namespace traits
         {
             //#############################################################################
-            //! The GPU CUDA/HIP block shared memory allocator.
-            class BlockSharedMemStUniformCudaHipBuiltIn : public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStUniformCudaHipBuiltIn>
+            template<
+                typename T,
+                std::size_t TuniqueId>
+            struct AllocVar<
+                T,
+                TuniqueId,
+                BlockSharedMemStUniformCudaHipBuiltIn>
             {
-            public:
                 //-----------------------------------------------------------------------------
-                //! Default constructor.
-                BlockSharedMemStUniformCudaHipBuiltIn() = default;
-                //-----------------------------------------------------------------------------
-                //! Copy constructor.
-                __device__ BlockSharedMemStUniformCudaHipBuiltIn(BlockSharedMemStUniformCudaHipBuiltIn const &) = delete;
-                //-----------------------------------------------------------------------------
-                //! Move constructor.
-                __device__ BlockSharedMemStUniformCudaHipBuiltIn(BlockSharedMemStUniformCudaHipBuiltIn &&) = delete;
-                //-----------------------------------------------------------------------------
-                //! Copy assignment operator.
-                __device__ auto operator=(BlockSharedMemStUniformCudaHipBuiltIn const &) -> BlockSharedMemStUniformCudaHipBuiltIn & = delete;
-                //-----------------------------------------------------------------------------
-                //! Move assignment operator.
-                __device__ auto operator=(BlockSharedMemStUniformCudaHipBuiltIn &&) -> BlockSharedMemStUniformCudaHipBuiltIn & = delete;
-                //-----------------------------------------------------------------------------
-                //! Destructor.
-                /*virtual*/ ~BlockSharedMemStUniformCudaHipBuiltIn() = default;
+                __device__ static auto allocVar(
+                    block::BlockSharedMemStUniformCudaHipBuiltIn const &)
+                -> T &
+                {
+                    __shared__ uint8_t shMem alignas(alignof(T)) [sizeof(T)];
+                    return *(
+                        reinterpret_cast<T*>( shMem ));
+                }
             };
-
-            namespace traits
+            //#############################################################################
+            template<>
+            struct FreeMem<
+                BlockSharedMemStUniformCudaHipBuiltIn>
             {
-                //#############################################################################
-                template<
-                    typename T,
-                    std::size_t TuniqueId>
-                struct AllocVar<
-                    T,
-                    TuniqueId,
-                    BlockSharedMemStUniformCudaHipBuiltIn>
+                //-----------------------------------------------------------------------------
+                __device__ static auto freeMem(
+                    block::BlockSharedMemStUniformCudaHipBuiltIn const &)
+                -> void
                 {
-                    //-----------------------------------------------------------------------------
-                    __device__ static auto allocVar(
-                        block::st::BlockSharedMemStUniformCudaHipBuiltIn const &)
-                    -> T &
-                    {
-                        __shared__ uint8_t shMem alignas(alignof(T)) [sizeof(T)];
-                        return *(
-                            reinterpret_cast<T*>( shMem ));
-                    }
-                };
-                //#############################################################################
-                template<>
-                struct FreeMem<
-                    BlockSharedMemStUniformCudaHipBuiltIn>
-                {
-                    //-----------------------------------------------------------------------------
-                    __device__ static auto freeMem(
-                        block::st::BlockSharedMemStUniformCudaHipBuiltIn const &)
-                    -> void
-                    {
-                        // Nothing to do. CUDA/HIP block shared memory is automatically freed when all threads left the block.
-                    }
-                };
-            }
+                    // Nothing to do. CUDA/HIP block shared memory is automatically freed when all threads left the block.
+                }
+            };
         }
     }
 }

--- a/include/alpaka/block/shared/st/BlockSharedMemStUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStUniformCudaHipBuiltIn.hpp
@@ -28,68 +28,65 @@
 
 namespace alpaka
 {
-    namespace block
+    //#############################################################################
+    //! The GPU CUDA/HIP block shared memory allocator.
+    class BlockSharedMemStUniformCudaHipBuiltIn : public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStUniformCudaHipBuiltIn>
+    {
+    public:
+        //-----------------------------------------------------------------------------
+        //! Default constructor.
+        BlockSharedMemStUniformCudaHipBuiltIn() = default;
+        //-----------------------------------------------------------------------------
+        //! Copy constructor.
+        __device__ BlockSharedMemStUniformCudaHipBuiltIn(BlockSharedMemStUniformCudaHipBuiltIn const &) = delete;
+        //-----------------------------------------------------------------------------
+        //! Move constructor.
+        __device__ BlockSharedMemStUniformCudaHipBuiltIn(BlockSharedMemStUniformCudaHipBuiltIn &&) = delete;
+        //-----------------------------------------------------------------------------
+        //! Copy assignment operator.
+        __device__ auto operator=(BlockSharedMemStUniformCudaHipBuiltIn const &) -> BlockSharedMemStUniformCudaHipBuiltIn & = delete;
+        //-----------------------------------------------------------------------------
+        //! Move assignment operator.
+        __device__ auto operator=(BlockSharedMemStUniformCudaHipBuiltIn &&) -> BlockSharedMemStUniformCudaHipBuiltIn & = delete;
+        //-----------------------------------------------------------------------------
+        //! Destructor.
+        /*virtual*/ ~BlockSharedMemStUniformCudaHipBuiltIn() = default;
+    };
+
+    namespace traits
     {
         //#############################################################################
-        //! The GPU CUDA/HIP block shared memory allocator.
-        class BlockSharedMemStUniformCudaHipBuiltIn : public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStUniformCudaHipBuiltIn>
+        template<
+            typename T,
+            std::size_t TuniqueId>
+        struct AllocVar<
+            T,
+            TuniqueId,
+            BlockSharedMemStUniformCudaHipBuiltIn>
         {
-        public:
             //-----------------------------------------------------------------------------
-            //! Default constructor.
-            BlockSharedMemStUniformCudaHipBuiltIn() = default;
-            //-----------------------------------------------------------------------------
-            //! Copy constructor.
-            __device__ BlockSharedMemStUniformCudaHipBuiltIn(BlockSharedMemStUniformCudaHipBuiltIn const &) = delete;
-            //-----------------------------------------------------------------------------
-            //! Move constructor.
-            __device__ BlockSharedMemStUniformCudaHipBuiltIn(BlockSharedMemStUniformCudaHipBuiltIn &&) = delete;
-            //-----------------------------------------------------------------------------
-            //! Copy assignment operator.
-            __device__ auto operator=(BlockSharedMemStUniformCudaHipBuiltIn const &) -> BlockSharedMemStUniformCudaHipBuiltIn & = delete;
-            //-----------------------------------------------------------------------------
-            //! Move assignment operator.
-            __device__ auto operator=(BlockSharedMemStUniformCudaHipBuiltIn &&) -> BlockSharedMemStUniformCudaHipBuiltIn & = delete;
-            //-----------------------------------------------------------------------------
-            //! Destructor.
-            /*virtual*/ ~BlockSharedMemStUniformCudaHipBuiltIn() = default;
+            __device__ static auto allocVar(
+                BlockSharedMemStUniformCudaHipBuiltIn const &)
+            -> T &
+            {
+                __shared__ uint8_t shMem alignas(alignof(T)) [sizeof(T)];
+                return *(
+                    reinterpret_cast<T*>( shMem ));
+            }
         };
-
-        namespace traits
+        //#############################################################################
+        template<>
+        struct FreeMem<
+            BlockSharedMemStUniformCudaHipBuiltIn>
         {
-            //#############################################################################
-            template<
-                typename T,
-                std::size_t TuniqueId>
-            struct AllocVar<
-                T,
-                TuniqueId,
-                BlockSharedMemStUniformCudaHipBuiltIn>
+            //-----------------------------------------------------------------------------
+            __device__ static auto freeMem(
+                BlockSharedMemStUniformCudaHipBuiltIn const &)
+            -> void
             {
-                //-----------------------------------------------------------------------------
-                __device__ static auto allocVar(
-                    block::BlockSharedMemStUniformCudaHipBuiltIn const &)
-                -> T &
-                {
-                    __shared__ uint8_t shMem alignas(alignof(T)) [sizeof(T)];
-                    return *(
-                        reinterpret_cast<T*>( shMem ));
-                }
-            };
-            //#############################################################################
-            template<>
-            struct FreeMem<
-                BlockSharedMemStUniformCudaHipBuiltIn>
-            {
-                //-----------------------------------------------------------------------------
-                __device__ static auto freeMem(
-                    block::BlockSharedMemStUniformCudaHipBuiltIn const &)
-                -> void
-                {
-                    // Nothing to do. CUDA/HIP block shared memory is automatically freed when all threads left the block.
-                }
-            };
-        }
+                // Nothing to do. CUDA/HIP block shared memory is automatically freed when all threads left the block.
+            }
+        };
     }
 }
 

--- a/include/alpaka/block/shared/st/Traits.hpp
+++ b/include/alpaka/block/shared/st/Traits.hpp
@@ -20,78 +20,73 @@ namespace alpaka
     //! The grid block specifics
     namespace block
     {
+        struct ConceptBlockSharedSt{};
+
         //-----------------------------------------------------------------------------
-        //! The block shared static memory operation specifics.
-        namespace st
+        //! The block shared static memory operation traits.
+        namespace traits
         {
-            struct ConceptBlockSharedSt{};
-
-            //-----------------------------------------------------------------------------
-            //! The block shared static memory operation traits.
-            namespace traits
-            {
-                //#############################################################################
-                //! The block shared static memory variable allocation operation trait.
-                template<
-                    typename T,
-                    std::size_t TuniqueId,
-                    typename TBlockSharedMemSt,
-                    typename TSfinae = void>
-                struct AllocVar;
-                //#############################################################################
-                //! The block shared static memory free operation trait.
-                template<
-                    typename TBlockSharedMemSt,
-                    typename TSfinae = void>
-                struct FreeMem;
-            }
-
-            //-----------------------------------------------------------------------------
-            //! Allocates a variable in block shared static memory.
-            //!
-            //! The allocated variable is uninitialized and not default constructed!
-            //!
-            //! \tparam T The element type.
-            //! \tparam TuniqueId id those is unique inside a kernel
-            //! \tparam TBlockSharedMemSt The block shared allocator implementation type.
-            //! \param blockSharedMemSt The block shared allocator implementation.
-            ALPAKA_NO_HOST_ACC_WARNING
+            //#############################################################################
+            //! The block shared static memory variable allocation operation trait.
             template<
                 typename T,
                 std::size_t TuniqueId,
-                typename TBlockSharedMemSt>
-            ALPAKA_FN_ACC auto allocVar(
-                TBlockSharedMemSt const & blockSharedMemSt)
-            -> T &
-            {
-                using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedSt, TBlockSharedMemSt>;
-                return
-                    traits::AllocVar<
-                        T,
-                        TuniqueId,
-                        ImplementationBase>
-                    ::allocVar(
-                        blockSharedMemSt);
-            }
-
-            //-----------------------------------------------------------------------------
-            //! Frees all block shared static memory.
-            //!
-            //! \tparam TBlockSharedMemSt The block shared allocator implementation type.
-            //! \param blockSharedMemSt The block shared allocator implementation.
-            ALPAKA_NO_HOST_ACC_WARNING
+                typename TBlockSharedMemSt,
+                typename TSfinae = void>
+            struct AllocVar;
+            //#############################################################################
+            //! The block shared static memory free operation trait.
             template<
-                typename TBlockSharedMemSt>
-            ALPAKA_FN_ACC auto freeMem(
-                TBlockSharedMemSt & blockSharedMemSt)
-            -> void
-            {
-                using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedSt, TBlockSharedMemSt>;
-                traits::FreeMem<
+                typename TBlockSharedMemSt,
+                typename TSfinae = void>
+            struct FreeMem;
+        }
+
+        //-----------------------------------------------------------------------------
+        //! Allocates a variable in block shared static memory.
+        //!
+        //! The allocated variable is uninitialized and not default constructed!
+        //!
+        //! \tparam T The element type.
+        //! \tparam TuniqueId id those is unique inside a kernel
+        //! \tparam TBlockSharedMemSt The block shared allocator implementation type.
+        //! \param blockSharedMemSt The block shared allocator implementation.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T,
+            std::size_t TuniqueId,
+            typename TBlockSharedMemSt>
+        ALPAKA_FN_ACC auto allocVar(
+            TBlockSharedMemSt const & blockSharedMemSt)
+        -> T &
+        {
+            using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedSt, TBlockSharedMemSt>;
+            return
+                traits::AllocVar<
+                    T,
+                    TuniqueId,
                     ImplementationBase>
-                ::freeMem(
+                ::allocVar(
                     blockSharedMemSt);
-            }
+        }
+
+        //-----------------------------------------------------------------------------
+        //! Frees all block shared static memory.
+        //!
+        //! \tparam TBlockSharedMemSt The block shared allocator implementation type.
+        //! \param blockSharedMemSt The block shared allocator implementation.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename TBlockSharedMemSt>
+        ALPAKA_FN_ACC auto freeMem(
+            TBlockSharedMemSt & blockSharedMemSt)
+        -> void
+        {
+            using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedSt, TBlockSharedMemSt>;
+            traits::FreeMem<
+                ImplementationBase>
+            ::freeMem(
+                blockSharedMemSt);
         }
     }
 }

--- a/include/alpaka/block/shared/st/Traits.hpp
+++ b/include/alpaka/block/shared/st/Traits.hpp
@@ -16,77 +16,72 @@
 
 namespace alpaka
 {
+    struct ConceptBlockSharedSt{};
+
     //-----------------------------------------------------------------------------
-    //! The grid block specifics
-    namespace block
+    //! The block shared static memory operation traits.
+    namespace traits
     {
-        struct ConceptBlockSharedSt{};
-
-        //-----------------------------------------------------------------------------
-        //! The block shared static memory operation traits.
-        namespace traits
-        {
-            //#############################################################################
-            //! The block shared static memory variable allocation operation trait.
-            template<
-                typename T,
-                std::size_t TuniqueId,
-                typename TBlockSharedMemSt,
-                typename TSfinae = void>
-            struct AllocVar;
-            //#############################################################################
-            //! The block shared static memory free operation trait.
-            template<
-                typename TBlockSharedMemSt,
-                typename TSfinae = void>
-            struct FreeMem;
-        }
-
-        //-----------------------------------------------------------------------------
-        //! Allocates a variable in block shared static memory.
-        //!
-        //! The allocated variable is uninitialized and not default constructed!
-        //!
-        //! \tparam T The element type.
-        //! \tparam TuniqueId id those is unique inside a kernel
-        //! \tparam TBlockSharedMemSt The block shared allocator implementation type.
-        //! \param blockSharedMemSt The block shared allocator implementation.
-        ALPAKA_NO_HOST_ACC_WARNING
+        //#############################################################################
+        //! The block shared static memory variable allocation operation trait.
         template<
             typename T,
             std::size_t TuniqueId,
-            typename TBlockSharedMemSt>
-        ALPAKA_FN_ACC auto allocVar(
-            TBlockSharedMemSt const & blockSharedMemSt)
-        -> T &
-        {
-            using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedSt, TBlockSharedMemSt>;
-            return
-                traits::AllocVar<
-                    T,
-                    TuniqueId,
-                    ImplementationBase>
-                ::allocVar(
-                    blockSharedMemSt);
-        }
-
-        //-----------------------------------------------------------------------------
-        //! Frees all block shared static memory.
-        //!
-        //! \tparam TBlockSharedMemSt The block shared allocator implementation type.
-        //! \param blockSharedMemSt The block shared allocator implementation.
-        ALPAKA_NO_HOST_ACC_WARNING
+            typename TBlockSharedMemSt,
+            typename TSfinae = void>
+        struct AllocVar;
+        //#############################################################################
+        //! The block shared static memory free operation trait.
         template<
-            typename TBlockSharedMemSt>
-        ALPAKA_FN_ACC auto freeMem(
-            TBlockSharedMemSt & blockSharedMemSt)
-        -> void
-        {
-            using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedSt, TBlockSharedMemSt>;
-            traits::FreeMem<
+            typename TBlockSharedMemSt,
+            typename TSfinae = void>
+        struct FreeMem;
+    }
+
+    //-----------------------------------------------------------------------------
+    //! Allocates a variable in block shared static memory.
+    //!
+    //! The allocated variable is uninitialized and not default constructed!
+    //!
+    //! \tparam T The element type.
+    //! \tparam TuniqueId id those is unique inside a kernel
+    //! \tparam TBlockSharedMemSt The block shared allocator implementation type.
+    //! \param blockSharedMemSt The block shared allocator implementation.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<
+        typename T,
+        std::size_t TuniqueId,
+        typename TBlockSharedMemSt>
+    ALPAKA_FN_ACC auto allocVar(
+        TBlockSharedMemSt const & blockSharedMemSt)
+    -> T &
+    {
+        using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedSt, TBlockSharedMemSt>;
+        return
+            traits::AllocVar<
+                T,
+                TuniqueId,
                 ImplementationBase>
-            ::freeMem(
+            ::allocVar(
                 blockSharedMemSt);
-        }
+    }
+
+    //-----------------------------------------------------------------------------
+    //! Frees all block shared static memory.
+    //!
+    //! \tparam TBlockSharedMemSt The block shared allocator implementation type.
+    //! \param blockSharedMemSt The block shared allocator implementation.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<
+        typename TBlockSharedMemSt>
+    ALPAKA_FN_ACC auto freeMem(
+        TBlockSharedMemSt & blockSharedMemSt)
+    -> void
+    {
+        using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedSt, TBlockSharedMemSt>;
+        traits::FreeMem<
+            ImplementationBase>
+        ::freeMem(
+            blockSharedMemSt);
     }
 }

--- a/include/alpaka/block/sync/BlockSyncBarrierFiber.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierFiber.hpp
@@ -22,101 +22,98 @@
 
 namespace alpaka
 {
-    namespace block
+    //#############################################################################
+    //! The thread id map barrier block synchronization.
+    template<
+        typename TIdx>
+    class BlockSyncBarrierFiber : public concepts::Implements<ConceptBlockSync, BlockSyncBarrierFiber<TIdx>>
+    {
+    public:
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST BlockSyncBarrierFiber(
+            TIdx const & blockThreadCount) :
+                m_barrier(static_cast<std::size_t>(blockThreadCount)),
+                m_threadCount(blockThreadCount),
+                m_curThreadCount(static_cast<TIdx>(0u)),
+                m_generation(static_cast<TIdx>(0u))
+        {}
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST BlockSyncBarrierFiber(BlockSyncBarrierFiber const &) = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST BlockSyncBarrierFiber(BlockSyncBarrierFiber &&) = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST auto operator=(BlockSyncBarrierFiber const &) -> BlockSyncBarrierFiber & = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST auto operator=(BlockSyncBarrierFiber &&) -> BlockSyncBarrierFiber & = delete;
+        //-----------------------------------------------------------------------------
+        /*virtual*/ ~BlockSyncBarrierFiber() = default;
+
+        boost::fibers::barrier mutable m_barrier;
+
+        TIdx mutable m_threadCount;
+        TIdx mutable m_curThreadCount;
+        TIdx mutable m_generation;
+        int mutable m_result[2u];
+    };
+
+    namespace traits
     {
         //#############################################################################
-        //! The thread id map barrier block synchronization.
         template<
             typename TIdx>
-        class BlockSyncBarrierFiber : public concepts::Implements<ConceptBlockSync, BlockSyncBarrierFiber<TIdx>>
+        struct SyncBlockThreads<
+            BlockSyncBarrierFiber<TIdx>>
         {
-        public:
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST BlockSyncBarrierFiber(
-                TIdx const & blockThreadCount) :
-                    m_barrier(static_cast<std::size_t>(blockThreadCount)),
-                    m_threadCount(blockThreadCount),
-                    m_curThreadCount(static_cast<TIdx>(0u)),
-                    m_generation(static_cast<TIdx>(0u))
-            {}
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST BlockSyncBarrierFiber(BlockSyncBarrierFiber const &) = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST BlockSyncBarrierFiber(BlockSyncBarrierFiber &&) = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST auto operator=(BlockSyncBarrierFiber const &) -> BlockSyncBarrierFiber & = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST auto operator=(BlockSyncBarrierFiber &&) -> BlockSyncBarrierFiber & = delete;
-            //-----------------------------------------------------------------------------
-            /*virtual*/ ~BlockSyncBarrierFiber() = default;
-
-            boost::fibers::barrier mutable m_barrier;
-
-            TIdx mutable m_threadCount;
-            TIdx mutable m_curThreadCount;
-            TIdx mutable m_generation;
-            int mutable m_result[2u];
+            ALPAKA_FN_HOST static auto syncBlockThreads(
+                BlockSyncBarrierFiber<TIdx> const & blockSync)
+            -> void
+            {
+                blockSync.m_barrier.wait();
+            }
         };
 
-        namespace traits
+        //#############################################################################
+        template<
+            typename TOp,
+            typename TIdx>
+        struct SyncBlockThreadsPredicate<
+            TOp,
+            BlockSyncBarrierFiber<TIdx>>
         {
-            //#############################################################################
-            template<
-                typename TIdx>
-            struct SyncBlockThreads<
-                BlockSyncBarrierFiber<TIdx>>
+            //-----------------------------------------------------------------------------
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(
+                BlockSyncBarrierFiber<TIdx> const & blockSync,
+                int predicate)
+            -> int
             {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto syncBlockThreads(
-                    block::BlockSyncBarrierFiber<TIdx> const & blockSync)
-                -> void
+                if(blockSync.m_curThreadCount == blockSync.m_threadCount)
                 {
-                    blockSync.m_barrier.wait();
+                    blockSync.m_curThreadCount = static_cast<TIdx>(0u);
+                    ++blockSync.m_generation;
                 }
-            };
 
-            //#############################################################################
-            template<
-                typename TOp,
-                typename TIdx>
-            struct SyncBlockThreadsPredicate<
-                TOp,
-                BlockSyncBarrierFiber<TIdx>>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_NO_HOST_ACC_WARNING
-                ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(
-                    block::BlockSyncBarrierFiber<TIdx> const & blockSync,
-                    int predicate)
-                -> int
+                auto const generationMod2(blockSync.m_generation % static_cast<TIdx>(2u));
+
+                // The first fiber will reset the value to the initial value.
+                if(blockSync.m_curThreadCount == static_cast<TIdx>(0u))
                 {
-                    if(blockSync.m_curThreadCount == blockSync.m_threadCount)
-                    {
-                        blockSync.m_curThreadCount = static_cast<TIdx>(0u);
-                        ++blockSync.m_generation;
-                    }
-
-                    auto const generationMod2(blockSync.m_generation % static_cast<TIdx>(2u));
-
-                    // The first fiber will reset the value to the initial value.
-                    if(blockSync.m_curThreadCount == static_cast<TIdx>(0u))
-                    {
-                        blockSync.m_result[generationMod2] = TOp::InitialValue;
-                    }
-
-                    ++blockSync.m_curThreadCount;
-
-                    // We do not have to lock because there is only ever one fiber active per block.
-                    blockSync.m_result[generationMod2] = TOp()(blockSync.m_result[generationMod2], predicate);
-
-                    // After all block threads have combined their values ...
-                    blockSync.m_barrier.wait();
-
-                    // ... the result can be returned.
-                    return blockSync.m_result[generationMod2];
+                    blockSync.m_result[generationMod2] = TOp::InitialValue;
                 }
-            };
-        }
+
+                ++blockSync.m_curThreadCount;
+
+                // We do not have to lock because there is only ever one fiber active per block.
+                blockSync.m_result[generationMod2] = TOp()(blockSync.m_result[generationMod2], predicate);
+
+                // After all block threads have combined their values ...
+                blockSync.m_barrier.wait();
+
+                // ... the result can be returned.
+                return blockSync.m_result[generationMod2];
+            }
+        };
     }
 }
 

--- a/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
@@ -71,7 +71,7 @@ namespace alpaka
             //#############################################################################
             template<>
             struct AtomicOp<
-                op::Count>
+                blockOp::Count>
             {
                 void operator()(int& result, bool value)
                 {
@@ -82,7 +82,7 @@ namespace alpaka
             //#############################################################################
             template<>
             struct AtomicOp<
-                op::LogicalAnd>
+                blockOp::LogicalAnd>
             {
                 void operator()(int& result, bool value)
                 {
@@ -93,7 +93,7 @@ namespace alpaka
             //#############################################################################
             template<>
             struct AtomicOp<
-                op::LogicalOr>
+                blockOp::LogicalOr>
             {
                 void operator()(int& result, bool value)
                 {

--- a/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
@@ -18,133 +18,130 @@
 
 namespace alpaka
 {
-    namespace block
+    //#############################################################################
+    //! The OpenMP barrier block synchronization.
+    class BlockSyncBarrierOmp : public concepts::Implements<ConceptBlockSync, BlockSyncBarrierOmp>
+    {
+    public:
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST BlockSyncBarrierOmp() :
+            m_generation(0u)
+        {}
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST BlockSyncBarrierOmp(BlockSyncBarrierOmp const &) = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST BlockSyncBarrierOmp(BlockSyncBarrierOmp &&) = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST auto operator=(BlockSyncBarrierOmp const &) -> BlockSyncBarrierOmp & = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST auto operator=(BlockSyncBarrierOmp &&) -> BlockSyncBarrierOmp & = delete;
+        //-----------------------------------------------------------------------------
+        /*virtual*/ ~BlockSyncBarrierOmp() = default;
+
+        std::uint8_t mutable m_generation;
+        int mutable m_result[2];
+    };
+
+    namespace traits
     {
         //#############################################################################
-        //! The OpenMP barrier block synchronization.
-        class BlockSyncBarrierOmp : public concepts::Implements<ConceptBlockSync, BlockSyncBarrierOmp>
+        template<>
+        struct SyncBlockThreads<
+            BlockSyncBarrierOmp>
         {
-        public:
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST BlockSyncBarrierOmp() :
-                m_generation(0u)
-            {}
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST BlockSyncBarrierOmp(BlockSyncBarrierOmp const &) = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST BlockSyncBarrierOmp(BlockSyncBarrierOmp &&) = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST auto operator=(BlockSyncBarrierOmp const &) -> BlockSyncBarrierOmp & = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST auto operator=(BlockSyncBarrierOmp &&) -> BlockSyncBarrierOmp & = delete;
-            //-----------------------------------------------------------------------------
-            /*virtual*/ ~BlockSyncBarrierOmp() = default;
+            ALPAKA_FN_HOST static auto syncBlockThreads(
+                BlockSyncBarrierOmp const & blockSync)
+            -> void
+            {
+                alpaka::ignore_unused(blockSync);
 
-            std::uint8_t mutable m_generation;
-            int mutable m_result[2];
+                // NOTE: This waits for all threads in all blocks.
+                // If multiple blocks are executed in parallel this is not optimal.
+                #pragma omp barrier
+            }
         };
 
-        namespace traits
+        namespace detail
         {
-            //#############################################################################
-            template<>
-            struct SyncBlockThreads<
-                BlockSyncBarrierOmp>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto syncBlockThreads(
-                    block::BlockSyncBarrierOmp const & blockSync)
-                -> void
-                {
-                    alpaka::ignore_unused(blockSync);
-
-                    // NOTE: This waits for all threads in all blocks.
-                    // If multiple blocks are executed in parallel this is not optimal.
-                    #pragma omp barrier
-                }
-            };
-
-            namespace detail
-            {
-                //#############################################################################
-                template<
-                    typename TOp>
-                struct AtomicOp;
-                //#############################################################################
-                template<>
-                struct AtomicOp<
-                    block::op::Count>
-                {
-                    void operator()(int& result, bool value)
-                    {
-                        #pragma omp atomic
-                        result += static_cast<int>(value);
-                    }
-                };
-                //#############################################################################
-                template<>
-                struct AtomicOp<
-                    block::op::LogicalAnd>
-                {
-                    void operator()(int& result, bool value)
-                    {
-                        #pragma omp atomic
-                        result &= static_cast<int>(value);
-                    }
-                };
-                //#############################################################################
-                template<>
-                struct AtomicOp<
-                    block::op::LogicalOr>
-                {
-                    void operator()(int& result, bool value)
-                    {
-                        #pragma omp atomic
-                        result |= static_cast<int>(value);
-                    }
-                };
-            }
-
             //#############################################################################
             template<
                 typename TOp>
-            struct SyncBlockThreadsPredicate<
-                TOp,
-                BlockSyncBarrierOmp>
+            struct AtomicOp;
+            //#############################################################################
+            template<>
+            struct AtomicOp<
+                op::Count>
             {
-                //-----------------------------------------------------------------------------
-                ALPAKA_NO_HOST_ACC_WARNING
-                ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(
-                    block::BlockSyncBarrierOmp const & blockSync,
-                    int predicate)
-                -> int
+                void operator()(int& result, bool value)
                 {
-                    // The first thread initializes the value.
-                    // There is an implicit barrier at the end of omp single.
-                    // NOTE: This code is executed only once for all OpenMP threads.
-                    // If multiple blocks with multiple threads are executed in parallel
-                    // this reduction is executed only for one block!
-                    #pragma omp single
-                    {
-                        ++blockSync.m_generation;
-                        blockSync.m_result[blockSync.m_generation % 2u] = TOp::InitialValue;
-                    }
-
-                    auto const generationMod2(blockSync.m_generation % 2u);
-                    int& result(blockSync.m_result[generationMod2]);
-                    bool const predicateBool(predicate != 0);
-
-                    detail::AtomicOp<TOp>()(result, predicateBool);
-
-                    // Wait for all threads to write their predicate into the vector.
-                    // NOTE: This waits for all threads in all blocks.
-                    // If multiple blocks are executed in parallel this is not optimal.
-                    #pragma omp barrier
-
-                    return blockSync.m_result[generationMod2];
+                    #pragma omp atomic
+                    result += static_cast<int>(value);
+                }
+            };
+            //#############################################################################
+            template<>
+            struct AtomicOp<
+                op::LogicalAnd>
+            {
+                void operator()(int& result, bool value)
+                {
+                    #pragma omp atomic
+                    result &= static_cast<int>(value);
+                }
+            };
+            //#############################################################################
+            template<>
+            struct AtomicOp<
+                op::LogicalOr>
+            {
+                void operator()(int& result, bool value)
+                {
+                    #pragma omp atomic
+                    result |= static_cast<int>(value);
                 }
             };
         }
+
+        //#############################################################################
+        template<
+            typename TOp>
+        struct SyncBlockThreadsPredicate<
+            TOp,
+            BlockSyncBarrierOmp>
+        {
+            //-----------------------------------------------------------------------------
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(
+                BlockSyncBarrierOmp const & blockSync,
+                int predicate)
+            -> int
+            {
+                // The first thread initializes the value.
+                // There is an implicit barrier at the end of omp single.
+                // NOTE: This code is executed only once for all OpenMP threads.
+                // If multiple blocks with multiple threads are executed in parallel
+                // this reduction is executed only for one block!
+                #pragma omp single
+                {
+                    ++blockSync.m_generation;
+                    blockSync.m_result[blockSync.m_generation % 2u] = TOp::InitialValue;
+                }
+
+                auto const generationMod2(blockSync.m_generation % 2u);
+                int& result(blockSync.m_result[generationMod2]);
+                bool const predicateBool(predicate != 0);
+
+                detail::AtomicOp<TOp>()(result, predicateBool);
+
+                // Wait for all threads to write their predicate into the vector.
+                // NOTE: This waits for all threads in all blocks.
+                // If multiple blocks are executed in parallel this is not optimal.
+                #pragma omp barrier
+
+                return blockSync.m_result[generationMod2];
+            }
+        };
     }
 }
 

--- a/include/alpaka/block/sync/BlockSyncBarrierThread.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierThread.hpp
@@ -23,75 +23,72 @@
 
 namespace alpaka
 {
-    namespace block
+    //#############################################################################
+    //! The thread id map barrier block synchronization.
+    template<
+        typename TIdx>
+    class BlockSyncBarrierThread : public concepts::Implements<ConceptBlockSync, BlockSyncBarrierThread<TIdx>>
+    {
+    public:
+        using Barrier = core::threads::BarrierThread<TIdx>;
+        using BarrierWithPredicate = core::threads::BarrierThreadWithPredicate<TIdx>;
+
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST BlockSyncBarrierThread(
+            TIdx const & blockThreadCount) :
+                m_barrier(blockThreadCount),
+                m_barrierWithPredicate(blockThreadCount)
+        {}
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST BlockSyncBarrierThread(BlockSyncBarrierThread const &) = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST BlockSyncBarrierThread(BlockSyncBarrierThread &&) = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST auto operator=(BlockSyncBarrierThread const &) -> BlockSyncBarrierThread & = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_HOST auto operator=(BlockSyncBarrierThread &&) -> BlockSyncBarrierThread & = delete;
+        //-----------------------------------------------------------------------------
+        /*virtual*/ ~BlockSyncBarrierThread() = default;
+
+        Barrier mutable m_barrier;
+        BarrierWithPredicate mutable m_barrierWithPredicate;
+    };
+
+    namespace traits
     {
         //#############################################################################
-        //! The thread id map barrier block synchronization.
         template<
             typename TIdx>
-        class BlockSyncBarrierThread : public concepts::Implements<ConceptBlockSync, BlockSyncBarrierThread<TIdx>>
+        struct SyncBlockThreads<
+            BlockSyncBarrierThread<TIdx>>
         {
-        public:
-            using Barrier = core::threads::BarrierThread<TIdx>;
-            using BarrierWithPredicate = core::threads::BarrierThreadWithPredicate<TIdx>;
-
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST BlockSyncBarrierThread(
-                TIdx const & blockThreadCount) :
-                    m_barrier(blockThreadCount),
-                    m_barrierWithPredicate(blockThreadCount)
-            {}
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST BlockSyncBarrierThread(BlockSyncBarrierThread const &) = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST BlockSyncBarrierThread(BlockSyncBarrierThread &&) = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST auto operator=(BlockSyncBarrierThread const &) -> BlockSyncBarrierThread & = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_HOST auto operator=(BlockSyncBarrierThread &&) -> BlockSyncBarrierThread & = delete;
-            //-----------------------------------------------------------------------------
-            /*virtual*/ ~BlockSyncBarrierThread() = default;
-
-            Barrier mutable m_barrier;
-            BarrierWithPredicate mutable m_barrierWithPredicate;
+            ALPAKA_FN_HOST static auto syncBlockThreads(
+                BlockSyncBarrierThread<TIdx> const & blockSync)
+            -> void
+            {
+                blockSync.m_barrier.wait();
+            }
         };
 
-        namespace traits
+        //#############################################################################
+        template<
+            typename TOp,
+            typename TIdx>
+        struct SyncBlockThreadsPredicate<
+            TOp,
+            BlockSyncBarrierThread<TIdx>>
         {
-            //#############################################################################
-            template<
-                typename TIdx>
-            struct SyncBlockThreads<
-                BlockSyncBarrierThread<TIdx>>
+            //-----------------------------------------------------------------------------
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(
+                BlockSyncBarrierThread<TIdx> const & blockSync,
+                int predicate)
+            -> int
             {
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto syncBlockThreads(
-                    block::BlockSyncBarrierThread<TIdx> const & blockSync)
-                -> void
-                {
-                    blockSync.m_barrier.wait();
-                }
-            };
-
-            //#############################################################################
-            template<
-                typename TOp,
-                typename TIdx>
-            struct SyncBlockThreadsPredicate<
-                TOp,
-                BlockSyncBarrierThread<TIdx>>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_NO_HOST_ACC_WARNING
-                ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(
-                    block::BlockSyncBarrierThread<TIdx> const & blockSync,
-                    int predicate)
-                -> int
-                {
-                    return blockSync.m_barrierWithPredicate.template wait<TOp>(predicate);
-                }
-            };
-        }
+                return blockSync.m_barrierWithPredicate.template wait<TOp>(predicate);
+            }
+        };
     }
 }
 

--- a/include/alpaka/block/sync/BlockSyncNoOp.hpp
+++ b/include/alpaka/block/sync/BlockSyncNoOp.hpp
@@ -16,63 +16,60 @@
 
 namespace alpaka
 {
-    namespace block
+    //#############################################################################
+    //! The no op block synchronization.
+    class BlockSyncNoOp : public concepts::Implements<ConceptBlockSync, BlockSyncNoOp>
+    {
+    public:
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_ACC BlockSyncNoOp() = default;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_ACC BlockSyncNoOp(BlockSyncNoOp const &) = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_ACC BlockSyncNoOp(BlockSyncNoOp &&) = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_ACC auto operator=(BlockSyncNoOp const &) -> BlockSyncNoOp & = delete;
+        //-----------------------------------------------------------------------------
+        ALPAKA_FN_ACC auto operator=(BlockSyncNoOp &&) -> BlockSyncNoOp & = delete;
+        //-----------------------------------------------------------------------------
+        /*virtual*/ ALPAKA_FN_ACC ~BlockSyncNoOp() = default;
+    };
+
+    namespace traits
     {
         //#############################################################################
-        //! The no op block synchronization.
-        class BlockSyncNoOp : public concepts::Implements<ConceptBlockSync, BlockSyncNoOp>
+        template<>
+        struct SyncBlockThreads<
+            BlockSyncNoOp>
         {
-        public:
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC BlockSyncNoOp() = default;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC BlockSyncNoOp(BlockSyncNoOp const &) = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC BlockSyncNoOp(BlockSyncNoOp &&) = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC auto operator=(BlockSyncNoOp const &) -> BlockSyncNoOp & = delete;
-            //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC auto operator=(BlockSyncNoOp &&) -> BlockSyncNoOp & = delete;
-            //-----------------------------------------------------------------------------
-            /*virtual*/ ALPAKA_FN_ACC ~BlockSyncNoOp() = default;
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_ACC static auto syncBlockThreads(
+                BlockSyncNoOp const & blockSync)
+            -> void
+            {
+                alpaka::ignore_unused(blockSync);
+                // Nothing to do.
+            }
         };
 
-        namespace traits
+        //#############################################################################
+        template<
+            typename TOp>
+        struct SyncBlockThreadsPredicate<
+            TOp,
+            BlockSyncNoOp>
         {
-            //#############################################################################
-            template<>
-            struct SyncBlockThreads<
-                BlockSyncNoOp>
+            //-----------------------------------------------------------------------------
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(
+                BlockSyncNoOp const & blockSync,
+                int predicate)
+            -> int
             {
-                //-----------------------------------------------------------------------------
-                ALPAKA_NO_HOST_ACC_WARNING
-                ALPAKA_FN_ACC static auto syncBlockThreads(
-                    block::BlockSyncNoOp const & blockSync)
-                -> void
-                {
-                    alpaka::ignore_unused(blockSync);
-                    // Nothing to do.
-                }
-            };
-
-            //#############################################################################
-            template<
-                typename TOp>
-            struct SyncBlockThreadsPredicate<
-                TOp,
-                BlockSyncNoOp>
-            {
-                //-----------------------------------------------------------------------------
-                ALPAKA_NO_HOST_ACC_WARNING
-                ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(
-                    block::BlockSyncNoOp const & blockSync,
-                    int predicate)
-                -> int
-                {
-                    alpaka::ignore_unused(blockSync);
-                    return predicate;
-                }
-            };
-        }
+                alpaka::ignore_unused(blockSync);
+                return predicate;
+            }
+        };
     }
 }

--- a/include/alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp
@@ -25,133 +25,130 @@
 
 namespace alpaka
 {
-    namespace block
+    //#############################################################################
+    //! The GPU CUDA/HIP block synchronization.
+    class BlockSyncUniformCudaHipBuiltIn : public concepts::Implements<ConceptBlockSync, BlockSyncUniformCudaHipBuiltIn>
+    {
+    public:
+        //-----------------------------------------------------------------------------
+        BlockSyncUniformCudaHipBuiltIn() = default;
+        //-----------------------------------------------------------------------------
+        __device__ BlockSyncUniformCudaHipBuiltIn(BlockSyncUniformCudaHipBuiltIn const &) = delete;
+        //-----------------------------------------------------------------------------
+        __device__ BlockSyncUniformCudaHipBuiltIn(BlockSyncUniformCudaHipBuiltIn &&) = delete;
+        //-----------------------------------------------------------------------------
+        __device__ auto operator=(BlockSyncUniformCudaHipBuiltIn const &) -> BlockSyncUniformCudaHipBuiltIn & = delete;
+        //-----------------------------------------------------------------------------
+        __device__ auto operator=(BlockSyncUniformCudaHipBuiltIn &&) -> BlockSyncUniformCudaHipBuiltIn & = delete;
+        //-----------------------------------------------------------------------------
+        /*virtual*/ ~BlockSyncUniformCudaHipBuiltIn() = default;
+    };
+
+    namespace traits
     {
         //#############################################################################
-        //! The GPU CUDA/HIP block synchronization.
-        class BlockSyncUniformCudaHipBuiltIn : public concepts::Implements<ConceptBlockSync, BlockSyncUniformCudaHipBuiltIn>
+        template<>
+        struct SyncBlockThreads<
+            BlockSyncUniformCudaHipBuiltIn>
         {
-        public:
             //-----------------------------------------------------------------------------
-            BlockSyncUniformCudaHipBuiltIn() = default;
-            //-----------------------------------------------------------------------------
-            __device__ BlockSyncUniformCudaHipBuiltIn(BlockSyncUniformCudaHipBuiltIn const &) = delete;
-            //-----------------------------------------------------------------------------
-            __device__ BlockSyncUniformCudaHipBuiltIn(BlockSyncUniformCudaHipBuiltIn &&) = delete;
-            //-----------------------------------------------------------------------------
-            __device__ auto operator=(BlockSyncUniformCudaHipBuiltIn const &) -> BlockSyncUniformCudaHipBuiltIn & = delete;
-            //-----------------------------------------------------------------------------
-            __device__ auto operator=(BlockSyncUniformCudaHipBuiltIn &&) -> BlockSyncUniformCudaHipBuiltIn & = delete;
-            //-----------------------------------------------------------------------------
-            /*virtual*/ ~BlockSyncUniformCudaHipBuiltIn() = default;
+            __device__ static auto syncBlockThreads(
+                BlockSyncUniformCudaHipBuiltIn const & /*blockSync*/)
+            -> void
+            {
+                __syncthreads();
+            }
         };
 
-        namespace traits
+        //#############################################################################
+        template<>
+        struct SyncBlockThreadsPredicate<
+            op::Count,
+            BlockSyncUniformCudaHipBuiltIn>
         {
-            //#############################################################################
-            template<>
-            struct SyncBlockThreads<
-                BlockSyncUniformCudaHipBuiltIn>
+            //-----------------------------------------------------------------------------
+            __device__ static auto syncBlockThreadsPredicate(
+                BlockSyncUniformCudaHipBuiltIn const & /*blockSync*/,
+                int predicate)
+            -> int
             {
-                //-----------------------------------------------------------------------------
-                __device__ static auto syncBlockThreads(
-                    block::BlockSyncUniformCudaHipBuiltIn const & /*blockSync*/)
-                -> void
-                {
-                    __syncthreads();
-                }
-            };
-
-            //#############################################################################
-            template<>
-            struct SyncBlockThreadsPredicate<
-                block::op::Count,
-                BlockSyncUniformCudaHipBuiltIn>
-            {
-                //-----------------------------------------------------------------------------
-                __device__ static auto syncBlockThreadsPredicate(
-                    block::BlockSyncUniformCudaHipBuiltIn const & /*blockSync*/,
-                    int predicate)
-                -> int
-                {
 #if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && BOOST_COMP_HIP
-                    // workaround for unsupported syncthreads_* operation on AMD hardware without sync extension
-                    __shared__ int tmp;
-                    __syncthreads();
-                    if(threadIdx.x==0)
-                        tmp=0;
-                    __syncthreads();
-                    if(predicate)
-                        atomicAdd(&tmp, 1);
-                    __syncthreads();
+                // workaround for unsupported syncthreads_* operation on AMD hardware without sync extension
+                __shared__ int tmp;
+                __syncthreads();
+                if(threadIdx.x==0)
+                    tmp=0;
+                __syncthreads();
+                if(predicate)
+                    atomicAdd(&tmp, 1);
+                __syncthreads();
 
-                    return tmp;
+                return tmp;
 #else
-                    return __syncthreads_count(predicate);
+                return __syncthreads_count(predicate);
 #endif
-                }
-            };
+            }
+        };
 
-            //#############################################################################
-            template<>
-            struct SyncBlockThreadsPredicate<
-                block::op::LogicalAnd,
-                BlockSyncUniformCudaHipBuiltIn>
+        //#############################################################################
+        template<>
+        struct SyncBlockThreadsPredicate<
+            op::LogicalAnd,
+            BlockSyncUniformCudaHipBuiltIn>
+        {
+            //-----------------------------------------------------------------------------
+            __device__ static auto syncBlockThreadsPredicate(
+                BlockSyncUniformCudaHipBuiltIn const & /*blockSync*/,
+                int predicate)
+            -> int
             {
-                //-----------------------------------------------------------------------------
-                __device__ static auto syncBlockThreadsPredicate(
-                    block::BlockSyncUniformCudaHipBuiltIn const & /*blockSync*/,
-                    int predicate)
-                -> int
-                {
 #if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && BOOST_COMP_HIP
-                    // workaround for unsupported syncthreads_* operation on AMD hardware without sync extension
-                    __shared__ int tmp;
-                    __syncthreads();
-                    if(threadIdx.x==0)
-                        tmp=1;
-                    __syncthreads();
-                    if(!predicate)
-                        atomicAnd(&tmp, 0);
-                    __syncthreads();
+                // workaround for unsupported syncthreads_* operation on AMD hardware without sync extension
+                __shared__ int tmp;
+                __syncthreads();
+                if(threadIdx.x==0)
+                    tmp=1;
+                __syncthreads();
+                if(!predicate)
+                    atomicAnd(&tmp, 0);
+                __syncthreads();
 
-                    return tmp;
+                return tmp;
 #else
-                    return __syncthreads_and(predicate);
+                return __syncthreads_and(predicate);
 #endif
-                }
-            };
+            }
+        };
 
-            //#############################################################################
-            template<>
-            struct SyncBlockThreadsPredicate<
-                block::op::LogicalOr,
-                BlockSyncUniformCudaHipBuiltIn>
+        //#############################################################################
+        template<>
+        struct SyncBlockThreadsPredicate<
+            op::LogicalOr,
+            BlockSyncUniformCudaHipBuiltIn>
+        {
+            //-----------------------------------------------------------------------------
+            __device__ static auto syncBlockThreadsPredicate(
+                BlockSyncUniformCudaHipBuiltIn const & /*blockSync*/,
+                int predicate)
+            -> int
             {
-                //-----------------------------------------------------------------------------
-                __device__ static auto syncBlockThreadsPredicate(
-                    block::BlockSyncUniformCudaHipBuiltIn const & /*blockSync*/,
-                    int predicate)
-                -> int
-                {
 #if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__==0 && BOOST_COMP_HIP
-                    // workaround for unsupported syncthreads_* operation on AMD hardware without sync extension
-                    __shared__ int tmp;
-                    __syncthreads();
-                    if(threadIdx.x==0)
-                        tmp=0;
-                    __syncthreads();
-                    if(predicate)
-                        atomicOr(&tmp, 1);
-                    __syncthreads();
+                // workaround for unsupported syncthreads_* operation on AMD hardware without sync extension
+                __shared__ int tmp;
+                __syncthreads();
+                if(threadIdx.x==0)
+                    tmp=0;
+                __syncthreads();
+                if(predicate)
+                    atomicOr(&tmp, 1);
+                __syncthreads();
 
-                    return tmp;
+                return tmp;
 #else
-                    return __syncthreads_or(predicate);
+                return __syncthreads_or(predicate);
 #endif
-                }
-            };
-        }
+            }
+        };
     }
 }
 

--- a/include/alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
         //#############################################################################
         template<>
         struct SyncBlockThreadsPredicate<
-            op::Count,
+            blockOp::Count,
             BlockSyncUniformCudaHipBuiltIn>
         {
             //-----------------------------------------------------------------------------
@@ -93,7 +93,7 @@ namespace alpaka
         //#############################################################################
         template<>
         struct SyncBlockThreadsPredicate<
-            op::LogicalAnd,
+            blockOp::LogicalAnd,
             BlockSyncUniformCudaHipBuiltIn>
         {
             //-----------------------------------------------------------------------------
@@ -123,7 +123,7 @@ namespace alpaka
         //#############################################################################
         template<>
         struct SyncBlockThreadsPredicate<
-            op::LogicalOr,
+            blockOp::LogicalOr,
             BlockSyncUniformCudaHipBuiltIn>
         {
             //-----------------------------------------------------------------------------

--- a/include/alpaka/block/sync/Traits.hpp
+++ b/include/alpaka/block/sync/Traits.hpp
@@ -58,8 +58,8 @@ namespace alpaka
     }
 
     //-----------------------------------------------------------------------------
-    //! Defines operation functors.
-    namespace op
+    //! Defines block operation functors.
+    namespace blockOp
     {
         //#############################################################################
         //! The addition function object.

--- a/include/alpaka/block/sync/Traits.hpp
+++ b/include/alpaka/block/sync/Traits.hpp
@@ -16,134 +16,129 @@
 
 namespace alpaka
 {
+    struct ConceptBlockSync{};
+
     //-----------------------------------------------------------------------------
-    //! The grid block specifics
-    namespace block
+    //! The block synchronization traits.
+    namespace traits
     {
-        struct ConceptBlockSync{};
-
-        //-----------------------------------------------------------------------------
-        //! The block synchronization traits.
-        namespace traits
-        {
-            //#############################################################################
-            //! The block synchronization operation trait.
-            template<
-                typename TBlockSync,
-                typename TSfinae = void>
-            struct SyncBlockThreads;
-
-            //#############################################################################
-            //! The block synchronization and predicate operation trait.
-            template<
-                typename TOp,
-                typename TBlockSync,
-                typename TSfinae = void>
-            struct SyncBlockThreadsPredicate;
-        }
-
-        //-----------------------------------------------------------------------------
-        //! Synchronizes all threads within the current block (independently for all blocks).
-        //!
-        //! \tparam TBlockSync The block synchronization implementation type.
-        //! \param blockSync The block synchronization implementation.
-        ALPAKA_NO_HOST_ACC_WARNING
+        //#############################################################################
+        //! The block synchronization operation trait.
         template<
-            typename TBlockSync>
-        ALPAKA_FN_ACC auto syncBlockThreads(
-            TBlockSync const & blockSync)
-        -> void
-        {
-            using ImplementationBase = concepts::ImplementationBase<ConceptBlockSync, TBlockSync>;
-            traits::SyncBlockThreads<
-                ImplementationBase>
-            ::syncBlockThreads(
-                blockSync);
-        }
+            typename TBlockSync,
+            typename TSfinae = void>
+        struct SyncBlockThreads;
 
-        //-----------------------------------------------------------------------------
-        //! Defines operation functors.
-        namespace op
-        {
-            //#############################################################################
-            //! The addition function object.
-            struct Count
-            {
-                enum { InitialValue = 0u};
-
-                ALPAKA_NO_HOST_ACC_WARNING
-                template<
-                    typename T>
-                ALPAKA_FN_HOST_ACC auto operator()(
-                    T const & currentResult,
-                    T const & value) const
-                -> T
-                {
-                    return currentResult + static_cast<T>(value != static_cast<T>(0));
-                }
-            };
-            //#############################################################################
-            //! The logical and function object.
-            struct LogicalAnd
-            {
-                enum { InitialValue = 1u};
-
-                ALPAKA_NO_HOST_ACC_WARNING
-                template<
-                    typename T>
-                ALPAKA_FN_HOST_ACC auto operator()(
-                    T const & currentResult,
-                    T const & value) const
-                -> T
-                {
-                    return static_cast<T>(currentResult && (value != static_cast<T>(0)));
-                }
-            };
-            //#############################################################################
-            //! The logical or function object.
-            struct LogicalOr
-            {
-                enum { InitialValue = 0u};
-
-                ALPAKA_NO_HOST_ACC_WARNING
-                template<
-                    typename T>
-                ALPAKA_FN_HOST_ACC auto operator()(
-                    T const & currentResult,
-                    T const & value) const
-                -> T
-                {
-                    return static_cast<T>(currentResult || (value != static_cast<T>(0)));
-                }
-            };
-        }
-
-        //-----------------------------------------------------------------------------
-        //! Synchronizes all threads within the current block (independently for all blocks),
-        //! evaluates the predicate for all threads and returns the combination of all the results
-        //! computed via TOp.
-        //!
-        //! \tparam TOp The operation used to combine the predicate values of all threads.
-        //! \tparam TBlockSync The block synchronization implementation type.
-        //! \param blockSync The block synchronization implementation.
-        //! \param predicate The predicate value of the current thread.
-        ALPAKA_NO_HOST_ACC_WARNING
+        //#############################################################################
+        //! The block synchronization and predicate operation trait.
         template<
             typename TOp,
-            typename TBlockSync>
-        ALPAKA_FN_ACC auto syncBlockThreadsPredicate(
-            TBlockSync const & blockSync,
-            int predicate)
-        -> int
+            typename TBlockSync,
+            typename TSfinae = void>
+        struct SyncBlockThreadsPredicate;
+    }
+
+    //-----------------------------------------------------------------------------
+    //! Synchronizes all threads within the current block (independently for all blocks).
+    //!
+    //! \tparam TBlockSync The block synchronization implementation type.
+    //! \param blockSync The block synchronization implementation.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<
+        typename TBlockSync>
+    ALPAKA_FN_ACC auto syncBlockThreads(
+        TBlockSync const & blockSync)
+    -> void
+    {
+        using ImplementationBase = concepts::ImplementationBase<ConceptBlockSync, TBlockSync>;
+        traits::SyncBlockThreads<
+            ImplementationBase>
+        ::syncBlockThreads(
+            blockSync);
+    }
+
+    //-----------------------------------------------------------------------------
+    //! Defines operation functors.
+    namespace op
+    {
+        //#############################################################################
+        //! The addition function object.
+        struct Count
         {
-            using ImplementationBase = concepts::ImplementationBase<ConceptBlockSync, TBlockSync>;
-            return
-                traits::SyncBlockThreadsPredicate<
-                    TOp,
-                    ImplementationBase>
-                ::syncBlockThreadsPredicate(
-                    blockSync,
-                    predicate);
-        }
+            enum { InitialValue = 0u};
+
+            ALPAKA_NO_HOST_ACC_WARNING
+            template<
+                typename T>
+            ALPAKA_FN_HOST_ACC auto operator()(
+                T const & currentResult,
+                T const & value) const
+            -> T
+            {
+                return currentResult + static_cast<T>(value != static_cast<T>(0));
+            }
+        };
+        //#############################################################################
+        //! The logical and function object.
+        struct LogicalAnd
+        {
+            enum { InitialValue = 1u};
+
+            ALPAKA_NO_HOST_ACC_WARNING
+            template<
+                typename T>
+            ALPAKA_FN_HOST_ACC auto operator()(
+                T const & currentResult,
+                T const & value) const
+            -> T
+            {
+                return static_cast<T>(currentResult && (value != static_cast<T>(0)));
+            }
+        };
+        //#############################################################################
+        //! The logical or function object.
+        struct LogicalOr
+        {
+            enum { InitialValue = 0u};
+
+            ALPAKA_NO_HOST_ACC_WARNING
+            template<
+                typename T>
+            ALPAKA_FN_HOST_ACC auto operator()(
+                T const & currentResult,
+                T const & value) const
+            -> T
+            {
+                return static_cast<T>(currentResult || (value != static_cast<T>(0)));
+            }
+        };
+    }
+
+    //-----------------------------------------------------------------------------
+    //! Synchronizes all threads within the current block (independently for all blocks),
+    //! evaluates the predicate for all threads and returns the combination of all the results
+    //! computed via TOp.
+    //!
+    //! \tparam TOp The operation used to combine the predicate values of all threads.
+    //! \tparam TBlockSync The block synchronization implementation type.
+    //! \param blockSync The block synchronization implementation.
+    //! \param predicate The predicate value of the current thread.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<
+        typename TOp,
+        typename TBlockSync>
+    ALPAKA_FN_ACC auto syncBlockThreadsPredicate(
+        TBlockSync const & blockSync,
+        int predicate)
+    -> int
+    {
+        using ImplementationBase = concepts::ImplementationBase<ConceptBlockSync, TBlockSync>;
+        return
+            traits::SyncBlockThreadsPredicate<
+                TOp,
+                ImplementationBase>
+            ::syncBlockThreadsPredicate(
+                blockSync,
+                predicate);
     }
 }

--- a/include/alpaka/core/BarrierThread.hpp
+++ b/include/alpaka/core/BarrierThread.hpp
@@ -107,7 +107,7 @@ namespace alpaka
                 //#############################################################################
                 template<>
                 struct AtomicOp<
-                    op::Count>
+                    blockOp::Count>
                 {
                     void operator()(std::atomic<int>& result, bool value)
                     {
@@ -117,7 +117,7 @@ namespace alpaka
                 //#############################################################################
                 template<>
                 struct AtomicOp<
-                    op::LogicalAnd>
+                    blockOp::LogicalAnd>
                 {
                     void operator()(std::atomic<int>& result, bool value)
                     {
@@ -127,7 +127,7 @@ namespace alpaka
                 //#############################################################################
                 template<>
                 struct AtomicOp<
-                    op::LogicalOr>
+                    blockOp::LogicalOr>
                 {
                     void operator()(std::atomic<int>& result, bool value)
                     {

--- a/include/alpaka/core/BarrierThread.hpp
+++ b/include/alpaka/core/BarrierThread.hpp
@@ -107,7 +107,7 @@ namespace alpaka
                 //#############################################################################
                 template<>
                 struct AtomicOp<
-                    block::op::Count>
+                    op::Count>
                 {
                     void operator()(std::atomic<int>& result, bool value)
                     {
@@ -117,7 +117,7 @@ namespace alpaka
                 //#############################################################################
                 template<>
                 struct AtomicOp<
-                    block::op::LogicalAnd>
+                    op::LogicalAnd>
                 {
                     void operator()(std::atomic<int>& result, bool value)
                     {
@@ -127,7 +127,7 @@ namespace alpaka
                 //#############################################################################
                 template<>
                 struct AtomicOp<
-                    block::op::LogicalOr>
+                    op::LogicalOr>
                 {
                     void operator()(std::atomic<int>& result, bool value)
                     {

--- a/include/alpaka/kernel/TaskKernelCpuFibers.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuFibers.hpp
@@ -219,7 +219,7 @@ namespace alpaka
             acc.m_fibersToIndices.clear();
 
             // After a block has been processed, the shared memory has to be deleted.
-            block::freeMem(acc);
+            freeMem(acc);
         }
         //-----------------------------------------------------------------------------
         //! The function executed for each block thread.

--- a/include/alpaka/kernel/TaskKernelCpuFibers.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuFibers.hpp
@@ -219,7 +219,7 @@ namespace alpaka
             acc.m_fibersToIndices.clear();
 
             // After a block has been processed, the shared memory has to be deleted.
-            block::st::freeMem(acc);
+            block::freeMem(acc);
         }
         //-----------------------------------------------------------------------------
         //! The function executed for each block thread.

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -215,7 +215,7 @@ namespace alpaka
                     acc);
 
                 // After a block has been processed, the shared memory has to be deleted.
-                block::st::freeMem(acc);
+                block::freeMem(acc);
             }
         }
 

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -215,7 +215,7 @@ namespace alpaka
                     acc);
 
                 // After a block has been processed, the shared memory has to be deleted.
-                block::freeMem(acc);
+                freeMem(acc);
             }
         }
 

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -188,7 +188,7 @@ namespace alpaka
                     }
 
                     // After a block has been processed, the shared memory has to be deleted.
-                    block::st::freeMem(acc);
+                    block::freeMem(acc);
                 });
 
             // Reset the dynamic thread number setting.

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -184,11 +184,11 @@ namespace alpaka
 
                         // Wait for all threads to finish before deleting the shared memory.
                         // This is done by default if the omp 'nowait' clause is missing on the omp parallel directive
-                        //block::syncBlockThreads(acc);
+                        //syncBlockThreads(acc);
                     }
 
                     // After a block has been processed, the shared memory has to be deleted.
-                    block::freeMem(acc);
+                    freeMem(acc);
                 });
 
             // Reset the dynamic thread number setting.

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -141,7 +141,7 @@ namespace alpaka
                         acc);
 
                     // After a block has been processed, the shared memory has to be deleted.
-                    block::freeMem(acc);
+                    freeMem(acc);
                 });
         }
 

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -141,7 +141,7 @@ namespace alpaka
                         acc);
 
                     // After a block has been processed, the shared memory has to be deleted.
-                    block::st::freeMem(acc);
+                    block::freeMem(acc);
                 });
         }
 

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -153,7 +153,7 @@ namespace alpaka
 
                         boundKernelFnObj(acc);
 
-                        block::freeMem(acc);
+                        freeMem(acc);
             });
 
         }

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -153,7 +153,7 @@ namespace alpaka
 
                         boundKernelFnObj(acc);
 
-                        block::st::freeMem(acc);
+                        block::freeMem(acc);
             });
 
         }

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -215,7 +215,7 @@ namespace alpaka
             acc.m_threadToIndexMap.clear();
 
             // After a block has been processed, the shared memory has to be deleted.
-            block::st::freeMem(acc);
+            block::freeMem(acc);
         }
         //-----------------------------------------------------------------------------
         //! The function executed for each block thread on the host.

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -215,7 +215,7 @@ namespace alpaka
             acc.m_threadToIndexMap.clear();
 
             // After a block has been processed, the shared memory has to be deleted.
-            block::freeMem(acc);
+            freeMem(acc);
         }
         //-----------------------------------------------------------------------------
         //! The function executed for each block thread on the host.

--- a/include/alpaka/kernel/TaskKernelOmp5.hpp
+++ b/include/alpaka/kernel/TaskKernelOmp5.hpp
@@ -225,7 +225,7 @@ namespace alpaka
                     }
 
                     // After a block has been processed, the shared memory has to be deleted.
-                    // block::st::freeMem(acc);
+                    // block::freeMem(acc);
                 }
             }
 

--- a/include/alpaka/kernel/TaskKernelOmp5.hpp
+++ b/include/alpaka/kernel/TaskKernelOmp5.hpp
@@ -221,11 +221,11 @@ namespace alpaka
 
                         // Wait for all threads to finish before deleting the shared memory.
                         // This is done by default if the omp 'nowait' clause is missing
-                        //block::syncBlockThreads(acc);
+                        //syncBlockThreads(acc);
                     }
 
                     // After a block has been processed, the shared memory has to be deleted.
-                    // block::freeMem(acc);
+                    // freeMem(acc);
                 }
             }
 

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -81,7 +81,7 @@ public:
         auto const & blockThreadExtentVal(blockThreadExtentX);
 
         // Shared memory used to store the current blocks of A and B.
-        auto * const pBlockSharedA(alpaka::block::getMem<TElem>(acc));
+        auto * const pBlockSharedA(alpaka::getMem<TElem>(acc));
         auto * const pBlockSharedB(pBlockSharedA + blockThreadExtentX*blockThreadExtentY);
 
         auto const sharedBlockIdx1d(blockThreadIdxY*blockThreadExtentX + blockThreadIdxX);
@@ -115,7 +115,7 @@ public:
                 : B[BIdx1d]);
 
             // Synchronize to make sure the complete blocks are loaded before starting the computation.
-            alpaka::block::syncBlockThreads(acc);
+            alpaka::syncBlockThreads(acc);
 
             // Not really necessary because we wrote zeros into those cells.
             //if(insideC)
@@ -129,7 +129,7 @@ public:
             //}
 
             // Synchronize to make sure that the preceding computation is done before loading the next blocks of A and B.
-            alpaka::block::syncBlockThreads(acc);
+            alpaka::syncBlockThreads(acc);
         }
 
         // If the element is outside of the matrix it was only a helper thread that did not calculate any meaningful results.

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -81,7 +81,7 @@ public:
         auto const & blockThreadExtentVal(blockThreadExtentX);
 
         // Shared memory used to store the current blocks of A and B.
-        auto * const pBlockSharedA(alpaka::block::dyn::getMem<TElem>(acc));
+        auto * const pBlockSharedA(alpaka::block::getMem<TElem>(acc));
         auto * const pBlockSharedB(pBlockSharedA + blockThreadExtentX*blockThreadExtentY);
 
         auto const sharedBlockIdx1d(blockThreadIdxY*blockThreadExtentX + blockThreadIdxX);

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -47,7 +47,7 @@ public:
         Idx const blockThreadCount(alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u]);
 
         // Get the dynamically allocated shared memory.
-        Val * const pBlockShared(alpaka::block::dyn::getMem<Val>(acc));
+        Val * const pBlockShared(alpaka::block::getMem<Val>(acc));
 
         // Calculate linearized index of the thread in the block.
         Idx const blockThreadIdx1d(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -47,7 +47,7 @@ public:
         Idx const blockThreadCount(alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc)[0u]);
 
         // Get the dynamically allocated shared memory.
-        Val * const pBlockShared(alpaka::block::getMem<Val>(acc));
+        Val * const pBlockShared(alpaka::getMem<Val>(acc));
 
         // Calculate linearized index of the thread in the block.
         Idx const blockThreadIdx1d(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);
@@ -63,7 +63,7 @@ public:
 
 
         // Synchronize all threads because now we are writing to the memory again but inverse.
-        alpaka::block::syncBlockThreads(acc);
+        alpaka::syncBlockThreads(acc);
 
         // Do something useless.
         auto sum2 = static_cast<Val>(blockThreadIdx1d);
@@ -76,7 +76,7 @@ public:
 
 
         // Synchronize all threads again.
-        alpaka::block::syncBlockThreads(acc);
+        alpaka::syncBlockThreads(acc);
 
         // Now add up all the cells atomically and write the result to cell 0 of the shared memory.
         if(blockThreadIdx1d > 0)
@@ -85,7 +85,7 @@ public:
         }
 
 
-        alpaka::block::syncBlockThreads(acc);
+        alpaka::syncBlockThreads(acc);
 
         // Only master writes result to global memory.
         if(blockThreadIdx1d==0)

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -29,7 +29,7 @@ ALPAKA_FN_ACC auto testAtomicAdd(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -54,7 +54,7 @@ ALPAKA_FN_ACC auto testAtomicSub(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -79,7 +79,7 @@ ALPAKA_FN_ACC auto testAtomicMin(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -104,7 +104,7 @@ ALPAKA_FN_ACC auto testAtomicMax(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -129,7 +129,7 @@ ALPAKA_FN_ACC auto testAtomicExch(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -155,7 +155,7 @@ ALPAKA_FN_ACC auto testAtomicInc(
 -> void
 {
     // \TODO: Check reset to 0 at 'value'.
-    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(42);
     T const ret =
@@ -181,7 +181,7 @@ ALPAKA_FN_ACC auto testAtomicDec(
 -> void
 {
     // \TODO: Check reset to 'value' at 0.
-    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(42);
     T const ret =
@@ -206,7 +206,7 @@ ALPAKA_FN_ACC auto testAtomicAnd(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -231,7 +231,7 @@ ALPAKA_FN_ACC auto testAtomicOr(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -256,7 +256,7 @@ ALPAKA_FN_ACC auto testAtomicXor(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(operandOrig + static_cast<T>(4));
     T const ret =
@@ -281,7 +281,7 @@ ALPAKA_FN_ACC auto testAtomicCas(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::allocVar<T, __COUNTER__>(acc);
 
     //-----------------------------------------------------------------------------
     // with match

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -29,7 +29,7 @@ ALPAKA_FN_ACC auto testAtomicAdd(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -54,7 +54,7 @@ ALPAKA_FN_ACC auto testAtomicSub(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -79,7 +79,7 @@ ALPAKA_FN_ACC auto testAtomicMin(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -104,7 +104,7 @@ ALPAKA_FN_ACC auto testAtomicMax(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -129,7 +129,7 @@ ALPAKA_FN_ACC auto testAtomicExch(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -155,7 +155,7 @@ ALPAKA_FN_ACC auto testAtomicInc(
 -> void
 {
     // \TODO: Check reset to 0 at 'value'.
-    auto & operand = alpaka::block::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(42);
     T const ret =
@@ -181,7 +181,7 @@ ALPAKA_FN_ACC auto testAtomicDec(
 -> void
 {
     // \TODO: Check reset to 'value' at 0.
-    auto & operand = alpaka::block::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(42);
     T const ret =
@@ -206,7 +206,7 @@ ALPAKA_FN_ACC auto testAtomicAnd(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -231,7 +231,7 @@ ALPAKA_FN_ACC auto testAtomicOr(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(4);
     T const ret =
@@ -256,7 +256,7 @@ ALPAKA_FN_ACC auto testAtomicXor(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
     operand = operandOrig;
     T const value = static_cast<T>(operandOrig + static_cast<T>(4));
     T const ret =
@@ -281,7 +281,7 @@ ALPAKA_FN_ACC auto testAtomicCas(
     T operandOrig)
 -> void
 {
-    auto & operand = alpaka::block::st::allocVar<T, __COUNTER__>(acc);
+    auto & operand = alpaka::block::allocVar<T, __COUNTER__>(acc);
 
     //-----------------------------------------------------------------------------
     // with match

--- a/test/unit/block/shared/src/BlockSharedMemDyn.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemDyn.cpp
@@ -29,15 +29,15 @@ public:
     -> void
     {
         // Assure that the pointer is non null.
-        auto a = alpaka::block::getMem<std::uint32_t>(acc);
+        auto a = alpaka::getMem<std::uint32_t>(acc);
         ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != a);
 
         // Each call should return the same pointer ...
-        auto b = alpaka::block::getMem<std::uint32_t>(acc);
+        auto b = alpaka::getMem<std::uint32_t>(acc);
         ALPAKA_CHECK(*success, a == b);
 
         // ... even for different types.
-        auto c = alpaka::block::getMem<float>(acc);
+        auto c = alpaka::getMem<float>(acc);
         ALPAKA_CHECK(*success, a == reinterpret_cast<std::uint32_t *>(c));
     }
 };

--- a/test/unit/block/shared/src/BlockSharedMemDyn.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemDyn.cpp
@@ -29,15 +29,15 @@ public:
     -> void
     {
         // Assure that the pointer is non null.
-        auto a = alpaka::block::dyn::getMem<std::uint32_t>(acc);
+        auto a = alpaka::block::getMem<std::uint32_t>(acc);
         ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != a);
 
         // Each call should return the same pointer ...
-        auto b = alpaka::block::dyn::getMem<std::uint32_t>(acc);
+        auto b = alpaka::block::getMem<std::uint32_t>(acc);
         ALPAKA_CHECK(*success, a == b);
 
         // ... even for different types.
-        auto c = alpaka::block::dyn::getMem<float>(acc);
+        auto c = alpaka::block::getMem<float>(acc);
         ALPAKA_CHECK(*success, a == reinterpret_cast<std::uint32_t *>(c));
     }
 };

--- a/test/unit/block/shared/src/BlockSharedMemSt.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemSt.cpp
@@ -36,29 +36,29 @@ public:
         // Multiple runs to make sure it really works.
         for(std::size_t i=0u; i<10; ++i)
         {
-            auto & a = alpaka::block::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & a = alpaka::block::allocVar<std::uint32_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &a);
 
-            auto & b = alpaka::block::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & b = alpaka::block::allocVar<std::uint32_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &b);
 
-            auto & c = alpaka::block::st::allocVar<float, __COUNTER__>(acc);
+            auto & c = alpaka::block::allocVar<float, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<float *>(nullptr) != &c);
 
-            auto & d = alpaka::block::st::allocVar<double, __COUNTER__>(acc);
+            auto & d = alpaka::block::allocVar<double, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<double *>(nullptr) != &d);
 
-            auto & e = alpaka::block::st::allocVar<std::uint64_t, __COUNTER__>(acc);
+            auto & e = alpaka::block::allocVar<std::uint64_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint64_t *>(nullptr) != &e);
 
 
-            auto & f = alpaka::block::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            auto & f = alpaka::block::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &f[0]);
 
-            auto & g = alpaka::block::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            auto & g = alpaka::block::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &g[0]);
 
-            auto & h = alpaka::block::st::allocVar<alpaka::test::Array<double, 16>, __COUNTER__>(acc);
+            auto & h = alpaka::block::allocVar<alpaka::test::Array<double, 16>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<double *>(nullptr) != &h[0]);
         }
 #if BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(6, 0, 0)
@@ -99,19 +99,19 @@ public:
         // Multiple runs to make sure it really works.
         for(std::size_t i=0u; i<10; ++i)
         {
-            auto & a = alpaka::block::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-            auto & b = alpaka::block::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & a = alpaka::block::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & b = alpaka::block::allocVar<std::uint32_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, &a != &b);
-            auto & c = alpaka::block::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & c = alpaka::block::allocVar<std::uint32_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, &b != &c);
             ALPAKA_CHECK(*success, &a != &c);
             ALPAKA_CHECK(*success, &b != &c);
 
-            auto & d = alpaka::block::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            auto & d = alpaka::block::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, &a != &d[0]);
             ALPAKA_CHECK(*success, &b != &d[0]);
             ALPAKA_CHECK(*success, &c != &d[0]);
-            auto & e = alpaka::block::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            auto & e = alpaka::block::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, &a != &e[0]);
             ALPAKA_CHECK(*success, &b != &e[0]);
             ALPAKA_CHECK(*success, &c != &e[0]);

--- a/test/unit/block/shared/src/BlockSharedMemSt.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemSt.cpp
@@ -36,29 +36,29 @@ public:
         // Multiple runs to make sure it really works.
         for(std::size_t i=0u; i<10; ++i)
         {
-            auto & a = alpaka::block::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & a = alpaka::allocVar<std::uint32_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &a);
 
-            auto & b = alpaka::block::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & b = alpaka::allocVar<std::uint32_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &b);
 
-            auto & c = alpaka::block::allocVar<float, __COUNTER__>(acc);
+            auto & c = alpaka::allocVar<float, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<float *>(nullptr) != &c);
 
-            auto & d = alpaka::block::allocVar<double, __COUNTER__>(acc);
+            auto & d = alpaka::allocVar<double, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<double *>(nullptr) != &d);
 
-            auto & e = alpaka::block::allocVar<std::uint64_t, __COUNTER__>(acc);
+            auto & e = alpaka::allocVar<std::uint64_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint64_t *>(nullptr) != &e);
 
 
-            auto & f = alpaka::block::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            auto & f = alpaka::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &f[0]);
 
-            auto & g = alpaka::block::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            auto & g = alpaka::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &g[0]);
 
-            auto & h = alpaka::block::allocVar<alpaka::test::Array<double, 16>, __COUNTER__>(acc);
+            auto & h = alpaka::allocVar<alpaka::test::Array<double, 16>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, static_cast<double *>(nullptr) != &h[0]);
         }
 #if BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(6, 0, 0)
@@ -99,19 +99,19 @@ public:
         // Multiple runs to make sure it really works.
         for(std::size_t i=0u; i<10; ++i)
         {
-            auto & a = alpaka::block::allocVar<std::uint32_t, __COUNTER__>(acc);
-            auto & b = alpaka::block::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & a = alpaka::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & b = alpaka::allocVar<std::uint32_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, &a != &b);
-            auto & c = alpaka::block::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto & c = alpaka::allocVar<std::uint32_t, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, &b != &c);
             ALPAKA_CHECK(*success, &a != &c);
             ALPAKA_CHECK(*success, &b != &c);
 
-            auto & d = alpaka::block::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            auto & d = alpaka::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, &a != &d[0]);
             ALPAKA_CHECK(*success, &b != &d[0]);
             ALPAKA_CHECK(*success, &c != &d[0]);
-            auto & e = alpaka::block::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            auto & e = alpaka::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
             ALPAKA_CHECK(*success, &a != &e[0]);
             ALPAKA_CHECK(*success, &b != &e[0]);
             ALPAKA_CHECK(*success, &c != &e[0]);

--- a/test/unit/block/sync/src/BlockSync.cpp
+++ b/test/unit/block/sync/src/BlockSync.cpp
@@ -38,7 +38,7 @@ public:
         auto const blockThreadExtent1D = blockThreadExtent.prod();
 
         // Allocate shared memory.
-        Idx * const pBlockSharedArray = alpaka::block::dyn::getMem<Idx>(acc);
+        Idx * const pBlockSharedArray = alpaka::block::getMem<Idx>(acc);
    
         // Write the thread index into the shared memory.
         pBlockSharedArray[blockThreadIdx1D] = blockThreadIdx1D;

--- a/test/unit/block/sync/src/BlockSync.cpp
+++ b/test/unit/block/sync/src/BlockSync.cpp
@@ -38,13 +38,13 @@ public:
         auto const blockThreadExtent1D = blockThreadExtent.prod();
 
         // Allocate shared memory.
-        Idx * const pBlockSharedArray = alpaka::block::getMem<Idx>(acc);
+        Idx * const pBlockSharedArray = alpaka::getMem<Idx>(acc);
    
         // Write the thread index into the shared memory.
         pBlockSharedArray[blockThreadIdx1D] = blockThreadIdx1D;
 
         // Synchronize the threads in the block.
-        alpaka::block::syncBlockThreads(acc);
+        alpaka::syncBlockThreads(acc);
 
         // All other threads within the block should now have written their index into the shared memory.
         for(auto i(static_cast<Idx>(0u)); i < blockThreadExtent1D; ++i)

--- a/test/unit/block/sync/src/BlockSyncPredicate.cpp
+++ b/test/unit/block/sync/src/BlockSyncPredicate.cpp
@@ -35,53 +35,53 @@ public:
         auto const blockThreadIdx1D(alpaka::mapIdx<1u>(blockThreadIdx, blockThreadExtent)[0u]);
         auto const blockThreadExtent1D(blockThreadExtent.prod());
 
-        // syncBlockThreadsPredicate<alpaka::block::op::Count>
+        // syncBlockThreadsPredicate<alpaka::op::Count>
         {
             Idx const modulus(2u);
             int const predicate(static_cast<int>(blockThreadIdx1D % modulus));
-            auto const result(alpaka::block::syncBlockThreadsPredicate<alpaka::block::op::Count>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::Count>(acc, predicate));
             auto const expectedResult(static_cast<int>(blockThreadExtent1D / modulus));
             ALPAKA_CHECK(*success, expectedResult == result);
         }
         {
             Idx const modulus(3u);
             int const predicate(static_cast<int>(blockThreadIdx1D % modulus));
-            auto const result(alpaka::block::syncBlockThreadsPredicate<alpaka::block::op::Count>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::Count>(acc, predicate));
             auto const expectedResult(static_cast<int>(blockThreadExtent1D - ((blockThreadExtent1D + modulus - static_cast<Idx>(1u)) / modulus)));
             ALPAKA_CHECK(*success, expectedResult == result);
         }
 
-        // syncBlockThreadsPredicate<alpaka::block::op::LogicalAnd>
+        // syncBlockThreadsPredicate<alpaka::op::LogicalAnd>
         {
             int const predicate(1);
-            auto const result(alpaka::block::syncBlockThreadsPredicate<alpaka::block::op::LogicalAnd>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::LogicalAnd>(acc, predicate));
             ALPAKA_CHECK(*success, result == 1);
         }
         {
             int const predicate(0);
-            auto const result(alpaka::block::syncBlockThreadsPredicate<alpaka::block::op::LogicalAnd>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::LogicalAnd>(acc, predicate));
             ALPAKA_CHECK(*success, result == 0);
         }
         {
             int const predicate(blockThreadIdx1D != 0);
-            auto const result(alpaka::block::syncBlockThreadsPredicate<alpaka::block::op::LogicalAnd>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::LogicalAnd>(acc, predicate));
             ALPAKA_CHECK(*success, result == 0);
         }
 
-        // syncBlockThreadsPredicate<alpaka::block::op::LogicalOr>
+        // syncBlockThreadsPredicate<alpaka::op::LogicalOr>
         {
             int const predicate(1);
-            auto const result(alpaka::block::syncBlockThreadsPredicate<alpaka::block::op::LogicalOr>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::LogicalOr>(acc, predicate));
             ALPAKA_CHECK(*success, result == 1);
         }
         {
             int const predicate(0);
-            auto const result(alpaka::block::syncBlockThreadsPredicate<alpaka::block::op::LogicalOr>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::LogicalOr>(acc, predicate));
             ALPAKA_CHECK(*success, result == 0);
         }
         {
             int const predicate(static_cast<int>(blockThreadIdx1D != 1));
-            auto const result(alpaka::block::syncBlockThreadsPredicate<alpaka::block::op::LogicalOr>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::LogicalOr>(acc, predicate));
             ALPAKA_CHECK(*success, result == 1);
         }
     }

--- a/test/unit/block/sync/src/BlockSyncPredicate.cpp
+++ b/test/unit/block/sync/src/BlockSyncPredicate.cpp
@@ -35,53 +35,53 @@ public:
         auto const blockThreadIdx1D(alpaka::mapIdx<1u>(blockThreadIdx, blockThreadExtent)[0u]);
         auto const blockThreadExtent1D(blockThreadExtent.prod());
 
-        // syncBlockThreadsPredicate<alpaka::op::Count>
+        // syncBlockThreadsPredicate<alpaka::blockOp::Count>
         {
             Idx const modulus(2u);
             int const predicate(static_cast<int>(blockThreadIdx1D % modulus));
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::Count>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::Count>(acc, predicate));
             auto const expectedResult(static_cast<int>(blockThreadExtent1D / modulus));
             ALPAKA_CHECK(*success, expectedResult == result);
         }
         {
             Idx const modulus(3u);
             int const predicate(static_cast<int>(blockThreadIdx1D % modulus));
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::Count>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::Count>(acc, predicate));
             auto const expectedResult(static_cast<int>(blockThreadExtent1D - ((blockThreadExtent1D + modulus - static_cast<Idx>(1u)) / modulus)));
             ALPAKA_CHECK(*success, expectedResult == result);
         }
 
-        // syncBlockThreadsPredicate<alpaka::op::LogicalAnd>
+        // syncBlockThreadsPredicate<alpaka::blockOp::LogicalAnd>
         {
             int const predicate(1);
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::LogicalAnd>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::LogicalAnd>(acc, predicate));
             ALPAKA_CHECK(*success, result == 1);
         }
         {
             int const predicate(0);
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::LogicalAnd>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::LogicalAnd>(acc, predicate));
             ALPAKA_CHECK(*success, result == 0);
         }
         {
             int const predicate(blockThreadIdx1D != 0);
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::LogicalAnd>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::LogicalAnd>(acc, predicate));
             ALPAKA_CHECK(*success, result == 0);
         }
 
-        // syncBlockThreadsPredicate<alpaka::op::LogicalOr>
+        // syncBlockThreadsPredicate<alpaka::blockOp::LogicalOr>
         {
             int const predicate(1);
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::LogicalOr>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::LogicalOr>(acc, predicate));
             ALPAKA_CHECK(*success, result == 1);
         }
         {
             int const predicate(0);
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::LogicalOr>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::LogicalOr>(acc, predicate));
             ALPAKA_CHECK(*success, result == 0);
         }
         {
             int const predicate(static_cast<int>(blockThreadIdx1D != 1));
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::op::LogicalOr>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::LogicalOr>(acc, predicate));
             ALPAKA_CHECK(*success, result == 1);
         }
     }


### PR DESCRIPTION
See #1034

Also renames the namespace `alpaka::block::op` to `alpaka::blockOp` to not be confused with `alpaka::op` containing atomic operators. I think we should debate this!