### PR TITLE
Change block memory size back to be stored as 32 bit

### DIFF
--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -13,6 +13,7 @@
 #include <alpaka/core/Assert.hpp>
 #include <alpaka/core/Vectorize.hpp>
 
+#include <cstdint>
 #include <type_traits>
 #include <array>
 
@@ -32,7 +33,8 @@ namespace alpaka
         struct BlockSharedMemDynMemberStatic
         {
             //! Storage size in bytes
-            static constexpr std::size_t staticAllocBytes = TStaticAllocKiB<<10;
+            static constexpr std::uint32_t staticAllocBytes =
+                static_cast<std::uint32_t>(TStaticAllocKiB<<10u);
         };
     }
 
@@ -51,11 +53,10 @@ namespace alpaka
     public:
         //-----------------------------------------------------------------------------
         BlockSharedMemDynMember(std::size_t sizeBytes)
-            : m_dynPitch((sizeBytes / core::vectorization::defaultAlignment
-                    + (sizeBytes % core::vectorization::defaultAlignment > 0u)) * core::vectorization::defaultAlignment)
+            : m_dynPitch(getPitch(sizeBytes))
         {
 #if (defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (! defined NDEBUG)
-            ALPAKA_ASSERT(sizeBytes <= staticAllocBytes());
+            ALPAKA_ASSERT(static_cast<std::uint32_t>(sizeBytes) <= staticAllocBytes());
 #endif
         }
         //-----------------------------------------------------------------------------
@@ -78,20 +79,33 @@ namespace alpaka
             return m_mem.data() + m_dynPitch;
         }
 
-        /*! \return the remaining capacity for static block shared memory.
+        /*! \return the remaining capacity for static block shared memory,
+                    returns a 32-bit type for register efficiency on GPUs
             */
-        std::size_t staticMemCapacity() const
+        std::uint32_t staticMemCapacity() const
         {
             return staticAllocBytes() - m_dynPitch;
         }
 
-        //! Storage size in bytes
-        static constexpr std::size_t staticAllocBytes() {return detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes;}
+        //! \return size of statically allocated memory available for both
+        //!         dynamic and static shared memory. Value is of a 32-bit type
+        //!         for register efficiency on GPUs
+        static constexpr std::uint32_t staticAllocBytes()
+        {
+            return detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes;
+        }
 
     private:
 
+        static std::uint32_t getPitch(std::size_t sizeBytes)
+        {
+            constexpr auto alignment = core::vectorization::defaultAlignment;
+            return static_cast<std::uint32_t>(
+                (sizeBytes / alignment + (sizeBytes % alignment > 0u)) * alignment);
+        }
+
         mutable std::array<uint8_t, detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes> m_mem;
-        std::size_t m_dynPitch;
+        std::uint32_t m_dynPitch;
     };
 #if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
 #pragma warning(pop)

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -29,7 +29,9 @@ namespace alpaka
         public:
             //-----------------------------------------------------------------------------
 #ifndef NDEBUG
-            BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t capacity) : m_mem(mem), m_capacity(capacity)
+            BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t capacity) :
+                m_mem(mem),
+                m_capacity(static_cast<std::uint32_t>(capacity))
             {
 #ifdef ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST
                 ALPAKA_ASSERT( ( m_mem == nullptr ) == ( m_capacity == 0u ) );
@@ -53,7 +55,7 @@ namespace alpaka
             void alloc() const
             {
                 m_allocdBytes = allocPitch<T>();
-                m_allocdBytes += sizeof(T);
+                m_allocdBytes += static_cast<std::uint32_t>(sizeof(T));
 #if (defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (! defined NDEBUG)
                 ALPAKA_ASSERT(m_allocdBytes <= m_capacity);
 #endif
@@ -78,20 +80,21 @@ namespace alpaka
             }
 
         private:
-            mutable std::size_t m_allocdBytes = 0;
+            mutable std::uint32_t m_allocdBytes = 0;
             mutable uint8_t* m_mem;
 #ifndef NDEBUG
-            const std::size_t m_capacity;
+            const std::uint32_t m_capacity;
 #endif
 
             template<typename T>
-            std::size_t allocPitch() const
+            std::uint32_t allocPitch() const
             {
                 static_assert(
                     core::vectorization::defaultAlignment >= alignof(T),
                     "Unable to get block shared static memory for types with alignment higher than defaultAlignment!");
-                constexpr std::size_t align = std::max(TDataAlignBytes, alignof(T));
-                return (m_allocdBytes/align + (m_allocdBytes%align>0))*align;
+                constexpr std::uint32_t align = static_cast<std::uint32_t>(
+                    std::max(TDataAlignBytes, alignof(T)));
+                return (m_allocdBytes/align + (m_allocdBytes%align>0u))*align;
             }
         };
     }


### PR DESCRIPTION
The change to 64 bit was introduced as part of #1141.
It was later discovered that this can lead to performance detriment on GPUs, as discussed in https://github.com/alpaka-group/alpaka/commit/6b13898a8cece81b4222b739027f77bc3aab4b15#commitcomment-43688079
Revert the storage back to 32 bit, but now use a fixed-width type.