### PR TITLE
fix bug in `isPinned()` and `pin()`

### DIFF
--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -464,7 +464,7 @@ namespace alpaka
                 BufCpu<TElem, TDim, TIdx> & buf)
             -> void
             {
-                unpin(*buf.m_spBufCpuImpl.get());
+                alpaka::unpin(*buf.m_spBufCpuImpl.get());
             }
         };
         //#############################################################################
@@ -514,7 +514,7 @@ namespace alpaka
                 BufCpu<TElem, TDim, TIdx> const & buf)
             -> bool
             {
-                return isPinned(*buf.m_spBufCpuImpl.get());
+                return alpaka::isPinned(*buf.m_spBufCpuImpl.get());
             }
         };
         //#############################################################################


### PR DESCRIPTION
With the renaming of the namespaces in #1173 some calls to the traits
are broken.
Instead of calling the trait the local member function is called again.