### PR TITLE
Rename atomic and block operation functors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - removed namespace `alpaka::vec`
 - removed namespace `alpaka::workdiv`
 - removed namespace `alpaka::acc`
+- renamed functors `alpaka::atomic::op::And` et. al. to `alpaka::AtomicAnd` et. al.
+- removed namespace `alpaka::atomic::op`
 - removed namespace `alpaka::atomic`
 - removed namespace `alpaka::queue`
 - removed namespace `alpaka::idx`
@@ -37,11 +39,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - removed namespace `alpaka::view`
 - removed namespace `alpaka::block::st`
 - removed namespace `alpaka::block::dyn`
-- renamed namespace `alpaka::block::op` to `alpaka::blockOp`
+- renamed functors `alpaka::block::op::LogicalAnd` et. al. to `alpaka::BlockAnd` et. al.
+- removed namespace `alpaka::block::op`
 - removed namespace `alpaka::block`
 
 ### New Features:
-- add functions `alpaka::atomicAdd` et. al. as shortcuts to `alpaka::atomicOp<alpaka::op::Add>` et. al. #1005
+- add functions `alpaka::atomicAnd` et. al. as shortcuts to `alpaka::atomicOp<alpaka::AtomicAnd>` et. al. #1005
 
 ## [0.5.0] - 2020-06-26
 ### Compatibility Changes:

--- a/include/alpaka/atomic/AtomicOmpBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicOmpBuiltIn.hpp
@@ -51,7 +51,7 @@ namespace alpaka
             typename T,
             typename THierarchy>
         struct AtomicOp<
-            op::Add,
+            AtomicAdd,
             AtomicOmpBuiltIn,
             T,
             THierarchy>
@@ -81,7 +81,7 @@ namespace alpaka
             typename T,
             typename THierarchy>
         struct AtomicOp<
-            op::Sub,
+            AtomicSub,
             AtomicOmpBuiltIn,
             T,
             THierarchy>
@@ -111,7 +111,7 @@ namespace alpaka
             typename T,
             typename THierarchy>
         struct AtomicOp<
-            op::Exch,
+            AtomicExch,
             AtomicOmpBuiltIn,
             T,
             THierarchy>
@@ -141,7 +141,7 @@ namespace alpaka
             typename T,
             typename THierarchy>
         struct AtomicOp<
-            op::And,
+            AtomicAnd,
             AtomicOmpBuiltIn,
             T,
             THierarchy>
@@ -171,7 +171,7 @@ namespace alpaka
             typename T,
             typename THierarchy>
         struct AtomicOp<
-            op::Or,
+            AtomicOr,
             AtomicOmpBuiltIn,
             T,
             THierarchy>
@@ -201,7 +201,7 @@ namespace alpaka
             typename T,
             typename THierarchy>
         struct AtomicOp<
-            op::Xor,
+            AtomicXor,
             AtomicOmpBuiltIn,
             T,
             THierarchy>

--- a/include/alpaka/atomic/AtomicUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicUniformCudaHipBuiltIn.hpp
@@ -66,7 +66,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Add,
+            AtomicAdd,
             AtomicUniformCudaHipBuiltIn,
             int,
             THierarchy>
@@ -86,7 +86,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Add,
+            AtomicAdd,
             AtomicUniformCudaHipBuiltIn,
             unsigned int,
             THierarchy>
@@ -106,7 +106,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Add,
+            AtomicAdd,
             AtomicUniformCudaHipBuiltIn,
             unsigned long int,
             THierarchy>
@@ -135,7 +135,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Add,
+            AtomicAdd,
             AtomicUniformCudaHipBuiltIn,
             unsigned long long int,
             THierarchy>
@@ -156,7 +156,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Add,
+            AtomicAdd,
             AtomicUniformCudaHipBuiltIn,
             float,
             THierarchy>
@@ -177,7 +177,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Add,
+            AtomicAdd,
             AtomicUniformCudaHipBuiltIn,
             double,
             THierarchy>
@@ -220,7 +220,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Sub,
+            AtomicSub,
             AtomicUniformCudaHipBuiltIn,
             int,
             THierarchy>
@@ -240,7 +240,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Sub,
+            AtomicSub,
             AtomicUniformCudaHipBuiltIn,
             unsigned int,
             THierarchy>
@@ -260,7 +260,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Sub,
+            AtomicSub,
             AtomicUniformCudaHipBuiltIn,
             unsigned long int,
             THierarchy>
@@ -282,7 +282,7 @@ namespace alpaka
                 alpaka::ignore_unused(value);
                 static_assert(
                     meta::DependentFalseType<THierarchy>::value,
-                    "atomicOp<op::Sub, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported when sizeof(unsigned long int) == 4");
+                    "atomicOp<AtomicSub, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported when sizeof(unsigned long int) == 4");
 #endif
             }
         };
@@ -295,7 +295,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Min,
+            AtomicMin,
             AtomicUniformCudaHipBuiltIn,
             int,
             THierarchy>
@@ -315,7 +315,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Min,
+            AtomicMin,
             AtomicUniformCudaHipBuiltIn,
             unsigned int,
             THierarchy>
@@ -335,7 +335,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Min,
+            AtomicMin,
             AtomicUniformCudaHipBuiltIn,
             unsigned long int,
             THierarchy>
