### PR TITLE
clang-format tinymt32.h

### DIFF
--- a/include/alpaka/rand/TinyMT/tinymt32.h
+++ b/include/alpaka/rand/TinyMT/tinymt32.h
@@ -6,6 +6,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+// clang-format off
 #ifndef TINYMT32_H
 #define TINYMT32_H
 /**


### PR DESCRIPTION
This file was forgotton during the recent clang-format of the code base.