### PR TITLE
Fix a comment copy-paste mistake in Omp5 check output function

### DIFF
--- a/include/alpaka/core/Omp5.hpp
+++ b/include/alpaka/core/Omp5.hpp
@@ -34,7 +34,7 @@ namespace alpaka
         namespace detail
         {
             //-----------------------------------------------------------------------------
-            //! CUDA runtime API error checking with log and exception, ignoring specific error values
+            //! OMP5 runtime API error checking with log and exception, ignoring specific error values
             ALPAKA_FN_HOST inline auto omp5Check(int const& error, char const* desc, char const* file, int const& line)
                 -> void
             {


### PR DESCRIPTION
Just noticed as I looked at this file while working on another PR.