### PR TITLE
CI: Add Latest Intel Compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,11 @@ jobs:
           os: ubuntu-latest
           env: {CXX: clang++, CC: clang,  ALPAKA_CI_CLANG_VER: 10,     ALPAKA_CI_STDLIB: libc++,    CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.73.0, ALPAKA_CI_CMAKE_VER: 3.15.7, OMP_NUM_THREADS: 4, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:20.04", CMAKE_CXX_FLAGS: "-fopenmp=libomp -fopenmp-targets=x86_64-pc-linux-gnu -Wno-openmp-mapping", ALPAKA_ACC_ANY_BT_OMP5_ENABLE: ON, ALPAKA_OFFLOAD_MAX_BLOCK_SIZE: 1, CMAKE_EXE_LINKER_FLAGS: "-fopenmp"}
 
+        # icpc
+        - name: linux_icpc_release
+          os: ubuntu-latest
+          env: {CXX: icpc,    CC: icc,                                 ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.75.0, ALPAKA_CI_CMAKE_VER: 3.19.2, OMP_NUM_THREADS: 2, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:20.04",                                                                                                                                         ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF}
+
         ## CUDA 9.0
         # nvcc + g++
         - name: linux_nvcc-9.0_gcc-5_debug

--- a/script/install.sh
+++ b/script/install.sh
@@ -51,6 +51,7 @@ if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
 then
     if [ "${CXX}" == "g++" ] ;then ./script/install_gcc.sh ;fi
     if [ "${CXX}" == "clang++" ] ;then source ./script/install_clang.sh ;fi
+    if [ "${CXX}" == "icpc" ] ;then source ./script/install_icpc.sh ;fi
 elif [ "$ALPAKA_CI_OS_NAME" = "macOS" ]
 then
     echo "### list all applications ###"

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -35,10 +35,12 @@ travis_retry rm -rf ${BOOST_ROOT} && git clone -b "${ALPAKA_CI_BOOST_BRANCH}" --
 if [ "$ALPAKA_CI_OS_NAME" = "Windows" ]
 then
     (cd "${BOOST_ROOT}"; ./bootstrap.bat)
+elif [ "${CXX}" == "icpc" ]
+then
+    (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="intel-linux" || cat bootstrap.log)
 else
-    (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="${CC}")
+    (cd "${BOOST_ROOT}"; sudo ./bootstrap.sh --with-toolset="${CC}" || cat bootstrap.log)
 fi
-(cd "${BOOST_ROOT}"; cat ./bootstrap.log)
 
 # Create file links.
 if [ "$ALPAKA_CI_OS_NAME" = "Windows" ]

--- a/script/install_icpc.sh
+++ b/script/install_icpc.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+#
+# Copyright 2020 Axel Huebl
+#
+# This file is part of alpaka.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+source ./script/travis_retry.sh
+
+source ./script/set.sh
+
+: "${CXX?'CXX must be specified'}"
+
+# Ref.: https://github.com/rscohn2/oneapi-ci
+# intel-basekit intel-hpckit are too large in size
+
+travis_retry sudo apt-get -qqq update
+travis_retry sudo apt-get install -y wget build-essential pkg-config cmake ca-certificates gnupg
+travis_retry sudo wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+
+sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+
+travis_retry sudo apt-get update
+
+#  See a list of oneAPI packages available for install
+echo "################################"
+sudo -E apt-cache pkgnames intel
+echo "################################"
+
+travis_retry sudo apt-get install -y intel-oneapi-dpcpp-cpp-compiler-pro intel-oneapi-mkl-devel intel-oneapi-openmp intel-oneapi-tbb-devel
+
+set +eu
+source /opt/intel/oneapi/setvars.sh
+set -eu
+
+which "${CXX}"
+${CXX} -v
+which "${CC}"
+${CC} -v

--- a/script/install_icpc.sh
+++ b/script/install_icpc.sh
@@ -33,7 +33,7 @@ echo "################################"
 sudo -E apt-cache pkgnames intel
 echo "################################"
 
-travis_retry sudo apt-get install -y intel-oneapi-dpcpp-cpp-compiler-pro intel-oneapi-mkl-devel intel-oneapi-openmp intel-oneapi-tbb-devel
+travis_retry sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-mkl-devel intel-oneapi-openmp intel-oneapi-tbb-devel
 
 set +eu
 source /opt/intel/oneapi/setvars.sh

--- a/script/run.sh
+++ b/script/run.sh
@@ -123,6 +123,13 @@ then
         CMAKE_EXE_LINKER_FLAGS="${CMAKE_EXE_LINKER_FLAGS} -lc++ -lc++abi"
     fi
 
+    if [ "${CXX}" == "icpc" ]
+    then
+        set +eu
+        which ${CXX} || source /opt/intel/oneapi/setvars.sh
+        set -eu
+    fi
+
     which "${CXX}"
     ${CXX} -v
 


### PR DESCRIPTION
Add latest `icpc`/`icc` to CI.

This is based on #1066 by @ax3l. Now that https://github.com/boostorg/build/pull/639 has been released with boost-1.75 we can build boost with icpc successfully.