### PR TITLE
fix gh-pages branch update

### DIFF
--- a/script/push_doc.sh
+++ b/script/push_doc.sh
@@ -19,7 +19,7 @@ cd docs/doxygen/html
 git config --global user.email "action@github.com"
 git config --global user.name "GitHub Action"
 
-git add .
+git add -f .
 
 git log -n 3
 


### PR DESCRIPTION
fix error:
https://github.com/alpaka-group/alpaka/runs/1536709047?check_suite_focus=true#step:5:21
```
git add .
+ git add .
The following paths are ignored by one of your .gitignore files:
docs/doxygen/html
hint: Use -f if you really want to add them.
hint: Turn this message off by running
hint: "git config advice.addIgnoredFile false"
Error: Process completed with exit code 1.
```

Use force `git add` to add html files to git even if the folder is in `.gitignore`