### PR TITLE
Make test/common a CMake INTERFACE library

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,8 +20,8 @@ endif()
 add_subdirectory(common)
 
 if(ALPAKA_ACC_GPU_CUDA_ENABLE AND ALPAKA_CUDA_COMPILER MATCHES "nvcc")
-    # NVCC does not incorporate the COMPILE_OPTIONS of a target but only the CMAKE_CXX_FLAGS
-    get_target_property(_COMMON_COMPILE_OPTIONS common COMPILE_OPTIONS)
+    # NVCC does not incorporate the INTERFACE_COMPILE_OPTIONS of a target but only the CMAKE_CXX_FLAGS
+    get_target_property(_COMMON_COMPILE_OPTIONS common INTERFACE_COMPILE_OPTIONS)
     # If the property does not exist, the variable is set to NOTFOUND.
     if(_COMMON_COMPILE_OPTIONS)
         string(REPLACE ";" " " _COMMON_COMPILE_OPTIONS_STRING "${_COMMON_COMPILE_OPTIONS}")

--- a/test/catch_main/CMakeLists.txt
+++ b/test/catch_main/CMakeLists.txt
@@ -11,9 +11,9 @@
 option(ALPAKA_USE_INTERNAL_CATCH2 "Use internally shipped Catch2" ON)
 
 if(ALPAKA_USE_INTERNAL_CATCH2)
-    message(STATUS "Catch2: Using INTERNAL version 2.11.0")
+    message(STATUS "Catch2: Using INTERNAL version 2.13.3")
 else()
-    find_package(Catch2 2.11.0 CONFIG REQUIRED)
+    find_package(Catch2 2.13.3 CONFIG REQUIRED)
     set_target_properties(Catch2::Catch2 PROPERTIES IMPORTED_GLOBAL TRUE)
     message(STATUS "Catch2: Found version ${Catch2_VERSION}")
 endif()

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -11,40 +11,36 @@
 cmake_minimum_required(VERSION 3.15)
 
 set(_COMMON_TARGET_NAME "common")
+set(_COMMON_COMPILE_OPTIONS_FILE "devCompileOptions.cmake")
 set(_COMMON_INCLUDE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/include")
-set(_COMMON_SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/src")
 
 # Add all the source files in all recursive subdirectories and group them accordingly.
 append_recursive_files_add_to_src_group("${_COMMON_INCLUDE_DIRECTORY}" "${_COMMON_INCLUDE_DIRECTORY}" "hpp" _COMMON_FILES_HEADER)
-append_recursive_files_add_to_src_group("${_COMMON_SOURCE_DIRECTORY}" "${_COMMON_SOURCE_DIRECTORY}" "cpp" _COMMON_FILES_SOURCE)
 
-add_library(${_COMMON_TARGET_NAME} STATIC
-            ${_COMMON_FILES_HEADER}
-            ${_COMMON_FILES_SOURCE}
-            "devCompileOptions.cmake")
+add_library(${_COMMON_TARGET_NAME} INTERFACE)
 
-target_link_libraries(${_COMMON_TARGET_NAME}
-                      PUBLIC alpaka::alpaka)
+target_include_directories(${_COMMON_TARGET_NAME} INTERFACE ${_COMMON_INCLUDE_DIRECTORY})
 
-target_include_directories(${_COMMON_TARGET_NAME}
-                           PUBLIC ${_COMMON_INCLUDE_DIRECTORY})
-
-include("devCompileOptions.cmake")
-target_compile_options(${_COMMON_TARGET_NAME}
-                       PUBLIC ${ALPAKA_DEV_COMPILE_OPTIONS})
+include(${_COMMON_COMPILE_OPTIONS_FILE})
+target_compile_options(${_COMMON_TARGET_NAME} INTERFACE ${ALPAKA_DEV_COMPILE_OPTIONS})
 
 if(MSVC)
-    target_compile_options(${_COMMON_TARGET_NAME} PUBLIC "/wd4996") # This function or variable may be unsafe. Consider using <safe_version> instead.
-    target_compile_options(${_COMMON_TARGET_NAME} PUBLIC "/bigobj")
+    target_compile_options(${_COMMON_TARGET_NAME} INTERFACE "/wd4996") # This function or variable may be unsafe. Consider using <safe_version> instead.
+    target_compile_options(${_COMMON_TARGET_NAME} INTERFACE "/bigobj")
 endif()
 
 if(ALPAKA_ACC_GPU_CUDA_ENABLE OR (ALPAKA_ACC_GPU_HIP_ENABLE AND HIP_PLATFORM MATCHES "nvcc"))
     # CUDA driver API is used by EventHostManualTrigger
-    target_link_libraries(${_COMMON_TARGET_NAME} PUBLIC "${CUDA_CUDA_LIBRARY}")
-    target_compile_definitions(${_COMMON_TARGET_NAME} PUBLIC "CUDA_API_PER_THREAD_DEFAULT_STREAM")
+    target_link_libraries(${_COMMON_TARGET_NAME} INTERFACE "${CUDA_CUDA_LIBRARY}")
+    target_compile_definitions(${_COMMON_TARGET_NAME} INTERFACE "CUDA_API_PER_THREAD_DEFAULT_STREAM")
 endif()
 
-set_target_properties(${_COMMON_TARGET_NAME} PROPERTIES FOLDER "test")
+target_link_libraries(${_COMMON_TARGET_NAME} INTERFACE alpaka::alpaka)
+target_link_libraries(${_COMMON_TARGET_NAME} INTERFACE CatchMain)
 
-target_link_libraries(${_COMMON_TARGET_NAME}
-                      PUBLIC CatchMain)
+if(TARGET ${_COMMON_TARGET_NAME})
+    # HACK: Workaround for the limitation that files added to INTERFACE targets (target_sources) can not be marked as PUBLIC or PRIVATE but only as INTERFACE.
+    # Therefore those files will be added to projects "linking" to the INTERFACE library, but are not added to the project itself within an IDE.
+    add_custom_target("${_COMMON_TARGET_NAME}Ide" SOURCES ${_COMMON_FILES_HEADER} ${_COMMON_COMPILE_OPTIONS_FILE})
+    set_target_properties("${_COMMON_TARGET_NAME}Ide" PROPERTIES FOLDER "test")
+endif()

--- a/test/common/src/Dummy.cpp
+++ b/test/common/src/Dummy.cpp
@@ -1,9 +1,0 @@
-/* Copyright 2019 Benjamin Worpitz
- *
- * This file is part of alpaka.
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
-// This file is here because CMake does not allow to create a header only library.


### PR DESCRIPTION
This PR contains two commits:

1. Bump the Catch2 version required by CMake to 2.13.3 (this was forgotten in #1215).
2. Make `test/common` an `INTERFACE` library. `test/common/src/Dummy.cpp` stated that CMake doesn't support header-only targets, but this is no longer true.