### PR TITLE
TestAccs: Fix OMP5/OACC GCC<11 checks

### DIFF
--- a/test/common/include/alpaka/test/acc/TestAccs.hpp
+++ b/test/common/include/alpaka/test/acc/TestAccs.hpp
@@ -83,15 +83,14 @@ namespace alpaka
 #if defined(ALPAKA_ACC_ANY_BT_OMP5_ENABLED) && !defined(TEST_UNIT_KERNEL_KERNEL_STD_FUNCTION)                         \
     && !(                                                                                                             \
         BOOST_COMP_GNUC                                                                                               \
-        && (((BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(11, 0, 0))                                                       \
-                 && /* tests excluded because of GCC10 Oacc / Omp5 target symbol bug with multiple units */           \
-                 defined(TEST_UNIT_BLOCK_SHARED)                                                                      \
-             || defined(TEST_UNIT_BLOCK_SYNC) || defined(TEST_UNIT_WARP) || defined(TEST_UNIT_INTRINSIC)              \
-             || defined(TEST_UNIT_KERNEL) || defined(TEST_UNIT_MEM_VIEW))                                             \
+        && (((BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(11, 0, 0)) /* tests excluded because of GCC10 Oacc / Omp5 target \
+                                                                   symbol bug with multiple units */                  \
+             && (defined(TEST_UNIT_BLOCK_SHARED) || defined(TEST_UNIT_BLOCK_SYNC) || defined(TEST_UNIT_WARP)          \
+                 || defined(TEST_UNIT_INTRINSIC) || defined(TEST_UNIT_KERNEL) || defined(TEST_UNIT_MEM_VIEW)))        \
             || defined(TEST_UNIT_MATH) /* because of static const members */                                          \
             ))                                                                                                        \
     && !(                                                                                                             \
-        !ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST                                                                             \
+        !defined(ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST)                                                                    \
         && (defined(TEST_UNIT_ATOMIC) /* clang nvptx atomic ICEs */                                                   \
             ))
             template<typename TDim, typename TIdx>
@@ -103,11 +102,10 @@ namespace alpaka
 #if defined(ALPAKA_ACC_ANY_BT_OACC_ENABLED) && !(defined(TEST_UNIT_KERNEL_KERNEL_STD_FUNCTION))                       \
     && !(                                                                                                             \
         BOOST_COMP_GNUC                                                                                               \
-        && (((BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(11, 0, 0))                                                       \
-                 && /* tests excluded because of GCC10 Oacc / Omp5 target symbol bug with multiple units */           \
-                 defined(TEST_UNIT_BLOCK_SHARED)                                                                      \
-             || defined(TEST_UNIT_BLOCK_SYNC) || defined(TEST_UNIT_WARP) || defined(TEST_UNIT_INTRINSIC)              \
-             || defined(TEST_UNIT_KERNEL) || defined(TEST_UNIT_MEM_VIEW))                                             \
+        && (((BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(11, 0, 0)) /* tests excluded because of GCC10 Oacc / Omp5 target \
+                                                                   symbol bug with multiple units */                  \
+             && (defined(TEST_UNIT_BLOCK_SHARED) || defined(TEST_UNIT_BLOCK_SYNC) || defined(TEST_UNIT_WARP)          \
+                 || defined(TEST_UNIT_INTRINSIC) || defined(TEST_UNIT_KERNEL) || defined(TEST_UNIT_MEM_VIEW)))        \
             || defined(TEST_UNIT_MATH) /* because of static const members */                                          \
             || defined(TEST_UNIT_MEM_BUF) /* actually works, but hangs when ran by ctest */                           \
             ))


### PR DESCRIPTION
* Fix OMP5/OACC GCC<11 
* alos fix check of ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST

Closes https://github.com/alpaka-group/alpaka/issues/1211