@@ -362,7 +362,7 @@ namespace alpaka
                 alpaka::ignore_unused(value);
                 static_assert(
                     meta::DependentFalseType<THierarchy>::value,
-                    "atomicOp<op::Min, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported on sm >= 3.5");
+                    "atomicOp<AtomicMin, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported on sm >= 3.5");
 #endif
 #endif
             }
@@ -372,7 +372,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Min,
+            AtomicMin,
             AtomicUniformCudaHipBuiltIn,
             unsigned long long int,
             THierarchy>
@@ -391,7 +391,7 @@ namespace alpaka
                 alpaka::ignore_unused(value);
                 static_assert(
                     meta::DependentFalseType<THierarchy>::value,
-                    "atomicOp<op::Min, AtomicUniformCudaHipBuiltIn, unsigned long long int> is only supported on sm >= 3.5");
+                    "atomicOp<AtomicMin, AtomicUniformCudaHipBuiltIn, unsigned long long int> is only supported on sm >= 3.5");
 #endif
             }
         };
@@ -404,7 +404,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Max,
+            AtomicMax,
             AtomicUniformCudaHipBuiltIn,
             int,
             THierarchy>
@@ -424,7 +424,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Max,
+            AtomicMax,
             AtomicUniformCudaHipBuiltIn,
             unsigned int,
             THierarchy>
@@ -443,7 +443,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Max,
+            AtomicMax,
             AtomicUniformCudaHipBuiltIn,
             unsigned long int,
             THierarchy>
@@ -470,7 +470,7 @@ namespace alpaka
                 alpaka::ignore_unused(value);
                 static_assert(
                     meta::DependentFalseType<THierarchy>::value,
-                    "atomicOp<op::Max, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported on sm >= 3.5");
+                    "atomicOp<AtomicMax, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported on sm >= 3.5");
 #endif
 #endif
             }
@@ -480,7 +480,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Max,
+            AtomicMax,
             AtomicUniformCudaHipBuiltIn,
             unsigned long long int,
             THierarchy>
@@ -499,7 +499,7 @@ namespace alpaka
                 alpaka::ignore_unused(value);
                 static_assert(
                     meta::DependentFalseType<THierarchy>::value,
-                    "atomicOp<op::Max, AtomicUniformCudaHipBuiltIn, unsigned long long int> is only supported on sm >= 3.5");
+                    "atomicOp<AtomicMax, AtomicUniformCudaHipBuiltIn, unsigned long long int> is only supported on sm >= 3.5");
 #endif
             }
         };
@@ -512,7 +512,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Exch,
+            AtomicExch,
             AtomicUniformCudaHipBuiltIn,
             int,
             THierarchy>
@@ -532,7 +532,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Exch,
+            AtomicExch,
             AtomicUniformCudaHipBuiltIn,
             unsigned int,
             THierarchy>
@@ -552,7 +552,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Exch,
+            AtomicExch,
             AtomicUniformCudaHipBuiltIn,
             unsigned long int,
             THierarchy>
@@ -581,7 +581,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Exch,
+            AtomicExch,
             AtomicUniformCudaHipBuiltIn,
             unsigned long long int,
             THierarchy>
@@ -601,7 +601,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Exch,
+            AtomicExch,
             AtomicUniformCudaHipBuiltIn,
             float,
             THierarchy>
@@ -625,7 +625,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Inc,
+            AtomicInc,
             AtomicUniformCudaHipBuiltIn,
             unsigned int,
             THierarchy>
@@ -645,7 +645,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Inc,
+            AtomicInc,
             AtomicUniformCudaHipBuiltIn,
             unsigned long int,
             THierarchy>
@@ -667,7 +667,7 @@ namespace alpaka
                 alpaka::ignore_unused(value);
                 static_assert(
                     meta::DependentFalseType<THierarchy>::value,
-                    "atomicOp<op::Inc, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported when sizeof(unsigned long int) == 4");
+                    "atomicOp<AtomicInc, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported when sizeof(unsigned long int) == 4");
 #endif
             }
         };
@@ -680,7 +680,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Dec,
+            AtomicDec,
             AtomicUniformCudaHipBuiltIn,
             unsigned int,
             THierarchy>
@@ -700,7 +700,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Dec,
+            AtomicDec,
             AtomicUniformCudaHipBuiltIn,
             unsigned long int,
             THierarchy>
@@ -722,7 +722,7 @@ namespace alpaka
                 alpaka::ignore_unused(value);
                 static_assert(
                     meta::DependentFalseType<THierarchy>::value,
-                    "atomicOp<op::Dec, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported when sizeof(unsigned long int) == 4");
+                    "atomicOp<AtomicDec, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported when sizeof(unsigned long int) == 4");
 #endif
             }
         };
@@ -735,7 +735,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::And,
+            AtomicAnd,
             AtomicUniformCudaHipBuiltIn,
             int,
             THierarchy>
@@ -755,7 +755,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::And,
+            AtomicAnd,
             AtomicUniformCudaHipBuiltIn,
             unsigned int,
             THierarchy>
@@ -775,7 +775,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::And,
+            AtomicAnd,
             AtomicUniformCudaHipBuiltIn,
             unsigned long int,
             THierarchy>
