### PR TITLE
fix zenodo file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -43,9 +43,7 @@
       "affiliation": "CASUS, Helmholtz-Zentrum Dresden-Rossendorf",
       "name": "Stephan, Jan",
       "orcid": "0000-0001-7839-4386"
-    }
-  ],
-  "contributors": [
+    },
     {
       "name": "Gehrke, Valentin",
       "affiliation": "TU Dresden"


### PR DESCRIPTION
Remove field contributors (not known by zenodo).

This PR is against the release and will be backported.