### PR TITLE
Add ALPAKA_ASSERT_OFFLOAD Macro

### DIFF
--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -53,9 +53,7 @@ namespace alpaka
         //-----------------------------------------------------------------------------
         BlockSharedMemDynMember(std::size_t sizeBytes) : m_dynPitch(getPitch(sizeBytes))
         {
-#if(defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (!defined NDEBUG)
-            ALPAKA_ASSERT(static_cast<std::uint32_t>(sizeBytes) <= staticAllocBytes());
-#endif
+            ALPAKA_ASSERT_OFFLOAD(static_cast<std::uint32_t>(sizeBytes) <= staticAllocBytes());
         }
         //-----------------------------------------------------------------------------
         BlockSharedMemDynMember(BlockSharedMemDynMember const&) = delete;

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -33,9 +33,7 @@ namespace alpaka
                 : m_mem(mem)
                 , m_capacity(static_cast<std::uint32_t>(capacity))
             {
-#    ifdef ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST
-                ALPAKA_ASSERT((m_mem == nullptr) == (m_capacity == 0u));
-#    endif
+                ALPAKA_ASSERT_OFFLOAD((m_mem == nullptr) == (m_capacity == 0u));
             }
 #else
             BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t) : m_mem(mem)
@@ -58,9 +56,7 @@ namespace alpaka
             {
                 m_allocdBytes = allocPitch<T>();
                 m_allocdBytes += static_cast<std::uint32_t>(sizeof(T));
-#if(defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (!defined NDEBUG)
-                ALPAKA_ASSERT(m_allocdBytes <= m_capacity);
-#endif
+                ALPAKA_ASSERT_OFFLOAD(m_allocdBytes <= m_capacity);
             }
 
 #if BOOST_COMP_GNUC

--- a/include/alpaka/core/Assert.hpp
+++ b/include/alpaka/core/Assert.hpp
@@ -18,6 +18,12 @@
 
 #define ALPAKA_ASSERT(EXPRESSION) assert(EXPRESSION)
 
+#ifdef ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST
+#    define ALPAKA_ASSERT_OFFLOAD(EXPRESSION) ALPAKA_ASSERT(EXPRESSION)
+#else
+#    define ALPAKA_ASSERT_OFFLOAD(EXPRESSION)
+#endif
+
 namespace alpaka
 {
     namespace core

--- a/test/unit/core/src/OmpScheduleTest.cpp
+++ b/test/unit/core/src/OmpScheduleTest.cpp
@@ -49,7 +49,7 @@ TEST_CASE("ompSetSchedule", "[core]")
     auto const expectedSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Dynamic, 3};
     alpaka::omp::setSchedule(expectedSchedule);
     // The check makes sense only when this feature is supported
-#if defined _OPENMP && _OPENMP >= 200805 && ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#if defined _OPENMP && _OPENMP >= 200805 && defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
     auto const actualSchedule = alpaka::omp::getSchedule();
     REQUIRE(expectedSchedule.kind == actualSchedule.kind);
     REQUIRE(expectedSchedule.chunkSize == actualSchedule.chunkSize);
@@ -64,7 +64,7 @@ TEST_CASE("ompSetNoSchedule", "[core]")
     auto const noSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::NoSchedule};
     alpaka::omp::setSchedule(noSchedule);
     // The check makes sense only when this feature is supported
-#if defined _OPENMP && _OPENMP >= 200805 && ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#if defined _OPENMP && _OPENMP >= 200805 && defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
     auto const actualSchedule = alpaka::omp::getSchedule();
     REQUIRE(expectedSchedule.kind == actualSchedule.kind);
     REQUIRE(expectedSchedule.chunkSize == actualSchedule.chunkSize);

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -34,7 +34,7 @@ struct KernelWithOmpScheduleBase
     }
 
     // Only check when the schedule feature is active
-#if defined _OPENMP && _OPENMP >= 200805 && ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#if defined _OPENMP && _OPENMP >= 200805 && defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TIdx>
     ALPAKA_FN_ACC auto operator()(alpaka::AccCpuOmp2Blocks<TDim, TIdx> const& acc, bool* success) const -> void


### PR DESCRIPTION
Reason: To avoid having even more `ALPAKA_ASSERT`s with extra guards https://github.com/alpaka-group/alpaka/pull/1258 ( [comment](https://github.com/alpaka-group/alpaka/pull/1258#discussion_r581796338) )

@psychocoderHPC Do you agree with this addition, to make your PR shorter?

(includes commit from https://github.com/alpaka-group/alpaka/pull/1259 )