@@ -802,7 +802,7 @@ namespace alpaka
                 alpaka::ignore_unused(value);
                 static_assert(
                     meta::DependentFalseType<THierarchy>::value,
-                    "atomicOp<op::And, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported on sm >= 3.5");
+                    "atomicOp<AtomicAnd, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported on sm >= 3.5");
 #endif
 #endif
             }
@@ -812,7 +812,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::And,
+            AtomicAnd,
             AtomicUniformCudaHipBuiltIn,
             unsigned long long int,
             THierarchy>
@@ -831,7 +831,7 @@ namespace alpaka
                 alpaka::ignore_unused(value);
                 static_assert(
                     meta::DependentFalseType<THierarchy>::value,
-                    "atomicOp<op::And, AtomicUniformCudaHipBuiltIn, unsigned long long int> is only supported on sm >= 3.5");
+                    "atomicOp<AtomicAnd, AtomicUniformCudaHipBuiltIn, unsigned long long int> is only supported on sm >= 3.5");
 #endif
             }
         };
@@ -844,7 +844,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Or,
+            AtomicOr,
             AtomicUniformCudaHipBuiltIn,
             int,
             THierarchy>
@@ -864,7 +864,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Or,
+            AtomicOr,
             AtomicUniformCudaHipBuiltIn,
             unsigned int,
             THierarchy>
@@ -884,7 +884,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Or,
+            AtomicOr,
             AtomicUniformCudaHipBuiltIn,
             unsigned long int,
             THierarchy>
@@ -911,7 +911,7 @@ namespace alpaka
                 alpaka::ignore_unused(value);
                 static_assert(
                     meta::DependentFalseType<THierarchy>::value,
-                    "atomicOp<op::Or, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported on sm >= 3.5");
+                    "atomicOp<AtomicOr, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported on sm >= 3.5");
 #endif
 #endif
             }
@@ -921,7 +921,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Or,
+            AtomicOr,
             AtomicUniformCudaHipBuiltIn,
             unsigned long long int,
             THierarchy>
@@ -940,7 +940,7 @@ namespace alpaka
                 alpaka::ignore_unused(value);
                 static_assert(
                     meta::DependentFalseType<THierarchy>::value,
-                    "atomicOp<op::Or, AtomicUniformCudaHipBuiltIn, unsigned long long int> is only supported on sm >= 3.5");
+                    "atomicOp<AtomicOr, AtomicUniformCudaHipBuiltIn, unsigned long long int> is only supported on sm >= 3.5");
 #endif
             }
         };
@@ -953,7 +953,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Xor,
+            AtomicXor,
             AtomicUniformCudaHipBuiltIn,
             int,
             THierarchy>
@@ -973,7 +973,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Xor,
+            AtomicXor,
             AtomicUniformCudaHipBuiltIn,
             unsigned int,
             THierarchy>
@@ -993,7 +993,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Xor,
+            AtomicXor,
             AtomicUniformCudaHipBuiltIn,
             unsigned long int,
             THierarchy>
@@ -1020,7 +1020,7 @@ namespace alpaka
                 alpaka::ignore_unused(value);
                 static_assert(
                     meta::DependentFalseType<THierarchy>::value,
-                    "atomicOp<op::Xor, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported on sm >= 3.5");
+                    "atomicOp<AtomicXor, AtomicUniformCudaHipBuiltIn, unsigned long int> is only supported on sm >= 3.5");
 #endif
 #endif
             }
@@ -1030,7 +1030,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Xor,
+            AtomicXor,
             AtomicUniformCudaHipBuiltIn,
             unsigned long long int,
             THierarchy>
@@ -1049,7 +1049,7 @@ namespace alpaka
                 alpaka::ignore_unused(value);
                 static_assert(
                     meta::DependentFalseType<THierarchy>::value,
-                    "atomicOp<op::Xor, AtomicUniformCudaHipBuiltIn, unsigned long long int> is only supported on sm >= 3.5");
+                    "atomicOp<AtomicXor, AtomicUniformCudaHipBuiltIn, unsigned long long int> is only supported on sm >= 3.5");
 #endif
             }
         };
@@ -1062,7 +1062,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Cas,
+            AtomicCas,
             AtomicUniformCudaHipBuiltIn,
             int,
             THierarchy>
@@ -1083,7 +1083,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Cas,
+            AtomicCas,
             AtomicUniformCudaHipBuiltIn,
             unsigned int,
             THierarchy>
@@ -1104,7 +1104,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Cas,
+            AtomicCas,
             AtomicUniformCudaHipBuiltIn,
             unsigned long int,
             THierarchy>
@@ -1136,7 +1136,7 @@ namespace alpaka
         template<
             typename THierarchy>
         struct AtomicOp<
-            op::Cas,
+            AtomicCas,
             AtomicUniformCudaHipBuiltIn,
             unsigned long long int,
             THierarchy>

