### PR TITLE
Fix marking of unit tests for concepts

### DIFF
--- a/test/unit/core/src/ConceptsTest.cpp
+++ b/test/unit/core/src/ConceptsTest.cpp
@@ -67,96 +67,96 @@ struct ImplementerNonMatchingTaggedTaggedToBase
 };
 
 //-----------------------------------------------------------------------------
-TEST_CASE("ImplementerNotTagged", "[meta]")
+TEST_CASE("ImplementerNotTagged", "[core]")
 {
     using ImplementationBase = alpaka::concepts::ImplementationBase<ConceptExample, ImplementerNotTagged>;
 
     static_assert(
         std::is_same<ImplementerNotTagged, ImplementationBase>::value,
-        "alpaka::meta::ImplementationBase failed!");
+        "alpaka::concepts::ImplementationBase failed!");
 }
 
 //-----------------------------------------------------------------------------
-TEST_CASE("ImplementerNotTaggedButNonMatchingTagged", "[meta]")
+TEST_CASE("ImplementerNotTaggedButNonMatchingTagged", "[core]")
 {
     using ImplementationBase
         = alpaka::concepts::ImplementationBase<ConceptExample, ImplementerNotTaggedButNonMatchingTagged>;
 
     static_assert(
         std::is_same<ImplementerNotTaggedButNonMatchingTagged, ImplementationBase>::value,
-        "alpaka::meta::ImplementationBase failed!");
+        "alpaka::concepts::ImplementationBase failed!");
 }
 
 //-----------------------------------------------------------------------------
-TEST_CASE("ImplementerTagged", "[meta]")
+TEST_CASE("ImplementerTagged", "[core]")
 {
     using ImplementationBase = alpaka::concepts::ImplementationBase<ConceptExample, ImplementerTagged>;
 
     static_assert(
         std::is_same<ImplementerTagged, ImplementationBase>::value,
-        "alpaka::meta::ImplementationBase failed!");
+        "alpaka::concepts::ImplementationBase failed!");
 }
 
 //-----------------------------------------------------------------------------
-TEST_CASE("ImplementerTaggedButAlsoNonMatchingTagged", "[meta]")
+TEST_CASE("ImplementerTaggedButAlsoNonMatchingTagged", "[core]")
 {
     using ImplementationBase
         = alpaka::concepts::ImplementationBase<ConceptExample, ImplementerTaggedButAlsoNonMatchingTagged>;
 
     static_assert(
         std::is_same<ImplementerTaggedButAlsoNonMatchingTagged, ImplementationBase>::value,
-        "alpaka::meta::ImplementationBase failed!");
+        "alpaka::concepts::ImplementationBase failed!");
 }
 
 //-----------------------------------------------------------------------------
-TEST_CASE("ImplementerWithTaggedBaseAlsoNonMatchingTagged", "[meta]")
+TEST_CASE("ImplementerWithTaggedBaseAlsoNonMatchingTagged", "[core]")
 {
     using ImplementationBase
         = alpaka::concepts::ImplementationBase<ConceptExample, ImplementerWithTaggedBaseAlsoNonMatchingTagged>;
 
     static_assert(
         std::is_same<ImplementerTaggedButAlsoNonMatchingTagged, ImplementationBase>::value,
-        "alpaka::meta::ImplementationBase failed!");
+        "alpaka::concepts::ImplementationBase failed!");
 }
 
 //-----------------------------------------------------------------------------
-TEST_CASE("ImplementerWithTaggedBase", "[meta]")
+TEST_CASE("ImplementerWithTaggedBase", "[core]")
 {
     using ImplementationBase = alpaka::concepts::ImplementationBase<ConceptExample, ImplementerWithTaggedBase>;
 
     static_assert(
         std::is_same<ImplementerTagged, ImplementationBase>::value,
-        "alpaka::meta::ImplementationBase failed!");
+        "alpaka::concepts::ImplementationBase failed!");
 }
 
 //-----------------------------------------------------------------------------
-TEST_CASE("ImplementerTaggedToBase", "[meta]")
+TEST_CASE("ImplementerTaggedToBase", "[core]")
 {
     using ImplementationBase = alpaka::concepts::ImplementationBase<ConceptExample, ImplementerTaggedToBase>;
 
     static_assert(
         std::is_same<ImplementerNotTagged, ImplementationBase>::value,
-        "alpaka::meta::ImplementationBase failed!");
+        "alpaka::concepts::ImplementationBase failed!");
 }
 
 //-----------------------------------------------------------------------------
-TEST_CASE("ImplementerTaggedToBaseAlsoNonMatchingTagged", "[meta]")
+TEST_CASE("ImplementerTaggedToBaseAlsoNonMatchingTagged", "[core]")
 {
     using ImplementationBase
         = alpaka::concepts::ImplementationBase<ConceptExample, ImplementerTaggedToBaseAlsoNonMatchingTagged>;
 
     static_assert(
         std::is_same<ImplementerNotTaggedButNonMatchingTagged, ImplementationBase>::value,
-        "alpaka::meta::ImplementationBase failed!");
+        "alpaka::concepts::ImplementationBase failed!");
 }
 
 //-----------------------------------------------------------------------------
-TEST_CASE("ImplementerNonMatchingTaggedTaggedToBase", "[meta]")
+TEST_CASE("ImplementerNonMatchingTaggedTaggedToBase", "[core]")
 {
     using ImplementationBase
         = alpaka::concepts::ImplementationBase<ConceptExample, ImplementerNonMatchingTaggedTaggedToBase>;
 
     static_assert(
         std::is_same<ImplementerNotTagged, ImplementationBase>::value,
-        "alpaka::meta::ImplementationBase failed!");
+        "alpaka::concepts::ImplementationBase failed!");
 }


### PR DESCRIPTION
I guess the implementation was moved at some point, as it caused these tests being somewhat misattributed. Change their suite to `[core]`, so that they follow the schema for other unit tests. Also fixed the output to have the actual namespace `alpaka::concepts::` instead of (I guess used at some past) `alpaka::meta::`.