### PR TITLE
fix OpenPower CPU name detection

### DIFF
--- a/include/alpaka/dev/cpu/SysInfo.hpp
+++ b/include/alpaka/dev/cpu/SysInfo.hpp
@@ -124,7 +124,7 @@ namespace alpaka
                 }
                 return std::string(cpuBrandString);
 #else
-                assert(false); // if we got here there is a bug in the cpuid() function
+                return std::string("unknown");
 #endif
             }
             //-----------------------------------------------------------------------------


### PR DESCRIPTION
For non x86 systems we assert if `getCpuName()`.
This PR changes the behavior and returns `unknown` for non x86 systems.

This PR is going directly in the release 0.6.0 and will be backported after the release.

# Reason for changing the behavior

I do not think that it is required to assert the code only because we do not know the name of the CPU. 
We can later add for OpenPower and ARM methods to query the CPU name, until this is implemented I do not see a reason to follow the old behavior.