--- a/include/alpaka/atomic/Op.hpp
+++ b/include/alpaka/atomic/Op.hpp
@@ -16,245 +16,241 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
-    //! Defines operation functors.
-    namespace op
+    //#############################################################################
+    //! The addition function object.
+    struct AtomicAdd
     {
-        //#############################################################################
-        //! The addition function object.
-        struct Add
+        //-----------------------------------------------------------------------------
+        //! \return The old value of addr.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T>
+        ALPAKA_FN_HOST_ACC auto operator()(
+            T * const addr,
+            T const & value) const
+        -> T
         {
-            //-----------------------------------------------------------------------------
-            //! \return The old value of addr.
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename T>
-            ALPAKA_FN_HOST_ACC auto operator()(
-                T * const addr,
-                T const & value) const
-            -> T
-            {
-                auto const old(*addr);
-                auto & ref(*addr);
+            auto const old(*addr);
+            auto & ref(*addr);
 #if BOOST_COMP_GNUC 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #endif
-                ref += value;
-                return old;
+            ref += value;
+            return old;
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic pop
 #endif
-            }
-        };
-        //#############################################################################
-        //! The subtraction function object.
-        struct Sub
+        }
+    };
+    //#############################################################################
+    //! The subtraction function object.
+    struct AtomicSub
+    {
+        //-----------------------------------------------------------------------------
+        //! \return The old value of addr.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T>
+        ALPAKA_FN_HOST_ACC auto operator()(
+            T * const addr,
+            T const & value) const
+        -> T
         {
-            //-----------------------------------------------------------------------------
-            //! \return The old value of addr.
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename T>
-            ALPAKA_FN_HOST_ACC auto operator()(
-                T * const addr,
-                T const & value) const
-            -> T
-            {
-                auto const old(*addr);
-                auto & ref(*addr);
+            auto const old(*addr);
+            auto & ref(*addr);
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #endif
-                ref -= value;
+            ref -= value;
 #if BOOST_COMP_GNUC
 #pragma GCC diagnostic pop
 #endif
-                return old;
-            }
-        };
-        //#############################################################################
-        //! The minimum function object.
-        struct Min
+            return old;
+        }
+    };
+    //#############################################################################
+    //! The minimum function object.
+    struct AtomicMin
+    {
+        //-----------------------------------------------------------------------------
+        //! \return The old value of addr.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T>
+        ALPAKA_FN_HOST_ACC auto operator()(
+            T * const addr,
+            T const & value) const
+        -> T
         {
-            //-----------------------------------------------------------------------------
-            //! \return The old value of addr.
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename T>
-            ALPAKA_FN_HOST_ACC auto operator()(
-                T * const addr,
-                T const & value) const
-            -> T
-            {
-                auto const old(*addr);
-                auto & ref(*addr);
-                ref = std::min(ref, value);
-                return old;
-            }
-        };
-        //#############################################################################
-        //! The maximum function object.
-        struct Max
+            auto const old(*addr);
+            auto & ref(*addr);
+            ref = std::min(ref, value);
+            return old;
+        }
+    };
+    //#############################################################################
+    //! The maximum function object.
+    struct AtomicMax
+    {
+        //-----------------------------------------------------------------------------
+        //! \return The old value of addr.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T>
+        ALPAKA_FN_HOST_ACC auto operator()(
+            T * const addr,
+            T const & value) const
+        -> T
         {
-            //-----------------------------------------------------------------------------
-            //! \return The old value of addr.
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename T>
-            ALPAKA_FN_HOST_ACC auto operator()(
-                T * const addr,
-                T const & value) const
-            -> T
-            {
-                auto const old(*addr);
-                auto & ref(*addr);
-                ref = std::max(ref, value);
-                return old;
-            }
-        };
-        //#############################################################################
-        //! The exchange function object.
-        struct Exch
+            auto const old(*addr);
+            auto & ref(*addr);
+            ref = std::max(ref, value);
+            return old;
+        }
+    };
+    //#############################################################################
+    //! The exchange function object.
+    struct AtomicExch
+    {
+        //-----------------------------------------------------------------------------
+        //! \return The old value of addr.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T>
+        ALPAKA_FN_HOST_ACC auto operator()(
+            T * const addr,
+            T const & value) const
+        -> T
         {
-            //-----------------------------------------------------------------------------
-            //! \return The old value of addr.
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename T>
-            ALPAKA_FN_HOST_ACC auto operator()(
-                T * const addr,
-                T const & value) const
-            -> T
-            {
-                auto const old(*addr);
-                auto & ref(*addr);
-                ref = value;
-                return old;
-            }
-        };
-        //#############################################################################
-        //! The increment function object.
-        struct Inc
+            auto const old(*addr);
+            auto & ref(*addr);
+            ref = value;
+            return old;
+        }
+    };
+    //#############################################################################
+    //! The increment function object.
+    struct AtomicInc
+    {
+        //-----------------------------------------------------------------------------
+        //! Increments up to value, then reset to 0.
+        //!
+        //! \return The old value of addr.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T>
+        ALPAKA_FN_HOST_ACC auto operator()(
+            T * const addr,
+            T const & value) const
+        -> T
         {
-            //-----------------------------------------------------------------------------
-            //! Increments up to value, then reset to 0.
-            //!
-            //! \return The old value of addr.
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename T>
-            ALPAKA_FN_HOST_ACC auto operator()(
-                T * const addr,
-                T const & value) const
-            -> T
-            {
-                auto const old(*addr);
-                auto & ref(*addr);
-                ref = ((old >= value) ? 0 : static_cast<T>(old + 1));
-                return old;
-            }
-        };
-        //#############################################################################
-        //! The decrement function object.
-        struct Dec
+            auto const old(*addr);
+            auto & ref(*addr);
+            ref = ((old >= value) ? 0 : static_cast<T>(old + 1));
+            return old;
+        }
+    };
+    //#############################################################################
+    //! The decrement function object.
+    struct AtomicDec
+    {
+        //-----------------------------------------------------------------------------
+        //! Decrement down to 0, then reset to value.
+        //!
+        //! \return The old value of addr.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T>
+        ALPAKA_FN_HOST_ACC auto operator()(
+            T * const addr,
+            T const & value) const
+        -> T
         {
-            //-----------------------------------------------------------------------------
-            //! Decrement down to 0, then reset to value.
-            //!
-            //! \return The old value of addr.
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename T>
-            ALPAKA_FN_HOST_ACC auto operator()(
-                T * const addr,
-                T const & value) const
-            -> T
-            {
-                auto const old(*addr);
-                auto & ref(*addr);
-                ref = (((old == 0) || (old > value)) ? value : static_cast<T>(old - 1));
-                return old;
-            }
-        };
-        //#############################################################################
-        //! The and function object.
-        struct And
+            auto const old(*addr);
+            auto & ref(*addr);
+            ref = (((old == 0) || (old > value)) ? value : static_cast<T>(old - 1));
+            return old;
+        }
+    };
+    //#############################################################################
+    //! The and function object.
+    struct AtomicAnd
+    {
+        //-----------------------------------------------------------------------------
+        //! \return The old value of addr.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T>
+        ALPAKA_FN_HOST_ACC auto operator()(
+            T * const addr,
+            T const & value) const
+        -> T
         {
-            //-----------------------------------------------------------------------------
-            //! \return The old value of addr.
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename T>
-            ALPAKA_FN_HOST_ACC auto operator()(
-                T * const addr,
-                T const & value) const
-            -> T
-            {
-                auto const old(*addr);
-                auto & ref(*addr);
-                ref &= value;
-                return old;
-            }
-        };
-        //#############################################################################
-        //! The or function object.
-        struct Or
+            auto const old(*addr);
+            auto & ref(*addr);
+            ref &= value;
+            return old;
+        }
+    };
+    //#############################################################################
+    //! The or function object.
+    struct AtomicOr
+    {
+        //-----------------------------------------------------------------------------
+        //! \return The old value of addr.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T>
+        ALPAKA_FN_HOST_ACC auto operator()(
+            T * const addr,
+            T const & value) const
+        -> T
         {
-            //-----------------------------------------------------------------------------
-            //! \return The old value of addr.
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename T>
-            ALPAKA_FN_HOST_ACC auto operator()(
-                T * const addr,
-                T const & value) const
-            -> T
-            {
-                auto const old(*addr);
-                auto & ref(*addr);
-                ref |= value;
-                return old;
-            }
-        };
-        //#############################################################################
-        //! The exclusive or function object.
-        struct Xor
+            auto const old(*addr);
+            auto & ref(*addr);
+            ref |= value;
+            return old;
+        }
+    };
+    //#############################################################################
+    //! The exclusive or function object.
+    struct AtomicXor
+    {
+        //-----------------------------------------------------------------------------
+        //! \return The old value of addr.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T>
+        ALPAKA_FN_HOST_ACC auto operator()(
+            T * const addr,
+            T const & value) const
+        -> T
         {
-            //-----------------------------------------------------------------------------
-            //! \return The old value of addr.
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename T>
-            ALPAKA_FN_HOST_ACC auto operator()(
-                T * const addr,
-                T const & value) const
-            -> T
-            {
-                auto const old(*addr);
-                auto & ref(*addr);
-                ref ^= value;
-                return old;
-            }
-        };
-        //#############################################################################
-        //! The compare and swap function object.
-        struct Cas
+            auto const old(*addr);
+            auto & ref(*addr);
+            ref ^= value;
+            return old;
+        }
+    };
+    //#############################################################################
+    //! The compare and swap function object.
+    struct AtomicCas
+    {
+        //-----------------------------------------------------------------------------
+        //! \return The old value of addr.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T>
+        ALPAKA_FN_HOST_ACC auto operator()(
+            T * addr,
+            T const & compare,
+            T const & value) const
+        -> T
         {
-            //-----------------------------------------------------------------------------
-            //! \return The old value of addr.
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename T>
-            ALPAKA_FN_HOST_ACC auto operator()(
-                T * addr,
-                T const & compare,
-                T const & value) const
-            -> T
-            {
-                auto const old(*addr);
-                auto & ref(*addr);
+            auto const old(*addr);
+            auto & ref(*addr);
 
 // gcc-7.4.0 assumes for an optimization that a signed overflow does not occur here.
 // That's fine, so ignore that warning.
@@ -262,12 +258,11 @@ namespace alpaka
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-overflow"
 #endif
-                ref = ((old == compare) ? value : old);
+            ref = ((old == compare) ? value : old);
 #if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 4, 0))
 #pragma GCC diagnostic pop
 #endif
-                return old;
-            }
-        };
-    }
+            return old;
+        }
+    };
 }

