### PR TITLE
Add BOOST_COMP_INTEL to the Boost.Predef unit test

### DIFF
--- a/test/unit/core/src/BoostPredefTest.cpp
+++ b/test/unit/core/src/BoostPredefTest.cpp
@@ -40,6 +40,9 @@ TEST_CASE("printDefines", "[core]")
 #if BOOST_COMP_GNUC
     std::cout << "BOOST_COMP_GNUC:" << BOOST_COMP_GNUC << std::endl;
 #endif
+#if BOOST_COMP_INTEL
+    std::cout << "BOOST_COMP_INTEL:" << BOOST_COMP_INTEL << std::endl;
+#endif
 #if BOOST_COMP_MSVC
     std::cout << "BOOST_COMP_MSVC:" << BOOST_COMP_MSVC << std::endl;
 #endif


### PR DESCRIPTION
I forgot it when `BOOST_COMP_INTEL` was added to our `BoostPredef.hpp` in #1070.