### PR TITLE
Fix ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED checked without defined

### DIFF
--- a/test/unit/core/src/OmpScheduleTest.cpp
+++ b/test/unit/core/src/OmpScheduleTest.cpp
@@ -49,7 +49,7 @@ TEST_CASE("ompSetSchedule", "[core]")
     auto const expectedSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Dynamic, 3};
     alpaka::omp::setSchedule(expectedSchedule);
     // The check makes sense only when this feature is supported
-#if defined _OPENMP && _OPENMP >= 200805 && ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#if defined _OPENMP && _OPENMP >= 200805 && defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
     auto const actualSchedule = alpaka::omp::getSchedule();
     REQUIRE(expectedSchedule.kind == actualSchedule.kind);
     REQUIRE(expectedSchedule.chunkSize == actualSchedule.chunkSize);
@@ -64,7 +64,7 @@ TEST_CASE("ompSetNoSchedule", "[core]")
     auto const noSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::NoSchedule};
     alpaka::omp::setSchedule(noSchedule);
     // The check makes sense only when this feature is supported
-#if defined _OPENMP && _OPENMP >= 200805 && ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#if defined _OPENMP && _OPENMP >= 200805 && defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
     auto const actualSchedule = alpaka::omp::getSchedule();
     REQUIRE(expectedSchedule.kind == actualSchedule.kind);
     REQUIRE(expectedSchedule.chunkSize == actualSchedule.chunkSize);

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -34,7 +34,7 @@ struct KernelWithOmpScheduleBase
     }
 
     // Only check when the schedule feature is active
-#if defined _OPENMP && _OPENMP >= 200805 && ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#if defined _OPENMP && _OPENMP >= 200805 && defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TIdx>
     ALPAKA_FN_ACC auto operator()(alpaka::AccCpuOmp2Blocks<TDim, TIdx> const& acc, bool* success) const -> void


### PR DESCRIPTION
Fix compiler errors of the form
```
test/unit/core/src/OmpScheduleTest.cpp:52:45: error: 'ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED' is not defined, evaluates to 0 [-Werror,-Wundef]
#if defined _OPENMP && _OPENMP >= 200805 && ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
                                            ^
```
when `ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED` is not enabled.