--- a/include/alpaka/atomic/Traits.hpp
+++ b/include/alpaka/atomic/Traits.hpp
@@ -164,7 +164,7 @@ namespace alpaka
             THierarchy const& hier = THierarchy())
         -> T
     {
-        return atomicOp<op::Add>(atomic, addr, value, hier);
+        return atomicOp<AtomicAdd>(atomic, addr, value, hier);
     }
 
     //-----------------------------------------------------------------------------
@@ -187,7 +187,7 @@ namespace alpaka
             THierarchy const& hier = THierarchy())
         -> T
     {
-        return atomicOp<op::Sub>(atomic, addr, value, hier);
+        return atomicOp<AtomicSub>(atomic, addr, value, hier);
     }
 
     //-----------------------------------------------------------------------------
@@ -210,7 +210,7 @@ namespace alpaka
             THierarchy const& hier = THierarchy())
         -> T
     {
-        return atomicOp<op::Min>(atomic, addr, value, hier);
+        return atomicOp<AtomicMin>(atomic, addr, value, hier);
     }
 
     //-----------------------------------------------------------------------------
@@ -233,7 +233,7 @@ namespace alpaka
             THierarchy const& hier = THierarchy())
         -> T
     {
-        return atomicOp<op::Max>(atomic, addr, value, hier);
+        return atomicOp<AtomicMax>(atomic, addr, value, hier);
     }
 
     //-----------------------------------------------------------------------------
