### PR TITLE
HIP: fix missing fast math compiler option

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -658,6 +658,10 @@ if(ALPAKA_ACC_GPU_HIP_ENABLE)
                     MESSAGE(FATAL_ERROR "Could not find rocRAND (also searched in: HIP_ROOT_DIR=${HIP_ROOT_DIR}/rocrand).")
                 endif()
 
+                if(ALPAKA_HIP_FAST_MATH)
+                    list(APPEND HIP_HIPCC_FLAGS -ffast-math)
+                endif()
+
                 # possible architectures can be found https://github.com/llvm/llvm-project/blob/master/clang/lib/Basic/Cuda.cpp#L65
                 # 900 -> AMD Vega64
                 # 902 -> AMD Vega 10


### PR DESCRIPTION
For HIP-clang setting fast math is ignored because no the option is not given to the compiler.

This PR is against the release 0.6.0 and will be backported after we released.


Note: CMake option `HIP_HIPCC_FLAGS` is for HIP-clang also ignored. This is currently not fixable because the clang/hipcc option `-cl-denorms-are-zero` and `-fcuda-flush-denormals-to-zero` produces the compiler warning: 

```
clang-12: warning: argument unused during compilation: '-fcuda-flush-denormals-to-zero' [-Wunused-command-line-argument]
```

From the diff: https://reviews.llvm.org/D48287 I would say it should for for AMD devices with `-cl-denorms-are-zero` but it is not.