### PR TITLE
fix travis_retry

### DIFF
--- a/script/travis_retry.sh
+++ b/script/travis_retry.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2019 Benjamin Worpitz
+# Copyright 2019 Benjamin Worpitz, Rene Widera
 #
 # This file is part of alpaka.
 #
@@ -9,9 +9,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set -euo pipefail
+ANSI_RED="\033[31m"
+ANSI_RESET="\033[0m"
 
 travis_retry() {
+  set +euo pipefail
   local result=0
   local count=1
   while [ $count -le 3 ]; do


### PR DESCRIPTION
`travis_retry` script function was not working because `pipefail` always
stoped the shell if a command fails.

- add missing color definitions, required else an error fired
- fix command execution to allow error handling