### PR TITLE
backport's from develop to 0.6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           os: ubuntu-latest
           env: {CXX: clang++, CC: clang,  ALPAKA_CI_CLANG_VER: 8,      ALPAKA_CI_STDLIB: libc++,    CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.73.0, ALPAKA_CI_CMAKE_VER: 3.17.5, OMP_NUM_THREADS: 4, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04", ALPAKA_CI_ANALYSIS: ON, ALPAKA_DEBUG: 2}
         - name: linux_nvcc-9.1_gcc-5_debug_analysis
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.65.1, ALPAKA_CI_CMAKE_VER: 3.15.7, OMP_NUM_THREADS: 4, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:16.04", ALPAKA_CI_ANALYSIS: ON, ALPAKA_DEBUG: 2, ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "9.1", ALPAKA_CUDA_COMPILER: nvcc,        ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         - name: linux_clang-9_cuda-9.2_debug_analysis
           os: ubuntu-latest
@@ -224,10 +224,10 @@ jobs:
         # gcc 6 ASan is triggered within libtbb.so
         # gcc 7 ASan introduced 'stack-use-after-scope' which is triggered by GOMP_parallel
         - name: linux_gcc-5_release
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.66.0, ALPAKA_CI_CMAKE_VER: 3.15.7, OMP_NUM_THREADS: 3, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04"}
         - name: linux_gcc-6_debug_c++17
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 6,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.70.0, ALPAKA_CI_CMAKE_VER: 3.16.5, OMP_NUM_THREADS: 2, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04", ALPAKA_CXX_STANDARD: 17, CMAKE_CXX_EXTENSIONS: OFF}
         - name: linux_gcc-7_release
           os: ubuntu-latest
@@ -271,7 +271,7 @@ jobs:
         ## CUDA 9.0
         # nvcc + g++
         - name: linux_nvcc-9.0_gcc-5_debug
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.65.1, ALPAKA_CI_CMAKE_VER: 3.16.5,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "9.0", ALPAKA_CUDA_COMPILER: nvcc, ALPAKA_CUDA_ARCH: "70",                         ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         # clang++
         - name: linux_clang-6_cuda-9.0_debug
@@ -287,7 +287,7 @@ jobs:
         ## CUDA 9.1
         # nvcc + g++
         - name: linux_nvcc-9.1_gcc-5_release
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.65.1, ALPAKA_CI_CMAKE_VER: 3.19.0,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "9.1", ALPAKA_CUDA_COMPILER: nvcc,                                                 ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         # nvcc + clang++
         - name: linux_nvcc-9.1_clang-4_debug
@@ -304,10 +304,10 @@ jobs:
         ## CUDA 9.2
         # nvcc + g++
         - name: linux_nvcc-9.2_gcc-5_release
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.68.0, ALPAKA_CI_CMAKE_VER: 3.16.5,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:16.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "9.2", ALPAKA_CUDA_COMPILER: nvcc, ALPAKA_CUDA_ARCH: "30;35",                      ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         - name: linux_nvcc-9.2_gcc-6_debug_separable_compilation
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 6,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.74.0, ALPAKA_CI_CMAKE_VER: 3.18.5,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "9.2", ALPAKA_CUDA_COMPILER: nvcc, ALPAKA_CUDA_NVCC_SEPARABLE_COMPILATION: ON,     ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         - name: linux_nvcc-9.2_gcc-7_release_extended_lambda_off
           os: ubuntu-latest
@@ -333,10 +333,10 @@ jobs:
         ## CUDA 10.0
         # nvcc + g++
         - name: linux_nvcc-10.0_gcc-5_release
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.65.1, ALPAKA_CI_CMAKE_VER: 3.15.7,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "10.0", ALPAKA_CUDA_COMPILER: nvcc,                                                ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         - name: linux_nvcc-10.0_gcc-6_debug
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 6,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.68.0, ALPAKA_CI_CMAKE_VER: 3.19.0,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:16.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "10.0", ALPAKA_CUDA_COMPILER: nvcc,                                                ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         - name: linux_nvcc-10.0_gcc-7_release
           os: ubuntu-latest
@@ -365,10 +365,10 @@ jobs:
         ## CUDA 10.1
         # nvcc + g++
         - name: linux_nvcc-10.1_gcc-5_debug
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.68.0, ALPAKA_CI_CMAKE_VER: 3.16.9,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:16.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "10.1", ALPAKA_CUDA_COMPILER: nvcc,                                                ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         - name: linux_nvcc-10.1_gcc-6_release
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 6,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.65.1, ALPAKA_CI_CMAKE_VER: 3.17.5,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:16.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "10.1", ALPAKA_CUDA_COMPILER: nvcc, ALPAKA_CUDA_ARCH: "30;35",                     ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         - name: linux_nvcc-10.1_gcc-7_debug
           os: ubuntu-latest
@@ -403,10 +403,10 @@ jobs:
         ## CUDA 10.2
         # nvcc + g++
         - name: linux_nvcc-10.2_gcc-5_debug
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.65.1, ALPAKA_CI_CMAKE_VER: 3.19.0,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:16.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "10.2", ALPAKA_CUDA_COMPILER: nvcc, ALPAKA_CUDA_ARCH: "30;35",                     ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         - name: linux_nvcc-10.2_gcc-6_release
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 6,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.68.0, ALPAKA_CI_CMAKE_VER: 3.16.9,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:16.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "10.2", ALPAKA_CUDA_COMPILER: nvcc,                                                ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         - name: linux_nvcc-10.2_gcc-7_debug
           os: ubuntu-latest
@@ -434,10 +434,10 @@ jobs:
         ## CUDA 11.0
         # nvcc + g++
         - name: linux_nvcc-11.0_gcc-5_debug
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.65.1, ALPAKA_CI_CMAKE_VER: 3.15.7,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:16.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "11.0", ALPAKA_CUDA_COMPILER: nvcc, ALPAKA_CUDA_ARCH: "35;80",                     ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         - name: linux_nvcc-11.0_gcc-6_release
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 6,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.68.0, ALPAKA_CI_CMAKE_VER: 3.16.9,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:16.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "11.0", ALPAKA_CUDA_COMPILER: nvcc,                                                ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         - name: linux_nvcc-11.0_gcc-7_debug
           os: ubuntu-latest
@@ -471,10 +471,10 @@ jobs:
         ## CUDA 11.1
         # nvcc + g++
         - name: linux_nvcc-11.1_gcc-5_debug
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.65.1, ALPAKA_CI_CMAKE_VER: 3.15.7,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:16.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "11.1", ALPAKA_CUDA_COMPILER: nvcc,                                                ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         - name: linux_nvcc-11.1_gcc-6_release
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 6,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.68.0, ALPAKA_CI_CMAKE_VER: 3.16.9,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:16.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "11.1", ALPAKA_CUDA_COMPILER: nvcc,                                                ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
         - name: linux_nvcc-11.1_gcc-7_debug
           os: ubuntu-latest
@@ -513,10 +513,10 @@ jobs:
 
         ## HIP
         - name: linux_hip_nvcc-9.2_gcc-5_debug_hip_only
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.67.0, ALPAKA_CI_CMAKE_VER: 3.15.7,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "rrawther/rocm3.5_ubuntu16.04_py3.6_pytorch-ssd", ALPAKA_ACC_GPU_HIP_ENABLE: ON, ALPAKA_ACC_GPU_HIP_ONLY_MODE: ON, ALPAKA_HIP_PLATFORM: clang, ALPAKA_CUDA_COMPILER: clang, ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE: OFF, ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF, ALPAKA_ACC_GPU_CUDA_ENABLE: OFF}
         - name: linux_hip_nvcc-9.2_gcc-5_release_hip_only
