### PR TITLE
document return value of `empty()` and `isComplete()`

### DIFF
--- a/include/alpaka/event/Traits.hpp
+++ b/include/alpaka/event/Traits.hpp
@@ -36,6 +36,10 @@ namespace alpaka
 
     //-----------------------------------------------------------------------------
     //! Tests if the given event has already been completed.
+    //!
+    //! \warning This function is allowed to return false negatives. An already completed event can reported as
+    //! uncompleted because the status information are not fully propagated by the used alpaka backend.
+    //! \return true event is finished/complete else false.
     template<typename TEvent>
     ALPAKA_FN_HOST auto isComplete(TEvent const& event) -> bool
     {

--- a/include/alpaka/queue/Traits.hpp
+++ b/include/alpaka/queue/Traits.hpp
@@ -55,6 +55,10 @@ namespace alpaka
 
     //-----------------------------------------------------------------------------
     //! Tests if the queue is empty (all ops in the given queue have been completed).
+    //!
+    //! \warning This function is allowed to return false negatives. An empty queue can reported as
+    //! non empty because the status information are not fully propagated by the used alpaka backend.
+    //! \return true queue is empty else false.
     template<typename TQueue>
     ALPAKA_FN_HOST auto empty(TQueue const& queue) -> bool
     {


### PR DESCRIPTION
Document false negative return value for `alpaka::empty()` and `alpaka::isComplete()`.

The false negatives are definitive happen with HIP and CUDA. Maybe it can happen with OpenACC and OpenMP offloading too.