### PR TITLE
Enable ADL for math functions

### DIFF
--- a/docs/source/dev/details.rst
+++ b/docs/source/dev/details.rst
@@ -242,3 +242,19 @@ The ``std::enable_if`` template results in a valid expression, if the condition 
 Therefore it can be used to disable specializations depending on arbitrary boolean conditions.
 It is utilized in the case where the ``TaskId`` member is unequal one or the ``TQueue`` does not inherit from ``UserQueue``.
 In this cirumstances, the condition itself results in valid code but because it evaluates to false, the ``std::enable_if`` specialization results in invalid code and the whole ``Enqueue`` template specialization gets omitted.
+
+Argument dependent lookup for math functions
+--------------------------------------------
+
+Alpaka comes with a set of basic mathematical functions in the namespace `alpaka::math`.
+These functions are dispatched in two ways to support user defined overloads of these functions.
+
+Let's take `alpaka::math::abs` as an example:
+When `alpaka::math::abs(acc, value)` is called, a concrete implementation of `abs` is picked via template specialization.
+Concretely, something similar to `alpaka::math::traits::Abs<decltype(acc), decltype(value)>{}(acc, value)` is called.
+This allows alpaka (and the user) to specialize the template `alpaka::math::traits::Abs` for various backends and various argument types.
+E.g. alpaka contains specializations for `float` and `double`.
+If there is no specialization within alpaka (or by the user), the default implementation of `alpaka::math::traits::Abs<....>{}(acc, value)` will just call `abs(value)`.
+This is called an unqualified call and C++ will try to find a function called `abs` in the namespace where the type of `value` is defined.
+This feature is called Argument Dependent Lookup (ADL).
+Using ADL for types which are not covered by specializations in alpaka allows a user to bring their own implementation for which `abs` is meaningful, e.g. a custom implementation of complex numbers or a fixed precision type.