-          os: ubuntu-latest
+          os: ubuntu-18.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 5,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.74.0, ALPAKA_CI_CMAKE_VER: 3.19.0,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "rrawther/rocm3.5_ubuntu16.04_py3.6_pytorch-ssd", ALPAKA_ACC_GPU_HIP_ENABLE: ON, ALPAKA_ACC_GPU_HIP_ONLY_MODE: ON, ALPAKA_HIP_PLATFORM: clang, ALPAKA_CUDA_COMPILER: clang, ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE: OFF, ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF, ALPAKA_ACC_GPU_CUDA_ENABLE: OFF}
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.6.1] - 2021-XX-XX
+### Bug Fixes:
+- CI: use ubuntu-18.04 for gcc-5 and gcc-6 builds #1252
+- fix OpenMP 5 shared memory allocation #1254
+
+### Misc
+- add ALPAKA_ASSERT_OFFLOAD Macro #1260
+
 
 ## [0.6.0] - 2021-01-20
 ### Compatibility Changes:

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -53,9 +53,7 @@ namespace alpaka
         //-----------------------------------------------------------------------------
         BlockSharedMemDynMember(std::size_t sizeBytes) : m_dynPitch(getPitch(sizeBytes))
         {
-#if(defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (!defined NDEBUG)
-            ALPAKA_ASSERT(static_cast<std::uint32_t>(sizeBytes) <= staticAllocBytes());
-#endif
+            ALPAKA_ASSERT_OFFLOAD(static_cast<std::uint32_t>(sizeBytes) <= staticAllocBytes());
         }
         //-----------------------------------------------------------------------------
         BlockSharedMemDynMember(BlockSharedMemDynMember const&) = delete;

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -33,9 +33,7 @@ namespace alpaka
                 : m_mem(mem)
                 , m_capacity(static_cast<std::uint32_t>(capacity))
             {
-#    ifdef ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST
-                ALPAKA_ASSERT((m_mem == nullptr) == (m_capacity == 0u));
-#    endif
+                ALPAKA_ASSERT_OFFLOAD((m_mem == nullptr) == (m_capacity == 0u));
             }
 #else
             BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t) : m_mem(mem)