@@ -256,7 +256,7 @@ namespace alpaka
             THierarchy const& hier = THierarchy())
         -> T
     {
-        return atomicOp<op::Exch>(atomic, addr, value, hier);
+        return atomicOp<AtomicExch>(atomic, addr, value, hier);
     }
 
     //-----------------------------------------------------------------------------
@@ -279,7 +279,7 @@ namespace alpaka
             THierarchy const& hier = THierarchy())
         -> T
     {
-        return atomicOp<op::Inc>(atomic, addr, value, hier);
+        return atomicOp<AtomicInc>(atomic, addr, value, hier);
     }
 
     //-----------------------------------------------------------------------------
@@ -302,7 +302,7 @@ namespace alpaka
             THierarchy const& hier = THierarchy())
         -> T
     {
-        return atomicOp<op::Dec>(atomic, addr, value, hier);
+        return atomicOp<AtomicDec>(atomic, addr, value, hier);
     }
 
     //-----------------------------------------------------------------------------
@@ -325,7 +325,7 @@ namespace alpaka
             THierarchy const& hier = THierarchy())
         -> T
     {
-        return atomicOp<op::And>(atomic, addr, value, hier);
+        return atomicOp<AtomicAnd>(atomic, addr, value, hier);
     }
 
     //-----------------------------------------------------------------------------
@@ -348,7 +348,7 @@ namespace alpaka
             THierarchy const& hier = THierarchy())
         -> T
     {
-        return atomicOp<op::Or>(atomic, addr, value, hier);
+        return atomicOp<AtomicOr>(atomic, addr, value, hier);
     }
 
     //-----------------------------------------------------------------------------
@@ -371,7 +371,7 @@ namespace alpaka
             THierarchy const& hier = THierarchy())
         -> T
     {
-        return atomicOp<op::Xor>(atomic, addr, value, hier);
+        return atomicOp<AtomicXor>(atomic, addr, value, hier);
     }
 
     //-----------------------------------------------------------------------------
@@ -396,6 +396,6 @@ namespace alpaka
             THierarchy const& hier = THierarchy())
         -> T
     {
-        return atomicOp<op::Cas>(atomic, addr, compare, value, hier);
+        return atomicOp<AtomicCas>(atomic, addr, compare, value, hier);
     }
 }

--- a/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
@@ -71,7 +71,7 @@ namespace alpaka
             //#############################################################################
             template<>
             struct AtomicOp<