--- a/include/alpaka/math/abs/AbsStdLib.hpp
+++ b/include/alpaka/math/abs/AbsStdLib.hpp
@@ -36,7 +36,7 @@ namespace alpaka
                 TArg,
                 std::enable_if_t<std::is_arithmetic<TArg>::value && std::is_signed<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto abs(AbsStdLib const& abs_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(AbsStdLib const& abs_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(abs_ctx);
                     return std::abs(arg);

--- a/include/alpaka/math/abs/AbsUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Abs<AbsUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto abs(AbsUniformCudaHipBuiltIn const& abs_ctx, TArg const& arg)
+                __device__ auto operator()(AbsUniformCudaHipBuiltIn const& abs_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(abs_ctx);
                     return ::abs(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Abs<AbsUniformCudaHipBuiltIn, double>
             {
-                __device__ static auto abs(AbsUniformCudaHipBuiltIn const& abs_ctx, double const& arg)
+                __device__ auto operator()(AbsUniformCudaHipBuiltIn const& abs_ctx, double const& arg)
                 {
                     alpaka::ignore_unused(abs_ctx);
                     return ::fabs(arg);
@@ -79,7 +79,7 @@ namespace alpaka
             template<>
             struct Abs<AbsUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto abs(AbsUniformCudaHipBuiltIn const& abs_ctx, float const& arg) -> float
+                __device__ auto operator()(AbsUniformCudaHipBuiltIn const& abs_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(abs_ctx);
                     return ::fabsf(arg);

--- a/include/alpaka/math/abs/Traits.hpp
+++ b/include/alpaka/math/abs/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -29,7 +30,16 @@ namespace alpaka
             //#############################################################################
             //! The abs trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Abs;
+            struct Abs
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find abs(TArg) in the namespace of your type.
+                    return abs(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/abs/Traits.hpp
+++ b/include/alpaka/math/abs/Traits.hpp
@@ -44,7 +44,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto abs(T const& abs_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathAbs, T>;
-            return traits::Abs<ImplementationBase, TArg>::abs(abs_ctx, arg);
+            return traits::Abs<ImplementationBase, TArg>{}(abs_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/acos/AcosStdLib.hpp
+++ b/include/alpaka/math/acos/AcosStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Acos<AcosStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto acos(AcosStdLib const& acos_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(AcosStdLib const& acos_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(acos_ctx);
                     return std::acos(arg);

--- a/include/alpaka/math/acos/AcosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Acos<AcosUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto acos(AcosUniformCudaHipBuiltIn const& acos_ctx, TArg const& arg)
+                __device__ auto operator()(AcosUniformCudaHipBuiltIn const& acos_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(acos_ctx);
                     return ::acos(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Acos<AcosUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto acos(AcosUniformCudaHipBuiltIn const& acos_ctx, float const& arg) -> float
+                __device__ auto operator()(AcosUniformCudaHipBuiltIn const& acos_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(acos_ctx);
                     return ::acosf(arg);

--- a/include/alpaka/math/acos/Traits.hpp
+++ b/include/alpaka/math/acos/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The acos trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Acos;
+            struct Acos
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find acos(TArg) in the namespace of your type.
+                    return acos(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/acos/Traits.hpp
+++ b/include/alpaka/math/acos/Traits.hpp
@@ -45,7 +45,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto acos(T const& acos_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathAcos, T>;
-            return traits::Acos<ImplementationBase, TArg>::acos(acos_ctx, arg);
+            return traits::Acos<ImplementationBase, TArg>{}(acos_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/asin/AsinStdLib.hpp
+++ b/include/alpaka/math/asin/AsinStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Asin<AsinStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto asin(AsinStdLib const& asin_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(AsinStdLib const& asin_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(asin_ctx);
                     return std::asin(arg);

--- a/include/alpaka/math/asin/AsinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Asin<AsinUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto asin(AsinUniformCudaHipBuiltIn const& asin_ctx, TArg const& arg)
+                __device__ auto operator()(AsinUniformCudaHipBuiltIn const& asin_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(asin_ctx);
                     return ::asin(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Asin<AsinUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto asin(AsinUniformCudaHipBuiltIn const& asin_ctx, float const& arg) -> float
+                __device__ auto operator()(AsinUniformCudaHipBuiltIn const& asin_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(asin_ctx);
                     return ::asinf(arg);

--- a/include/alpaka/math/asin/Traits.hpp
+++ b/include/alpaka/math/asin/Traits.hpp
@@ -45,7 +45,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto asin(T const& asin_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathAsin, T>;
-            return traits::Asin<ImplementationBase, TArg>::asin(asin_ctx, arg);
+            return traits::Asin<ImplementationBase, TArg>{}(asin_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/asin/Traits.hpp
+++ b/include/alpaka/math/asin/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The asin trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Asin;
+            struct Asin
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find asin(TArg) in the namespace of your type.
+                    return asin(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/atan/AtanStdLib.hpp
+++ b/include/alpaka/math/atan/AtanStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Atan<AtanStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto atan(AtanStdLib const& atan_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(AtanStdLib const& atan_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(atan_ctx);
                     return std::atan(arg);

--- a/include/alpaka/math/atan/AtanUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Atan<AtanUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto atan(AtanUniformCudaHipBuiltIn const& atan_ctx, TArg const& arg)
+                __device__ auto operator()(AtanUniformCudaHipBuiltIn const& atan_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(atan_ctx);
                     return ::atan(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Atan<AtanUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto atan(AtanUniformCudaHipBuiltIn const& atan_ctx, float const& arg) -> float
+                __device__ auto operator()(AtanUniformCudaHipBuiltIn const& atan_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(atan_ctx);
                     return ::atanf(arg);

--- a/include/alpaka/math/atan/Traits.hpp
+++ b/include/alpaka/math/atan/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The atan trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Atan;
+            struct Atan
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find atan(TArg) in the namespace of your type.
+                    return atan(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/atan/Traits.hpp
+++ b/include/alpaka/math/atan/Traits.hpp
@@ -41,7 +41,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto atan(T const& atan_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathAtan, T>;
-            return traits::Atan<ImplementationBase, TArg>::atan(atan_ctx, arg);
+            return traits::Atan<ImplementationBase, TArg>{}(atan_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/atan2/Atan2StdLib.hpp
+++ b/include/alpaka/math/atan2/Atan2StdLib.hpp
@@ -36,7 +36,7 @@ namespace alpaka
                 Tx,
                 std::enable_if_t<std::is_arithmetic<Ty>::value && std::is_arithmetic<Tx>::value>>
             {
-                ALPAKA_FN_HOST static auto atan2(Atan2StdLib const& abs, Ty const& y, Tx const& x)
+                ALPAKA_FN_HOST auto operator()(Atan2StdLib const& abs, Ty const& y, Tx const& x)
                 {
                     alpaka::ignore_unused(abs);
                     return std::atan2(y, x);

--- a/include/alpaka/math/atan2/Atan2UniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2UniformCudaHipBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 Tx,
                 std::enable_if_t<std::is_floating_point<Ty>::value && std::is_floating_point<Tx>::value>>
             {
-                __device__ static auto atan2(Atan2UniformCudaHipBuiltIn const& atan2_ctx, Ty const& y, Tx const& x)
+                __device__ auto operator()(Atan2UniformCudaHipBuiltIn const& atan2_ctx, Ty const& y, Tx const& x)
                 {
                     alpaka::ignore_unused(atan2_ctx);
                     return ::atan2(y, x);
@@ -73,10 +73,8 @@ namespace alpaka
             template<>
             struct Atan2<Atan2UniformCudaHipBuiltIn, float, float>
             {
-                __device__ static auto atan2(
-                    Atan2UniformCudaHipBuiltIn const& atan2_ctx,
-                    float const& y,
-                    float const& x) -> float
+                __device__ auto operator()(Atan2UniformCudaHipBuiltIn const& atan2_ctx, float const& y, float const& x)
+                    -> float
                 {
                     alpaka::ignore_unused(atan2_ctx);
                     return ::atan2f(y, x);

--- a/include/alpaka/math/atan2/Traits.hpp
+++ b/include/alpaka/math/atan2/Traits.hpp
@@ -44,7 +44,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto atan2(T const& atan2_ctx, Ty const& y, Tx const& x)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathAtan2, T>;
-            return traits::Atan2<ImplementationBase, Ty, Tx>::atan2(atan2_ctx, y, x);
+            return traits::Atan2<ImplementationBase, Ty, Tx>{}(atan2_ctx, y, x);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/atan2/Traits.hpp
+++ b/include/alpaka/math/atan2/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The atan2 trait.
             template<typename T, typename Ty, typename Tx, typename TSfinae = void>
-            struct Atan2;
+            struct Atan2
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, Ty const& y, Tx const& x)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find atan2(Tx, Ty) in the namespace of your type.
+                    return atan2(y, x);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/cbrt/CbrtStdLib.hpp
+++ b/include/alpaka/math/cbrt/CbrtStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Cbrt<CbrtStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto cbrt(CbrtStdLib const& cbrt_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(CbrtStdLib const& cbrt_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(cbrt_ctx);
                     return std::cbrt(arg);

--- a/include/alpaka/math/cbrt/CbrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Cbrt<CbrtUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                __device__ static auto cbrt(CbrtUniformCudaHipBuiltIn const& cbrt_ctx, TArg const& arg)
+                __device__ auto operator()(CbrtUniformCudaHipBuiltIn const& cbrt_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(cbrt_ctx);
                     return ::cbrt(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Cbrt<CbrtUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto cbrt(CbrtUniformCudaHipBuiltIn const& cbrt_ctx, float const& arg) -> float
+                __device__ auto operator()(CbrtUniformCudaHipBuiltIn const& cbrt_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(cbrt_ctx);
                     return ::cbrtf(arg);

--- a/include/alpaka/math/cbrt/Traits.hpp
+++ b/include/alpaka/math/cbrt/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The cbrt trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Cbrt;
+            struct Cbrt
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find cbrt(TArg) in the namespace of your type.
+                    return cbrt(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/cbrt/Traits.hpp
+++ b/include/alpaka/math/cbrt/Traits.hpp
@@ -42,7 +42,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto cbrt(T const& cbrt_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathCbrt, T>;
-            return traits::Cbrt<ImplementationBase, TArg>::cbrt(cbrt_ctx, arg);
+            return traits::Cbrt<ImplementationBase, TArg>{}(cbrt_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/ceil/CeilStdLib.hpp
+++ b/include/alpaka/math/ceil/CeilStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Ceil<CeilStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto ceil(CeilStdLib const& ceil_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(CeilStdLib const& ceil_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(ceil_ctx);
                     return std::ceil(arg);

--- a/include/alpaka/math/ceil/CeilUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Ceil<CeilUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto ceil(CeilUniformCudaHipBuiltIn const& ceil_ctx, TArg const& arg)
+                __device__ auto operator()(CeilUniformCudaHipBuiltIn const& ceil_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(ceil_ctx);
                     return ::ceil(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Ceil<CeilUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto ceil(CeilUniformCudaHipBuiltIn const& ceil_ctx, float const& arg) -> float
+                __device__ auto operator()(CeilUniformCudaHipBuiltIn const& ceil_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(ceil_ctx);
                     return ::ceilf(arg);

--- a/include/alpaka/math/ceil/Traits.hpp
+++ b/include/alpaka/math/ceil/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The ceil trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Ceil;
+            struct Ceil
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find ceil(TArg) in the namespace of your type.
+                    return ceil(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/ceil/Traits.hpp
+++ b/include/alpaka/math/ceil/Traits.hpp
@@ -42,7 +42,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto ceil(T const& ceil_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathCeil, T>;
-            return traits::Ceil<ImplementationBase, TArg>::ceil(ceil_ctx, arg);
+            return traits::Ceil<ImplementationBase, TArg>{}(ceil_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/cos/CosStdLib.hpp
+++ b/include/alpaka/math/cos/CosStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Cos<CosStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto cos(CosStdLib const& cos_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(CosStdLib const& cos_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(cos_ctx);
                     return std::cos(arg);

--- a/include/alpaka/math/cos/CosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Cos<CosUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto cos(CosUniformCudaHipBuiltIn const& cos_ctx, TArg const& arg)
+                __device__ auto operator()(CosUniformCudaHipBuiltIn const& cos_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(cos_ctx);
                     return ::cos(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Cos<CosUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto cos(CosUniformCudaHipBuiltIn const& cos_ctx, float const& arg) -> float
+                __device__ auto operator()(CosUniformCudaHipBuiltIn const& cos_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(cos_ctx);
                     return ::cosf(arg);

--- a/include/alpaka/math/cos/Traits.hpp
+++ b/include/alpaka/math/cos/Traits.hpp
@@ -42,7 +42,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto cos(T const& cos_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathCos, T>;
-            return traits::Cos<ImplementationBase, TArg>::cos(cos_ctx, arg);
+            return traits::Cos<ImplementationBase, TArg>{}(cos_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/cos/Traits.hpp
+++ b/include/alpaka/math/cos/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The cos trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Cos;
+            struct Cos
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find cos(TArg) in the namespace of your type.
+                    return cos(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/erf/ErfStdLib.hpp
+++ b/include/alpaka/math/erf/ErfStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Erf<ErfStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto erf(ErfStdLib const& erf_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(ErfStdLib const& erf_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(erf_ctx);
                     return std::erf(arg);

--- a/include/alpaka/math/erf/ErfUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Erf<ErfUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto erf(ErfUniformCudaHipBuiltIn const& erf_ctx, TArg const& arg)
+                __device__ auto operator()(ErfUniformCudaHipBuiltIn const& erf_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(erf_ctx);
                     return ::erf(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Erf<ErfUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto erf(ErfUniformCudaHipBuiltIn const& erf_ctx, float const& arg) -> float
+                __device__ auto operator()(ErfUniformCudaHipBuiltIn const& erf_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(erf_ctx);
                     return ::erff(arg);

--- a/include/alpaka/math/erf/Traits.hpp
+++ b/include/alpaka/math/erf/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The erf trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Erf;
+            struct Erf
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find erf(TArg) in the namespace of your type.
+                    return erf(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/erf/Traits.hpp
+++ b/include/alpaka/math/erf/Traits.hpp
@@ -42,7 +42,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto erf(T const& erf_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathErf, T>;
-            return traits::Erf<ImplementationBase, TArg>::erf(erf_ctx, arg);
+            return traits::Erf<ImplementationBase, TArg>{}(erf_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/exp/ExpStdLib.hpp
+++ b/include/alpaka/math/exp/ExpStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Exp<ExpStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto exp(ExpStdLib const& exp_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(ExpStdLib const& exp_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(exp_ctx);
                     return std::exp(arg);

--- a/include/alpaka/math/exp/ExpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Exp<ExpUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto exp(ExpUniformCudaHipBuiltIn const& exp_ctx, TArg const& arg)
+                __device__ auto operator()(ExpUniformCudaHipBuiltIn const& exp_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(exp_ctx);
                     return ::exp(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Exp<ExpUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto exp(ExpUniformCudaHipBuiltIn const& exp_ctx, float const& arg) -> float
+                __device__ auto operator()(ExpUniformCudaHipBuiltIn const& exp_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(exp_ctx);
                     return ::expf(arg);

--- a/include/alpaka/math/exp/Traits.hpp
+++ b/include/alpaka/math/exp/Traits.hpp
@@ -42,7 +42,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto exp(T const& exp_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathExp, T>;
-            return traits::Exp<ImplementationBase, TArg>::exp(exp_ctx, arg);
+            return traits::Exp<ImplementationBase, TArg>{}(exp_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/exp/Traits.hpp
+++ b/include/alpaka/math/exp/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The exp trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Exp;
+            struct Exp
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find exp(TArg) in the namespace of your type.
+                    return exp(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/floor/FloorStdLib.hpp
+++ b/include/alpaka/math/floor/FloorStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Floor<FloorStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto floor(FloorStdLib const& floor_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(FloorStdLib const& floor_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(floor_ctx);
                     return std::floor(arg);

--- a/include/alpaka/math/floor/FloorUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Floor<FloorUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto floor(FloorUniformCudaHipBuiltIn const& floor_ctx, TArg const& arg)
+                __device__ auto operator()(FloorUniformCudaHipBuiltIn const& floor_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(floor_ctx);
                     return ::floor(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Floor<FloorUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto floor(FloorUniformCudaHipBuiltIn const& floor_ctx, float const& arg) -> float
+                __device__ auto operator()(FloorUniformCudaHipBuiltIn const& floor_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(floor_ctx);
                     return ::floorf(arg);

--- a/include/alpaka/math/floor/Traits.hpp
+++ b/include/alpaka/math/floor/Traits.hpp
@@ -42,7 +42,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto floor(T const& floor_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathFloor, T>;
-            return traits::Floor<ImplementationBase, TArg>::floor(floor_ctx, arg);
+            return traits::Floor<ImplementationBase, TArg>{}(floor_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/floor/Traits.hpp
+++ b/include/alpaka/math/floor/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The floor trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Floor;
+            struct Floor
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find floor(TArg) in the namespace of your type.
+                    return floor(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/fmod/FmodStdLib.hpp
+++ b/include/alpaka/math/fmod/FmodStdLib.hpp
@@ -36,7 +36,7 @@ namespace alpaka
                 Ty,
                 std::enable_if_t<std::is_arithmetic<Tx>::value && std::is_arithmetic<Ty>::value>>
             {
-                ALPAKA_FN_HOST static auto fmod(FmodStdLib const& fmod_ctx, Tx const& x, Ty const& y)
+                ALPAKA_FN_HOST auto operator()(FmodStdLib const& fmod_ctx, Tx const& x, Ty const& y)
                 {
                     alpaka::ignore_unused(fmod_ctx);
                     return std::fmod(x, y);

--- a/include/alpaka/math/fmod/FmodUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodUniformCudaHipBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 Ty,
                 std::enable_if_t<std::is_floating_point<Tx>::value && std::is_floating_point<Ty>::value>>
             {
-                __device__ static auto fmod(FmodUniformCudaHipBuiltIn const& fmod_ctx, Tx const& x, Ty const& y)
+                __device__ auto operator()(FmodUniformCudaHipBuiltIn const& fmod_ctx, Tx const& x, Ty const& y)
                 {
                     alpaka::ignore_unused(fmod_ctx);
                     return ::fmod(x, y);
@@ -73,7 +73,7 @@ namespace alpaka
             template<>
             struct Fmod<FmodUniformCudaHipBuiltIn, float, float>
             {
-                __device__ static auto fmod(FmodUniformCudaHipBuiltIn const& fmod_ctx, float const& x, float const& y)
+                __device__ auto operator()(FmodUniformCudaHipBuiltIn const& fmod_ctx, float const& x, float const& y)
                     -> float
                 {
                     alpaka::ignore_unused(fmod_ctx);

--- a/include/alpaka/math/fmod/Traits.hpp
+++ b/include/alpaka/math/fmod/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The fmod trait.
             template<typename T, typename Tx, typename Ty, typename TSfinae = void>
-            struct Fmod;
+            struct Fmod
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, Tx const& x, Ty const& y)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find fmod(Tx, Ty) in the namespace of your type.
+                    return fmod(x, y);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/fmod/Traits.hpp
+++ b/include/alpaka/math/fmod/Traits.hpp
@@ -44,7 +44,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto fmod(T const& fmod_ctx, Tx const& x, Ty const& y)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathFmod, T>;
-            return traits::Fmod<ImplementationBase, Tx, Ty>::fmod(fmod_ctx, x, y);
+            return traits::Fmod<ImplementationBase, Tx, Ty>{}(fmod_ctx, x, y);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/log/LogStdLib.hpp
+++ b/include/alpaka/math/log/LogStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Log<LogStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto log(LogStdLib const& log_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(LogStdLib const& log_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(log_ctx);
                     return std::log(arg);

--- a/include/alpaka/math/log/LogUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/log/LogUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Log<LogUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto log(LogUniformCudaHipBuiltIn const& log_ctx, TArg const& arg)
+                __device__ auto operator()(LogUniformCudaHipBuiltIn const& log_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(log_ctx);
                     return ::log(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Log<LogUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto log(LogUniformCudaHipBuiltIn const& log_ctx, float const& arg) -> float
+                __device__ auto operator()(LogUniformCudaHipBuiltIn const& log_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(log_ctx);
                     return ::logf(arg);

--- a/include/alpaka/math/log/Traits.hpp
+++ b/include/alpaka/math/log/Traits.hpp
@@ -46,7 +46,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto log(T const& log_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathLog, T>;
-            return traits::Log<ImplementationBase, TArg>::log(log_ctx, arg);
+            return traits::Log<ImplementationBase, TArg>{}(log_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/log/Traits.hpp
+++ b/include/alpaka/math/log/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The log trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Log;
+            struct Log
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find log(TArg) in the namespace of your type.
+                    return log(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/max/MaxStdLib.hpp
+++ b/include/alpaka/math/max/MaxStdLib.hpp
@@ -33,7 +33,7 @@ namespace alpaka
             template<typename Tx, typename Ty>
             struct Max<MaxStdLib, Tx, Ty, std::enable_if_t<std::is_integral<Tx>::value && std::is_integral<Ty>::value>>
             {
-                ALPAKA_FN_HOST static auto max(MaxStdLib const& max_ctx, Tx const& x, Ty const& y)
+                ALPAKA_FN_HOST auto operator()(MaxStdLib const& max_ctx, Tx const& x, Ty const& y)
                 {
                     alpaka::ignore_unused(max_ctx);
                     return std::max(x, y);
@@ -50,7 +50,7 @@ namespace alpaka
                     std::is_arithmetic<Tx>::value && std::is_arithmetic<Ty>::value
                     && !(std::is_integral<Tx>::value && std::is_integral<Ty>::value)>>
             {
-                ALPAKA_FN_HOST static auto max(MaxStdLib const& max_ctx, Tx const& x, Ty const& y)
+                ALPAKA_FN_HOST auto operator()(MaxStdLib const& max_ctx, Tx const& x, Ty const& y)
                 {
                     alpaka::ignore_unused(max_ctx);
                     return std::fmax(x, y);

--- a/include/alpaka/math/max/MaxUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxUniformCudaHipBuiltIn.hpp
@@ -62,7 +62,7 @@ namespace alpaka
                 Ty,
                 std::enable_if_t<std::is_integral<Tx>::value && std::is_integral<Ty>::value>>
             {
-                __device__ static auto max(MaxUniformCudaHipBuiltIn const& max_ctx, Tx const& x, Ty const& y)
+                __device__ auto operator()(MaxUniformCudaHipBuiltIn const& max_ctx, Tx const& x, Ty const& y)
                     -> decltype(::max(x, y))
                 {
                     alpaka::ignore_unused(max_ctx);
@@ -80,7 +80,7 @@ namespace alpaka
                     std::is_arithmetic<Tx>::value && std::is_arithmetic<Ty>::value
                     && !(std::is_integral<Tx>::value && std::is_integral<Ty>::value)>>
             {
-                __device__ static auto max(MaxUniformCudaHipBuiltIn const& max_ctx, Tx const& x, Ty const& y)
+                __device__ auto operator()(MaxUniformCudaHipBuiltIn const& max_ctx, Tx const& x, Ty const& y)
                     -> decltype(::fmax(x, y))
                 {
                     alpaka::ignore_unused(max_ctx);

--- a/include/alpaka/math/max/Traits.hpp
+++ b/include/alpaka/math/max/Traits.hpp
@@ -45,7 +45,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto max(T const& max_ctx, Tx const& x, Ty const& y)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathMax, T>;
-            return traits::Max<ImplementationBase, Tx, Ty>::max(max_ctx, x, y);
+            return traits::Max<ImplementationBase, Tx, Ty>{}(max_ctx, x, y);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/max/Traits.hpp
+++ b/include/alpaka/math/max/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The max trait.
             template<typename T, typename Tx, typename Ty, typename TSfinae = void>
-            struct Max;
+            struct Max
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, Tx const& x, Ty const& y)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find max(Tx, Ty) in the namespace of your type.
+                    return max(x, y);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/min/MinStdLib.hpp
+++ b/include/alpaka/math/min/MinStdLib.hpp
@@ -33,7 +33,7 @@ namespace alpaka
             template<typename Tx, typename Ty>
             struct Min<MinStdLib, Tx, Ty, std::enable_if_t<std::is_integral<Tx>::value && std::is_integral<Ty>::value>>
             {
-                ALPAKA_FN_HOST static auto min(MinStdLib const& min_ctx, Tx const& x, Ty const& y)
+                ALPAKA_FN_HOST auto operator()(MinStdLib const& min_ctx, Tx const& x, Ty const& y)
                 {
                     alpaka::ignore_unused(min_ctx);
                     return std::min(x, y);
@@ -50,7 +50,7 @@ namespace alpaka
                     std::is_arithmetic<Tx>::value && std::is_arithmetic<Ty>::value
                     && !(std::is_integral<Tx>::value && std::is_integral<Ty>::value)>>
             {
-                ALPAKA_FN_HOST static auto min(MinStdLib const& min_ctx, Tx const& x, Ty const& y)
+                ALPAKA_FN_HOST auto operator()(MinStdLib const& min_ctx, Tx const& x, Ty const& y)
                 {
                     alpaka::ignore_unused(min_ctx);
                     return std::fmin(x, y);

--- a/include/alpaka/math/min/MinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/min/MinUniformCudaHipBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 Ty,
                 std::enable_if_t<std::is_integral<Tx>::value && std::is_integral<Ty>::value>>
             {
-                __device__ static auto min(MinUniformCudaHipBuiltIn const& min_ctx, Tx const& x, Ty const& y)
+                __device__ auto operator()(MinUniformCudaHipBuiltIn const& min_ctx, Tx const& x, Ty const& y)
                     -> decltype(::min(x, y))
                 {
                     alpaka::ignore_unused(min_ctx);
@@ -81,7 +81,7 @@ namespace alpaka
                     std::is_arithmetic<Tx>::value && std::is_arithmetic<Ty>::value
                     && !(std::is_integral<Tx>::value && std::is_integral<Ty>::value)>>
             {
-                __device__ static auto min(MinUniformCudaHipBuiltIn const& min_ctx, Tx const& x, Ty const& y)
+                __device__ auto operator()(MinUniformCudaHipBuiltIn const& min_ctx, Tx const& x, Ty const& y)
                     -> decltype(::fmin(x, y))
                 {
                     alpaka::ignore_unused(min_ctx);

--- a/include/alpaka/math/min/Traits.hpp
+++ b/include/alpaka/math/min/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The min trait.
             template<typename T, typename Tx, typename Ty, typename TSfinae = void>
-            struct Min;
+            struct Min
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, Tx const& x, Ty const& y)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find min(Tx, Ty) in the namespace of your type.
+                    return min(x, y);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/min/Traits.hpp
+++ b/include/alpaka/math/min/Traits.hpp
@@ -45,7 +45,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto min(T const& min_ctx, Tx const& x, Ty const& y)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathMin, T>;
-            return traits::Min<ImplementationBase, Tx, Ty>::min(min_ctx, x, y);
+            return traits::Min<ImplementationBase, Tx, Ty>{}(min_ctx, x, y);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/pow/PowStdLib.hpp
+++ b/include/alpaka/math/pow/PowStdLib.hpp
@@ -36,7 +36,7 @@ namespace alpaka
                 TExp,
                 std::enable_if_t<std::is_arithmetic<TBase>::value && std::is_arithmetic<TExp>::value>>
             {
-                ALPAKA_FN_HOST static auto pow(PowStdLib const& pow_ctx, TBase const& base, TExp const& exp)
+                ALPAKA_FN_HOST auto operator()(PowStdLib const& pow_ctx, TBase const& base, TExp const& exp)
                 {
                     alpaka::ignore_unused(pow_ctx);
                     return std::pow(base, exp);

--- a/include/alpaka/math/pow/PowUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowUniformCudaHipBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 TExp,
                 std::enable_if_t<std::is_floating_point<TBase>::value && std::is_floating_point<TExp>::value>>
             {
-                __device__ static auto pow(PowUniformCudaHipBuiltIn const& pow_ctx, TBase const& base, TExp const& exp)
+                __device__ auto operator()(PowUniformCudaHipBuiltIn const& pow_ctx, TBase const& base, TExp const& exp)
                 {
                     alpaka::ignore_unused(pow_ctx);
                     return ::pow(base, exp);
@@ -73,7 +73,7 @@ namespace alpaka
             template<>
             struct Pow<PowUniformCudaHipBuiltIn, float, float>
             {
-                __device__ static auto pow(
+                __device__ auto operator()(
                     PowUniformCudaHipBuiltIn const& pow_ctx,
                     float const& base,
                     float const& exp) -> float

--- a/include/alpaka/math/pow/Traits.hpp
+++ b/include/alpaka/math/pow/Traits.hpp
@@ -48,7 +48,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto pow(T const& pow_ctx, TBase const& base, TExp const& exp)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathPow, T>;
-            return traits::Pow<ImplementationBase, TBase, TExp>::pow(pow_ctx, base, exp);
+            return traits::Pow<ImplementationBase, TBase, TExp>{}(pow_ctx, base, exp);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/pow/Traits.hpp
+++ b/include/alpaka/math/pow/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The pow trait.
             template<typename T, typename TBase, typename TExp, typename TSfinae = void>
-            struct Pow;
+            struct Pow
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TBase const& base, TExp const& exp)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find pow(base, exp) in the namespace of your type.
+                    return pow(base, exp);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/remainder/RemainderStdLib.hpp
+++ b/include/alpaka/math/remainder/RemainderStdLib.hpp
@@ -36,7 +36,7 @@ namespace alpaka
                 Ty,
                 std::enable_if_t<std::is_floating_point<Tx>::value && std::is_floating_point<Ty>::value>>
             {
-                ALPAKA_FN_HOST static auto remainder(RemainderStdLib const& remainder_ctx, Tx const& x, Ty const& y)
+                ALPAKA_FN_HOST auto operator()(RemainderStdLib const& remainder_ctx, Tx const& x, Ty const& y)
                 {
                     alpaka::ignore_unused(remainder_ctx);
                     return std::remainder(x, y);

--- a/include/alpaka/math/remainder/RemainderUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderUniformCudaHipBuiltIn.hpp
@@ -64,7 +64,7 @@ namespace alpaka
                 Ty,
                 std::enable_if_t<std::is_floating_point<Tx>::value && std::is_floating_point<Ty>::value>>
             {
-                __device__ static auto remainder(
+                __device__ auto operator()(
                     RemainderUniformCudaHipBuiltIn const& remainder_ctx,
                     Tx const& x,
                     Ty const& y)
@@ -77,7 +77,7 @@ namespace alpaka
             template<>
             struct Remainder<RemainderUniformCudaHipBuiltIn, float, float>
             {
-                __device__ static auto remainder(
+                __device__ auto operator()(
                     RemainderUniformCudaHipBuiltIn const& remainder_ctx,
                     float const& x,
                     float const& y) -> float

--- a/include/alpaka/math/remainder/Traits.hpp
+++ b/include/alpaka/math/remainder/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The remainder trait.
             template<typename T, typename Tx, typename Ty, typename TSfinae = void>
-            struct Remainder;
+            struct Remainder
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, Tx const& x, Ty const& y)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find remainder(Tx, Ty) in the namespace of your type.
+                    return remainder(x, y);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/remainder/Traits.hpp
+++ b/include/alpaka/math/remainder/Traits.hpp
@@ -44,7 +44,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto remainder(T const& remainder_ctx, Tx const& x, Ty const& y)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathRemainder, T>;
-            return traits::Remainder<ImplementationBase, Tx, Ty>::remainder(remainder_ctx, x, y);
+            return traits::Remainder<ImplementationBase, Tx, Ty>{}(remainder_ctx, x, y);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/round/RoundStdLib.hpp
+++ b/include/alpaka/math/round/RoundStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Round<RoundStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto round(RoundStdLib const& round_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(RoundStdLib const& round_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(round_ctx);
                     return std::round(arg);
@@ -43,7 +43,7 @@ namespace alpaka
             template<typename TArg>
             struct Lround<RoundStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto lround(RoundStdLib const& lround_ctx, TArg const& arg) -> long int
+                ALPAKA_FN_HOST auto operator()(RoundStdLib const& lround_ctx, TArg const& arg) -> long int
                 {
                     alpaka::ignore_unused(lround_ctx);
                     return std::lround(arg);
@@ -54,7 +54,7 @@ namespace alpaka
             template<typename TArg>
             struct Llround<RoundStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto llround(RoundStdLib const& llround_ctx, TArg const& arg) -> long int
+                ALPAKA_FN_HOST auto operator()(RoundStdLib const& llround_ctx, TArg const& arg) -> long int
                 {
                     alpaka::ignore_unused(llround_ctx);
                     return std::llround(arg);

--- a/include/alpaka/math/round/RoundUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Round<RoundUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto round(RoundUniformCudaHipBuiltIn const& round_ctx, TArg const& arg)
+                __device__ auto operator()(RoundUniformCudaHipBuiltIn const& round_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(round_ctx);
                     return ::round(arg);
@@ -70,8 +70,7 @@ namespace alpaka
             template<typename TArg>
             struct Lround<RoundUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto lround(RoundUniformCudaHipBuiltIn const& lround_ctx, TArg const& arg)
-                    -> long int
+                __device__ auto operator()(RoundUniformCudaHipBuiltIn const& lround_ctx, TArg const& arg) -> long int
                 {
                     alpaka::ignore_unused(lround_ctx);
                     return ::lround(arg);
@@ -82,8 +81,7 @@ namespace alpaka
             template<typename TArg>
             struct Llround<RoundUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto llround(RoundUniformCudaHipBuiltIn const& llround_ctx, TArg const& arg)
-                    -> long int
+                __device__ auto operator()(RoundUniformCudaHipBuiltIn const& llround_ctx, TArg const& arg) -> long int
                 {
                     alpaka::ignore_unused(llround_ctx);
                     return ::llround(arg);
@@ -93,7 +91,7 @@ namespace alpaka
             template<>
             struct Round<RoundUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto round(RoundUniformCudaHipBuiltIn const& round_ctx, float const& arg) -> float
+                __device__ auto operator()(RoundUniformCudaHipBuiltIn const& round_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(round_ctx);
                     return ::roundf(arg);

--- a/include/alpaka/math/round/Traits.hpp
+++ b/include/alpaka/math/round/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,17 +28,44 @@ namespace alpaka
             //#############################################################################
             //! The round trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Round;
+            struct Round
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find round(TArg) in the namespace of your type.
+                    return round(arg);
+                }
+            };
 
             //#############################################################################
             //! The round trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Lround;
+            struct Lround
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find lround(TArg) in the namespace of your type.
+                    return lround(arg);
+                }
+            };
 
             //#############################################################################
             //! The round trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Llround;
+            struct Llround
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find llround(TArg) in the namespace of your type.
+                    return llround(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/round/Traits.hpp
+++ b/include/alpaka/math/round/Traits.hpp
@@ -53,7 +53,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto round(T const& round_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathRound, T>;
-            return traits::Round<ImplementationBase, TArg>::round(round_ctx, arg);
+            return traits::Round<ImplementationBase, TArg>{}(round_ctx, arg);
         }
         //-----------------------------------------------------------------------------
         //! Computes the nearest integer value to arg (in integer format), rounding halfway cases away from zero,
@@ -68,7 +68,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto lround(T const& lround_ctx, TArg const& arg) -> long int
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathRound, T>;
-            return traits::Lround<ImplementationBase, TArg>::lround(lround_ctx, arg);
+            return traits::Lround<ImplementationBase, TArg>{}(lround_ctx, arg);
         }
         //-----------------------------------------------------------------------------
         //! Computes the nearest integer value to arg (in integer format), rounding halfway cases away from zero,
@@ -83,7 +83,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto llround(T const& llround_ctx, TArg const& arg) -> long long int
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathRound, T>;
-            return traits::Llround<ImplementationBase, TArg>::llround(llround_ctx, arg);
+            return traits::Llround<ImplementationBase, TArg>{}(llround_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/rsqrt/RsqrtStdLib.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Rsqrt<RsqrtStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto rsqrt(RsqrtStdLib const& rsqrt_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(RsqrtStdLib const& rsqrt_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(rsqrt_ctx);
                     return static_cast<TArg>(1) / std::sqrt(arg);

--- a/include/alpaka/math/rsqrt/RsqrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Rsqrt<RsqrtUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                __device__ static auto rsqrt(RsqrtUniformCudaHipBuiltIn const& rsqrt_ctx, TArg const& arg)
+                __device__ auto operator()(RsqrtUniformCudaHipBuiltIn const& rsqrt_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(rsqrt_ctx);
                     return ::rsqrt(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Rsqrt<RsqrtUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto rsqrt(RsqrtUniformCudaHipBuiltIn const& rsqrt_ctx, float const& arg) -> float
+                __device__ auto operator()(RsqrtUniformCudaHipBuiltIn const& rsqrt_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(rsqrt_ctx);
                     return ::rsqrtf(arg);

--- a/include/alpaka/math/rsqrt/Traits.hpp
+++ b/include/alpaka/math/rsqrt/Traits.hpp
@@ -46,7 +46,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto rsqrt(T const& rsqrt_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathRsqrt, T>;
-            return traits::Rsqrt<ImplementationBase, TArg>::rsqrt(rsqrt_ctx, arg);
+            return traits::Rsqrt<ImplementationBase, TArg>{}(rsqrt_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/rsqrt/Traits.hpp
+++ b/include/alpaka/math/rsqrt/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The rsqrt trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Rsqrt;
+            struct Rsqrt
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find rsqrt(TArg) in the namespace of your type.
+                    return rsqrt(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/sin/SinStdLib.hpp
+++ b/include/alpaka/math/sin/SinStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Sin<SinStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto sin(SinStdLib const& sin_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(SinStdLib const& sin_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(sin_ctx);
                     return std::sin(arg);

--- a/include/alpaka/math/sin/SinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Sin<SinUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto sin(SinUniformCudaHipBuiltIn const& sin_ctx, TArg const& arg)
+                __device__ auto operator()(SinUniformCudaHipBuiltIn const& sin_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(sin_ctx);
                     return ::sin(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Sin<SinUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto sin(SinUniformCudaHipBuiltIn const& sin_ctx, float const& arg) -> float
+                __device__ auto operator()(SinUniformCudaHipBuiltIn const& sin_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(sin_ctx);
                     return ::sinf(arg);

--- a/include/alpaka/math/sin/Traits.hpp
+++ b/include/alpaka/math/sin/Traits.hpp
@@ -42,7 +42,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto sin(T const& sin_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathSin, T>;
-            return traits::Sin<ImplementationBase, TArg>::sin(sin_ctx, arg);
+            return traits::Sin<ImplementationBase, TArg>{}(sin_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/sin/Traits.hpp
+++ b/include/alpaka/math/sin/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The sin trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Sin;
+            struct Sin
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find sin(TArg) in the namespace of your type.
+                    return sin(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/sincos/SinCosStdLib.hpp
+++ b/include/alpaka/math/sincos/SinCosStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct SinCos<SinCosStdLib, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto sincos(
+                ALPAKA_FN_HOST auto operator()(
                     SinCosStdLib const& sincos_ctx,
                     TArg const& arg,
                     TArg& result_sin,

--- a/include/alpaka/math/sincos/SinCosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sincos/SinCosUniformCudaHipBuiltIn.hpp
@@ -60,7 +60,7 @@ namespace alpaka
             template<>
             struct SinCos<SinCosUniformCudaHipBuiltIn, double>
             {
-                __device__ static auto sincos(
+                __device__ auto operator()(
                     SinCosUniformCudaHipBuiltIn const& sincos_ctx,
                     double const& arg,
                     double& result_sin,
@@ -75,7 +75,7 @@ namespace alpaka
             template<>
             struct SinCos<SinCosUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto sincos(
+                __device__ auto operator()(
                     SinCosUniformCudaHipBuiltIn const& sincos_ctx,
                     float const& arg,
                     float& result_sin,

--- a/include/alpaka/math/sincos/Traits.hpp
+++ b/include/alpaka/math/sincos/Traits.hpp
@@ -45,7 +45,7 @@ namespace alpaka
             -> void
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathSinCos, T>;
-            traits::SinCos<ImplementationBase, TArg>::sincos(sincos_ctx, arg, result_sin, result_cos);
+            traits::SinCos<ImplementationBase, TArg>{}(sincos_ctx, arg, result_sin, result_cos);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/sincos/Traits.hpp
+++ b/include/alpaka/math/sincos/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The sincos trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct SinCos;
+            struct SinCos
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg, TArg& result_sin, TArg& result_cos)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find sincos(TArg, TArg&, TArg&) in the namespace of your type.
+                    return sincos(arg, result_sin, result_cos);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/sqrt/SqrtStdLib.hpp
+++ b/include/alpaka/math/sqrt/SqrtStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Sqrt<SqrtStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto sqrt(SqrtStdLib const& sqrt_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(SqrtStdLib const& sqrt_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(sqrt_ctx);
                     return std::sqrt(arg);

--- a/include/alpaka/math/sqrt/SqrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Sqrt<SqrtUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto sqrt(SqrtUniformCudaHipBuiltIn const& sqrt_ctx, TArg const& arg)
+                __device__ auto operator()(SqrtUniformCudaHipBuiltIn const& sqrt_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(sqrt_ctx);
                     return ::sqrt(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Sqrt<SqrtUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto sqrt(SqrtUniformCudaHipBuiltIn const& sqrt_ctx, float const& arg) -> float
+                __device__ auto operator()(SqrtUniformCudaHipBuiltIn const& sqrt_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(sqrt_ctx);
                     return ::sqrtf(arg);

--- a/include/alpaka/math/sqrt/Traits.hpp
+++ b/include/alpaka/math/sqrt/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The sqrt trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Sqrt;
+            struct Sqrt
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find sqrt(TArg) in the namespace of your type.
+                    return sqrt(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/sqrt/Traits.hpp
+++ b/include/alpaka/math/sqrt/Traits.hpp
@@ -46,7 +46,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto sqrt(T const& sqrt_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathSqrt, T>;
-            return traits::Sqrt<ImplementationBase, TArg>::sqrt(sqrt_ctx, arg);
+            return traits::Sqrt<ImplementationBase, TArg>{}(sqrt_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/tan/TanStdLib.hpp
+++ b/include/alpaka/math/tan/TanStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Tan<TanStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto tan(TanStdLib const& tan_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(TanStdLib const& tan_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(tan_ctx);
                     return std::tan(arg);

--- a/include/alpaka/math/tan/TanUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Tan<TanUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto tan(TanUniformCudaHipBuiltIn const& tan_ctx, TArg const& arg)
+                __device__ auto operator()(TanUniformCudaHipBuiltIn const& tan_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(tan_ctx);
                     return ::tan(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Tan<TanUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto tan(TanUniformCudaHipBuiltIn const& tan_ctx, float const& arg) -> float
+                __device__ auto operator()(TanUniformCudaHipBuiltIn const& tan_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(tan_ctx);
                     return ::tanf(arg);

--- a/include/alpaka/math/tan/Traits.hpp
+++ b/include/alpaka/math/tan/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The tan trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Tan;
+            struct Tan
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find tan(TArg) in the namespace of your type.
+                    return tan(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/tan/Traits.hpp
+++ b/include/alpaka/math/tan/Traits.hpp
@@ -42,7 +42,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto tan(T const& tan_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathTan, T>;
-            return traits::Tan<ImplementationBase, TArg>::tan(tan_ctx, arg);
+            return traits::Tan<ImplementationBase, TArg>{}(tan_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/trunc/Traits.hpp
+++ b/include/alpaka/math/trunc/Traits.hpp
@@ -42,7 +42,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto trunc(T const& trunc_ctx, TArg const& arg)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptMathTrunc, T>;
-            return traits::Trunc<ImplementationBase, TArg>::trunc(trunc_ctx, arg);
+            return traits::Trunc<ImplementationBase, TArg>{}(trunc_ctx, arg);
         }
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/trunc/Traits.hpp
+++ b/include/alpaka/math/trunc/Traits.hpp
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 
@@ -27,7 +28,16 @@ namespace alpaka
             //#############################################################################
             //! The trunc trait.
             template<typename T, typename TArg, typename TSfinae = void>
-            struct Trunc;
+            struct Trunc
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find trunc(TArg) in the namespace of your type.
+                    return trunc(arg);
+                }
+            };
         } // namespace traits
 
         //-----------------------------------------------------------------------------

--- a/include/alpaka/math/trunc/TruncStdLib.hpp
+++ b/include/alpaka/math/trunc/TruncStdLib.hpp
@@ -32,7 +32,7 @@ namespace alpaka
             template<typename TArg>
             struct Trunc<TruncStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
             {
-                ALPAKA_FN_HOST static auto trunc(TruncStdLib const& trunc_ctx, TArg const& arg)
+                ALPAKA_FN_HOST auto operator()(TruncStdLib const& trunc_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(trunc_ctx);
                     return std::trunc(arg);

--- a/include/alpaka/math/trunc/TruncUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncUniformCudaHipBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             template<typename TArg>
             struct Trunc<TruncUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
             {
-                __device__ static auto trunc(TruncUniformCudaHipBuiltIn const& trunc_ctx, TArg const& arg)
+                __device__ auto operator()(TruncUniformCudaHipBuiltIn const& trunc_ctx, TArg const& arg)
                 {
                     alpaka::ignore_unused(trunc_ctx);
                     return ::trunc(arg);
@@ -69,7 +69,7 @@ namespace alpaka
             template<>
             struct Trunc<TruncUniformCudaHipBuiltIn, float>
             {
-                __device__ static auto trunc(TruncUniformCudaHipBuiltIn const& trunc_ctx, float const& arg) -> float
+                __device__ auto operator()(TruncUniformCudaHipBuiltIn const& trunc_ctx, float const& arg) -> float
                 {
                     alpaka::ignore_unused(trunc_ctx);
                     return ::truncf(arg);

--- a/test/unit/math/src/math.cpp
+++ b/test/unit/math/src/math.cpp
@@ -185,3 +185,264 @@ TEMPLATE_LIST_TEST_CASE("mathOps", "[math] [operator]", TestAccFunctorTuples)
 
     alpaka::meta::forEachType<DataTypes>(TestTemplate<Acc, Functor>());
 }
+
+namespace custom
+{
+    enum Custom
+    {
+        Abs,
+        Acos,
+        Asin,
+        Atan,
+        Atan2,
+        Cbrt,
+        Ceil,
+        Cos,
+        Erf,
+        Exp,
+        Floor,
+        Fmod,
+        Log,
+        Max,
+        Min,
+        Pow,
+        Remainder,
+        Round,
+        Lround,
+        Llround,
+        Rsqrt,
+        Sin,
+        Sincos,
+        Sqrt,
+        Tan,
+        Trunc,
+
+        Arg1 = 1024,
+        Arg2 = 2048,
+        Arg3 = 4096,
+    };
+
+    // struct Custom
+    //{
+    //};
+
+    ALPAKA_FN_HOST_ACC auto abs(Custom c);
+    ALPAKA_FN_HOST_ACC auto abs(Custom c)
+    {
+        return Custom::Abs | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto acos(Custom c);
+    ALPAKA_FN_HOST_ACC auto acos(Custom c)
+    {
+        return Custom::Acos | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto asin(Custom c);
+    ALPAKA_FN_HOST_ACC auto asin(Custom c)
+    {
+        return Custom::Asin | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto atan(Custom c);
+    ALPAKA_FN_HOST_ACC auto atan(Custom c)
+    {
+        return Custom::Atan | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto atan2(Custom a, Custom b);
+    ALPAKA_FN_HOST_ACC auto atan2(Custom a, Custom b)
+    {
+        return Custom::Atan2 | a | b;
+    }
+
+    ALPAKA_FN_HOST_ACC auto cbrt(Custom c);
+    ALPAKA_FN_HOST_ACC auto cbrt(Custom c)
+    {
+        return Custom::Cbrt | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto ceil(Custom c);
+    ALPAKA_FN_HOST_ACC auto ceil(Custom c)
+    {
+        return Custom::Ceil | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto cos(Custom c);
+    ALPAKA_FN_HOST_ACC auto cos(Custom c)
+    {
+        return Custom::Cos | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto erf(Custom c);
+    ALPAKA_FN_HOST_ACC auto erf(Custom c)
+    {
+        return Custom::Erf | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto exp(Custom c);
+    ALPAKA_FN_HOST_ACC auto exp(Custom c)
+    {
+        return Custom::Exp | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto floor(Custom c);
+    ALPAKA_FN_HOST_ACC auto floor(Custom c)
+    {
+        return Custom::Floor | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto fmod(Custom a, Custom b);
+    ALPAKA_FN_HOST_ACC auto fmod(Custom a, Custom b)
+    {
+        return Custom::Fmod | a | b;
+    }
+
+    ALPAKA_FN_HOST_ACC auto log(Custom c);
+    ALPAKA_FN_HOST_ACC auto log(Custom c)
+    {
+        return Custom::Log | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto max(Custom a, Custom b);
+    ALPAKA_FN_HOST_ACC auto max(Custom a, Custom b)
+    {
+        return Custom::Max | a | b;
+    }
+
+    ALPAKA_FN_HOST_ACC auto min(Custom a, Custom b);
+    ALPAKA_FN_HOST_ACC auto min(Custom a, Custom b)
+    {
+        return Custom::Min | a | b;
+    }
+
+    ALPAKA_FN_HOST_ACC auto pow(Custom a, Custom b);
+    ALPAKA_FN_HOST_ACC auto pow(Custom a, Custom b)
+    {
+        return Custom::Pow | a | b;
+    }
+
+    ALPAKA_FN_HOST_ACC auto remainder(Custom a, Custom b);
+    ALPAKA_FN_HOST_ACC auto remainder(Custom a, Custom b)
+    {
+        return Custom::Remainder | a | b;
+    }
+
+    ALPAKA_FN_HOST_ACC auto round(Custom c);
+    ALPAKA_FN_HOST_ACC auto round(Custom c)
+    {
+        return Custom::Round | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto lround(Custom c);
+    ALPAKA_FN_HOST_ACC auto lround(Custom c)
+    {
+        return Custom::Lround | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto llround(Custom c);
+    ALPAKA_FN_HOST_ACC auto llround(Custom c)
+    {
+        return Custom::Llround | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto rsqrt(Custom c);
+    ALPAKA_FN_HOST_ACC auto rsqrt(Custom c)
+    {
+        return Custom::Rsqrt | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto sin(Custom c);
+    ALPAKA_FN_HOST_ACC auto sin(Custom c)
+    {
+        return Custom::Sin | c;
+    }
+
+    ALPAKA_FN_HOST_ACC void sincos(Custom c, Custom& a, Custom& b);
+    ALPAKA_FN_HOST_ACC void sincos(Custom c, Custom& a, Custom& b)
+    {
+        a = static_cast<Custom>(Custom::Sincos | c | Custom::Arg2);
+        b = static_cast<Custom>(Custom::Sincos | c | Custom::Arg3);
+    }
+
+    ALPAKA_FN_HOST_ACC auto sqrt(Custom c);
+    ALPAKA_FN_HOST_ACC auto sqrt(Custom c)
+    {
+        return Custom::Sqrt | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto tan(Custom c);
+    ALPAKA_FN_HOST_ACC auto tan(Custom c)
+    {
+        return Custom::Tan | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto trunc(Custom c);
+    ALPAKA_FN_HOST_ACC auto trunc(Custom c)
+    {
+        return Custom::Trunc | c;
+    }
+} // namespace custom
+
+struct AdlKernel
+{
+    template<typename Acc>
+    ALPAKA_FN_ACC void operator()(Acc const& acc, bool* success) const noexcept
+    {
+        using custom::Custom;
+
+        ALPAKA_CHECK(*success, alpaka::math::abs(acc, Custom::Arg1) == (Custom::Abs | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::acos(acc, Custom::Arg1) == (Custom::Acos | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::asin(acc, Custom::Arg1) == (Custom::Asin | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::atan(acc, Custom::Arg1) == (Custom::Atan | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::cbrt(acc, Custom::Arg1) == (Custom::Cbrt | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::ceil(acc, Custom::Arg1) == (Custom::Ceil | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::cos(acc, Custom::Arg1) == (Custom::Cos | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::erf(acc, Custom::Arg1) == (Custom::Erf | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::exp(acc, Custom::Arg1) == (Custom::Exp | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::floor(acc, Custom::Arg1) == (Custom::Floor | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::log(acc, Custom::Arg1) == (Custom::Log | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::round(acc, Custom::Arg1) == (Custom::Round | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::lround(acc, Custom::Arg1) == (Custom::Lround | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::llround(acc, Custom::Arg1) == (Custom::Llround | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::rsqrt(acc, Custom::Arg1) == (Custom::Rsqrt | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::sin(acc, Custom::Arg1) == (Custom::Sin | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::sqrt(acc, Custom::Arg1) == (Custom::Sqrt | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::tan(acc, Custom::Arg1) == (Custom::Tan | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::trunc(acc, Custom::Arg1) == (Custom::Trunc | Custom::Arg1));
+
+        ALPAKA_CHECK(
+            *success,
+            alpaka::math::atan2(acc, Custom::Arg1, Custom::Arg2) == (Custom::Atan2 | Custom::Arg1 | Custom::Arg2));
+        ALPAKA_CHECK(
+            *success,
+            alpaka::math::fmod(acc, Custom::Arg1, Custom::Arg2) == (Custom::Fmod | Custom::Arg1 | Custom::Arg2));
+        ALPAKA_CHECK(
+            *success,
+            alpaka::math::max(acc, Custom::Arg1, Custom::Arg2) == (Custom::Max | Custom::Arg1 | Custom::Arg2));
+        ALPAKA_CHECK(
+            *success,
+            alpaka::math::min(acc, Custom::Arg1, Custom::Arg2) == (Custom::Min | Custom::Arg1 | Custom::Arg2));
+        ALPAKA_CHECK(
+            *success,
+            alpaka::math::pow(acc, Custom::Arg1, Custom::Arg2) == (Custom::Pow | Custom::Arg1 | Custom::Arg2));
+        ALPAKA_CHECK(
+            *success,
+            alpaka::math::remainder(acc, Custom::Arg1, Custom::Arg2)
+                == (Custom::Remainder | Custom::Arg1 | Custom::Arg2));
+
+        Custom a, b;
+        alpaka::math::sincos(acc, Custom::Arg1, a, b);
+        ALPAKA_CHECK(*success, a == (Custom::Sincos | Custom::Arg1 | Custom::Arg2));
+        ALPAKA_CHECK(*success, b == (Custom::Sincos | Custom::Arg1 | Custom::Arg3));
+    }
+};
+
+TEMPLATE_LIST_TEST_CASE("mathOps", "[math] [operator] [adl]", TestAccs)
+{
+    using Acc = TestType;
+    using Dim = alpaka::Dim<Acc>;
+    using Idx = alpaka::Idx<Acc>;
+    auto fixture = alpaka::test::KernelExecutionFixture<Acc>{alpaka::Vec<Dim, Idx>::ones()};
+    REQUIRE(fixture(AdlKernel{}));
+}


### PR DESCRIPTION
Pre-refactoring: Replace static functions of math trait implementations with `operator()`. We need this so we make unqualified calls without name lookup immediately finding the enclosing member function.

All math traits now have a default implementation which does an unqualified call to the corresponding math function. This allows to find overloads for user provided types which are not covered by alpaka or any backend. Integral and floating-point types are covered by the backends.