### PR TITLE
provide docker_retry

### DIFF
--- a/script/docker_ci.sh
+++ b/script/docker_ci.sh
@@ -11,6 +11,7 @@
 #
 
 source ./script/set.sh
+source ./script/docker_retry.sh
 
 # runtime and compile time options
 ALPAKA_DOCKER_ENV_LIST=()
@@ -159,4 +160,4 @@ then
     ALPAKA_DOCKER_ENV_LIST+=("--env" "ALPAKA_CUDA_NVCC_SEPARABLE_COMPILATION=${ALPAKA_CUDA_NVCC_SEPARABLE_COMPILATION}")
 fi
 
-docker run -v "$(pwd)":"$(pwd)" -w "$(pwd)" "${ALPAKA_DOCKER_ENV_LIST[@]}" "${ALPAKA_CI_DOCKER_BASE_IMAGE_NAME}" /bin/bash -c "./script/install.sh && ./script/run.sh"
+docker_retry docker run -v "$(pwd)":"$(pwd)" -w "$(pwd)" "${ALPAKA_DOCKER_ENV_LIST[@]}" "${ALPAKA_CI_DOCKER_BASE_IMAGE_NAME}" /bin/bash -c "./script/install.sh && ./script/run.sh"

--- a/script/docker_retry.sh
+++ b/script/docker_retry.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright 2019-2020 Benjamin Worpitz, Rene Widera
+#
+# This file is part of alpaka.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+ANSI_RED="\033[31m"
+ANSI_RESET="\033[0m"
+
+# rerun docker command if error 125 (
+#   - triggered by image download problems
+#   - wait 30 seconds before retry
+docker_retry() {
+  set +euo pipefail
+  local result=0
+  local count=1
+  while [ $count -le 3 ]; do
+    [ $result -eq 125 ] && {
+      echo -e "\n${ANSI_RED}The command \"$*\" failed. Retrying, $count of 3.${ANSI_RESET}\n" >&2
+    }
+    "$@"
+    result=$?
+    [ $result -ne 125 ] && break
+    count=$((count + 1))
+    sleep 30
+  done
+  [ $count -gt 3 ] && {
+    echo -e "\n${ANSI_RED}The command \"$*\" failed 3 times.${ANSI_RESET}\n" >&2
+  }
+  return $result
+}


### PR DESCRIPTION
Provide a bash function `docker_retry` based on travis_retry to retry execute docker if error `125` is showing up.

This tiny fix should avoid that our CI is crashing so often during the container download.