-                blockOp::Count>
+                BlockCount>
             {
                 void operator()(int& result, bool value)
                 {
@@ -82,7 +82,7 @@ namespace alpaka
             //#############################################################################
             template<>
             struct AtomicOp<
-                blockOp::LogicalAnd>
+                BlockAnd>
             {
                 void operator()(int& result, bool value)
                 {
@@ -93,7 +93,7 @@ namespace alpaka
             //#############################################################################
             template<>
             struct AtomicOp<
-                blockOp::LogicalOr>
+                BlockOr>
             {
                 void operator()(int& result, bool value)
                 {

--- a/include/alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
         //#############################################################################
         template<>
         struct SyncBlockThreadsPredicate<
-            blockOp::Count,
+            BlockCount,
             BlockSyncUniformCudaHipBuiltIn>
         {
             //-----------------------------------------------------------------------------
@@ -93,7 +93,7 @@ namespace alpaka
         //#############################################################################
         template<>
         struct SyncBlockThreadsPredicate<
-            blockOp::LogicalAnd,
+            BlockAnd,
             BlockSyncUniformCudaHipBuiltIn>
         {
             //-----------------------------------------------------------------------------
@@ -123,7 +123,7 @@ namespace alpaka
         //#############################################################################
         template<>
         struct SyncBlockThreadsPredicate<
-            blockOp::LogicalOr,
+            BlockOr,
             BlockSyncUniformCudaHipBuiltIn>
         {
             //-----------------------------------------------------------------------------

--- a/include/alpaka/block/sync/Traits.hpp
+++ b/include/alpaka/block/sync/Traits.hpp
@@ -57,62 +57,57 @@ namespace alpaka
             blockSync);
     }
 
-    //-----------------------------------------------------------------------------
-    //! Defines block operation functors.
-    namespace blockOp
+    //#############################################################################
+    //! The addition function object.
+    struct BlockCount
     {
-        //#############################################################################
-        //! The addition function object.
-        struct Count
-        {
-            enum { InitialValue = 0u};
+        enum { InitialValue = 0u};
 
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename T>
-            ALPAKA_FN_HOST_ACC auto operator()(
-                T const & currentResult,
-                T const & value) const
-            -> T
-            {
-                return currentResult + static_cast<T>(value != static_cast<T>(0));
-            }
-        };
-        //#############################################################################
-        //! The logical and function object.
-        struct LogicalAnd
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T>
+        ALPAKA_FN_HOST_ACC auto operator()(
+            T const & currentResult,
+            T const & value) const
+        -> T
         {
-            enum { InitialValue = 1u};
+            return currentResult + static_cast<T>(value != static_cast<T>(0));
+        }
+    };
+    //#############################################################################
+    //! The logical and function object.
+    struct BlockAnd
+    {
+        enum { InitialValue = 1u};
 
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename T>
-            ALPAKA_FN_HOST_ACC auto operator()(
-                T const & currentResult,
-                T const & value) const
-            -> T
-            {
-                return static_cast<T>(currentResult && (value != static_cast<T>(0)));
-            }
-        };
-        //#############################################################################
-        //! The logical or function object.
-        struct LogicalOr
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T>
+        ALPAKA_FN_HOST_ACC auto operator()(
+            T const & currentResult,
+            T const & value) const
+        -> T
         {
-            enum { InitialValue = 0u};
+            return static_cast<T>(currentResult && (value != static_cast<T>(0)));
+        }
+    };
+    //#############################################################################
+    //! The logical or function object.
+    struct BlockOr
+    {
+        enum { InitialValue = 0u};
 
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<
-                typename T>
-            ALPAKA_FN_HOST_ACC auto operator()(
-                T const & currentResult,
-                T const & value) const
-            -> T
-            {
-                return static_cast<T>(currentResult || (value != static_cast<T>(0)));
-            }
-        };
-    }
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename T>
+        ALPAKA_FN_HOST_ACC auto operator()(
+            T const & currentResult,
+            T const & value) const
+        -> T
+        {
+            return static_cast<T>(currentResult || (value != static_cast<T>(0)));
+        }
+    };
 
     //-----------------------------------------------------------------------------
     //! Synchronizes all threads within the current block (independently for all blocks),

--- a/include/alpaka/block/sync/Traits.hpp
+++ b/include/alpaka/block/sync/Traits.hpp
@@ -58,7 +58,7 @@ namespace alpaka
     }
 
     //#############################################################################
-    //! The addition function object.
+    //! The counting function object.
     struct BlockCount
     {
         enum { InitialValue = 0u};

--- a/include/alpaka/core/BarrierThread.hpp
+++ b/include/alpaka/core/BarrierThread.hpp
@@ -107,7 +107,7 @@ namespace alpaka
                 //#############################################################################
                 template<>
                 struct AtomicOp<
-                    blockOp::Count>
+                    BlockCount>
                 {
                     void operator()(std::atomic<int>& result, bool value)
                     {
@@ -117,7 +117,7 @@ namespace alpaka
                 //#############################################################################
                 template<>
                 struct AtomicOp<
-                    blockOp::LogicalAnd>
+                    BlockAnd>
                 {
                     void operator()(std::atomic<int>& result, bool value)
                     {
@@ -127,7 +127,7 @@ namespace alpaka
                 //#############################################################################
                 template<>
                 struct AtomicOp<
-                    blockOp::LogicalOr>
+                    BlockOr>
                 {
                     void operator()(std::atomic<int>& result, bool value)
                     {

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -36,7 +36,7 @@ ALPAKA_FN_ACC auto testAtomicAdd(
         operand = operandOrig;
         T const ret =
             alpaka::atomicOp<
-            alpaka::op::Add>(
+            alpaka::AtomicAdd>(
                 acc,
                 &operand,
                 value);
@@ -69,7 +69,7 @@ ALPAKA_FN_ACC auto testAtomicSub(
         operand = operandOrig;
         T const ret =
             alpaka::atomicOp<
-            alpaka::op::Sub>(
+            alpaka::AtomicSub>(
                 acc,
                 &operand,
                 value);
@@ -102,7 +102,7 @@ ALPAKA_FN_ACC auto testAtomicMin(
         operand = operandOrig;
         T const ret =
             alpaka::atomicOp<
-            alpaka::op::Min>(
+            alpaka::AtomicMin>(
                 acc,
                 &operand,
                 value);
@@ -135,7 +135,7 @@ ALPAKA_FN_ACC auto testAtomicMax(
         operand = operandOrig;
         T const ret =
             alpaka::atomicOp<
-            alpaka::op::Max>(
+            alpaka::AtomicMax>(
                 acc,
                 &operand,
                 value);
@@ -168,7 +168,7 @@ ALPAKA_FN_ACC auto testAtomicExch(
         operand = operandOrig;
         T const ret =
             alpaka::atomicOp<
-            alpaka::op::Exch>(
+            alpaka::AtomicExch>(
                 acc,
                 &operand,
                 value);
@@ -202,7 +202,7 @@ ALPAKA_FN_ACC auto testAtomicInc(
         operand = operandOrig;
         T const ret =
             alpaka::atomicOp<
-            alpaka::op::Inc>(
+            alpaka::AtomicInc>(
                 acc,
                 &operand,
                 value);
@@ -236,7 +236,7 @@ ALPAKA_FN_ACC auto testAtomicDec(
         operand = operandOrig;
         T const ret =
             alpaka::atomicOp<
-            alpaka::op::Dec>(
+            alpaka::AtomicDec>(
                 acc,
                 &operand,
                 value);
@@ -269,7 +269,7 @@ ALPAKA_FN_ACC auto testAtomicAnd(
         operand = operandOrig;
         T const ret =
             alpaka::atomicOp<
-            alpaka::op::And>(
+            alpaka::AtomicAnd>(
                 acc,
                 &operand,
                 value);
@@ -302,7 +302,7 @@ ALPAKA_FN_ACC auto testAtomicOr(
         operand = operandOrig;
         T const ret =
             alpaka::atomicOp<
-            alpaka::op::Or>(
+            alpaka::AtomicOr>(
                 acc,
                 &operand,
                 value);
@@ -335,7 +335,7 @@ ALPAKA_FN_ACC auto testAtomicXor(
         operand = operandOrig;
         T const ret =
             alpaka::atomicOp<
-            alpaka::op::Xor>(
+            alpaka::AtomicXor>(
                 acc,
                 &operand,
                 value);
@@ -373,7 +373,7 @@ ALPAKA_FN_ACC auto testAtomicCas(
             operand = operandOrig;
             T const ret =
                 alpaka::atomicOp<
-                alpaka::op::Cas>(
+                alpaka::AtomicCas>(
                     acc,
                     &operand,
                     compare,
@@ -398,7 +398,7 @@ ALPAKA_FN_ACC auto testAtomicCas(
             operand = operandOrig;
             T const ret =
                 alpaka::atomicOp<
-                alpaka::op::Cas>(
+                alpaka::AtomicCas>(
                     acc,
                     &operand,
                     compare,

--- a/test/unit/block/sync/src/BlockSyncPredicate.cpp
+++ b/test/unit/block/sync/src/BlockSyncPredicate.cpp
@@ -35,53 +35,53 @@ public:
         auto const blockThreadIdx1D(alpaka::mapIdx<1u>(blockThreadIdx, blockThreadExtent)[0u]);
         auto const blockThreadExtent1D(blockThreadExtent.prod());
 
-        // syncBlockThreadsPredicate<alpaka::blockOp::Count>
+        // syncBlockThreadsPredicate<alpaka::BlockCount>
         {
             Idx const modulus(2u);
             int const predicate(static_cast<int>(blockThreadIdx1D % modulus));
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::Count>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::BlockCount>(acc, predicate));
             auto const expectedResult(static_cast<int>(blockThreadExtent1D / modulus));
             ALPAKA_CHECK(*success, expectedResult == result);
         }
         {
             Idx const modulus(3u);
             int const predicate(static_cast<int>(blockThreadIdx1D % modulus));
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::Count>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::BlockCount>(acc, predicate));
             auto const expectedResult(static_cast<int>(blockThreadExtent1D - ((blockThreadExtent1D + modulus - static_cast<Idx>(1u)) / modulus)));
             ALPAKA_CHECK(*success, expectedResult == result);
         }
 
-        // syncBlockThreadsPredicate<alpaka::blockOp::LogicalAnd>
+        // syncBlockThreadsPredicate<alpaka::BlockAnd>
         {
             int const predicate(1);
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::LogicalAnd>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::BlockAnd>(acc, predicate));
             ALPAKA_CHECK(*success, result == 1);
         }
         {
             int const predicate(0);
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::LogicalAnd>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::BlockAnd>(acc, predicate));
             ALPAKA_CHECK(*success, result == 0);
         }
         {
             int const predicate(blockThreadIdx1D != 0);
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::LogicalAnd>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::BlockAnd>(acc, predicate));
             ALPAKA_CHECK(*success, result == 0);
         }
 
-        // syncBlockThreadsPredicate<alpaka::blockOp::LogicalOr>
+        // syncBlockThreadsPredicate<alpaka::BlockOr>
         {
             int const predicate(1);
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::LogicalOr>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::BlockOr>(acc, predicate));
             ALPAKA_CHECK(*success, result == 1);
         }
         {
             int const predicate(0);
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::LogicalOr>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::BlockOr>(acc, predicate));
             ALPAKA_CHECK(*success, result == 0);
         }
         {
             int const predicate(static_cast<int>(blockThreadIdx1D != 1));
-            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::blockOp::LogicalOr>(acc, predicate));
+            auto const result(alpaka::syncBlockThreadsPredicate<alpaka::BlockOr>(acc, predicate));
             ALPAKA_CHECK(*success, result == 1);
         }
     }


### PR DESCRIPTION
Rename functors `alpaka::op::And` et. al. to `alpaka::AtomicAnd` et. al.
Rename functors `alpaka::blockOp::LogicalAnd` et. al. to `alpaka::BlockAnd` et. al.

Discussed here: https://github.com/alpaka-group/alpaka/pull/1182#discussion_r512760653
Also see #1005 