### PR TITLE
[clang-format] Add .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,117 @@
+---
+# General options
+Language: Cpp
+Standard: c++17
+DisableFormat: false
+
+AccessModifierOffset: -4
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: false
+AlignEscapedNewlines: Right
+AlignOperands: false
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: BeforeComma
+BreakStringLiterals: true
+ColumnLimit: 119
+CommentPragmas:  '^ COMMENT pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+IncludeBlocks: Regroup
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentGotoLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: All
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 1000
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: Never
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+TabWidth: 4
+UseCRLF: false
+UseTab: Never
+
+# Project specific options
+IncludeCategories:
+  # Local headers (in "") above all else
+  - Regex: '"([A-Za-z0-9.\/-_])+"'
+    Priority: 1
+  # <alpaka/foo.hpp> after local headers
+  - Regex: '<alpaka/([A-Za-z0-9.\/-_])+>'
+    Priority: 2
+  # C++ standard library headers are the last group to be included
+  - Regex: '<([A-Za-z0-9\/-_])+>'
+    Priority: 4
+  # Includes that made it this far are third-party headers and will be placed
+  # below alpaka's includes
+  - Regex: '<([A-Za-z0-9.\/-_])+>'
+    Priority: 3
+
+# Future options - not supported in clang-format 11
+# AlignConsecutiveBitFields: false
+# AllowShortEnumsOnASingleLine: false
+# BitFieldColonSpacing: Both
+# IndentCaseBlocks: true
+# IndentExternBlock: AfterExternBlock
+# OperandAlignmentStyle: Align
+...

--- a/docs/source/dev/style.rst
+++ b/docs/source/dev/style.rst
@@ -6,6 +6,25 @@ Coding Guidelines
 .. attention::
    The Coding Guidelines are currently revised
 
+General
+-------
+
+* Use the ``.clang-format`` file supplied in alpaka's top-level directory to format your code. This will handle indentation,
+whitespace and braces automatically. Usage:
+
+.. code-block:: bash
+
+  clang-format-11 -i --style=file <sourcefile>
+
+* If you want to format the entire code base execute the following command from alpaka's top-level directory:
+
+.. code-block:: bash
+
+  find example include test -name '*.hpp' -o -name '*.cpp' | xargs clang-format-11 -i --style=file
+
+Windows users should use `Visual Studio's native clang-format integration
+<https://devblogs.microsoft.com/cppblog/clangformat-support-in-visual-studio-2017-15-7-preview-1/>`.
+
 Naming
 ------
 
@@ -55,31 +74,6 @@ Comments
 * For functions use
   ``//-----------------------------------------------------------------------------``
   to start the comment block.
-* Never write comments for closing braces (namespaces, classes, etc ...)
-
-
-Braces
-------
-
-* Braces (opening and closing) for classes, structs, functions, namespaces, etc. appear on a new line. Exception: If the function or class body is empty, the opening and closing braces are on the same (next) line.
-* Only braces for variable initialization can appear in-line.
-
-
-Indentation
------------
-
-* Always indent everything by *one level* (namespace body, class members, function body, ...)
-* Do not use more indentation e.g. to align function parameters.
-
-
-Spaces
-------
-
-* Trailing white-spaces are forbidden.
-* There is no space between keywords (if, for, ...) and the opening parenthesis.
-* There is no space after the opening ``(`` or ``<`` and before the closing ``)`` or ``>``.
-* There is a space before and after binary operators (=, \*, +, ...)
-* There is no space after the unary operators !, ~, ...
 
 
 Functions


### PR DESCRIPTION
This is the .clang-format file used for #1194 and #1203.

Application: From the top-level alpaka directory, execute

```bash
find example include test -name '*.hpp' -o -name '*.cpp' | xargs clang-format -i --style=file
```
I'm not certain about the best place in the docs to include the command. Any suggestions?