### PR TITLE
Add comments to math function traits that explain valid argument range

### DIFF
--- a/include/alpaka/math/acos/Traits.hpp
+++ b/include/alpaka/math/acos/Traits.hpp
@@ -34,6 +34,10 @@ namespace alpaka
         //-----------------------------------------------------------------------------
         //! Computes the principal value of the arc cosine.
         //!
+        //! The valid real argument range is [-1.0, 1.0]. For other values
+        //! the result may depend on the backend and compilation options, will
+        //! likely be NaN.
+        //!
         //! \tparam TArg The arg type.
         //! \param acos_ctx The object specializing Acos.
         //! \param arg The arg.

--- a/include/alpaka/math/asin/Traits.hpp
+++ b/include/alpaka/math/asin/Traits.hpp
@@ -34,6 +34,10 @@ namespace alpaka
         //-----------------------------------------------------------------------------
         //! Computes the principal value of the arc sine.
         //!
+        //! The valid real argument range is [-1.0, 1.0]. For other values
+        //! the result may depend on the backend and compilation options, will
+        //! likely be NaN.
+        //!
         //! \tparam TArg The arg type.
         //! \param asin_ctx The object specializing Asin.
         //! \param arg The arg.

--- a/include/alpaka/math/log/Traits.hpp
+++ b/include/alpaka/math/log/Traits.hpp
@@ -34,6 +34,10 @@ namespace alpaka
         //-----------------------------------------------------------------------------
         //! Computes the the natural (base e) logarithm of arg.
         //!
+        //! Valid real arguments are non-negative. For other values the result
+        //! may depend on the backend and compilation options, will likely
+        //! be NaN.
+        //!
         //! \tparam T The type of the object specializing Log.
         //! \tparam TArg The arg type.
         //! \param log_ctx The object specializing Log.

--- a/include/alpaka/math/pow/Traits.hpp
+++ b/include/alpaka/math/pow/Traits.hpp
@@ -35,6 +35,10 @@ namespace alpaka
         //-----------------------------------------------------------------------------
         //! Computes the value of base raised to the power exp.
         //!
+        //! Valid real arguments for base are non-negative. For other values
+        //! the result may depend on the backend and compilation options, will
+        //! likely be NaN.
+        //!
         //! \tparam T The type of the object specializing Pow.
         //! \tparam TBase The base type.
         //! \tparam TExp The exponent type.

--- a/include/alpaka/math/rsqrt/Traits.hpp
+++ b/include/alpaka/math/rsqrt/Traits.hpp
@@ -34,6 +34,10 @@ namespace alpaka
         //-----------------------------------------------------------------------------
         //! Computes the rsqrt.
         //!
+        //! Valid real arguments are positive. For other values the result
+        //! may depend on the backend and compilation options, will likely
+        //! be NaN.
+        //!
         //! \tparam T The type of the object specializing Rsqrt.
         //! \tparam TArg The arg type.
         //! \param rsqrt_ctx The object specializing Rsqrt.

--- a/include/alpaka/math/sqrt/Traits.hpp
+++ b/include/alpaka/math/sqrt/Traits.hpp
@@ -34,6 +34,10 @@ namespace alpaka
         //-----------------------------------------------------------------------------
         //! Computes the square root of arg.
         //!
+        //! Valid real arguments are non-negative. For other values the result
+        //! may depend on the backend and compilation options, will likely
+        //! be NaN.
+        //!
         //! \tparam T The type of the object specializing Sqrt.
         //! \tparam TArg The arg type.
         //! \param sqrt_ctx The object specializing Sqrt.


### PR DESCRIPTION
Since alpaka does not (and seemingly cannot easily) give any guarantee by itself, the formulation for invalid valies had to be rather vague.

The change is inspired by [this PIConGPU issue](https://github.com/ComputationalRadiationPhysics/picongpu/issues/3400).