### PR TITLE
Update the contributor list in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,13 +211,31 @@ Rules for contributions can be found in [CONTRIBUTING.md](CONTRIBUTING.md)
 Authors
 -------
 
-### Maintainers and Core Developers
+### Maintainers* and Core Developers
 
-- Benjamin Worpitz (original author)
-- Rene Widera
+- Benjamin Worpitz* (original author)
+- Dr. Sergei Bastrakov*
+- Simeon Ehrig
+- Bernhard Manfred Gruber
+- Dr. Axel Huebl*
+- Dr. Jeffrey Kelling
+- Jakob Krude
+- Jan Stephan*
+- Rene Widera*
 
 ### Former Members, Contributions and Thanks
 
 - Dr. Michael Bussmann
-- Axel Huebl
+- Mat Colgrove
+- Valentin Gehrke
+- Maximilian Knespel
+- Alexander Matthes
+- Hauke Mewes
+- Phil Nash
+- Mutsuo Saito
+- Jonas Schenke
+- Daniel Vollmer
+- Matthias Werner
+- Bert Wesarg
+- Malte Zacharias
 - Erik Zenker


### PR DESCRIPTION
This list was largely outdated.
Now it matches the release-0.6.0-rc4 zenodo file #1236.
The separation of core developers and contributors is based on contributions since the last release, [how we do for cupla](https://github.com/alpaka-group/cupla/pull/147#issuecomment-582306986).
Also mark maintainers with * like we do in other projects. Not sure if I got all maintainers right.

This PR is to 0.6.0-rc4 intentionally. After the release it will come to `develop` and so replace its outdated list