### PR TITLE
fix CI: use `travis_retry` for `git clone`

### DIFF
--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -10,6 +10,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
+source ./script/travis_retry.sh
 source ./script/set.sh
 
 : "${BOOST_ROOT?'BOOST_ROOT must be specified'}"
@@ -28,7 +29,7 @@ then
     : "${ALPAKA_CI_CL_VER?'ALPAKA_CI_CL_VER must be specified'}"
 fi
 
-git clone -b "${ALPAKA_CI_BOOST_BRANCH}" --quiet --recursive --single-branch --depth 1 https://github.com/boostorg/boost.git "${BOOST_ROOT}"
+travis_retry rm -rf ${BOOST_ROOT} && git clone -b "${ALPAKA_CI_BOOST_BRANCH}" --quiet --recursive --single-branch --depth 1 https://github.com/boostorg/boost.git "${BOOST_ROOT}"
 
 # Bootstrap boost.
 if [ "$ALPAKA_CI_OS_NAME" = "Windows" ]

--- a/script/run_doxygen.sh
+++ b/script/run_doxygen.sh
@@ -25,7 +25,7 @@ source ./script/set.sh
 #- Commit and push the branch: `git add --all`, `git commit -m"add gh-pages branch"`, `git push`
 
 # Clone the gh-pages branch into the docs/doxygen/html folder.
-git clone -b gh-pages https://x-access-token:${2}@github.com/${1}.git docs/doxygen/html
+travis_retry rm -rf docs/doxygen/html || git clone -b gh-pages https://x-access-token:${2}@github.com/${1}.git docs/doxygen/html
 
 cd docs/
 


### PR DESCRIPTION
follow up of #1192

Guard `git clone` by `travis_retry` to avoid that the CI fails during cloning.
The folder into which we are cloning must be removed to avoid cloning into an existing folder.