### PR TITLE
Fix declareVar<BlockSharedMemStOmp5>(): only thread 0 should alloc

### DIFF
--- a/include/alpaka/block/shared/st/BlockSharedMemStOmp5.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStOmp5.hpp
@@ -45,8 +45,10 @@ namespace alpaka
             static auto declareVar(BlockSharedMemStOmp5 const& smem) -> T&
             {
 #    pragma omp barrier
-                smem.alloc<T>();
-#    pragma omp barrier
+#    pragma omp single
+                {
+                    smem.alloc<T>();
+                }
                 return smem.getLatestVar<T>();
             }
         };


### PR DESCRIPTION
Bug when running more than one thread per block, probably a regression introduced during the refactor for the OMP5 backend PR.