@@ -58,9 +56,7 @@ namespace alpaka
             {
                 m_allocdBytes = allocPitch<T>();
                 m_allocdBytes += static_cast<std::uint32_t>(sizeof(T));
-#if(defined ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST) && (!defined NDEBUG)
-                ALPAKA_ASSERT(m_allocdBytes <= m_capacity);
-#endif
+                ALPAKA_ASSERT_OFFLOAD(m_allocdBytes <= m_capacity);
             }
 
 #if BOOST_COMP_GNUC

--- a/include/alpaka/block/shared/st/BlockSharedMemStOmp5.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStOmp5.hpp
@@ -45,8 +45,10 @@ namespace alpaka
             static auto declareVar(BlockSharedMemStOmp5 const& smem) -> T&
             {
 #    pragma omp barrier
-                smem.alloc<T>();
-#    pragma omp barrier
+#    pragma omp single
+                {
+                    smem.alloc<T>();
+                }
                 return smem.getLatestVar<T>();
             }
         };

--- a/include/alpaka/core/Assert.hpp
+++ b/include/alpaka/core/Assert.hpp
@@ -18,6 +18,12 @@
 
 #define ALPAKA_ASSERT(EXPRESSION) assert(EXPRESSION)
 
+#ifdef ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST
+#    define ALPAKA_ASSERT_OFFLOAD(EXPRESSION) ALPAKA_ASSERT(EXPRESSION)
+#else
+#    define ALPAKA_ASSERT_OFFLOAD(EXPRESSION)
+#endif
+
 namespace alpaka
 {
     namespace core

--- a/test/unit/core/src/OmpScheduleTest.cpp
+++ b/test/unit/core/src/OmpScheduleTest.cpp
@@ -49,7 +49,7 @@ TEST_CASE("ompSetSchedule", "[core]")
     auto const expectedSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Dynamic, 3};
     alpaka::omp::setSchedule(expectedSchedule);
     // The check makes sense only when this feature is supported
-#if defined _OPENMP && _OPENMP >= 200805 && ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#if defined _OPENMP && _OPENMP >= 200805 && defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
     auto const actualSchedule = alpaka::omp::getSchedule();
     REQUIRE(expectedSchedule.kind == actualSchedule.kind);
     REQUIRE(expectedSchedule.chunkSize == actualSchedule.chunkSize);
@@ -64,7 +64,7 @@ TEST_CASE("ompSetNoSchedule", "[core]")
     auto const noSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::NoSchedule};
     alpaka::omp::setSchedule(noSchedule);
     // The check makes sense only when this feature is supported
-#if defined _OPENMP && _OPENMP >= 200805 && ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#if defined _OPENMP && _OPENMP >= 200805 && defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
     auto const actualSchedule = alpaka::omp::getSchedule();
     REQUIRE(expectedSchedule.kind == actualSchedule.kind);
     REQUIRE(expectedSchedule.chunkSize == actualSchedule.chunkSize);

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -34,7 +34,7 @@ struct KernelWithOmpScheduleBase
     }
 
     // Only check when the schedule feature is active
-#if defined _OPENMP && _OPENMP >= 200805 && ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#if defined _OPENMP && _OPENMP >= 200805 && defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TIdx>
     ALPAKA_FN_ACC auto operator()(alpaka::AccCpuOmp2Blocks<TDim, TIdx> const& acc, bool* success) const -> void


### PR DESCRIPTION
Backport #1252, #1254 and #1260.
Update changelog.

This PR is against the 0.6.1 release branch.