### PR TITLE
Remove section comments

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -21,7 +21,6 @@
 #include <cstdint>
 #include <iostream>
 
-//-----------------------------------------------------------------------------
 template<size_t width>
 ALPAKA_FN_ACC size_t linIdxToPitchedIdx(size_t const globalIdx, size_t const pitch)
 {
@@ -30,11 +29,9 @@ ALPAKA_FN_ACC size_t linIdxToPitchedIdx(size_t const globalIdx, size_t const pit
     return idx_x + idx_y * pitch;
 }
 
-//#############################################################################
 //! Prints all elements of the buffer.
 struct PrintBufferKernel
 {
-    //-----------------------------------------------------------------------------
     template<typename TAcc, typename TData, typename TExtent>
     ALPAKA_FN_ACC auto operator()(
         TAcc const& acc,
@@ -56,11 +53,9 @@ struct PrintBufferKernel
 };
 
 
-//#############################################################################
 //! Tests if the value of the buffer on index i is equal to i.
 struct TestBufferKernel
 {
-    //-----------------------------------------------------------------------------
     template<typename TAcc, typename TData, typename TExtent>
     ALPAKA_FN_ACC auto operator()(
         TAcc const& acc,
@@ -88,7 +83,6 @@ struct TestBufferKernel
     }
 };
 
-//#############################################################################
 //! Fills values of buffer with increasing elements starting from 0
 struct FillBufferKernel
 {

--- a/example/heatEquation/src/heatEquation.cpp
+++ b/example/heatEquation/src/heatEquation.cpp
@@ -25,7 +25,6 @@
 #include <utility>
 
 
-//#############################################################################
 //! alpaka version of explicit finite-difference 1d heat equation solver
 //!
 //! Solving equation u_t(x, t) = u_xx(x, t) using a simple explicit scheme with

--- a/example/helloWorld/src/helloWorld.cpp
+++ b/example/helloWorld/src/helloWorld.cpp
@@ -20,13 +20,11 @@
 
 #include <iostream>
 
-//#############################################################################
 //! Hello World Kernel
 //!
 //! Prints "[x, y, z][gtid] Hello World" where tid is the global thread number.
 struct HelloWorldKernel
 {
-    //-----------------------------------------------------------------------------
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc) const -> void
     {

--- a/example/helloWorldLambda/src/helloWorldLambda.cpp
+++ b/example/helloWorldLambda/src/helloWorldLambda.cpp
@@ -20,7 +20,6 @@
 
 #include <functional>
 
-//-----------------------------------------------------------------------------
 //! This functions says hi to the world and
 //! can be encapsulated into a std::function
 //! and used as a kernel function. It is

--- a/example/kernelSpecialization/src/kernelSpecialization.cpp
+++ b/example/kernelSpecialization/src/kernelSpecialization.cpp
@@ -20,7 +20,6 @@
 
 #include <iostream>
 
-//#############################################################################
 //! Kernel to illustrate specialization for a particular accelerator
 //!
 //! It has a generic operator() implementation and an overload for the CUDA accelerator.
@@ -37,7 +36,6 @@
 //! For such a case, both template specialization and function overloading of the methods can be employed.
 struct Kernel
 {
-    //-----------------------------------------------------------------------------
     //! Implementation for the general case
     //!
     //! It will be called when no overload is a better match.

--- a/example/monteCarloIntegration/src/monteCarloIntegration.cpp
+++ b/example/monteCarloIntegration/src/monteCarloIntegration.cpp
@@ -22,11 +22,9 @@
 #include <cstdlib>
 #include <iostream>
 
-//#############################################################################
 //! This functor defines the function for which the integral is to be computed.
 struct Function
 {
-    //-----------------------------------------------------------------------------
     //! \tparam TAcc The accelerator environment to be executed on.
     //! \param acc The accelerator to be executed on.
     //! \param x The argument.
@@ -37,13 +35,11 @@ struct Function
     }
 };
 
-//#############################################################################
 //! The kernel executing the parallel logic.
 //! Each Thread generates X pseudo random numbers and compares them with the given function.
 //! The local result will be added to a global result.
 struct Kernel
 {
-    //-----------------------------------------------------------------------------
     //! The kernel entry point.
     //! \tparam TAcc The accelerator environment to be executed on.
     //! \tparam TFunctor A wrapper for a function.

--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -25,7 +25,6 @@
 // and OpenMP runtime supporting at least 3.0. Disable it for other cases.
 #if defined _OPENMP && _OPENMP >= 200805 && ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
 
-//#############################################################################
 //! OpenMP schedule demonstration kernel
 //!
 //! Prints distribution of alpaka thread indices between OpenMP threads.
@@ -33,7 +32,6 @@
 //! Sets no schedule explicitly, so the default is used, controlled by the OMP_SCHEDULE environment variable.
 struct OpenMPScheduleDefaultKernel
 {
-    //-----------------------------------------------------------------------------
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc) const -> void
     {
@@ -49,7 +47,6 @@ struct OpenMPScheduleDefaultKernel
     }
 };
 
-//#############################################################################
 //! Kernel that sets the schedule via a static member.
 //! We inherit OpenMPScheduleDefaultKernel just to reuse its operator().
 struct OpenMPScheduleMemberKernel : public OpenMPScheduleDefaultKernel
@@ -60,7 +57,6 @@ struct OpenMPScheduleMemberKernel : public OpenMPScheduleDefaultKernel
     static constexpr auto ompSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Static, 1};
 };
 
-//#############################################################################
 //! Kernel that sets the schedule via trait specialization.
 //! We inherit OpenMPScheduleDefaultKernel just to reuse its operator().
 //! The schedule trait specialization is given underneath this struct.

--- a/example/reduce/src/alpakaConfig.hpp
+++ b/example/reduce/src/alpakaConfig.hpp
@@ -27,7 +27,6 @@ using Idx = uint64_t;
 using Extent = uint64_t;
 using WorkDiv = alpaka::WorkDivMembers<Dim, Extent>;
 
-//-----------------------------------------------------------------------------
 //! Returns the supplied number or the maxumim number of threads per block for a
 //! specific accelerator.
 //!
@@ -39,7 +38,6 @@ static constexpr uint64_t getMaxBlockSize()
     return (TAcc::MaxBlockSize::value > TSize) ? TSize : TAcc::MaxBlockSize::value;
 }
 
-//#############################################################################
 //! Get Trait via struct.
 //!
 //! \tparam T The data type.
@@ -56,7 +54,6 @@ struct GetIterator
 // Note: Boost Fibers, OpenMP 2 Threads and TBB Blocks accelerators aren't implented
 
 #ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
-//#############################################################################
 //! OpenMP 2 Blocks defines
 //!
 //! Defines Host, Device, etc. for the OpenMP 2 Blocks accelerator.
@@ -77,7 +74,6 @@ struct GetIterator<T, TBuf, alpaka::AccCpuOmp2Blocks<TArgs...>>
 
 #ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
 #    ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-//#############################################################################
 //! OpenMP 5 defines
 //!
 //! Defines Host, Device, etc. for the OpenMP 5 accelerator.
@@ -103,7 +99,6 @@ struct GetIterator<T, TBuf, alpaka::AccOmp5<TArgs...>>
 #endif
 
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-//#############################################################################
 //! Serial CPU defines
 //!
 //! Defines Host, Device, etc. for the serial CPU accelerator.
@@ -122,7 +117,6 @@ struct GetIterator<T, TBuf, alpaka::AccCpuSerial<TArgs...>>
 #endif
 
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
-//#############################################################################
 //! CPU Threads defines
 //!
 //! Defines Host, Device, etc. for the CPU Threads accelerator.
@@ -142,7 +136,6 @@ struct GetIterator<T, TBuf, alpaka::AccCpuThreads<TArgs...>>
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 #    ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-//#############################################################################
 //! CUDA defines
 //!
 //! Defines Host, Device, etc. for the CUDA/HIP accelerator.

--- a/example/reduce/src/iterator.hpp
+++ b/example/reduce/src/iterator.hpp
@@ -19,7 +19,6 @@
 
 #include <alpaka/alpaka.hpp>
 
-//#############################################################################
 //! An iterator base class.
 //!
 //! \tparam T The type.
@@ -33,7 +32,6 @@ protected:
     const uint64_t mMaximum;
 
 public:
-    //-----------------------------------------------------------------------------
     //! Constructor.
     //!
     //! \param data A pointer to the data.
@@ -46,13 +44,11 @@ public:
     {
     }
 
-    //-----------------------------------------------------------------------------
     //! Constructor.
     //!
     //! \param other The other iterator object.
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE Iterator(const Iterator& other) = default;
 
-    //-----------------------------------------------------------------------------
     //! Compare operator.
     //!
     //! \param other The other object.
@@ -63,7 +59,6 @@ public:
         return (this->mData == other.mData) && (this->mIndex == other.mIndex) && (this->mMaximum == other.mMaximum);
     }
 
-    //-----------------------------------------------------------------------------
     //! Compare operator.
     //!
     //! \param other The other object.
@@ -74,7 +69,6 @@ public:
         return !operator==(other);
     }
 
-    //-----------------------------------------------------------------------------
     //! Compare operator.
     //!
     //! \param other The other object.
@@ -86,7 +80,6 @@ public:
         return mIndex < other.mIndex;
     }
 
-    //-----------------------------------------------------------------------------
     //! Compare operator.
     //!
     //! \param other The other object.
@@ -97,7 +90,6 @@ public:
         return mIndex > other.mIndex;
     }
 
-    //-----------------------------------------------------------------------------
     //! Compare operator.
     //!
     //! \param other The other object.
@@ -108,7 +100,6 @@ public:
         return mIndex <= other.mIndex;
     }
 
-    //-----------------------------------------------------------------------------
     //! Compare operator.
     //!
     //! \param other The other object.
@@ -120,7 +111,6 @@ public:
         return mIndex >= other.mIndex;
     }
 
-    //-----------------------------------------------------------------------------
     //! Returns the current element.
     //!
     //! Returns a reference to the current index.
@@ -130,7 +120,6 @@ public:
     }
 };
 
-//#############################################################################
 //! A CPU memory iterator.
 //!
 //! \tparam TAcc The accelerator type.
@@ -140,7 +129,6 @@ template<typename TAcc, typename T, typename TBuf = T>
 class IteratorCpu : public Iterator<T, TBuf>
 {
 public:
-    //-----------------------------------------------------------------------------
     //! Constructor.
     //!
     //! \param acc The accelerator object.
@@ -158,7 +146,6 @@ public:
     {
     }
 
-    //-----------------------------------------------------------------------------
     //! Returns the iterator for the last item.
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto end() const -> IteratorCpu
     {
@@ -167,7 +154,6 @@ public:
         return ret;
     }
 
-    //-----------------------------------------------------------------------------
     //! Increments the internal pointer to the next one and returns this
     //! element.
     //!
@@ -178,7 +164,6 @@ public:
         return *this;
     }
 
-    //-----------------------------------------------------------------------------
     //! Returns the current element and increments the internal pointer to the
     //! next one.
     //!
@@ -190,7 +175,6 @@ public:
         return ret;
     }
 
-    //-----------------------------------------------------------------------------
     //! Decrements the internal pointer to the previous one and returns the this
     //! element.
     //!
@@ -201,7 +185,6 @@ public:
         return *this;
     }
 
-    //-----------------------------------------------------------------------------
     //! Returns the current element and decrements the internal pointer to the
     //! previous one.
     //!
@@ -213,7 +196,6 @@ public:
         return ret;
     }
 
-    //-----------------------------------------------------------------------------
     //! Returns the index + a supplied offset.
     //!
     //! \param n The offset.
@@ -224,7 +206,6 @@ public:
         return ret;
     }
 
-    //-----------------------------------------------------------------------------
     //! Returns the index - a supplied offset.
     //!
     //! \param n The offset.
@@ -235,7 +216,6 @@ public:
         return ret;
     }
 
-    //-----------------------------------------------------------------------------
     //! Addition assignment.
     //!
     //! \param offset The offset.
@@ -247,7 +227,6 @@ public:
         return *this;
     }
 
-    //-----------------------------------------------------------------------------
     //! Substraction assignment.
     //!
     //! \param offset The offset.
@@ -260,7 +239,6 @@ public:
     }
 };
 
-//#############################################################################
 //! A GPU memory iterator.
 //!
 //! \tparam TAcc The accelerator type.
@@ -273,7 +251,6 @@ private:
     const uint32_t mGridSize;
 
 public:
-    //-----------------------------------------------------------------------------
     //! Constructor.
     //!
     //! \param data A pointer to the data.
@@ -287,7 +264,6 @@ public:
     {
     }
 
-    //-----------------------------------------------------------------------------
     //! Returns the iterator for the last item.
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto end() const -> IteratorGpu
     {
@@ -296,7 +272,6 @@ public:
         return ret;
     }
 
-    //-----------------------------------------------------------------------------
     //! Increments the internal pointer to the next one and returns this
     //! element.
     //!
@@ -307,7 +282,6 @@ public:
         return *this;
     }
 
-    //-----------------------------------------------------------------------------
     //! Returns the current element and increments the internal pointer to the
     //! next one.
     //!
@@ -319,7 +293,6 @@ public:
         return ret;
     }
 
-    //-----------------------------------------------------------------------------
     //! Decrements the internal pointer to the previous one and returns the this
     //! element.
     //!
@@ -330,7 +303,6 @@ public:
         return *this;
     }
 
-    //-----------------------------------------------------------------------------
     //! Returns the current element and decrements the internal pointer to the
     //! previous one.
     //!
@@ -342,7 +314,6 @@ public:
         return ret;
     }
 
-    //-----------------------------------------------------------------------------
     //! Returns the index + a supplied offset.
     //!
     //! \param n The offset.
@@ -353,7 +324,6 @@ public:
         return ret;
     }
 
-    //-----------------------------------------------------------------------------
     //! Returns the index - a supplied offset.
     //!
     //! \param n The offset.
@@ -364,7 +334,6 @@ public:
         return ret;
     }
 
-    //-----------------------------------------------------------------------------
     //! Addition assignment.
     //!
     //! \param offset The offset.
@@ -376,7 +345,6 @@ public:
         return *this;
     }
 
-    //-----------------------------------------------------------------------------
     //! Substraction assignment.
     //!
     //! \param offset The offset.

--- a/example/reduce/src/kernel.hpp
+++ b/example/reduce/src/kernel.hpp
@@ -19,14 +19,12 @@
 
 #include <alpaka/alpaka.hpp>
 
-//#############################################################################
 //! A cheap wrapper around a C-style array in heap memory.
 template<typename T, uint64_t size>
 struct cheapArray
 {
     T data[size];
 
-    //-----------------------------------------------------------------------------
     //! Access operator.
     //!
     //! \param index The index of the element to be accessed.
@@ -37,7 +35,6 @@ struct cheapArray
         return data[index];
     }
 
-    //-----------------------------------------------------------------------------
     //! Access operator.
     //!
     //! \param index The index of the element to be accessed.
@@ -49,7 +46,6 @@ struct cheapArray
     }
 };
 
-//#############################################################################
 //! A reduction kernel.
 //!
 //! \tparam TBlockSize The block size.
@@ -60,7 +56,6 @@ struct ReduceKernel
 {
     ALPAKA_NO_HOST_ACC_WARNING
 
-    //-----------------------------------------------------------------------------
     //! The kernel entry point.
     //!
     //! \tparam TAcc The accelerator environment.

--- a/example/reduce/src/reduce.cpp
+++ b/example/reduce/src/reduce.cpp
@@ -44,7 +44,6 @@ using QueueProperty = alpaka::Blocking;
 using QueueAcc = alpaka::Queue<Acc, QueueProperty>;
 using MaxBlockSize = Accelerator::MaxBlockSize;
 
-//-----------------------------------------------------------------------------
 //! Reduces the numbers 1 to n.
 //!
 //! \tparam T The data type.

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -23,12 +23,10 @@
 #include <random>
 #include <typeinfo>
 
-//#############################################################################
 //! A vector addition kernel.
 class VectorAddKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     //! The kernel entry point.
     //!
     //! \tparam TAcc The accelerator environment to be executed on.

--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -50,7 +50,6 @@ namespace alpaka
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelCpuFibers;
 
-    //#############################################################################
     //! The CPU fibers accelerator.
     //!
     //! This accelerator allows parallel kernel execution on a CPU device.
@@ -89,7 +88,6 @@ namespace alpaka
         friend class ::alpaka::TaskKernelCpuFibers;
 
     private:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST AccCpuFibers(TWorkDiv const& workDiv, std::size_t const& blockSharedMemDynSizeBytes)
             : WorkDivMembers<TDim, TIdx>(workDiv)
@@ -115,15 +113,10 @@ namespace alpaka
         }
 
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AccCpuFibers(AccCpuFibers const&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AccCpuFibers(AccCpuFibers&&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(AccCpuFibers const&) -> AccCpuFibers& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(AccCpuFibers&&) -> AccCpuFibers& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~AccCpuFibers() = default;
 
     private:
@@ -138,19 +131,16 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU fibers accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
         struct AccType<AccCpuFibers<TDim, TIdx>>
         {
             using type = AccCpuFibers<TDim, TIdx>;
         };
-        //#############################################################################
         //! The CPU fibers accelerator device properties get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccDevProps<AccCpuFibers<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccDevProps(DevCpu const& dev) -> alpaka::AccDevProps<TDim, TIdx>
             {
 #    ifdef ALPAKA_CI
@@ -180,19 +170,16 @@ namespace alpaka
                         getMemBytes(dev)};
             }
         };
-        //#############################################################################
         //! The CPU fibers accelerator name trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccName<AccCpuFibers<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccName() -> std::string
             {
                 return "AccCpuFibers<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
 
-        //#############################################################################
         //! The CPU fibers accelerator device type trait specialization.
         template<typename TDim, typename TIdx>
         struct DevType<AccCpuFibers<TDim, TIdx>>
@@ -200,7 +187,6 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The CPU fibers accelerator dimension getter trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<AccCpuFibers<TDim, TIdx>>
@@ -208,12 +194,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU fibers accelerator execution task type trait specialization.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
         struct CreateTaskKernel<AccCpuFibers<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
                 TKernelFnObj const& kernelFnObj,
@@ -226,7 +210,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU fibers execution task platform type trait specialization.
         template<typename TDim, typename TIdx>
         struct PltfType<AccCpuFibers<TDim, TIdx>>
@@ -234,7 +217,6 @@ namespace alpaka
             using type = PltfCpu;
         };
 
-        //#############################################################################
         //! The CPU fibers accelerator idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<AccCpuFibers<TDim, TIdx>>

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -52,7 +52,6 @@ namespace alpaka
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelCpuOmp2Blocks;
 
-    //#############################################################################
     //! The CPU OpenMP 2.0 block accelerator.
     //!
     //! This accelerator allows parallel kernel execution on a CPU device.
@@ -90,7 +89,6 @@ namespace alpaka
         friend class ::alpaka::TaskKernelCpuOmp2Blocks;
 
     private:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST AccCpuOmp2Blocks(TWorkDiv const& workDiv, std::size_t const& blockSharedMemDynSizeBytes)
             : WorkDivMembers<TDim, TIdx>(workDiv)
@@ -112,15 +110,10 @@ namespace alpaka
         }
 
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AccCpuOmp2Blocks(AccCpuOmp2Blocks const&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AccCpuOmp2Blocks(AccCpuOmp2Blocks&&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(AccCpuOmp2Blocks const&) -> AccCpuOmp2Blocks& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(AccCpuOmp2Blocks&&) -> AccCpuOmp2Blocks& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~AccCpuOmp2Blocks() = default;
 
     private:
@@ -130,19 +123,16 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU OpenMP 2.0 block accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
         struct AccType<AccCpuOmp2Blocks<TDim, TIdx>>
         {
             using type = AccCpuOmp2Blocks<TDim, TIdx>;
         };
-        //#############################################################################
         //! The CPU OpenMP 2.0 block accelerator device properties get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccDevProps<AccCpuOmp2Blocks<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccDevProps(DevCpu const& dev) -> alpaka::AccDevProps<TDim, TIdx>
             {
                 alpaka::ignore_unused(dev);
@@ -165,19 +155,16 @@ namespace alpaka
                         static_cast<size_t>(AccCpuOmp2Blocks<TDim, TIdx>::staticAllocBytes())};
             }
         };
-        //#############################################################################
         //! The CPU OpenMP 2.0 block accelerator name trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccName<AccCpuOmp2Blocks<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccName() -> std::string
             {
                 return "AccCpuOmp2Blocks<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 block accelerator device type trait specialization.
         template<typename TDim, typename TIdx>
         struct DevType<AccCpuOmp2Blocks<TDim, TIdx>>
@@ -185,7 +172,6 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 block accelerator dimension getter trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<AccCpuOmp2Blocks<TDim, TIdx>>
@@ -193,12 +179,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 block accelerator execution task type trait specialization.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
         struct CreateTaskKernel<AccCpuOmp2Blocks<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
                 TKernelFnObj const& kernelFnObj,
@@ -211,7 +195,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 block execution task platform type trait specialization.
         template<typename TDim, typename TIdx>
         struct PltfType<AccCpuOmp2Blocks<TDim, TIdx>>
@@ -219,7 +202,6 @@ namespace alpaka
             using type = PltfCpu;
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 block accelerator idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<AccCpuOmp2Blocks<TDim, TIdx>>

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -54,7 +54,6 @@ namespace alpaka
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelCpuOmp2Threads;
 
-    //#############################################################################
     //! The CPU OpenMP 2.0 thread accelerator.
     //!
     //! This accelerator allows parallel kernel execution on a CPU device.
@@ -91,7 +90,6 @@ namespace alpaka
         friend class ::alpaka::TaskKernelCpuOmp2Threads;
 
     private:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST AccCpuOmp2Threads(TWorkDiv const& workDiv, std::size_t const& blockSharedMemDynSizeBytes)
             : WorkDivMembers<TDim, TIdx>(workDiv)
@@ -117,15 +115,10 @@ namespace alpaka
         }
 
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AccCpuOmp2Threads(AccCpuOmp2Threads const&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AccCpuOmp2Threads(AccCpuOmp2Threads&&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(AccCpuOmp2Threads const&) -> AccCpuOmp2Threads& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(AccCpuOmp2Threads&&) -> AccCpuOmp2Threads& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~AccCpuOmp2Threads() = default;
 
     private:
@@ -135,19 +128,16 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU OpenMP 2.0 thread accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
         struct AccType<AccCpuOmp2Threads<TDim, TIdx>>
         {
             using type = AccCpuOmp2Threads<TDim, TIdx>;
         };
-        //#############################################################################
         //! The CPU OpenMP 2.0 thread accelerator device properties get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccDevProps<AccCpuOmp2Threads<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccDevProps(DevCpu const& dev) -> alpaka::AccDevProps<TDim, TIdx>
             {
 #    ifdef ALPAKA_CI
@@ -173,19 +163,16 @@ namespace alpaka
                         getMemBytes(dev)};
             }
         };
-        //#############################################################################
         //! The CPU OpenMP 2.0 thread accelerator name trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccName<AccCpuOmp2Threads<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccName() -> std::string
             {
                 return "AccCpuOmp2Threads<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 thread accelerator device type trait specialization.
         template<typename TDim, typename TIdx>
         struct DevType<AccCpuOmp2Threads<TDim, TIdx>>
@@ -193,7 +180,6 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 thread accelerator dimension getter trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<AccCpuOmp2Threads<TDim, TIdx>>
@@ -201,12 +187,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 thread accelerator execution task type trait specialization.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
         struct CreateTaskKernel<AccCpuOmp2Threads<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
                 TKernelFnObj const& kernelFnObj,
@@ -219,7 +203,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 thread execution task platform type trait specialization.
         template<typename TDim, typename TIdx>
         struct PltfType<AccCpuOmp2Threads<TDim, TIdx>>
@@ -227,7 +210,6 @@ namespace alpaka
             using type = PltfCpu;
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 thread accelerator idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<AccCpuOmp2Threads<TDim, TIdx>>

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -47,7 +47,6 @@ namespace alpaka
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelCpuSerial;
 
-    //#############################################################################
     //! The CPU serial accelerator.
     //!
     //! This accelerator allows serial kernel execution on a CPU device.
@@ -84,7 +83,6 @@ namespace alpaka
         friend class ::alpaka::TaskKernelCpuSerial;
 
     private:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST AccCpuSerial(TWorkDiv const& workDiv, size_t const& blockSharedMemDynSizeBytes)
             : WorkDivMembers<TDim, TIdx>(workDiv)
@@ -106,15 +104,10 @@ namespace alpaka
         }
 
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AccCpuSerial(AccCpuSerial const&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AccCpuSerial(AccCpuSerial&&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(AccCpuSerial const&) -> AccCpuSerial& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(AccCpuSerial&&) -> AccCpuSerial& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~AccCpuSerial() = default;
 
     private:
@@ -124,19 +117,16 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU serial accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
         struct AccType<AccCpuSerial<TDim, TIdx>>
         {
             using type = AccCpuSerial<TDim, TIdx>;
         };
-        //#############################################################################
         //! The CPU serial accelerator device properties get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccDevProps<AccCpuSerial<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccDevProps(DevCpu const& dev) -> AccDevProps<TDim, TIdx>
             {
                 alpaka::ignore_unused(dev);
@@ -159,19 +149,16 @@ namespace alpaka
                         static_cast<size_t>(AccCpuSerial<TDim, TIdx>::staticAllocBytes())};
             }
         };
-        //#############################################################################
         //! The CPU serial accelerator name trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccName<AccCpuSerial<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccName() -> std::string
             {
                 return "AccCpuSerial<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
 
-        //#############################################################################
         //! The CPU serial accelerator device type trait specialization.
         template<typename TDim, typename TIdx>
         struct DevType<AccCpuSerial<TDim, TIdx>>
@@ -179,7 +166,6 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The CPU serial accelerator dimension getter trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<AccCpuSerial<TDim, TIdx>>
@@ -187,12 +173,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU serial accelerator execution task type trait specialization.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
         struct CreateTaskKernel<AccCpuSerial<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
                 TKernelFnObj const& kernelFnObj,
@@ -205,7 +189,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU serial execution task platform type trait specialization.
         template<typename TDim, typename TIdx>
         struct PltfType<AccCpuSerial<TDim, TIdx>>
@@ -213,7 +196,6 @@ namespace alpaka
             using type = PltfCpu;
         };
 
-        //#############################################################################
         //! The CPU serial accelerator idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<AccCpuSerial<TDim, TIdx>>

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -47,7 +47,6 @@ namespace alpaka
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelCpuTbbBlocks;
 
-    //#############################################################################
     //! The CPU TBB block accelerator.
     template<
         typename TDim,
@@ -81,7 +80,6 @@ namespace alpaka
         friend class ::alpaka::TaskKernelCpuTbbBlocks;
 
     private:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST AccCpuTbbBlocks(TWorkDiv const& workDiv, std::size_t const& blockSharedMemDynSizeBytes)
             : WorkDivMembers<TDim, TIdx>(workDiv)
@@ -103,15 +101,10 @@ namespace alpaka
         }
 
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AccCpuTbbBlocks(AccCpuTbbBlocks const&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AccCpuTbbBlocks(AccCpuTbbBlocks&&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(AccCpuTbbBlocks const&) -> AccCpuTbbBlocks& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(AccCpuTbbBlocks&&) -> AccCpuTbbBlocks& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~AccCpuTbbBlocks() = default;
 
     private:
@@ -121,19 +114,16 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU TBB block accelerator type trait specialization.
         template<typename TDim, typename TIdx>
         struct AccType<AccCpuTbbBlocks<TDim, TIdx>>
         {
             using type = AccCpuTbbBlocks<TDim, TIdx>;
         };
-        //#############################################################################
         //! The CPU TBB block accelerator device properties get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccDevProps<AccCpuTbbBlocks<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccDevProps(DevCpu const& dev) -> AccDevProps<TDim, TIdx>
             {
                 alpaka::ignore_unused(dev);
@@ -156,19 +146,16 @@ namespace alpaka
                         static_cast<size_t>(AccCpuTbbBlocks<TDim, TIdx>::staticAllocBytes())};
             }
         };
-        //#############################################################################
         //! The CPU TBB block accelerator name trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccName<AccCpuTbbBlocks<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccName() -> std::string
             {
                 return "AccCpuTbbBlocks<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
 
-        //#############################################################################
         //! The CPU TBB block accelerator device type trait specialization.
         template<typename TDim, typename TIdx>
         struct DevType<AccCpuTbbBlocks<TDim, TIdx>>
@@ -176,7 +163,6 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The CPU TBB block accelerator dimension getter trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<AccCpuTbbBlocks<TDim, TIdx>>
@@ -184,12 +170,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU TBB block accelerator execution task type trait specialization.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
         struct CreateTaskKernel<AccCpuTbbBlocks<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
                 TKernelFnObj const& kernelFnObj,
@@ -202,7 +186,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU TBB block execution task platform type trait specialization.
         template<typename TDim, typename TIdx>
         struct PltfType<AccCpuTbbBlocks<TDim, TIdx>>
@@ -210,7 +193,6 @@ namespace alpaka
             using type = PltfCpu;
         };
 
-        //#############################################################################
         //! The CPU TBB block accelerator idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<AccCpuTbbBlocks<TDim, TIdx>>

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -49,7 +49,6 @@ namespace alpaka
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelCpuThreads;
 
-    //#############################################################################
     //! The CPU threads accelerator.
     //!
     //! This accelerator allows parallel kernel execution on a CPU device.
@@ -86,7 +85,6 @@ namespace alpaka
         friend class ::alpaka::TaskKernelCpuThreads;
 
     private:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST AccCpuThreads(TWorkDiv const& workDiv, std::size_t const& blockSharedMemDynSizeBytes)
             : WorkDivMembers<TDim, TIdx>(workDiv)
@@ -112,15 +110,10 @@ namespace alpaka
         }
 
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AccCpuThreads(AccCpuThreads const&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AccCpuThreads(AccCpuThreads&&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(AccCpuThreads const&) -> AccCpuThreads& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(AccCpuThreads&&) -> AccCpuThreads& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~AccCpuThreads() = default;
 
     private:
@@ -136,19 +129,16 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU threads accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
         struct AccType<AccCpuThreads<TDim, TIdx>>
         {
             using type = AccCpuThreads<TDim, TIdx>;
         };
-        //#############################################################################
         //! The CPU threads accelerator device properties get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccDevProps<AccCpuThreads<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccDevProps(DevCpu const& dev) -> AccDevProps<TDim, TIdx>
             {
 #    ifdef ALPAKA_CI
@@ -179,19 +169,16 @@ namespace alpaka
                         getMemBytes(dev)};
             }
         };
-        //#############################################################################
         //! The CPU threads accelerator name trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccName<AccCpuThreads<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccName() -> std::string
             {
                 return "AccCpuThreads<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
 
-        //#############################################################################
         //! The CPU threads accelerator device type trait specialization.
         template<typename TDim, typename TIdx>
         struct DevType<AccCpuThreads<TDim, TIdx>>
@@ -199,7 +186,6 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The CPU threads accelerator dimension getter trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<AccCpuThreads<TDim, TIdx>>
@@ -207,12 +193,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU threads accelerator execution task type trait specialization.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
         struct CreateTaskKernel<AccCpuThreads<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
                 TKernelFnObj const& kernelFnObj,
@@ -225,7 +209,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU threads execution task platform type trait specialization.
         template<typename TDim, typename TIdx>
         struct PltfType<AccCpuThreads<TDim, TIdx>>
@@ -233,7 +216,6 @@ namespace alpaka
             using type = PltfCpu;
         };
 
-        //#############################################################################
         //! The CPU threads accelerator idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<AccCpuThreads<TDim, TIdx>>

--- a/include/alpaka/acc/AccDevProps.hpp
+++ b/include/alpaka/acc/AccDevProps.hpp
@@ -17,7 +17,6 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The acceleration properties on a device.
     //
     // \TODO:
@@ -28,7 +27,6 @@ namespace alpaka
         static_assert(
             sizeof(TIdx) >= sizeof(int),
             "Index type is not supported, consider using int or a larger type.");
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AccDevProps(
             TIdx const& multiProcessorCount,
             Vec<TDim, TIdx> const& gridBlockExtentMax,

--- a/include/alpaka/acc/AccGpuCudaRt.hpp
+++ b/include/alpaka/acc/AccGpuCudaRt.hpp
@@ -36,7 +36,6 @@ namespace alpaka
     template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelGpuUniformCudaHipRt;
 
-    //#############################################################################
     //! The GPU CUDA accelerator.
     //!
     //! This accelerator allows parallel kernel execution on devices supporting CUDA.
@@ -50,28 +49,21 @@ namespace alpaka
             "Index type is not supported, consider using int or a larger type.");
 
     public:
-        //-----------------------------------------------------------------------------
         __device__ AccGpuCudaRt(Vec<TDim, TIdx> const& threadElemExtent)
             : AccGpuUniformCudaHipRt<TDim, TIdx>(threadElemExtent)
         {
         }
 
     public:
-        //-----------------------------------------------------------------------------
         __device__ AccGpuCudaRt(AccGpuCudaRt const&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ AccGpuCudaRt(AccGpuCudaRt&&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(AccGpuCudaRt const&) -> AccGpuCudaRt& = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(AccGpuCudaRt&&) -> AccGpuCudaRt& = delete;
-        //-----------------------------------------------------------------------------
         ~AccGpuCudaRt() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         //! The GPU CUDA accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
         struct AccType<AccGpuCudaRt<TDim, TIdx>>
@@ -79,24 +71,20 @@ namespace alpaka
             using type = AccGpuCudaRt<TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The GPU CUDA accelerator name trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccName<AccGpuCudaRt<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccName() -> std::string
             {
                 return "AccGpuCudaRt<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
 
-        //#############################################################################
         //! The GPU CUDA accelerator execution task type trait specialization.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
         struct CreateTaskKernel<AccGpuCudaRt<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
                 TKernelFnObj const& kernelFnObj,

--- a/include/alpaka/acc/AccGpuHipRt.hpp
+++ b/include/alpaka/acc/AccGpuHipRt.hpp
@@ -36,7 +36,6 @@ namespace alpaka
     template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelGpuUniformCudaHipRt;
 
-    //#############################################################################
     //! The GPU HIP accelerator.
     //!
     //! This accelerator allows parallel kernel execution on devices supporting HIP
@@ -50,28 +49,21 @@ namespace alpaka
             "Index type is not supported, consider using int or a larger type.");
 
     public:
-        //-----------------------------------------------------------------------------
         __device__ AccGpuHipRt(Vec<TDim, TIdx> const& threadElemExtent)
             : AccGpuUniformCudaHipRt<TDim, TIdx>(threadElemExtent)
         {
         }
 
     public:
-        //-----------------------------------------------------------------------------
         __device__ AccGpuHipRt(AccGpuHipRt const&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ AccGpuHipRt(AccGpuHipRt&&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(AccGpuHipRt const&) -> AccGpuHipRt& = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(AccGpuHipRt&&) -> AccGpuHipRt& = delete;
-        //-----------------------------------------------------------------------------
         ~AccGpuHipRt() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         //! The GPU HIP accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
         struct AccType<AccGpuHipRt<TDim, TIdx>>
@@ -79,24 +71,20 @@ namespace alpaka
             using type = AccGpuHipRt<TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The GPU Hip accelerator name trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccName<AccGpuHipRt<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccName() -> std::string
             {
                 return "AccGpuHipRt<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
 
-        //#############################################################################
         //! The GPU HIP accelerator execution task type trait specialization.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
         struct CreateTaskKernel<AccGpuHipRt<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
                 TKernelFnObj const& kernelFnObj,

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -55,7 +55,6 @@ namespace alpaka
     template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelGpuUniformCudaHipRt;
 
-    //#############################################################################
     //! The GPU CUDA accelerator.
     //!
     //! This accelerator allows parallel kernel execution on devices supporting CUDA.
@@ -86,7 +85,6 @@ namespace alpaka
             "Index type is not supported, consider using int or a larger type.");
 
     public:
-        //-----------------------------------------------------------------------------
         __device__ AccGpuUniformCudaHipRt(Vec<TDim, TIdx> const& threadElemExtent)
             : WorkDivUniformCudaHipBuiltIn<TDim, TIdx>(threadElemExtent)
             , gb::IdxGbUniformCudaHipBuiltIn<TDim, TIdx>()
@@ -108,33 +106,25 @@ namespace alpaka
     public:
         // using baseType = AccUniformCudaHip<TDim,TIdx>;
 
-        //-----------------------------------------------------------------------------
         __device__ AccGpuUniformCudaHipRt(AccGpuUniformCudaHipRt const&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ AccGpuUniformCudaHipRt(AccGpuUniformCudaHipRt&&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(AccGpuUniformCudaHipRt const&) -> AccGpuUniformCudaHipRt& = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(AccGpuUniformCudaHipRt&&) -> AccGpuUniformCudaHipRt& = delete;
-        //-----------------------------------------------------------------------------
         ~AccGpuUniformCudaHipRt() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         //! The GPU CUDA accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
         struct AccType<AccGpuUniformCudaHipRt<TDim, TIdx>>
         {
             using type = AccGpuUniformCudaHipRt<TDim, TIdx>;
         };
-        //#############################################################################
         //! The GPU CUDA accelerator device properties get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccDevProps<AccGpuUniformCudaHipRt<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccDevProps(DevUniformCudaHipRt const& dev) -> AccDevProps<TDim, TIdx>
             {
 #    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
@@ -220,19 +210,16 @@ namespace alpaka
 #    endif
             }
         };
-        //#############################################################################
         //! The GPU CUDA accelerator name trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccName<AccGpuUniformCudaHipRt<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccName() -> std::string
             {
                 return "AccGpuUniformCudaHipRt<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
 
-        //#############################################################################
         //! The GPU CUDA accelerator device type trait specialization.
         template<typename TDim, typename TIdx>
         struct DevType<AccGpuUniformCudaHipRt<TDim, TIdx>>
@@ -240,7 +227,6 @@ namespace alpaka
             using type = DevUniformCudaHipRt;
         };
 
-        //#############################################################################
         //! The GPU CUDA accelerator dimension getter trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<AccGpuUniformCudaHipRt<TDim, TIdx>>
@@ -250,7 +236,6 @@ namespace alpaka
     } // namespace traits
     namespace detail
     {
-        //#############################################################################
         //! specialization of the TKernelFnObj return type evaluation
         //
         // It is not possible to determine the result type of a __device__ lambda for CUDA on the host side.
@@ -267,12 +252,10 @@ namespace alpaka
     } // namespace detail
     namespace traits
     {
-        //#############################################################################
         //! The GPU CUDA accelerator execution task type trait specialization.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
         struct CreateTaskKernel<AccGpuUniformCudaHipRt<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
                 TKernelFnObj const& kernelFnObj,
@@ -287,7 +270,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU CUDA execution task platform type trait specialization.
         template<typename TDim, typename TIdx>
         struct PltfType<AccGpuUniformCudaHipRt<TDim, TIdx>>
@@ -295,7 +277,6 @@ namespace alpaka
             using type = PltfUniformCudaHipRt;
         };
 
-        //#############################################################################
         //! The GPU CUDA accelerator idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<AccGpuUniformCudaHipRt<TDim, TIdx>>

--- a/include/alpaka/acc/AccOacc.hpp
+++ b/include/alpaka/acc/AccOacc.hpp
@@ -61,7 +61,6 @@ namespace alpaka
     constexpr size_t oaccMaxWorkerNum = 1;
 #    endif
 
-    //#############################################################################
     //! The OpenACC accelerator.
     template<
         typename TDim,
@@ -90,7 +89,6 @@ namespace alpaka
         friend class ::alpaka::TaskKernelOacc;
 
     protected:
-        //-----------------------------------------------------------------------------
         AccOacc(TIdx const& blockThreadIdx, CtxBlockOacc<TDim, TIdx>& blockShared)
             : bt::IdxBtLinear<TDim, TIdx>(blockThreadIdx)
             , AtomicHierarchy<
@@ -106,15 +104,10 @@ namespace alpaka
         }
 
     public:
-        //-----------------------------------------------------------------------------
         AccOacc(AccOacc const&) = delete;
-        //-----------------------------------------------------------------------------
         AccOacc(AccOacc&&) = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(AccOacc const&) -> AccOacc& = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(AccOacc&&) -> AccOacc& = delete;
-        //-----------------------------------------------------------------------------
         ~AccOacc() = default;
 
         CtxBlockOacc<TDim, TIdx>& m_blockShared;
@@ -122,19 +115,16 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The OpenACC accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
         struct AccType<AccOacc<TDim, TIdx>>
         {
             using type = AccOacc<TDim, TIdx>;
         };
-        //#############################################################################
         //! The OpenACC accelerator device properties get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccDevProps<AccOacc<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccDevProps(DevOacc const& dev) -> AccDevProps<TDim, TIdx>
             {
                 alpaka::ignore_unused(dev);
@@ -166,19 +156,16 @@ namespace alpaka
                         CtxBlockOacc<TDim, TIdx>::staticAllocBytes()};
             }
         };
-        //#############################################################################
         //! The OpenACC accelerator name trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccName<AccOacc<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccName() -> std::string
             {
                 return "AccOacc<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
 
-        //#############################################################################
         //! The OpenACC accelerator device type trait specialization.
         template<typename TDim, typename TIdx>
         struct DevType<AccOacc<TDim, TIdx>>
@@ -186,7 +173,6 @@ namespace alpaka
             using type = DevOacc;
         };
 
-        //#############################################################################
         //! The OpenACC accelerator dimension getter trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<AccOacc<TDim, TIdx>>
@@ -194,12 +180,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The OpenACC accelerator execution task type trait specialization.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
         struct CreateTaskKernel<AccOacc<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
                 TKernelFnObj const& kernelFnObj,
@@ -212,7 +196,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC execution task platform type trait specialization.
         template<typename TDim, typename TIdx>
         struct PltfType<AccOacc<TDim, TIdx>>
@@ -220,7 +203,6 @@ namespace alpaka
             using type = PltfOacc;
         };
 
-        //#############################################################################
         //! The OpenACC accelerator idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<AccOacc<TDim, TIdx>>
@@ -228,12 +210,10 @@ namespace alpaka
             using type = TIdx;
         };
 
-        //#############################################################################
         //! The OpenACC accelerator grid block index get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetIdx<AccOacc<TDim, TIdx>, origin::Grid, unit::Blocks>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current block in the grid.
             template<typename TWorkDiv>
             static auto getIdx(AccOacc<TDim, TIdx> const& idx, TWorkDiv const& workDiv) -> Vec<TDim, TIdx>
@@ -248,7 +228,6 @@ namespace alpaka
         template<typename TIdx>
         struct GetIdx<AccOacc<DimInt<1u>, TIdx>, origin::Grid, unit::Blocks>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current block in the grid.
             template<typename TWorkDiv>
             static auto getIdx(AccOacc<DimInt<1u>, TIdx> const& idx, TWorkDiv const&) -> Vec<DimInt<1u>, TIdx>
@@ -257,7 +236,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         template<typename T, typename TDim, typename TIdx>
         struct GetDynSharedMem<T, AccOacc<TDim, TIdx>>
         {
@@ -266,7 +244,6 @@ namespace alpaka
 #        pragma GCC diagnostic ignored "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases
                                                       // required alignment of target type"
 #    endif
-            //-----------------------------------------------------------------------------
             static auto getMem(AccOacc<TDim, TIdx> const& mem) -> T*
             {
                 return reinterpret_cast<T*>(mem.m_blockShared.dynMemBegin());
@@ -276,33 +253,27 @@ namespace alpaka
 #    endif
         };
 
-        //#############################################################################
         template<typename T, typename TDim, typename TIdx, std::size_t TuniqueId>
         struct DeclareSharedVar<T, TuniqueId, AccOacc<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             static auto declareVar(AccOacc<TDim, TIdx> const& smem) -> T&
             {
                 return alpaka::declareSharedVar<T, TuniqueId>(smem.m_blockShared);
             }
         };
 
-        //#############################################################################
         template<typename TDim, typename TIdx>
         struct FreeSharedVars<AccOacc<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             static auto freeVars(AccOacc<TDim, TIdx> const& smem) -> void
             {
                 alpaka::freeSharedVars(smem.m_blockShared);
             }
         };
 
-        //#############################################################################
         template<typename TDim, typename TIdx>
         struct SyncBlockThreads<AccOacc<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             //! Execute op with single thread (any idx, last thread to
             //! arrive at barrier executes) syncing before and after
             template<typename TOp>
@@ -311,18 +282,15 @@ namespace alpaka
                 SyncBlockThreads<CtxBlockOacc<TDim, TIdx>>::masterOpBlockThreads(acc.m_blockShared, op);
             }
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto syncBlockThreads(AccOacc<TDim, TIdx> const& acc) -> void
             {
                 SyncBlockThreads<CtxBlockOacc<TDim, TIdx>>::syncBlockThreads(acc.m_blockShared);
             }
         };
 
-        //#############################################################################
         template<typename TOp, typename TDim, typename TIdx>
         struct SyncBlockThreadsPredicate<TOp, AccOacc<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(AccOacc<TDim, TIdx> const& acc, int predicate) -> int
             {
@@ -332,12 +300,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC grid block extent trait specialization.
         template<typename TDim, typename TIdx>
         struct GetWorkDiv<AccOacc<TDim, TIdx>, origin::Grid, unit::Blocks>
         {
-            //-----------------------------------------------------------------------------
             //! \return The number of blocks in each dimension of the grid.
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST_ACC static auto getWorkDiv(AccOacc<TDim, TIdx> const& workDiv) -> Vec<TDim, TIdx>
@@ -347,12 +313,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC block thread extent trait specialization.
         template<typename TDim, typename TIdx>
         struct GetWorkDiv<AccOacc<TDim, TIdx>, origin::Block, unit::Threads>
         {
-            //-----------------------------------------------------------------------------
             //! \return The number of threads in each dimension of a block.
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST_ACC static auto getWorkDiv(AccOacc<TDim, TIdx> const& workDiv) -> Vec<TDim, TIdx>
@@ -362,12 +326,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC thread element extent trait specialization.
         template<typename TDim, typename TIdx>
         struct GetWorkDiv<AccOacc<TDim, TIdx>, origin::Thread, unit::Elems>
         {
-            //-----------------------------------------------------------------------------
             //! \return The number of elements in each dimension of a thread.
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST_ACC static auto getWorkDiv(AccOacc<TDim, TIdx> const& workDiv) -> Vec<TDim, TIdx>

--- a/include/alpaka/acc/AccOmp5.hpp
+++ b/include/alpaka/acc/AccOmp5.hpp
@@ -51,7 +51,6 @@ namespace alpaka
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelOmp5;
 
-    //#############################################################################
     //! The CPU OpenMP 5.0 accelerator.
     //!
     //! This accelerator allows parallel kernel execution on an OpenMP target device.
@@ -88,7 +87,6 @@ namespace alpaka
         friend class ::alpaka::TaskKernelOmp5;
 
     private:
-        //-----------------------------------------------------------------------------
         AccOmp5(
             Vec<TDim, TIdx> const& gridBlockExtent,
             Vec<TDim, TIdx> const& blockThreadExtent,
@@ -115,33 +113,25 @@ namespace alpaka
         }
 
     public:
-        //-----------------------------------------------------------------------------
         AccOmp5(AccOmp5 const&) = delete;
-        //-----------------------------------------------------------------------------
         AccOmp5(AccOmp5&&) = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(AccOmp5 const&) -> AccOmp5& = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(AccOmp5&&) -> AccOmp5& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~AccOmp5() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         //! The OpenMP 5.0 accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
         struct AccType<AccOmp5<TDim, TIdx>>
         {
             using type = AccOmp5<TDim, TIdx>;
         };
-        //#############################################################################
         //! The OpenMP 5.0 accelerator device properties get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccDevProps<AccOmp5<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccDevProps(DevOmp5 const& dev) -> AccDevProps<TDim, TIdx>
             {
                 alpaka::ignore_unused(dev);
@@ -190,19 +180,16 @@ namespace alpaka
                         AccOmp5<TDim, TIdx>::staticAllocBytes()};
             }
         };
-        //#############################################################################
         //! The OpenMP 5.0 accelerator name trait specialization.
         template<typename TDim, typename TIdx>
         struct GetAccName<AccOmp5<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccName() -> std::string
             {
                 return "AccOmp5<" + std::to_string(TDim::value) + "," + typeid(TIdx).name() + ">";
             }
         };
 
-        //#############################################################################
         //! The OpenMP 5.0 accelerator device type trait specialization.
         template<typename TDim, typename TIdx>
         struct DevType<AccOmp5<TDim, TIdx>>
@@ -210,7 +197,6 @@ namespace alpaka
             using type = DevOmp5;
         };
 
-        //#############################################################################
         //! The OpenMP 5.0 accelerator dimension getter trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<AccOmp5<TDim, TIdx>>
@@ -218,12 +204,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The OpenMP 5.0 accelerator execution task type trait specialization.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
         struct CreateTaskKernel<AccOmp5<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
                 TKernelFnObj const& kernelFnObj,
@@ -236,7 +220,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenMP 5.0 execution task platform type trait specialization.
         template<typename TDim, typename TIdx>
         struct PltfType<AccOmp5<TDim, TIdx>>
@@ -244,7 +227,6 @@ namespace alpaka
             using type = PltfOmp5;
         };
 
-        //#############################################################################
         //! The OpenMP 5.0 accelerator idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<AccOmp5<TDim, TIdx>>

--- a/include/alpaka/acc/Traits.hpp
+++ b/include/alpaka/acc/Traits.hpp
@@ -32,42 +32,35 @@ namespace alpaka
     struct ConceptAcc
     {
     };
-    //-----------------------------------------------------------------------------
     //! The accelerator traits.
     namespace traits
     {
-        //#############################################################################
         //! The accelerator type trait.
         template<typename T, typename TSfinae = void>
         struct AccType;
 
-        //#############################################################################
         //! The device properties get trait.
         template<typename TAcc, typename TSfinae = void>
         struct GetAccDevProps;
 
-        //#############################################################################
         //! The accelerator name trait.
         //!
         //! The default implementation returns the mangled class name.
         template<typename TAcc, typename TSfinae = void>
         struct GetAccName
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccName() -> std::string
             {
                 return typeid(TAcc).name();
             }
         };
 
-        //#############################################################################
         //! The GPU CUDA accelerator device properties get trait specialization.
         template<typename TAcc>
         struct GetAccDevProps<
             TAcc,
             typename std::enable_if<concepts::ImplementsConcept<ConceptUniformCudaHip, TAcc>::value>::type>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getAccDevProps(typename alpaka::traits::DevType<TAcc>::type const& dev)
                 -> AccDevProps<typename traits::DimType<TAcc>::type, typename traits::IdxType<TAcc>::type>
             {
@@ -77,12 +70,10 @@ namespace alpaka
         };
     } // namespace traits
 
-    //#############################################################################
     //! The accelerator type trait alias template to remove the ::type.
     template<typename T>
     using Acc = typename traits::AccType<T>::type;
 
-    //-----------------------------------------------------------------------------
     //! \return The acceleration properties on the given device.
     template<typename TAcc, typename TDev>
     ALPAKA_FN_HOST auto getAccDevProps(TDev const& dev) -> AccDevProps<Dim<TAcc>, Idx<TAcc>>
@@ -91,7 +82,6 @@ namespace alpaka
         return traits::GetAccDevProps<ImplementationBase>::getAccDevProps(dev);
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The accelerator name
     //!
     //! \tparam TAcc The accelerator type.
@@ -119,7 +109,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The GPU HIP accelerator device type trait specialization.
         template<typename TAcc>
         struct DevType<
@@ -130,7 +119,6 @@ namespace alpaka
             using type = typename DevType<ImplementationBase>::type;
         };
 
-        //#############################################################################
         //! The CPU HIP execution task platform type trait specialization.
         template<typename TAcc>
         struct PltfType<
@@ -141,7 +129,6 @@ namespace alpaka
             using type = typename PltfType<ImplementationBase>::type;
         };
 
-        //#############################################################################
         //! The GPU HIP accelerator dimension getter trait specialization.
         template<typename TAcc>
         struct DimType<
@@ -152,7 +139,6 @@ namespace alpaka
             using type = typename DimType<ImplementationBase>::type;
         };
 
-        //#############################################################################
         //! The GPU HIP accelerator idx type trait specialization.
         template<typename TAcc>
         struct IdxType<

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -9,14 +9,10 @@
 
 #pragma once
 
-//#############################################################################
 // Include the whole library.
-//#############################################################################
 
-//-----------------------------------------------------------------------------
 // version number
 #include <alpaka/version.hpp>
-//-----------------------------------------------------------------------------
 // acc
 #include <alpaka/acc/AccCpuFibers.hpp>
 #include <alpaka/acc/AccCpuOmp2Blocks.hpp>
@@ -31,7 +27,6 @@
 #include <alpaka/acc/AccOacc.hpp>
 #include <alpaka/acc/AccOmp5.hpp>
 #include <alpaka/acc/Traits.hpp>
-//-----------------------------------------------------------------------------
 // atomic
 #include <alpaka/atomic/AtomicNoOp.hpp>
 #include <alpaka/atomic/AtomicOmpBuiltIn.hpp>
@@ -39,22 +34,17 @@
 #include <alpaka/atomic/AtomicUniformCudaHipBuiltIn.hpp>
 #include <alpaka/atomic/Op.hpp>
 #include <alpaka/atomic/Traits.hpp>
-//-----------------------------------------------------------------------------
 // block
-//-----------------------------------------------------------------------------
 // shared
-//-----------------------------------------------------------------------------
 // dynamic
 #include <alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp>
 #include <alpaka/block/shared/dyn/BlockSharedMemDynUniformCudaHipBuiltIn.hpp>
 #include <alpaka/block/shared/dyn/Traits.hpp>
-//-----------------------------------------------------------------------------
 // static
 #include <alpaka/block/shared/st/BlockSharedMemStMember.hpp>
 #include <alpaka/block/shared/st/BlockSharedMemStMemberMasterSync.hpp>
 #include <alpaka/block/shared/st/BlockSharedMemStUniformCudaHipBuiltIn.hpp>
 #include <alpaka/block/shared/st/Traits.hpp>
-//-----------------------------------------------------------------------------
 // sync
 #include <alpaka/block/sync/BlockSyncBarrierFiber.hpp>
 #include <alpaka/block/sync/BlockSyncBarrierOmp.hpp>
@@ -62,7 +52,6 @@
 #include <alpaka/block/sync/BlockSyncNoOp.hpp>
 #include <alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp>
 #include <alpaka/block/sync/Traits.hpp>
-//-----------------------------------------------------------------------------
 // core
 #include <alpaka/core/Align.hpp>
 #include <alpaka/core/AlignedAlloc.hpp>
@@ -83,28 +72,23 @@
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/core/Utility.hpp>
 #include <alpaka/core/Vectorize.hpp>
-//-----------------------------------------------------------------------------
 // dev
 #include <alpaka/dev/DevCpu.hpp>
 #include <alpaka/dev/DevUniformCudaHipRt.hpp>
 #include <alpaka/dev/Traits.hpp>
 #include <alpaka/dev/cpu/Wait.hpp>
-//-----------------------------------------------------------------------------
 // dim
 #include <alpaka/dim/DimArithmetic.hpp>
 #include <alpaka/dim/DimIntegralConst.hpp>
 #include <alpaka/dim/Traits.hpp>
-//-----------------------------------------------------------------------------
 // event
 #include <alpaka/event/EventCpu.hpp>
 #include <alpaka/event/EventOacc.hpp>
 #include <alpaka/event/EventOmp5.hpp>
 #include <alpaka/event/EventUniformCudaHipRt.hpp>
 #include <alpaka/event/Traits.hpp>
-//-----------------------------------------------------------------------------
 // extent
 #include <alpaka/extent/Traits.hpp>
-//-----------------------------------------------------------------------------
 // idx
 #include <alpaka/idx/Accessors.hpp>
 #include <alpaka/idx/MapIdx.hpp>
@@ -116,7 +100,6 @@
 #include <alpaka/idx/bt/IdxBtZero.hpp>
 #include <alpaka/idx/gb/IdxGbRef.hpp>
 #include <alpaka/idx/gb/IdxGbUniformCudaHipBuiltIn.hpp>
-//-----------------------------------------------------------------------------
 // kernel
 #include <alpaka/kernel/TaskKernelCpuFibers.hpp>
 #include <alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp>
@@ -128,11 +111,9 @@
 #include <alpaka/kernel/TaskKernelOacc.hpp>
 #include <alpaka/kernel/TaskKernelOmp5.hpp>
 #include <alpaka/kernel/Traits.hpp>
-//-----------------------------------------------------------------------------
 // math
 #include <alpaka/math/MathStdLib.hpp>
 #include <alpaka/math/MathUniformCudaHipBuiltIn.hpp>
-//-----------------------------------------------------------------------------
 // mem
 #include <alpaka/mem/alloc/AllocCpuAligned.hpp>
 #include <alpaka/mem/alloc/AllocCpuNew.hpp>
@@ -148,7 +129,6 @@
 #include <alpaka/mem/view/ViewStdArray.hpp>
 #include <alpaka/mem/view/ViewStdVector.hpp>
 #include <alpaka/mem/view/ViewSubView.hpp>
-//-----------------------------------------------------------------------------
 // meta
 #include <alpaka/meta/Apply.hpp>
 #include <alpaka/meta/ApplyTuple.hpp>
@@ -167,24 +147,19 @@
 #include <alpaka/meta/Set.hpp>
 #include <alpaka/meta/Transform.hpp>
 #include <alpaka/meta/Void.hpp>
-//-----------------------------------------------------------------------------
 // offset
 #include <alpaka/offset/Traits.hpp>
-//-----------------------------------------------------------------------------
 // platform
 #include <alpaka/pltf/PltfCpu.hpp>
 #include <alpaka/pltf/PltfOacc.hpp>
 #include <alpaka/pltf/PltfOmp5.hpp>
 #include <alpaka/pltf/PltfUniformCudaHipRt.hpp>
 #include <alpaka/pltf/Traits.hpp>
-//-----------------------------------------------------------------------------
 // rand
 #include <alpaka/rand/RandUniformCudaHipRand.hpp>
 #include <alpaka/rand/Traits.hpp>
-//-----------------------------------------------------------------------------
 // idx
 #include <alpaka/idx/Traits.hpp>
-//-----------------------------------------------------------------------------
 // queue
 #include <alpaka/queue/Properties.hpp>
 #include <alpaka/queue/QueueCpuBlocking.hpp>
@@ -194,18 +169,14 @@
 #include <alpaka/queue/QueueUniformCudaHipRtBlocking.hpp>
 #include <alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp>
 #include <alpaka/queue/Traits.hpp>
-//-----------------------------------------------------------------------------
 // time
 #include <alpaka/time/Traits.hpp>
-//-----------------------------------------------------------------------------
 // wait
 #include <alpaka/wait/Traits.hpp>
-//-----------------------------------------------------------------------------
 // workdiv
 #include <alpaka/workdiv/Traits.hpp>
 #include <alpaka/workdiv/WorkDivHelpers.hpp>
 #include <alpaka/workdiv/WorkDivMembers.hpp>
-//-----------------------------------------------------------------------------
 // vec
 #include <alpaka/vec/Traits.hpp>
 #include <alpaka/vec/Vec.hpp>

--- a/include/alpaka/atomic/AtomicHierarchy.hpp
+++ b/include/alpaka/atomic/AtomicHierarchy.hpp
@@ -17,7 +17,6 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! build a single class to inherit from different atomic implementations
     //
     //  This implementation inherit from all three hierarchies.

--- a/include/alpaka/atomic/AtomicNoOp.hpp
+++ b/include/alpaka/atomic/AtomicNoOp.hpp
@@ -14,39 +14,29 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The CPU fibers accelerator atomic ops.
     class AtomicNoOp
     {
     public:
-        //-----------------------------------------------------------------------------
         AtomicNoOp() = default;
-        //-----------------------------------------------------------------------------
         AtomicNoOp(AtomicNoOp const&) = delete;
-        //-----------------------------------------------------------------------------
         AtomicNoOp(AtomicNoOp&&) = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(AtomicNoOp const&) -> AtomicNoOp& = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(AtomicNoOp&&) -> AtomicNoOp& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~AtomicNoOp() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU fibers accelerator atomic operation.
         template<typename TOp, typename T, typename THierarchy>
         struct AtomicOp<TOp, AtomicNoOp, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto atomicOp(AtomicNoOp const& atomic, T* const addr, T const& value) -> T
             {
                 alpaka::ignore_unused(atomic);
                 return TOp()(addr, value);
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto atomicOp(
                 AtomicNoOp const& atomic,
                 T* const addr,

--- a/include/alpaka/atomic/AtomicOaccBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicOaccBuiltIn.hpp
@@ -20,7 +20,6 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The OpenACC accelerator's atomic ops.
     //
     //  Atomics can be used in the blocks and threads hierarchy levels.
@@ -28,17 +27,11 @@ namespace alpaka
     class AtomicOaccBuiltIn
     {
     public:
-        //-----------------------------------------------------------------------------
         AtomicOaccBuiltIn() = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST_ACC AtomicOaccBuiltIn(AtomicOaccBuiltIn const&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST_ACC AtomicOaccBuiltIn(AtomicOaccBuiltIn&&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST_ACC auto operator=(AtomicOaccBuiltIn const&) -> AtomicOaccBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST_ACC auto operator=(AtomicOaccBuiltIn&&) -> AtomicOaccBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         ~AtomicOaccBuiltIn() = default;
     };
 
@@ -48,12 +41,10 @@ namespace alpaka
         // "omp atomic capture {}" works for PGI and GCC, using this even though non-standart
         // #if _OPENACC >= 201510
 
-        //#############################################################################
         //! The OpenACC accelerators atomic operation: ADD
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicAdd, AtomicOaccBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST_ACC static auto atomicOp(AtomicOaccBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -68,12 +59,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC accelerators atomic operation: SUB
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicSub, AtomicOaccBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST_ACC static auto atomicOp(AtomicOaccBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -88,12 +77,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC accelerators atomic operation: EXCH
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicExch, AtomicOaccBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST_ACC static auto atomicOp(AtomicOaccBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -112,12 +99,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC accelerators atomic operation: AND
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicAnd, AtomicOaccBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST_ACC static auto atomicOp(AtomicOaccBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -132,12 +117,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC accelerators atomic operation: OR
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicOr, AtomicOaccBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST_ACC static auto atomicOp(AtomicOaccBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -152,12 +135,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC accelerators atomic operation: XOR
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicXor, AtomicOaccBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST_ACC static auto atomicOp(AtomicOaccBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -172,12 +153,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC accelerators atomic operation: Min
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicMin, AtomicOaccBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST_ACC static auto atomicOp(AtomicOaccBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -192,12 +171,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC accelerators atomic operation: Max
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicMax, AtomicOaccBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST_ACC static auto atomicOp(AtomicOaccBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -212,12 +189,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC accelerators atomic operation: Inc
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicInc, AtomicOaccBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST_ACC static auto atomicOp(AtomicOaccBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -232,12 +207,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC accelerators atomic operation: Dec
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicDec, AtomicOaccBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST_ACC static auto atomicOp(AtomicOaccBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -252,12 +225,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC accelerators atomic operation: Cas
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicCas, AtomicOaccBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST_ACC static auto atomicOp(
                 AtomicOaccBuiltIn const&,
                 T* const addr,

--- a/include/alpaka/atomic/AtomicOmpBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicOmpBuiltIn.hpp
@@ -16,7 +16,6 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The OpenMP accelerators atomic ops.
     //
     //  Atomics can be used in the blocks and threads hierarchy levels.
@@ -24,17 +23,11 @@ namespace alpaka
     class AtomicOmpBuiltIn
     {
     public:
-        //-----------------------------------------------------------------------------
         AtomicOmpBuiltIn() = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AtomicOmpBuiltIn(AtomicOmpBuiltIn const&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST AtomicOmpBuiltIn(AtomicOmpBuiltIn&&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(AtomicOmpBuiltIn const&) -> AtomicOmpBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(AtomicOmpBuiltIn&&) -> AtomicOmpBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~AtomicOmpBuiltIn() = default;
     };
 
@@ -44,12 +37,10 @@ namespace alpaka
 // "omp atomic capture" is not supported before OpenMP 3.1
 #    if _OPENMP >= 201107
 
-        //#############################################################################
         //! The OpenMP accelerators atomic operation: ADD
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicAdd, AtomicOmpBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -64,12 +55,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenMP accelerators atomic operation: SUB
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicSub, AtomicOmpBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -84,12 +73,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenMP accelerators atomic operation: EXCH
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicExch, AtomicOmpBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -104,12 +91,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenMP accelerators atomic operation: AND
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicAnd, AtomicOmpBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -124,12 +109,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenMP accelerators atomic operation: OR
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicOr, AtomicOmpBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -144,12 +127,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenMP accelerators atomic operation: XOR
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicXor, AtomicOmpBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -166,14 +147,12 @@ namespace alpaka
 
 #    endif // _OPENMP >= 201107
 
-        //#############################################################################
         //! The OpenMP accelerators atomic operation
         //
         // generic implementations for operations where native atomics are not available
         template<typename TOp, typename T, typename THierarchy>
         struct AtomicOp<TOp, AtomicOmpBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
             {
                 T old;
@@ -185,7 +164,6 @@ namespace alpaka
                 }
                 return old;
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto atomicOp(
                 AtomicOmpBuiltIn const&,
                 T* const addr,

--- a/include/alpaka/atomic/AtomicStdLibLock.hpp
+++ b/include/alpaka/atomic/AtomicStdLibLock.hpp
@@ -17,7 +17,6 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The CPU threads accelerator atomic ops.
     //
     //  Atomics can be used in the grids, blocks and threads hierarchy levels.
@@ -38,7 +37,6 @@ namespace alpaka
                                                              : nextPowerOf2(value, bit + 1u);
         }
 
-        //-----------------------------------------------------------------------------
         //! get a hash value of the pointer
         //
         // This is no perfect hash, there will be collisions if the size of pointer type
@@ -53,23 +51,16 @@ namespace alpaka
             return (ptrAddr / typeSizePowerOf2);
         }
 
-        //-----------------------------------------------------------------------------
         AtomicStdLibLock() = default;
-        //-----------------------------------------------------------------------------
         AtomicStdLibLock(AtomicStdLibLock const&) = delete;
-        //-----------------------------------------------------------------------------
         AtomicStdLibLock(AtomicStdLibLock&&) = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(AtomicStdLibLock const&) -> AtomicStdLibLock& = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(AtomicStdLibLock&&) -> AtomicStdLibLock& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~AtomicStdLibLock() = default;
 
         template<typename TPtr>
         std::mutex& getMutex(TPtr const* const ptr) const
         {
-            //-----------------------------------------------------------------------------
             //! get the size of the hash table
             //
             // The size is at least 1 or THashTableSize rounded up to the next power of 2
@@ -93,12 +84,10 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU threads accelerator atomic operation.
         template<typename TOp, typename T, typename THierarchy, size_t THashTableSize>
         struct AtomicOp<TOp, AtomicStdLibLock<THashTableSize>, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto atomicOp(
                 AtomicStdLibLock<THashTableSize> const& atomic,
                 T* const addr,
@@ -107,7 +96,6 @@ namespace alpaka
                 std::lock_guard<std::mutex> lock(atomic.getMutex(addr));
                 return TOp()(addr, value);
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto atomicOp(
                 AtomicStdLibLock<THashTableSize> const& atomic,
                 T* const addr,

--- a/include/alpaka/atomic/AtomicUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicUniformCudaHipBuiltIn.hpp
@@ -30,7 +30,6 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The GPU CUDA/HIP accelerator atomic ops.
     //
     //  Atomics can be used in the hierarchy level grids, blocks and threads.
@@ -38,48 +37,36 @@ namespace alpaka
     class AtomicUniformCudaHipBuiltIn
     {
     public:
-        //-----------------------------------------------------------------------------
         AtomicUniformCudaHipBuiltIn() = default;
-        //-----------------------------------------------------------------------------
         __device__ AtomicUniformCudaHipBuiltIn(AtomicUniformCudaHipBuiltIn const&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ AtomicUniformCudaHipBuiltIn(AtomicUniformCudaHipBuiltIn&&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(AtomicUniformCudaHipBuiltIn const&) -> AtomicUniformCudaHipBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(AtomicUniformCudaHipBuiltIn&&) -> AtomicUniformCudaHipBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~AtomicUniformCudaHipBuiltIn() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         //! The specializations to execute the requested atomic ops of the CUDA/HIP accelerator.
         // See: http://docs.nvidia.com/cuda/cuda-c-programming-guide/#atomic-functions how to implement everything with
         // CAS
 
-        //-----------------------------------------------------------------------------
         // Add.
 
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicAdd, AtomicUniformCudaHipBuiltIn, int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(AtomicUniformCudaHipBuiltIn const&, int* const addr, int const& value)
                 -> int
             {
                 return ::atomicAdd(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIP accelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicAdd, AtomicUniformCudaHipBuiltIn, unsigned int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned int* const addr,
@@ -88,12 +75,10 @@ namespace alpaka
                 return ::atomicAdd(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIP accelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicAdd, AtomicUniformCudaHipBuiltIn, unsigned long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             //
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
@@ -109,12 +94,10 @@ namespace alpaka
 #    endif
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIP accelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicAdd, AtomicUniformCudaHipBuiltIn, unsigned long long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             //
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
@@ -124,12 +107,10 @@ namespace alpaka
                 return ::atomicAdd(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIP accelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicAdd, AtomicUniformCudaHipBuiltIn, float, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             //
             __device__ static auto atomicOp(AtomicUniformCudaHipBuiltIn const&, float* const addr, float const& value)
                 -> float
@@ -137,12 +118,10 @@ namespace alpaka
                 return ::atomicAdd(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIP accelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicAdd, AtomicUniformCudaHipBuiltIn, double, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 double* const addr,
@@ -171,27 +150,22 @@ namespace alpaka
             }
         };
 
-        //-----------------------------------------------------------------------------
         // Sub.
 
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIP accelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicSub, AtomicUniformCudaHipBuiltIn, int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(AtomicUniformCudaHipBuiltIn const&, int* const addr, int const& value)
                 -> int
             {
                 return ::atomicSub(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIP accelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicSub, AtomicUniformCudaHipBuiltIn, unsigned int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned int* const addr,
@@ -200,12 +174,10 @@ namespace alpaka
                 return ::atomicSub(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicSub, AtomicUniformCudaHipBuiltIn, unsigned long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             //
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
@@ -225,27 +197,22 @@ namespace alpaka
             }
         };
 
-        //-----------------------------------------------------------------------------
         // Min.
 
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicMin, AtomicUniformCudaHipBuiltIn, int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(AtomicUniformCudaHipBuiltIn const&, int* const addr, int const& value)
                 -> int
             {
                 return ::atomicMin(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicMin, AtomicUniformCudaHipBuiltIn, unsigned int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned int* const addr,
@@ -254,12 +221,10 @@ namespace alpaka
                 return ::atomicMin(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicMin, AtomicUniformCudaHipBuiltIn, unsigned long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             //
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
@@ -284,12 +249,10 @@ namespace alpaka
 #    endif
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicMin, AtomicUniformCudaHipBuiltIn, unsigned long long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned long long int* const addr,
@@ -308,22 +271,18 @@ namespace alpaka
             }
         };
 
-        //-----------------------------------------------------------------------------
         // Max.
 
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicMax, AtomicUniformCudaHipBuiltIn, int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(AtomicUniformCudaHipBuiltIn const&, int* const addr, int const& value)
                 -> int
             {
                 return ::atomicMax(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicMax, AtomicUniformCudaHipBuiltIn, unsigned int, THierarchy>
@@ -336,12 +295,10 @@ namespace alpaka
                 return ::atomicMax(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicMax, AtomicUniformCudaHipBuiltIn, unsigned long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             //
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
@@ -366,12 +323,10 @@ namespace alpaka
 #    endif
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicMax, AtomicUniformCudaHipBuiltIn, unsigned long long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned long long int* const addr,
@@ -390,27 +345,22 @@ namespace alpaka
             }
         };
 
-        //-----------------------------------------------------------------------------
         // Exch.
 
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicExch, AtomicUniformCudaHipBuiltIn, int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(AtomicUniformCudaHipBuiltIn const&, int* const addr, int const& value)
                 -> int
             {
                 return ::atomicExch(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicExch, AtomicUniformCudaHipBuiltIn, unsigned int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned int* const addr,
@@ -419,12 +369,10 @@ namespace alpaka
                 return ::atomicExch(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicExch, AtomicUniformCudaHipBuiltIn, unsigned long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             //
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
@@ -440,12 +388,10 @@ namespace alpaka
 #    endif
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicExch, AtomicUniformCudaHipBuiltIn, unsigned long long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned long long int* const addr,
@@ -454,12 +400,10 @@ namespace alpaka
                 return ::atomicExch(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicExch, AtomicUniformCudaHipBuiltIn, float, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(AtomicUniformCudaHipBuiltIn const&, float* const addr, float const& value)
                 -> float
             {
@@ -467,15 +411,12 @@ namespace alpaka
             }
         };
 
-        //-----------------------------------------------------------------------------
         // Inc.
 
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicInc, AtomicUniformCudaHipBuiltIn, unsigned int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned int* const addr,
@@ -484,12 +425,10 @@ namespace alpaka
                 return ::atomicInc(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicInc, AtomicUniformCudaHipBuiltIn, unsigned long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             //
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
@@ -509,15 +448,12 @@ namespace alpaka
             }
         };
 
-        //-----------------------------------------------------------------------------
         // Dec.
 
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicDec, AtomicUniformCudaHipBuiltIn, unsigned int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned int* const addr,
@@ -526,12 +462,10 @@ namespace alpaka
                 return ::atomicDec(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicDec, AtomicUniformCudaHipBuiltIn, unsigned long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             //
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
@@ -551,27 +485,22 @@ namespace alpaka
             }
         };
 
-        //-----------------------------------------------------------------------------
         // And.
 
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicAnd, AtomicUniformCudaHipBuiltIn, int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(AtomicUniformCudaHipBuiltIn const&, int* const addr, int const& value)
                 -> int
             {
                 return ::atomicAnd(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicAnd, AtomicUniformCudaHipBuiltIn, unsigned int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned int* const addr,
@@ -580,12 +509,10 @@ namespace alpaka
                 return ::atomicAnd(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicAnd, AtomicUniformCudaHipBuiltIn, unsigned long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             //
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
@@ -610,12 +537,10 @@ namespace alpaka
 #    endif
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicAnd, AtomicUniformCudaHipBuiltIn, unsigned long long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned long long int* const addr,
@@ -634,27 +559,22 @@ namespace alpaka
             }
         };
 
-        //-----------------------------------------------------------------------------
         // Or.
 
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicOr, AtomicUniformCudaHipBuiltIn, int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(AtomicUniformCudaHipBuiltIn const&, int* const addr, int const& value)
                 -> int
             {
                 return ::atomicOr(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicOr, AtomicUniformCudaHipBuiltIn, unsigned int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned int* const addr,
@@ -663,12 +583,10 @@ namespace alpaka
                 return ::atomicOr(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicOr, AtomicUniformCudaHipBuiltIn, unsigned long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             //
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
@@ -693,12 +611,10 @@ namespace alpaka
 #    endif
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicOr, AtomicUniformCudaHipBuiltIn, unsigned long long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned long long int* const addr,
@@ -717,27 +633,22 @@ namespace alpaka
             }
         };
 
-        //-----------------------------------------------------------------------------
         // Xor.
 
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicXor, AtomicUniformCudaHipBuiltIn, int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(AtomicUniformCudaHipBuiltIn const&, int* const addr, int const& value)
                 -> int
             {
                 return ::atomicXor(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicXor, AtomicUniformCudaHipBuiltIn, unsigned int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned int* const addr,
@@ -746,12 +657,10 @@ namespace alpaka
                 return ::atomicXor(addr, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicXor, AtomicUniformCudaHipBuiltIn, unsigned long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             //
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
@@ -776,12 +685,10 @@ namespace alpaka
 #    endif
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicXor, AtomicUniformCudaHipBuiltIn, unsigned long long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned long long int* const addr,
@@ -800,15 +707,12 @@ namespace alpaka
             }
         };
 
-        //-----------------------------------------------------------------------------
         // Cas.
 
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicCas, AtomicUniformCudaHipBuiltIn, int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 int* const addr,
@@ -818,12 +722,10 @@ namespace alpaka
                 return ::atomicCAS(addr, compare, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicCas, AtomicUniformCudaHipBuiltIn, unsigned int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned int* const addr,
@@ -833,12 +735,10 @@ namespace alpaka
                 return ::atomicCAS(addr, compare, value);
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicCas, AtomicUniformCudaHipBuiltIn, unsigned long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             //
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
@@ -859,12 +759,10 @@ namespace alpaka
 #    endif
             }
         };
-        //-----------------------------------------------------------------------------
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename THierarchy>
         struct AtomicOp<AtomicCas, AtomicUniformCudaHipBuiltIn, unsigned long long int, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const&,
                 unsigned long long int* const addr,
@@ -875,12 +773,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The GPU CUDA/HIPaccelerator atomic operation.
         template<typename TOp, typename T, typename THierarchy>
         struct AtomicOp<TOp, AtomicUniformCudaHipBuiltIn, T, THierarchy>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(AtomicUniformCudaHipBuiltIn const& atomic, T* const addr, T const& value)
                 -> T
             {
@@ -893,7 +789,6 @@ namespace alpaka
 
                 return T();
             }
-            //-----------------------------------------------------------------------------
             __device__ static auto atomicOp(
                 AtomicUniformCudaHipBuiltIn const& atomic,
                 T* const addr,

--- a/include/alpaka/atomic/Op.hpp
+++ b/include/alpaka/atomic/Op.hpp
@@ -16,11 +16,9 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The addition function object.
     struct AtomicAdd
     {
-        //-----------------------------------------------------------------------------
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename T>
@@ -39,11 +37,9 @@ namespace alpaka
 #endif
         }
     };
-    //#############################################################################
     //! The subtraction function object.
     struct AtomicSub
     {
-        //-----------------------------------------------------------------------------
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename T>
@@ -62,11 +58,9 @@ namespace alpaka
             return old;
         }
     };
-    //#############################################################################
     //! The minimum function object.
     struct AtomicMin
     {
-        //-----------------------------------------------------------------------------
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename T>
@@ -78,11 +72,9 @@ namespace alpaka
             return old;
         }
     };
-    //#############################################################################
     //! The maximum function object.
     struct AtomicMax
     {
-        //-----------------------------------------------------------------------------
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename T>
@@ -94,11 +86,9 @@ namespace alpaka
             return old;
         }
     };
-    //#############################################################################
     //! The exchange function object.
     struct AtomicExch
     {
-        //-----------------------------------------------------------------------------
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename T>
@@ -110,11 +100,9 @@ namespace alpaka
             return old;
         }
     };
-    //#############################################################################
     //! The increment function object.
     struct AtomicInc
     {
-        //-----------------------------------------------------------------------------
         //! Increments up to value, then reset to 0.
         //!
         //! \return The old value of addr.
@@ -128,11 +116,9 @@ namespace alpaka
             return old;
         }
     };
-    //#############################################################################
     //! The decrement function object.
     struct AtomicDec
     {
-        //-----------------------------------------------------------------------------
         //! Decrement down to 0, then reset to value.
         //!
         //! \return The old value of addr.
@@ -146,11 +132,9 @@ namespace alpaka
             return old;
         }
     };
-    //#############################################################################
     //! The and function object.
     struct AtomicAnd
     {
-        //-----------------------------------------------------------------------------
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename T>
@@ -162,11 +146,9 @@ namespace alpaka
             return old;
         }
     };
-    //#############################################################################
     //! The or function object.
     struct AtomicOr
     {
-        //-----------------------------------------------------------------------------
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename T>
@@ -178,11 +160,9 @@ namespace alpaka
             return old;
         }
     };
-    //#############################################################################
     //! The exclusive or function object.
     struct AtomicXor
     {
-        //-----------------------------------------------------------------------------
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename T>
@@ -194,11 +174,9 @@ namespace alpaka
             return old;
         }
     };
-    //#############################################################################
     //! The compare and swap function object.
     struct AtomicCas
     {
-        //-----------------------------------------------------------------------------
         //! \return The old value of addr.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename T>

--- a/include/alpaka/atomic/Traits.hpp
+++ b/include/alpaka/atomic/Traits.hpp
@@ -55,17 +55,14 @@ namespace alpaka
     template<typename THierarchy>
     using AtomicHierarchyConcept = typename detail::AtomicHierarchyConceptType<THierarchy>::type;
 
-    //-----------------------------------------------------------------------------
     //! The atomic operation traits.
     namespace traits
     {
-        //#############################################################################
         //! The atomic operation trait.
         template<typename TOp, typename TAtomic, typename T, typename THierarchy, typename TSfinae = void>
         struct AtomicOp;
     } // namespace traits
 
-    //-----------------------------------------------------------------------------
     //! Executes the given operation atomically.
     //!
     //! \tparam TOp The operation type.
@@ -86,7 +83,6 @@ namespace alpaka
         return traits::AtomicOp<TOp, ImplementationBase, T, THierarchy>::atomicOp(atomic, addr, value);
     }
 
-    //-----------------------------------------------------------------------------
     //! Executes the given operation atomically.
     //!
     //! \tparam TOp The operation type.
@@ -109,7 +105,6 @@ namespace alpaka
         return traits::AtomicOp<TOp, ImplementationBase, T, THierarchy>::atomicOp(atomic, addr, compare, value);
     }
 
-    //-----------------------------------------------------------------------------
     //! Executes an atomic add operation.
     //!
     //! \tparam T The value type.
@@ -128,7 +123,6 @@ namespace alpaka
         return atomicOp<AtomicAdd>(atomic, addr, value, hier);
     }
 
-    //-----------------------------------------------------------------------------
     //! Executes an atomic sub operation.
     //!
     //! \tparam T The value type.
@@ -147,7 +141,6 @@ namespace alpaka
         return atomicOp<AtomicSub>(atomic, addr, value, hier);
     }
 
-    //-----------------------------------------------------------------------------
     //! Executes an atomic min operation.
     //!
     //! \tparam T The value type.
@@ -166,7 +159,6 @@ namespace alpaka
         return atomicOp<AtomicMin>(atomic, addr, value, hier);
     }
 
-    //-----------------------------------------------------------------------------
     //! Executes an atomic max operation.
     //!
     //! \tparam T The value type.
@@ -185,7 +177,6 @@ namespace alpaka
         return atomicOp<AtomicMax>(atomic, addr, value, hier);
     }
 
-    //-----------------------------------------------------------------------------
     //! Executes an atomic exchange operation.
     //!
     //! \tparam T The value type.
@@ -204,7 +195,6 @@ namespace alpaka
         return atomicOp<AtomicExch>(atomic, addr, value, hier);
     }
 
-    //-----------------------------------------------------------------------------
     //! Executes an atomic increment operation.
     //!
     //! \tparam T The value type.
@@ -223,7 +213,6 @@ namespace alpaka
         return atomicOp<AtomicInc>(atomic, addr, value, hier);
     }
 
-    //-----------------------------------------------------------------------------
     //! Executes an atomic decrement operation.
     //!
     //! \tparam T The value type.
@@ -242,7 +231,6 @@ namespace alpaka
         return atomicOp<AtomicDec>(atomic, addr, value, hier);
     }
 
-    //-----------------------------------------------------------------------------
     //! Executes an atomic and operation.
     //!
     //! \tparam T The value type.
@@ -261,7 +249,6 @@ namespace alpaka
         return atomicOp<AtomicAnd>(atomic, addr, value, hier);
     }
 
-    //-----------------------------------------------------------------------------
     //! Executes an atomic or operation.
     //!
     //! \tparam T The value type.
@@ -280,7 +267,6 @@ namespace alpaka
         return atomicOp<AtomicOr>(atomic, addr, value, hier);
     }
 
-    //-----------------------------------------------------------------------------
     //! Executes an atomic xor operation.
     //!
     //! \tparam T The value type.
@@ -299,7 +285,6 @@ namespace alpaka
         return atomicOp<AtomicXor>(atomic, addr, value, hier);
     }
 
-    //-----------------------------------------------------------------------------
     //! Executes an atomic compare-and-swap operation.
     //!
     //! \tparam TAtomic The atomic implementation type.

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 {
     namespace detail
     {
-        //#############################################################################
         //! "namespace" for static constexpr members that should be in BlockSharedMemDynMember
         //! but cannot be because having a static const member breaks GCC 10
         //! OpenMP target and OpenACC: type not mappable.
@@ -41,7 +40,6 @@ namespace alpaka
 #    pragma warning(push)
 #    pragma warning(disable : 4324) // warning C4324: structure was padded due to alignment specifier
 #endif
-    //#############################################################################
     //! Dynamic block shared memory provider using fixed-size
     //! member array to allocate memory on the stack or in shared
     //! memory.
@@ -50,20 +48,14 @@ namespace alpaka
         : public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynMember<TStaticAllocKiB>>
     {
     public:
-        //-----------------------------------------------------------------------------
         BlockSharedMemDynMember(std::size_t sizeBytes) : m_dynPitch(getPitch(sizeBytes))
         {
             ALPAKA_ASSERT_OFFLOAD(static_cast<std::uint32_t>(sizeBytes) <= staticAllocBytes());
         }
-        //-----------------------------------------------------------------------------
         BlockSharedMemDynMember(BlockSharedMemDynMember const&) = delete;
-        //-----------------------------------------------------------------------------
         BlockSharedMemDynMember(BlockSharedMemDynMember&&) = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(BlockSharedMemDynMember const&) -> BlockSharedMemDynMember& = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(BlockSharedMemDynMember&&) -> BlockSharedMemDynMember& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~BlockSharedMemDynMember() = default;
 
         uint8_t* dynMemBegin() const
@@ -110,7 +102,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         template<typename T, std::size_t TStaticAllocKiB>
         struct GetDynSharedMem<T, BlockSharedMemDynMember<TStaticAllocKiB>>
         {
@@ -119,7 +110,6 @@ namespace alpaka
 #    pragma GCC diagnostic ignored                                                                                    \
         "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
 #endif
-            //-----------------------------------------------------------------------------
             static auto getMem(BlockSharedMemDynMember<TStaticAllocKiB> const& mem) -> T*
             {
                 static_assert(

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynUniformCudaHipBuiltIn.hpp
@@ -27,35 +27,26 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The GPU CUDA/HIP block shared memory allocator.
     class BlockSharedMemDynUniformCudaHipBuiltIn
         : public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynUniformCudaHipBuiltIn>
     {
     public:
-        //-----------------------------------------------------------------------------
         BlockSharedMemDynUniformCudaHipBuiltIn() = default;
-        //-----------------------------------------------------------------------------
         __device__ BlockSharedMemDynUniformCudaHipBuiltIn(BlockSharedMemDynUniformCudaHipBuiltIn const&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ BlockSharedMemDynUniformCudaHipBuiltIn(BlockSharedMemDynUniformCudaHipBuiltIn&&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(BlockSharedMemDynUniformCudaHipBuiltIn const&)
             -> BlockSharedMemDynUniformCudaHipBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(BlockSharedMemDynUniformCudaHipBuiltIn&&)
             -> BlockSharedMemDynUniformCudaHipBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~BlockSharedMemDynUniformCudaHipBuiltIn() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         template<typename T>
         struct GetDynSharedMem<T, BlockSharedMemDynUniformCudaHipBuiltIn>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto getMem(BlockSharedMemDynUniformCudaHipBuiltIn const&) -> T*
             {
                 // Because unaligned access to variables is not allowed in device code,

--- a/include/alpaka/block/shared/dyn/Traits.hpp
+++ b/include/alpaka/block/shared/dyn/Traits.hpp
@@ -20,17 +20,14 @@ namespace alpaka
     {
     };
 
-    //-----------------------------------------------------------------------------
     //! The block shared dynamic memory operation traits.
     namespace traits
     {
-        //#############################################################################
         //! The block shared dynamic memory get trait.
         template<typename T, typename TBlockSharedMemDyn, typename TSfinae = void>
         struct GetDynSharedMem;
     } // namespace traits
 
-    //-----------------------------------------------------------------------------
     //! Get block shared dynamic memory.
     //!
     //! The available size of the memory can be defined by specializing the trait

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -20,7 +20,6 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! Static block shared memory provider using a pointer to
     //! externally allocated fixed-size memory, likely provided by
     //! BlockSharedMemDynMember.
@@ -36,11 +35,9 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         template<typename T, std::size_t TDataAlignBytes, std::size_t TuniqueId>
         struct DeclareSharedVar<T, TuniqueId, BlockSharedMemStMember<TDataAlignBytes>>
         {
-            //-----------------------------------------------------------------------------
             static auto declareVar(BlockSharedMemStMember<TDataAlignBytes> const& smem) -> T&
             {
                 auto* data = smem.template getVarPtr<T>(TuniqueId);
@@ -54,11 +51,9 @@ namespace alpaka
                 return *data;
             }
         };
-        //#############################################################################
         template<std::size_t TDataAlignBytes>
         struct FreeSharedVars<BlockSharedMemStMember<TDataAlignBytes>>
         {
-            //-----------------------------------------------------------------------------
             static auto freeVars(BlockSharedMemStMember<TDataAlignBytes> const&) -> void
             {
                 // shared memory block data will be reused

--- a/include/alpaka/block/shared/st/BlockSharedMemStMemberMasterSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMemberMasterSync.hpp
@@ -50,11 +50,9 @@ namespace alpaka
 #    pragma GCC diagnostic ignored                                                                                    \
         "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
 #endif
-        //#############################################################################
         template<typename T, std::size_t TDataAlignBytes, std::size_t TuniqueId>
         struct DeclareSharedVar<T, TuniqueId, BlockSharedMemStMemberMasterSync<TDataAlignBytes>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto declareVar(
                 BlockSharedMemStMemberMasterSync<TDataAlignBytes> const& blockSharedMemSt) -> T&
             {
@@ -81,11 +79,9 @@ namespace alpaka
 #if BOOST_COMP_GNUC
 #    pragma GCC diagnostic pop
 #endif
-        //#############################################################################
         template<std::size_t TDataAlignBytes>
         struct FreeSharedVars<BlockSharedMemStMemberMasterSync<TDataAlignBytes>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto freeVars(BlockSharedMemStMemberMasterSync<TDataAlignBytes> const&) -> void
             {
                 // shared memory block data will be reused

--- a/include/alpaka/block/shared/st/BlockSharedMemStOmp5.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStOmp5.hpp
@@ -25,7 +25,6 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The OpenMP 5 block shared memory allocator.
     class BlockSharedMemStOmp5
         : public detail::BlockSharedMemStMemberImpl<4>
@@ -37,11 +36,9 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         template<typename T, std::size_t TuniqueId>
         struct DeclareSharedVar<T, TuniqueId, BlockSharedMemStOmp5>
         {
-            //-----------------------------------------------------------------------------
             static auto declareVar(BlockSharedMemStOmp5 const& smem) -> T&
             {
                 auto* data = smem.template getVarPtr<T>(TuniqueId);
@@ -61,11 +58,9 @@ namespace alpaka
                 return *data;
             }
         };
-        //#############################################################################
         template<>
         struct FreeSharedVars<BlockSharedMemStOmp5>
         {
-            //-----------------------------------------------------------------------------
             static auto freeVars(BlockSharedMemStOmp5 const&) -> void
             {
                 // shared memory block data will be reused

--- a/include/alpaka/block/shared/st/BlockSharedMemStUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStUniformCudaHipBuiltIn.hpp
@@ -28,52 +28,41 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The GPU CUDA/HIP block shared memory allocator.
     class BlockSharedMemStUniformCudaHipBuiltIn
         : public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStUniformCudaHipBuiltIn>
     {
     public:
-        //-----------------------------------------------------------------------------
         //! Default constructor.
         BlockSharedMemStUniformCudaHipBuiltIn() = default;
-        //-----------------------------------------------------------------------------
         //! Copy constructor.
         __device__ BlockSharedMemStUniformCudaHipBuiltIn(BlockSharedMemStUniformCudaHipBuiltIn const&) = delete;
-        //-----------------------------------------------------------------------------
         //! Move constructor.
         __device__ BlockSharedMemStUniformCudaHipBuiltIn(BlockSharedMemStUniformCudaHipBuiltIn&&) = delete;
-        //-----------------------------------------------------------------------------
         //! Copy assignment operator.
         __device__ auto operator=(BlockSharedMemStUniformCudaHipBuiltIn const&)
             -> BlockSharedMemStUniformCudaHipBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         //! Move assignment operator.
         __device__ auto operator=(BlockSharedMemStUniformCudaHipBuiltIn&&)
             -> BlockSharedMemStUniformCudaHipBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         //! Destructor.
         /*virtual*/ ~BlockSharedMemStUniformCudaHipBuiltIn() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         template<typename T, std::size_t TuniqueId>
         struct DeclareSharedVar<T, TuniqueId, BlockSharedMemStUniformCudaHipBuiltIn>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto declareVar(BlockSharedMemStUniformCudaHipBuiltIn const&) -> T&
             {
                 __shared__ uint8_t shMem alignas(alignof(T))[sizeof(T)];
                 return *(reinterpret_cast<T*>(shMem));
             }
         };
-        //#############################################################################
         template<>
         struct FreeSharedVars<BlockSharedMemStUniformCudaHipBuiltIn>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto freeVars(BlockSharedMemStUniformCudaHipBuiltIn const&) -> void
             {
                 // Nothing to do. CUDA/HIP block shared memory is automatically freed when all threads left the block.

--- a/include/alpaka/block/shared/st/Traits.hpp
+++ b/include/alpaka/block/shared/st/Traits.hpp
@@ -20,21 +20,17 @@ namespace alpaka
     {
     };
 
-    //-----------------------------------------------------------------------------
     //! The block shared static memory operation traits.
     namespace traits
     {
-        //#############################################################################
         //! The block shared static memory variable allocation operation trait.
         template<typename T, std::size_t TuniqueId, typename TBlockSharedMemSt, typename TSfinae = void>
         struct DeclareSharedVar;
-        //#############################################################################
         //! The block shared static memory free operation trait.
         template<typename TBlockSharedMemSt, typename TSfinae = void>
         struct FreeSharedVars;
     } // namespace traits
 
-    //-----------------------------------------------------------------------------
     //! Declare a block shared variable.
     //!
     //! The variable is uninitialized and not default constructed!
@@ -54,7 +50,6 @@ namespace alpaka
         return traits::DeclareSharedVar<T, TuniqueId, ImplementationBase>::declareVar(blockSharedMemSt);
     }
 
-    //-----------------------------------------------------------------------------
     //! Frees all memory used by block shared variables.
     //!
     //! \tparam TBlockSharedMemSt The block shared allocator implementation type.

--- a/include/alpaka/block/shared/st/detail/BlockSharedMemStMemberImpl.hpp
+++ b/include/alpaka/block/shared/st/detail/BlockSharedMemStMemberImpl.hpp
@@ -22,7 +22,6 @@ namespace alpaka
 {
     namespace detail
     {
-        //#############################################################################
         //! Implementation of static block shared memory provider.
         //!
         //! externally allocated fixed-size memory, likely provided by BlockSharedMemDynMember.
@@ -41,7 +40,6 @@ namespace alpaka
             static constexpr uint32_t metaDataSize = sizeof(MetaData);
 
         public:
-            //-----------------------------------------------------------------------------
 #ifndef NDEBUG
             BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t capacity)
                 : m_mem(mem)
@@ -54,15 +52,10 @@ namespace alpaka
             {
             }
 #endif
-            //-----------------------------------------------------------------------------
             BlockSharedMemStMemberImpl(BlockSharedMemStMemberImpl const&) = delete;
-            //-----------------------------------------------------------------------------
             BlockSharedMemStMemberImpl(BlockSharedMemStMemberImpl&&) = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(BlockSharedMemStMemberImpl const&) -> BlockSharedMemStMemberImpl& = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(BlockSharedMemStMemberImpl&&) -> BlockSharedMemStMemberImpl& = delete;
-            //-----------------------------------------------------------------------------
             /*virtual*/ ~BlockSharedMemStMemberImpl() = default;
 
             template<typename T>

--- a/include/alpaka/block/sync/BlockSyncBarrierFiber.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierFiber.hpp
@@ -20,13 +20,11 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The thread id map barrier block synchronization.
     template<typename TIdx>
     class BlockSyncBarrierFiber : public concepts::Implements<ConceptBlockSync, BlockSyncBarrierFiber<TIdx>>
     {
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST BlockSyncBarrierFiber(TIdx const& blockThreadCount)
             : m_barrier(static_cast<std::size_t>(blockThreadCount))
             , m_threadCount(blockThreadCount)
@@ -34,15 +32,10 @@ namespace alpaka
             , m_generation(static_cast<TIdx>(0u))
         {
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST BlockSyncBarrierFiber(BlockSyncBarrierFiber const&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST BlockSyncBarrierFiber(BlockSyncBarrierFiber&&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(BlockSyncBarrierFiber const&) -> BlockSyncBarrierFiber& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(BlockSyncBarrierFiber&&) -> BlockSyncBarrierFiber& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~BlockSyncBarrierFiber() = default;
 
         boost::fibers::barrier mutable m_barrier;
@@ -55,22 +48,18 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         template<typename TIdx>
         struct SyncBlockThreads<BlockSyncBarrierFiber<TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto syncBlockThreads(BlockSyncBarrierFiber<TIdx> const& blockSync) -> void
             {
                 blockSync.m_barrier.wait();
             }
         };
 
-        //#############################################################################
         template<typename TOp, typename TIdx>
         struct SyncBlockThreadsPredicate<TOp, BlockSyncBarrierFiber<TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(
                 BlockSyncBarrierFiber<TIdx> const& blockSync,

--- a/include/alpaka/block/sync/BlockSyncBarrierOacc.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierOacc.hpp
@@ -19,22 +19,15 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The OpenACC barrier block synchronization.
     class BlockSyncBarrierOacc
     {
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST BlockSyncBarrierOacc() = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST BlockSyncBarrierOacc(BlockSyncBarrierOacc const&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST BlockSyncBarrierOacc(BlockSyncBarrierOacc&&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(BlockSyncBarrierOacc const&) -> BlockSyncBarrierOacc& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(BlockSyncBarrierOacc&&) -> BlockSyncBarrierOacc& = delete;
-        //-----------------------------------------------------------------------------
         ~BlockSyncBarrierOacc() = default;
 
         std::uint8_t mutable m_generation = 0u;

--- a/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
@@ -17,24 +17,17 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The OpenMP barrier block synchronization.
     class BlockSyncBarrierOmp : public concepts::Implements<ConceptBlockSync, BlockSyncBarrierOmp>
     {
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST BlockSyncBarrierOmp() : m_generation(0u)
         {
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST BlockSyncBarrierOmp(BlockSyncBarrierOmp const&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST BlockSyncBarrierOmp(BlockSyncBarrierOmp&&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(BlockSyncBarrierOmp const&) -> BlockSyncBarrierOmp& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(BlockSyncBarrierOmp&&) -> BlockSyncBarrierOmp& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~BlockSyncBarrierOmp() = default;
 
         std::uint8_t mutable m_generation;
@@ -43,11 +36,9 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         template<>
         struct SyncBlockThreads<BlockSyncBarrierOmp>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto syncBlockThreads(BlockSyncBarrierOmp const& blockSync) -> void
             {
                 alpaka::ignore_unused(blockSync);
@@ -60,10 +51,8 @@ namespace alpaka
 
         namespace detail
         {
-            //#############################################################################
             template<typename TOp>
             struct AtomicOp;
-            //#############################################################################
             template<>
             struct AtomicOp<BlockCount>
             {
@@ -73,7 +62,6 @@ namespace alpaka
                     result += static_cast<int>(value);
                 }
             };
-            //#############################################################################
             template<>
             struct AtomicOp<BlockAnd>
             {
@@ -83,7 +71,6 @@ namespace alpaka
                     result &= static_cast<int>(value);
                 }
             };
-            //#############################################################################
             template<>
             struct AtomicOp<BlockOr>
             {
@@ -95,11 +82,9 @@ namespace alpaka
             };
         } // namespace detail
 
-        //#############################################################################
         template<typename TOp>
         struct SyncBlockThreadsPredicate<TOp, BlockSyncBarrierOmp>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(BlockSyncBarrierOmp const& blockSync, int predicate)
                 -> int

--- a/include/alpaka/block/sync/BlockSyncBarrierThread.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierThread.hpp
@@ -21,7 +21,6 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The thread id map barrier block synchronization.
     template<typename TIdx>
     class BlockSyncBarrierThread : public concepts::Implements<ConceptBlockSync, BlockSyncBarrierThread<TIdx>>
@@ -30,21 +29,15 @@ namespace alpaka
         using Barrier = core::threads::BarrierThread<TIdx>;
         using BarrierWithPredicate = core::threads::BarrierThreadWithPredicate<TIdx>;
 
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST BlockSyncBarrierThread(TIdx const& blockThreadCount)
             : m_barrier(blockThreadCount)
             , m_barrierWithPredicate(blockThreadCount)
         {
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST BlockSyncBarrierThread(BlockSyncBarrierThread const&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST BlockSyncBarrierThread(BlockSyncBarrierThread&&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(BlockSyncBarrierThread const&) -> BlockSyncBarrierThread& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(BlockSyncBarrierThread&&) -> BlockSyncBarrierThread& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~BlockSyncBarrierThread() = default;
 
         Barrier mutable m_barrier;
@@ -53,22 +46,18 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         template<typename TIdx>
         struct SyncBlockThreads<BlockSyncBarrierThread<TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto syncBlockThreads(BlockSyncBarrierThread<TIdx> const& blockSync) -> void
             {
                 blockSync.m_barrier.wait();
             }
         };
 
-        //#############################################################################
         template<typename TOp, typename TIdx>
         struct SyncBlockThreadsPredicate<TOp, BlockSyncBarrierThread<TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(
                 BlockSyncBarrierThread<TIdx> const& blockSync,

--- a/include/alpaka/block/sync/BlockSyncNoOp.hpp
+++ b/include/alpaka/block/sync/BlockSyncNoOp.hpp
@@ -15,32 +15,23 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The no op block synchronization.
     class BlockSyncNoOp : public concepts::Implements<ConceptBlockSync, BlockSyncNoOp>
     {
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_ACC BlockSyncNoOp() = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_ACC BlockSyncNoOp(BlockSyncNoOp const&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_ACC BlockSyncNoOp(BlockSyncNoOp&&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_ACC auto operator=(BlockSyncNoOp const&) -> BlockSyncNoOp& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_ACC auto operator=(BlockSyncNoOp&&) -> BlockSyncNoOp& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ALPAKA_FN_ACC ~BlockSyncNoOp() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         template<>
         struct SyncBlockThreads<BlockSyncNoOp>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_ACC static auto syncBlockThreads(BlockSyncNoOp const& blockSync) -> void
             {
@@ -49,11 +40,9 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         template<typename TOp>
         struct SyncBlockThreadsPredicate<TOp, BlockSyncNoOp>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(BlockSyncNoOp const& blockSync, int predicate) -> int
             {

--- a/include/alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp
@@ -25,44 +25,33 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The GPU CUDA/HIP block synchronization.
     class BlockSyncUniformCudaHipBuiltIn
         : public concepts::Implements<ConceptBlockSync, BlockSyncUniformCudaHipBuiltIn>
     {
     public:
-        //-----------------------------------------------------------------------------
         BlockSyncUniformCudaHipBuiltIn() = default;
-        //-----------------------------------------------------------------------------
         __device__ BlockSyncUniformCudaHipBuiltIn(BlockSyncUniformCudaHipBuiltIn const&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ BlockSyncUniformCudaHipBuiltIn(BlockSyncUniformCudaHipBuiltIn&&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(BlockSyncUniformCudaHipBuiltIn const&) -> BlockSyncUniformCudaHipBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(BlockSyncUniformCudaHipBuiltIn&&) -> BlockSyncUniformCudaHipBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~BlockSyncUniformCudaHipBuiltIn() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         template<>
         struct SyncBlockThreads<BlockSyncUniformCudaHipBuiltIn>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto syncBlockThreads(BlockSyncUniformCudaHipBuiltIn const& /*blockSync*/) -> void
             {
                 __syncthreads();
             }
         };
 
-        //#############################################################################
         template<>
         struct SyncBlockThreadsPredicate<BlockCount, BlockSyncUniformCudaHipBuiltIn>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto syncBlockThreadsPredicate(
                 BlockSyncUniformCudaHipBuiltIn const& /*blockSync*/,
                 int predicate) -> int
@@ -85,11 +74,9 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         template<>
         struct SyncBlockThreadsPredicate<BlockAnd, BlockSyncUniformCudaHipBuiltIn>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto syncBlockThreadsPredicate(
                 BlockSyncUniformCudaHipBuiltIn const& /*blockSync*/,
                 int predicate) -> int
@@ -112,11 +99,9 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         template<>
         struct SyncBlockThreadsPredicate<BlockOr, BlockSyncUniformCudaHipBuiltIn>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto syncBlockThreadsPredicate(
                 BlockSyncUniformCudaHipBuiltIn const& /*blockSync*/,
                 int predicate) -> int

--- a/include/alpaka/block/sync/Traits.hpp
+++ b/include/alpaka/block/sync/Traits.hpp
@@ -20,22 +20,18 @@ namespace alpaka
     {
     };
 
-    //-----------------------------------------------------------------------------
     //! The block synchronization traits.
     namespace traits
     {
-        //#############################################################################
         //! The block synchronization operation trait.
         template<typename TBlockSync, typename TSfinae = void>
         struct SyncBlockThreads;
 
-        //#############################################################################
         //! The block synchronization and predicate operation trait.
         template<typename TOp, typename TBlockSync, typename TSfinae = void>
         struct SyncBlockThreadsPredicate;
     } // namespace traits
 
-    //-----------------------------------------------------------------------------
     //! Synchronizes all threads within the current block (independently for all blocks).
     //!
     //! \tparam TBlockSync The block synchronization implementation type.
@@ -48,7 +44,6 @@ namespace alpaka
         traits::SyncBlockThreads<ImplementationBase>::syncBlockThreads(blockSync);
     }
 
-    //#############################################################################
     //! The counting function object.
     struct BlockCount
     {
@@ -64,7 +59,6 @@ namespace alpaka
             return currentResult + static_cast<T>(value != static_cast<T>(0));
         }
     };
-    //#############################################################################
     //! The logical and function object.
     struct BlockAnd
     {
@@ -80,7 +74,6 @@ namespace alpaka
             return static_cast<T>(currentResult && (value != static_cast<T>(0)));
         }
     };
-    //#############################################################################
     //! The logical or function object.
     struct BlockOr
     {
@@ -97,7 +90,6 @@ namespace alpaka
         }
     };
 
-    //-----------------------------------------------------------------------------
     //! Synchronizes all threads within the current block (independently for all blocks),
     //! evaluates the predicate for all threads and returns the combination of all the results
     //! computed via TOp.

--- a/include/alpaka/core/Align.hpp
+++ b/include/alpaka/core/Align.hpp
@@ -18,23 +18,19 @@ namespace alpaka
 {
     namespace core
     {
-        //-----------------------------------------------------------------------------
         //! Rounds to the next higher power of two (if not already power of two).
         // Adapted from llvm/ADT/SmallPtrSet.h
         template<std::size_t N>
         struct RoundUpToPowerOfTwo;
 
-        //-----------------------------------------------------------------------------
         //! Defines implementation details that should not be used directly by the user.
         namespace detail
         {
-            //-----------------------------------------------------------------------------
             //! Base case for N being a power of two.
             template<std::size_t N, bool TisPowerTwo>
             struct RoundUpToPowerOfTwoHelper : std::integral_constant<std::size_t, N>
             {
             };
-            //-----------------------------------------------------------------------------
             //! Case for N not being a power of two.
             // We could just use NextVal = N+1, but this converges faster.  N|(N-1) sets
             // the right-most zero bits to one all at once, e.g. 0b0011000 -> 0b0011111.
@@ -44,18 +40,15 @@ namespace alpaka
             {
             };
         } // namespace detail
-        //-----------------------------------------------------------------------------
         template<std::size_t N>
         struct RoundUpToPowerOfTwo
             : std::integral_constant<std::size_t, detail::RoundUpToPowerOfTwoHelper<N, (N & (N - 1)) == 0>::value>
         {
         };
 
-        //-----------------------------------------------------------------------------
         //! The alignment specifics.
         namespace align
         {
-            //-----------------------------------------------------------------------------
             //! Calculates the optimal alignment for data of the given size.
             template<std::size_t TsizeBytes>
             struct OptimalAlignment

--- a/include/alpaka/core/AlignedAlloc.hpp
+++ b/include/alpaka/core/AlignedAlloc.hpp
@@ -22,7 +22,6 @@ namespace alpaka
 {
     namespace core
     {
-        //-----------------------------------------------------------------------------
         //! Rounds to the next higher power of two (if not already power of two).
         // Adapted from llvm/ADT/SmallPtrSet.h
         ALPAKA_FN_INLINE ALPAKA_FN_HOST void* alignedAlloc(size_t alignment, size_t size)
@@ -50,13 +49,11 @@ namespace alpaka
 #endif
         }
 
-        //#############################################################################
         //! destroy aligned object and free aligned memory
         struct AlignedDelete
         {
             constexpr AlignedDelete() = default;
 
-            //-----------------------------------------------------------------------------
             //! Calls ~T() on ptr to destroy the object and then calls aligned_free to free the allocated memory.
             template<typename T>
             void operator()(T* ptr) const

--- a/include/alpaka/core/Assert.hpp
+++ b/include/alpaka/core/Assert.hpp
@@ -30,10 +30,8 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             template<typename TArg, typename TSfinae = void>
             struct AssertValueUnsigned;
-            //#############################################################################
             template<typename TArg>
             struct AssertValueUnsigned<TArg, std::enable_if_t<!std::is_unsigned<TArg>::value>>
             {
@@ -47,7 +45,6 @@ namespace alpaka
 #endif
                 }
             };
-            //#############################################################################
             template<typename TArg>
             struct AssertValueUnsigned<TArg, std::enable_if_t<std::is_unsigned<TArg>::value>>
             {
@@ -59,7 +56,6 @@ namespace alpaka
                 }
             };
         } // namespace detail
-        //-----------------------------------------------------------------------------
         //! This method checks integral values if they are greater or equal zero.
         //! The implementation prevents warnings for checking this for unsigned types.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -71,10 +67,8 @@ namespace alpaka
 
         namespace detail
         {
-            //#############################################################################
             template<typename TLhs, typename TRhs, typename TSfinae = void>
             struct AssertGreaterThan;
-            //#############################################################################
             template<typename TLhs, typename TRhs>
             struct AssertGreaterThan<
                 TLhs,
@@ -91,7 +85,6 @@ namespace alpaka
 #endif
                 }
             };
-            //#############################################################################
             template<typename TLhs, typename TRhs>
             struct AssertGreaterThan<
                 TLhs,
@@ -106,7 +99,6 @@ namespace alpaka
                 }
             };
         } // namespace detail
-        //-----------------------------------------------------------------------------
         //! This method asserts that the integral value TArg is less than Tidx.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TLhs, typename TRhs>

--- a/include/alpaka/core/BarrierThread.hpp
+++ b/include/alpaka/core/BarrierThread.hpp
@@ -28,31 +28,23 @@ namespace alpaka
     {
         namespace threads
         {
-            //#############################################################################
             //! A self-resetting barrier.
             template<typename TIdx>
             class BarrierThread final
             {
             public:
-                //-----------------------------------------------------------------------------
                 explicit BarrierThread(TIdx const& threadCount)
                     : m_threadCount(threadCount)
                     , m_curThreadCount(threadCount)
                     , m_generation(0)
                 {
                 }
-                //-----------------------------------------------------------------------------
                 BarrierThread(BarrierThread const&) = delete;
-                //-----------------------------------------------------------------------------
                 BarrierThread(BarrierThread&&) = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(BarrierThread const&) -> BarrierThread& = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(BarrierThread&&) -> BarrierThread& = delete;
-                //-----------------------------------------------------------------------------
                 ~BarrierThread() = default;
 
-                //-----------------------------------------------------------------------------
                 //! Waits for all the other threads to reach the barrier.
                 auto wait() -> void
                 {
@@ -100,10 +92,8 @@ namespace alpaka
 
             namespace detail
             {
-                //#############################################################################
                 template<typename TOp>
                 struct AtomicOp;
-                //#############################################################################
                 template<>
                 struct AtomicOp<BlockCount>
                 {
@@ -112,7 +102,6 @@ namespace alpaka
                         result += static_cast<int>(value);
                     }
                 };
-                //#############################################################################
                 template<>
                 struct AtomicOp<BlockAnd>
                 {
@@ -121,7 +110,6 @@ namespace alpaka
                         result &= static_cast<int>(value);
                     }
                 };
-                //#############################################################################
                 template<>
                 struct AtomicOp<BlockOr>
                 {
@@ -132,31 +120,23 @@ namespace alpaka
                 };
             } // namespace detail
 
-            //#############################################################################
             //! A self-resetting barrier with barrier.
             template<typename TIdx>
             class BarrierThreadWithPredicate final
             {
             public:
-                //-----------------------------------------------------------------------------
                 explicit BarrierThreadWithPredicate(TIdx const& threadCount)
                     : m_threadCount(threadCount)
                     , m_curThreadCount(threadCount)
                     , m_generation(0)
                 {
                 }
-                //-----------------------------------------------------------------------------
                 BarrierThreadWithPredicate(BarrierThreadWithPredicate const& other) = delete;
-                //-----------------------------------------------------------------------------
                 BarrierThreadWithPredicate(BarrierThreadWithPredicate&&) = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(BarrierThreadWithPredicate const&) -> BarrierThreadWithPredicate& = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(BarrierThreadWithPredicate&&) -> BarrierThreadWithPredicate& = delete;
-                //-----------------------------------------------------------------------------
                 ~BarrierThreadWithPredicate() = default;
 
-                //-----------------------------------------------------------------------------
                 //! Waits for all the other threads to reach the barrier.
                 template<typename TOp>
                 ALPAKA_FN_HOST auto wait(int predicate) -> int

--- a/include/alpaka/core/BoostPredef.hpp
+++ b/include/alpaka/core/BoostPredef.hpp
@@ -11,7 +11,6 @@
 
 #include <boost/predef.h>
 
-//-----------------------------------------------------------------------------
 // In boost since 1.68.0
 // BOOST_PREDEF_MAKE_10_VVRRP(V)
 #if !defined(BOOST_PREDEF_MAKE_10_VVRRP)
@@ -37,7 +36,6 @@
 #    endif
 #endif
 
-//-----------------------------------------------------------------------------
 // HSA device architecture detection (HSA generated via HIP(clang))
 #if !defined(BOOST_ARCH_HSA)
 #    if defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__ == 1 && defined(__HIP__)
@@ -49,7 +47,6 @@
 #    endif
 #endif
 
-//-----------------------------------------------------------------------------
 // hip compiler detection
 #if !defined(BOOST_COMP_HIP)
 #    if defined(__HIP__)
@@ -59,7 +56,6 @@
 #    endif
 #endif
 
-//-----------------------------------------------------------------------------
 // In boost since 1.68.0
 // CUDA language detection
 // - clang defines __CUDA__ and __CUDACC__ when compiling CUDA code ('-x cuda')
@@ -73,7 +69,6 @@
 #    endif
 #endif
 
-//-----------------------------------------------------------------------------
 // In boost since 1.68.0
 // CUDA device architecture detection
 #if !defined(BOOST_ARCH_PTX)
@@ -84,7 +79,6 @@
 #    endif
 #endif
 
-//-----------------------------------------------------------------------------
 // In boost since 1.68.0
 // nvcc CUDA compiler detection
 
@@ -112,7 +106,6 @@
 #    endif
 #endif
 
-//-----------------------------------------------------------------------------
 // clang CUDA compiler detection
 // Currently __CUDA__ is only defined by clang when compiling CUDA code.
 #if defined(__clang__) && defined(__CUDA__)
@@ -121,7 +114,6 @@
 #    define BOOST_COMP_CLANG_CUDA BOOST_VERSION_NUMBER_NOT_AVAILABLE
 #endif
 
-//-----------------------------------------------------------------------------
 // Intel compiler detection
 // BOOST_COMP_INTEL_EMULATED is defined by boost instead of BOOST_COMP_INTEL
 #if defined(BOOST_COMP_INTEL) && defined(BOOST_COMP_INTEL_EMULATED)
@@ -129,7 +121,6 @@
 #    define BOOST_COMP_INTEL BOOST_COMP_INTEL_EMULATED
 #endif
 
-//-----------------------------------------------------------------------------
 // PGI and NV HPC SDK compiler detection
 // BOOST_COMP_PGI_EMULATED is defined by boost instead of BOOST_COMP_PGI
 #if defined(BOOST_COMP_PGI) && defined(BOOST_COMP_PGI_EMULATED)

--- a/include/alpaka/core/ClipCast.hpp
+++ b/include/alpaka/core/ClipCast.hpp
@@ -18,7 +18,6 @@ namespace alpaka
 {
     namespace core
     {
-        //-----------------------------------------------------------------------------
         //! \return The input casted and clipped to T.
         template<typename T, typename V>
         auto clipCast(V const& val) -> T

--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -17,7 +17,6 @@
 #    include <intrin.h>
 #endif
 
-//-----------------------------------------------------------------------------
 //! All functions that can be used on an accelerator have to be attributed with ALPAKA_FN_ACC or ALPAKA_FN_HOST_ACC.
 //!
 //! Usage:
@@ -38,14 +37,11 @@
 #    define ALPAKA_FN_HOST
 #endif
 
-//-----------------------------------------------------------------------------
 //! Disable nvcc warning:
 //! 'calling a __host__ function from __host__ __device__ function.'
-//!
 //! Usage:
 //! ALPAKA_NO_HOST_ACC_WARNING
 //! ALPAKA_FN_HOST_ACC function_declaration()
-//!
 //! WARNING: Only use this method if there is no other way.
 //! Most cases can be solved by #if BOOST_ARCH_PTX or #if BOOST_LANG_CUDA.
 #if(BOOST_LANG_CUDA && !BOOST_COMP_CLANG_CUDA) || BOOST_LANG_HIP
@@ -58,7 +54,6 @@
 #    define ALPAKA_NO_HOST_ACC_WARNING
 #endif
 
-//-----------------------------------------------------------------------------
 //! Macro defining the inline function attribute.
 #if BOOST_LANG_CUDA || BOOST_LANG_HIP
 #    define ALPAKA_FN_INLINE __forceinline__
@@ -66,7 +61,6 @@
 #    define ALPAKA_FN_INLINE inline
 #endif
 
-//-----------------------------------------------------------------------------
 //! This macro defines a variable lying in global accelerator device memory.
 //!
 //! Example:
@@ -88,7 +82,6 @@
 #    define ALPAKA_STATIC_ACC_MEM_GLOBAL
 #endif
 
-//-----------------------------------------------------------------------------
 //! This macro defines a variable lying in constant accelerator device memory.
 //!
 //! Example:

--- a/include/alpaka/core/Concepts.hpp
+++ b/include/alpaka/core/Concepts.hpp
@@ -15,7 +15,6 @@ namespace alpaka
 {
     namespace concepts
     {
-        //#############################################################################
         //! Tag used in class inheritance hierarchies that describes that a specific concept (TConcept)
         //! is implemented by the given base class (TBase).
         template<typename TConcept, typename TBase>
@@ -23,7 +22,6 @@ namespace alpaka
         {
         };
 
-        //#############################################################################
         //! Checks whether the concept is implemented by the given class
         template<typename TConcept, typename TDerived>
         struct ImplementsConcept
@@ -37,12 +35,10 @@ namespace alpaka
 
         namespace detail
         {
-            //#############################################################################
             //! Returns the type that implements the given concept in the inheritance hierarchy.
             template<typename TConcept, typename TDerived, typename Sfinae = void>
             struct ImplementationBaseType;
 
-            //#############################################################################
             //! Base case for types that do not inherit from "Implements<TConcept, ...>" is the type itself.
             template<typename TConcept, typename TDerived>
             struct ImplementationBaseType<
@@ -53,7 +49,6 @@ namespace alpaka
                 using type = TDerived;
             };
 
-            //#############################################################################
             //! For types that inherit from "Implements<TConcept, ...>" it finds the base class (TBase) which
             //! implements the concept.
             template<typename TConcept, typename TDerived>
@@ -73,7 +68,6 @@ namespace alpaka
             };
         } // namespace detail
 
-        //#############################################################################
         //! Returns the type that implements the given concept in the inheritance hierarchy.
         template<typename TConcept, typename TDerived>
         using ImplementationBase = typename detail::ImplementationBaseType<TConcept, TDerived>::type;

--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -9,12 +9,10 @@
 
 #pragma once
 
-//-----------------------------------------------------------------------------
 // Clang does not support exceptions when natively compiling device code.
 // This is no problem at some places but others explicitly rely on std::exception_ptr,
 // std::current_exception, std::make_exception_ptr, etc. which are not declared in device code.
 // Therefore, we can not even parse those parts when compiling device code.
-//-----------------------------------------------------------------------------
 #include <alpaka/core/BoostPredef.hpp>
 #include <alpaka/core/Common.hpp>
 
@@ -35,22 +33,18 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             template<typename T>
             class ThreadSafeQueue : private std::queue<T>
             {
             public:
-                //-----------------------------------------------------------------------------
                 ThreadSafeQueue()
                 {
                 }
-                //-----------------------------------------------------------------------------
                 //! \return If the queue is empty.
                 auto empty() const -> bool
                 {
                     return std::queue<T>::empty();
                 }
-                //-----------------------------------------------------------------------------
                 //! Pushes the given value onto the back of the queue.
                 auto push(T&& t) -> void
                 {
@@ -58,7 +52,6 @@ namespace alpaka
 
                     std::queue<T>::push(std::forward<T>(t));
                 }
-                //-----------------------------------------------------------------------------
                 //! Pops the given value from the front of the queue.
                 auto pop(T& t) -> bool
                 {
@@ -80,7 +73,6 @@ namespace alpaka
                 std::mutex m_Mutex;
             };
 
-            //#############################################################################
             //! ITaskPkg.
             // \NOTE: We can not use std::packaged_task as it forces the use of std::future
             // but we additionally support boost::fibers::promise.
@@ -91,10 +83,8 @@ namespace alpaka
             class ITaskPkg
             {
             public:
-                //-----------------------------------------------------------------------------
                 virtual ~ITaskPkg() = default;
 
-                //-----------------------------------------------------------------------------
                 //! Runs this task.
                 auto runTask() noexcept -> void
                 {
@@ -112,14 +102,12 @@ namespace alpaka
                 }
 
             private:
-                //-----------------------------------------------------------------------------
                 //! The execution function.
                 virtual auto run() -> void = 0;
 
             public:
 // Workaround: Clang can not support this when natively compiling device code. See ConcurrentExecPool.hpp.
 #if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_PTX)
-                //-----------------------------------------------------------------------------
                 //! Sets an exception.
                 virtual auto setException(std::exception_ptr const& exceptPtr) -> void = 0;
 #endif
@@ -128,7 +116,6 @@ namespace alpaka
 #    pragma clang diagnostic pop
 #endif
 
-            //#############################################################################
             template<
                 template<typename TFnObjReturn>
                 class TPromise,
@@ -136,7 +123,6 @@ namespace alpaka
                 typename TFnObjReturn = decltype(std::declval<TFnObj>()())>
             class TaskPkg;
 
-            //#############################################################################
             //! TaskPkg with return type.
             //!
             //! \tparam TPromise The promise type returned by the task.
@@ -146,13 +132,11 @@ namespace alpaka
             class TaskPkg final : public ITaskPkg
             {
             public:
-                //-----------------------------------------------------------------------------
                 TaskPkg(TFnObj&& func) : m_Promise(), m_FnObj(std::move(func))
                 {
                 }
 
             private:
-                //-----------------------------------------------------------------------------
                 //! The execution function.
                 virtual auto run() -> void final
                 {
@@ -162,7 +146,6 @@ namespace alpaka
             public:
 // Workaround: Clang can not support this when natively compiling device code. See ConcurrentExecPool.hpp.
 #if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_PTX)
-                //-----------------------------------------------------------------------------
                 //! Sets an exception.
                 virtual auto setException(std::exception_ptr const& exceptPtr) -> void final
                 {
@@ -177,7 +160,6 @@ namespace alpaka
                 std::remove_reference_t<TFnObj> m_FnObj;
             };
 
-            //#############################################################################
             //! TaskPkg without return type.
             //!
             //! \tparam TPromise The promise type returned by the task.
@@ -186,13 +168,11 @@ namespace alpaka
             class TaskPkg<TPromise, TFnObj, void> final : public ITaskPkg
             {
             public:
-                //-----------------------------------------------------------------------------
                 TaskPkg(TFnObj&& func) : m_Promise(), m_FnObj(std::move(func))
                 {
                 }
 
             private:
-                //-----------------------------------------------------------------------------
                 //! The execution function.
                 virtual auto run() -> void final
                 {
@@ -203,7 +183,6 @@ namespace alpaka
             public:
 // Workaround: Clang can not support this when natively compiling device code. See ConcurrentExecPool.hpp.
 #if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_PTX)
-                //-----------------------------------------------------------------------------
                 //! Sets an exception.
                 virtual auto setException(std::exception_ptr const& exceptPtr) -> void final
                 {
@@ -218,7 +197,6 @@ namespace alpaka
                 std::remove_reference_t<TFnObj> m_FnObj;
             };
 
-            //-----------------------------------------------------------------------------
             template<
                 typename TFnObj0,
                 typename TFnObj1,
@@ -230,7 +208,6 @@ namespace alpaka
                 return std::move(ret);
             }
 
-            //-----------------------------------------------------------------------------
             template<
                 typename TFnObj0,
                 typename TFnObj1,
@@ -241,7 +218,6 @@ namespace alpaka
                 fn1();
             }
 
-            //#############################################################################
             //! ConcurrentExecPool using yield.
             //!
             //! \tparam TConcurrentExec The type of concurrent executor (for example std::thread).
@@ -262,7 +238,6 @@ namespace alpaka
             class ConcurrentExecPool final
             {
             public:
-                //-----------------------------------------------------------------------------
                 //! Creates a concurrent executor pool with a specific number of concurrent executors and a maximum
                 //! number of queued tasks.
                 //!
@@ -289,16 +264,11 @@ namespace alpaka
                         m_vConcurrentExecs.emplace_back([this]() { concurrentExecFn(); });
                     }
                 }
-                //-----------------------------------------------------------------------------
                 ConcurrentExecPool(ConcurrentExecPool const&) = delete;
-                //-----------------------------------------------------------------------------
                 ConcurrentExecPool(ConcurrentExecPool&&) = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(ConcurrentExecPool const&) -> ConcurrentExecPool& = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(ConcurrentExecPool&&) -> ConcurrentExecPool& = delete;
 
-                //-----------------------------------------------------------------------------
                 //! Completes any currently running task normally.
                 //! Signals a std::runtime_error exception to any other tasks that was not able to run.
                 ~ConcurrentExecPool()
@@ -322,7 +292,6 @@ namespace alpaka
                     }
                 }
 
-                //-----------------------------------------------------------------------------
                 //! Runs the given function on one of the pool in First In First Out (FIFO) order.
                 //!
                 //! \tparam TFnObj  The function type.
@@ -356,13 +325,11 @@ namespace alpaka
 
                     return future;
                 }
-                //-----------------------------------------------------------------------------
                 //! \return The number of concurrent executors available.
                 auto getConcurrentExecutionCount() const -> TIdx
                 {
                     return m_vConcurrentExecs.size();
                 }
-                //-----------------------------------------------------------------------------
                 //! \return If the thread pool is idle.
                 auto isIdle() const -> bool
                 {
@@ -370,7 +337,6 @@ namespace alpaka
                 }
 
             private:
-                //-----------------------------------------------------------------------------
                 //! The function the concurrent executors are executing.
                 void concurrentExecFn()
                 {
@@ -391,7 +357,6 @@ namespace alpaka
                     }
                 }
 
-                //-----------------------------------------------------------------------------
                 //! Joins all concurrent executors.
                 void joinAllConcurrentExecs()
                 {
@@ -400,7 +365,6 @@ namespace alpaka
                         concurrentExec.join();
                     }
                 }
-                //-----------------------------------------------------------------------------
                 //! Pops a task from the queue.
                 auto popTask(std::shared_ptr<ITaskPkg>& out) -> bool
                 {
@@ -418,7 +382,6 @@ namespace alpaka
                 std::atomic<bool> m_bShutdownFlag;
             };
 
-            //#############################################################################
             //! ConcurrentExecPool using a condition variable to wait for new work.
             //!
             //! \tparam TConcurrentExec The type of concurrent executor (for example std::thread).
@@ -437,7 +400,6 @@ namespace alpaka
             class ConcurrentExecPool<TIdx, TConcurrentExec, TPromise, TYield, TMutex, TCondVar, false> final
             {
             public:
-                //-----------------------------------------------------------------------------
                 //! Creates a concurrent executors pool with a specific number of concurrent executors and a maximum
                 //! number of queued tasks.
                 //!
@@ -466,16 +428,11 @@ namespace alpaka
                         m_vConcurrentExecs.emplace_back([this]() { concurrentExecFn(); });
                     }
                 }
-                //-----------------------------------------------------------------------------
                 ConcurrentExecPool(ConcurrentExecPool const&) = delete;
-                //-----------------------------------------------------------------------------
                 ConcurrentExecPool(ConcurrentExecPool&&) = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(ConcurrentExecPool const&) -> ConcurrentExecPool& = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(ConcurrentExecPool&&) -> ConcurrentExecPool& = delete;
 
-                //-----------------------------------------------------------------------------
                 //! Completes any currently running task normally.
                 //! Signals a std::runtime_error exception to any other tasks that was not able to run.
                 ~ConcurrentExecPool()
@@ -505,7 +462,6 @@ namespace alpaka
                     }
                 }
 
-                //-----------------------------------------------------------------------------
                 //! Runs the given function on one of the pool in First In First Out (FIFO) order.
                 //!
                 //! \tparam TFnObj  The function type.
@@ -544,13 +500,11 @@ namespace alpaka
 
                     return future;
                 }
-                //-----------------------------------------------------------------------------
                 //! \return The number of concurrent executors available.
                 auto getConcurrentExecutionCount() const -> TIdx
                 {
                     return m_vConcurrentExecs.size();
                 }
-                //-----------------------------------------------------------------------------
                 //! \return If the thread pool is idle.
                 auto isIdle() const -> bool
                 {
@@ -558,7 +512,6 @@ namespace alpaka
                 }
 
             private:
-                //-----------------------------------------------------------------------------
                 //! The function the concurrent executors are executing.
                 void concurrentExecFn()
                 {
@@ -588,7 +541,6 @@ namespace alpaka
                     }
                 }
 
-                //-----------------------------------------------------------------------------
                 //! Joins all concurrent executors.
                 void joinAllConcurrentExecs()
                 {
@@ -597,7 +549,6 @@ namespace alpaka
                         concurrentExec.join();
                     }
                 }
-                //-----------------------------------------------------------------------------
                 //! Pops a task from the queue.
                 auto popTask(std::shared_ptr<ITaskPkg>& out) -> bool
                 {

--- a/include/alpaka/core/Cuda.hpp
+++ b/include/alpaka/core/Cuda.hpp
@@ -60,7 +60,6 @@ namespace alpaka
     {
         namespace detail
         {
-            //-----------------------------------------------------------------------------
             //! CUDA driver API error checking with log and exception, ignoring specific error values
             ALPAKA_FN_HOST inline auto cudaDrvCheck(
                 CUresult const& error,
@@ -103,22 +102,18 @@ namespace alpaka
     } // namespace cuda
 } // namespace alpaka
 
-//-----------------------------------------------------------------------------
 //! CUDA driver error checking with log and exception.
 #    define ALPAKA_CUDA_DRV_CHECK(cmd) ::alpaka::cuda::detail::cudaDrvCheck(cmd, #    cmd, __FILE__, __LINE__)
 
 
-//-----------------------------------------------------------------------------
 // CUDA vector_types.h trait specializations.
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The CUDA specifics.
     namespace cuda
     {
         namespace traits
         {
-            //#############################################################################
             //! The CUDA vectors 1D dimension get trait specialization.
             template<typename T>
             struct IsCudaBuiltInType
@@ -164,7 +159,6 @@ namespace alpaka
     } // namespace cuda
     namespace traits
     {
-        //#############################################################################
         //! The CUDA vectors 1D dimension get trait specialization.
         template<typename T>
         struct DimType<
@@ -178,7 +172,6 @@ namespace alpaka
         {
             using type = DimInt<1u>;
         };
-        //#############################################################################
         //! The CUDA vectors 2D dimension get trait specialization.
         template<typename T>
         struct DimType<
@@ -192,7 +185,6 @@ namespace alpaka
         {
             using type = DimInt<2u>;
         };
-        //#############################################################################
         //! The CUDA vectors 3D dimension get trait specialization.
         template<typename T>
         struct DimType<
@@ -213,7 +205,6 @@ namespace alpaka
         {
             using type = DimInt<3u>;
         };
-        //#############################################################################
         //! The CUDA vectors 4D dimension get trait specialization.
         template<typename T>
         struct DimType<
@@ -228,7 +219,6 @@ namespace alpaka
             using type = DimInt<4u>;
         };
 
-        //#############################################################################
         //! The CUDA vectors elem type trait specialization.
         template<typename T>
         struct ElemType<T, std::enable_if_t<cuda::traits::IsCudaBuiltInType<T>::value>>
@@ -240,7 +230,6 @@ namespace alpaka
     {
         namespace traits
         {
-            //#############################################################################
             //! The CUDA vectors extent get trait specialization.
             template<typename TExtent>
             struct GetExtent<
@@ -254,7 +243,6 @@ namespace alpaka
                     return extent.x;
                 }
             };
-            //#############################################################################
             //! The CUDA vectors extent get trait specialization.
             template<typename TExtent>
             struct GetExtent<
@@ -268,7 +256,6 @@ namespace alpaka
                     return extent.y;
                 }
             };
-            //#############################################################################
             //! The CUDA vectors extent get trait specialization.
             template<typename TExtent>
             struct GetExtent<
@@ -282,7 +269,6 @@ namespace alpaka
                     return extent.z;
                 }
             };
-            //#############################################################################
             //! The CUDA vectors extent get trait specialization.
             template<typename TExtent>
             struct GetExtent<
@@ -296,7 +282,6 @@ namespace alpaka
                     return extent.w;
                 }
             };
-            //#############################################################################
             //! The CUDA vectors extent set trait specialization.
             template<typename TExtent, typename TExtentVal>
             struct SetExtent<
@@ -311,7 +296,6 @@ namespace alpaka
                     extent.x = extentVal;
                 }
             };
-            //#############################################################################
             //! The CUDA vectors extent set trait specialization.
             template<typename TExtent, typename TExtentVal>
             struct SetExtent<
@@ -326,7 +310,6 @@ namespace alpaka
                     extent.y = extentVal;
                 }
             };
-            //#############################################################################
             //! The CUDA vectors extent set trait specialization.
             template<typename TExtent, typename TExtentVal>
             struct SetExtent<
@@ -341,7 +324,6 @@ namespace alpaka
                     extent.z = extentVal;
                 }
             };
-            //#############################################################################
             //! The CUDA vectors extent set trait specialization.
             template<typename TExtent, typename TExtentVal>
             struct SetExtent<
@@ -360,7 +342,6 @@ namespace alpaka
     } // namespace extent
     namespace traits
     {
-        //#############################################################################
         //! The CUDA vectors offset get trait specialization.
         template<typename TOffsets>
         struct GetOffset<
@@ -374,7 +355,6 @@ namespace alpaka
                 return offsets.x;
             }
         };
-        //#############################################################################
         //! The CUDA vectors offset get trait specialization.
         template<typename TOffsets>
         struct GetOffset<
@@ -388,7 +368,6 @@ namespace alpaka
                 return offsets.y;
             }
         };
-        //#############################################################################
         //! The CUDA vectors offset get trait specialization.
         template<typename TOffsets>
         struct GetOffset<
@@ -402,7 +381,6 @@ namespace alpaka
                 return offsets.z;
             }
         };
-        //#############################################################################
         //! The CUDA vectors offset get trait specialization.
         template<typename TOffsets>
         struct GetOffset<
@@ -416,7 +394,6 @@ namespace alpaka
                 return offsets.w;
             }
         };
-        //#############################################################################
         //! The CUDA vectors offset set trait specialization.
         template<typename TOffsets, typename TOffset>
         struct SetOffset<
@@ -431,7 +408,6 @@ namespace alpaka
                 offsets.x = offset;
             }
         };
-        //#############################################################################
         //! The CUDA vectors offset set trait specialization.
         template<typename TOffsets, typename TOffset>
         struct SetOffset<
@@ -446,7 +422,6 @@ namespace alpaka
                 offsets.y = offset;
             }
         };
-        //#############################################################################
         //! The CUDA vectors offset set trait specialization.
         template<typename TOffsets, typename TOffset>
         struct SetOffset<
@@ -461,7 +436,6 @@ namespace alpaka
                 offsets.z = offset;
             }
         };
-        //#############################################################################
         //! The CUDA vectors offset set trait specialization.
         template<typename TOffsets, typename TOffset>
         struct SetOffset<
@@ -477,7 +451,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CUDA vectors idx type trait specialization.
         template<typename TIdx>
         struct IdxType<TIdx, std::enable_if_t<cuda::traits::IsCudaBuiltInType<TIdx>::value>>

--- a/include/alpaka/core/Debug.hpp
+++ b/include/alpaka/core/Debug.hpp
@@ -14,18 +14,14 @@
 #include <iostream>
 #include <string>
 
-//-----------------------------------------------------------------------------
 //! The no debug level.
 #define ALPAKA_DEBUG_DISABLED 0
-//-----------------------------------------------------------------------------
 //! The minimal debug level.
 #define ALPAKA_DEBUG_MINIMAL 1
-//-----------------------------------------------------------------------------
 //! The full debug level.
 #define ALPAKA_DEBUG_FULL 2
 
 #ifndef ALPAKA_DEBUG
-//-----------------------------------------------------------------------------
 //! Set the minimum log level if it is not defined.
 #    define ALPAKA_DEBUG ALPAKA_DEBUG_DISABLED
 #endif
@@ -36,25 +32,18 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             //! Scope logger.
             class ScopeLogStdOut final
             {
             public:
-                //-----------------------------------------------------------------------------
                 explicit ScopeLogStdOut(std::string const& sScope) : m_sScope(sScope)
                 {
                     std::cout << "[+] " << m_sScope << std::endl;
                 }
-                //-----------------------------------------------------------------------------
                 ScopeLogStdOut(ScopeLogStdOut const&) = delete;
-                //-----------------------------------------------------------------------------
                 ScopeLogStdOut(ScopeLogStdOut&&) = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(ScopeLogStdOut const&) -> ScopeLogStdOut& = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(ScopeLogStdOut&&) -> ScopeLogStdOut& = delete;
-                //-----------------------------------------------------------------------------
                 ~ScopeLogStdOut()
                 {
                     std::cout << "[-] " << m_sScope << std::endl;
@@ -67,7 +56,6 @@ namespace alpaka
     } // namespace core
 } // namespace alpaka
 
-//-----------------------------------------------------------------------------
 // Define ALPAKA_DEBUG_MINIMAL_LOG_SCOPE.
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
 #    define ALPAKA_DEBUG_MINIMAL_LOG_SCOPE ::alpaka::core::detail::ScopeLogStdOut const scopeLogStdOut(__func__)
@@ -75,7 +63,6 @@ namespace alpaka
 #    define ALPAKA_DEBUG_MINIMAL_LOG_SCOPE
 #endif
 
-//-----------------------------------------------------------------------------
 // Define ALPAKA_DEBUG_FULL_LOG_SCOPE.
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
 #    define ALPAKA_DEBUG_FULL_LOG_SCOPE ::alpaka::core::detail::ScopeLogStdOut const scopeLogStdOut(__func__)
@@ -83,7 +70,6 @@ namespace alpaka
 #    define ALPAKA_DEBUG_FULL_LOG_SCOPE
 #endif
 
-//-----------------------------------------------------------------------------
 // Define ALPAKA_DEBUG_BREAK.
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
 #    if BOOST_COMP_GNUC

--- a/include/alpaka/core/Decay.hpp
+++ b/include/alpaka/core/Decay.hpp
@@ -13,7 +13,6 @@
 
 #include <type_traits>
 
-//-----------------------------------------------------------------------------
 //! Wrapper around std::decay_t for parameter pack expansion expressions
 //
 // Works around Intel compiler internal error when used in empty template pack
@@ -25,7 +24,6 @@
 // The choice of macro over writing typename std::decay<Type>::type explicitly
 // in parameter pack expansion expressions is to avoid warnings from diagnostic
 // tools, and also for brevity.
-//-----------------------------------------------------------------------------
 #if BOOST_COMP_INTEL || BOOST_COMP_PGI
 #    define ALPAKA_DECAY_T(Type) typename std::decay<Type>::type
 #else

--- a/include/alpaka/core/Hip.hpp
+++ b/include/alpaka/core/Hip.hpp
@@ -39,17 +39,14 @@
 //! prefix a name with `hip`
 #    define ALPAKA_API_PREFIX(name) ALPAKA_PP_CONCAT_DO(hip, name)
 
-//-----------------------------------------------------------------------------
 // HIP vector_types.h trait specializations.
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The HIP specifics.
     namespace hip
     {
         namespace traits
         {
-            //#############################################################################
             //! The HIP vectors 1D dimension get trait specialization.
             template<typename T>
             struct IsHipBuiltInType
@@ -89,7 +86,6 @@ namespace alpaka
         // If you receive '"alpaka::traits::DimType" has already been defined'
         // then too many operators in the enable_if are used. Split them in two or more structs.
         // (compiler: gcc 5.3.0)
-        //#############################################################################
         //! The HIP vectors 1D dimension get trait specialization.
         template<typename T>
         struct DimType<
@@ -110,7 +106,6 @@ namespace alpaka
         {
             using type = DimInt<1u>;
         };
-        //#############################################################################
         //! The HIP vectors 2D dimension get trait specialization.
         template<typename T>
         struct DimType<
@@ -131,7 +126,6 @@ namespace alpaka
         {
             using type = DimInt<2u>;
         };
-        //#############################################################################
         //! The HIP vectors 3D dimension get trait specialization.
         template<typename T>
         struct DimType<
@@ -152,7 +146,6 @@ namespace alpaka
         {
             using type = DimInt<3u>;
         };
-        //#############################################################################
         //! The HIP vectors 4D dimension get trait specialization.
         template<typename T>
         struct DimType<
@@ -174,7 +167,6 @@ namespace alpaka
             using type = DimInt<4u>;
         };
 
-        //#############################################################################
         //! The HIP vectors elem type trait specialization.
         template<typename T>
         struct ElemType<T, std::enable_if_t<hip::traits::IsHipBuiltInType<T>::value>>
@@ -186,7 +178,6 @@ namespace alpaka
     {
         namespace traits
         {
-            //#############################################################################
             //! The HIP vectors extent get trait specialization.
             template<typename TExtent>
             struct GetExtent<
@@ -200,7 +191,6 @@ namespace alpaka
                     return extent.x;
                 }
             };
-            //#############################################################################
             //! The HIP vectors extent get trait specialization.
             template<typename TExtent>
             struct GetExtent<
@@ -214,7 +204,6 @@ namespace alpaka
                     return extent.y;
                 }
             };
-            //#############################################################################
             //! The HIP vectors extent get trait specialization.
             template<typename TExtent>
             struct GetExtent<
@@ -228,7 +217,6 @@ namespace alpaka
                     return extent.z;
                 }
             };
-            //#############################################################################
             //! The HIP vectors extent get trait specialization.
             template<typename TExtent>
             struct GetExtent<
@@ -242,7 +230,6 @@ namespace alpaka
                     return extent.w;
                 }
             };
-            //#############################################################################
             //! The HIP vectors extent set trait specialization.
             template<typename TExtent, typename TExtentVal>
             struct SetExtent<
@@ -257,7 +244,6 @@ namespace alpaka
                     extent.x = extentVal;
                 }
             };
-            //#############################################################################
             //! The HIP vectors extent set trait specialization.
             template<typename TExtent, typename TExtentVal>
             struct SetExtent<
@@ -272,7 +258,6 @@ namespace alpaka
                     extent.y = extentVal;
                 }
             };
-            //#############################################################################
             //! The HIP vectors extent set trait specialization.
             template<typename TExtent, typename TExtentVal>
             struct SetExtent<
@@ -287,7 +272,6 @@ namespace alpaka
                     extent.z = extentVal;
                 }
             };
-            //#############################################################################
             //! The HIP vectors extent set trait specialization.
             template<typename TExtent, typename TExtentVal>
             struct SetExtent<
@@ -306,7 +290,6 @@ namespace alpaka
     } // namespace extent
     namespace traits
     {
-        //#############################################################################
         //! The HIP vectors offset get trait specialization.
         template<typename TOffsets>
         struct GetOffset<
@@ -320,7 +303,6 @@ namespace alpaka
                 return offsets.x;
             }
         };
-        //#############################################################################
         //! The HIP vectors offset get trait specialization.
         template<typename TOffsets>
         struct GetOffset<
@@ -334,7 +316,6 @@ namespace alpaka
                 return offsets.y;
             }
         };
-        //#############################################################################
         //! The HIP vectors offset get trait specialization.
         template<typename TOffsets>
         struct GetOffset<
@@ -348,7 +329,6 @@ namespace alpaka
                 return offsets.z;
             }
         };
-        //#############################################################################
         //! The HIP vectors offset get trait specialization.
         template<typename TOffsets>
         struct GetOffset<
@@ -362,7 +342,6 @@ namespace alpaka
                 return offsets.w;
             }
         };
-        //#############################################################################
         //! The HIP vectors offset set trait specialization.
         template<typename TOffsets, typename TOffset>
         struct SetOffset<
@@ -377,7 +356,6 @@ namespace alpaka
                 offsets.x = offset;
             }
         };
-        //#############################################################################
         //! The HIP vectors offset set trait specialization.
         template<typename TOffsets, typename TOffset>
         struct SetOffset<
@@ -392,7 +370,6 @@ namespace alpaka
                 offsets.y = offset;
             }
         };
-        //#############################################################################
         //! The HIP vectors offset set trait specialization.
         template<typename TOffsets, typename TOffset>
         struct SetOffset<
@@ -407,7 +384,6 @@ namespace alpaka
                 offsets.z = offset;
             }
         };
-        //#############################################################################
         //! The HIP vectors offset set trait specialization.
         template<typename TOffsets, typename TOffset>
         struct SetOffset<
@@ -423,7 +399,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The HIP vectors idx type trait specialization.
         template<typename TIdx>
         struct IdxType<TIdx, std::enable_if_t<hip::traits::IsHipBuiltInType<TIdx>::value>>

--- a/include/alpaka/core/Omp5.hpp
+++ b/include/alpaka/core/Omp5.hpp
@@ -33,7 +33,6 @@ namespace alpaka
     {
         namespace detail
         {
-            //-----------------------------------------------------------------------------
             //! OMP5 runtime API error checking with log and exception, ignoring specific error values
             ALPAKA_FN_HOST inline auto omp5Check(int const& error, char const* desc, char const* file, int const& line)
                 -> void
@@ -56,7 +55,6 @@ namespace alpaka
     } // namespace omp5
 } // namespace alpaka
 
-//-----------------------------------------------------------------------------
 //! OMP5 runtime error checking with log and exception.
 #    define ALPAKA_OMP5_CHECK(cmd) ::alpaka::omp5::detail::omp5Check(cmd, #    cmd, __FILE__, __LINE__)
 

--- a/include/alpaka/core/OmpSchedule.hpp
+++ b/include/alpaka/core/OmpSchedule.hpp
@@ -22,7 +22,6 @@ namespace alpaka
 {
     namespace omp
     {
-        //#############################################################################
         //! Representation of OpenMP schedule information: kind and chunk size. This class can be used regardless of
         //! whether OpenMP is enabled.
         struct Schedule
@@ -60,7 +59,6 @@ namespace alpaka
             }
         };
 
-        //-----------------------------------------------------------------------------
         //! Get the OpenMP schedule that is applied when the runtime schedule is used.
         //!
         //! For OpenMP >= 3.0 returns the value of the internal control variable run-sched-var.
@@ -80,7 +78,6 @@ namespace alpaka
 #endif
         }
 
-        //-----------------------------------------------------------------------------
         //! Set the OpenMP schedule that is applied when the runtime schedule is used for future parallel regions.
         //!
         //! For OpenMP >= 3.0 sets the value of the internal control variable run-sched-var according to the given

--- a/include/alpaka/core/Positioning.hpp
+++ b/include/alpaka/core/Positioning.hpp
@@ -11,7 +11,6 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! Defines the parallelism hierarchy levels of alpaka
     namespace hierarchy
     {
@@ -27,31 +26,23 @@ namespace alpaka
         {
         };
     } // namespace hierarchy
-    //-----------------------------------------------------------------------------
     //! Defines the origins available for getting extent and indices of kernel executions.
     namespace origin
     {
-        //#############################################################################
         //! This type is used to get the extents/indices relative to the grid.
         struct Grid;
-        //#############################################################################
         //! This type is used to get the extent/indices relative to a/the current block.
         struct Block;
-        //#############################################################################
         //! This type is used to get the extents relative to the thread.
         struct Thread;
     } // namespace origin
-    //-----------------------------------------------------------------------------
     //! Defines the units available for getting extent and indices of kernel executions.
     namespace unit
     {
-        //#############################################################################
         //! This type is used to get the extent/indices in units of blocks.
         struct Blocks;
-        //#############################################################################
         //! This type is used to get the extent/indices in units of threads.
         struct Threads;
-        //#############################################################################
         //! This type is used to get the extents/indices in units of elements.
         struct Elems;
     } // namespace unit

--- a/include/alpaka/core/UniformCudaHip.hpp
+++ b/include/alpaka/core/UniformCudaHip.hpp
@@ -45,7 +45,6 @@ namespace alpaka
 #    else
             using Error_t = hipError_t;
 #    endif
-            //-----------------------------------------------------------------------------
             //! CUDA/HIP runtime API error checking with log and exception, ignoring specific error values
             ALPAKA_FN_HOST inline auto rtCheck(
                 Error_t const& error,
@@ -68,7 +67,6 @@ namespace alpaka
                     throw std::runtime_error(sError);
                 }
             }
-            //-----------------------------------------------------------------------------
             //! CUDA/Hip runtime API error checking with log and exception, ignoring specific error values
             // NOTE: All ignored errors have to be convertible to Error_t.
             template<typename... TErrors>
@@ -96,7 +94,6 @@ namespace alpaka
                     }
                 }
             }
-            //-----------------------------------------------------------------------------
             //! CUDA runtime API last error checking with log and exception.
             ALPAKA_FN_HOST inline auto rtCheckLastError(char const* desc, char const* file, int const& line) -> void
             {
@@ -108,7 +105,6 @@ namespace alpaka
 } // namespace alpaka
 
 #    if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
-  //-----------------------------------------------------------------------------
 //! CUDA runtime error checking with log and exception, ignoring specific error values
 #        define ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(cmd, ...)                                                     \
             ::alpaka::uniform_cuda_hip::detail::rtCheckLastError(                                                     \
@@ -121,7 +117,6 @@ namespace alpaka
 #            pragma clang diagnostic push
 #            pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #        endif
-  //-----------------------------------------------------------------------------
 //! CUDA runtime error checking with log and exception, ignoring specific error values
 #        define ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(cmd, ...)                                                     \
             ::alpaka::uniform_cuda_hip::detail::rtCheckLastError(                                                     \
@@ -134,7 +129,6 @@ namespace alpaka
 #        endif
 #    endif
 
-//-----------------------------------------------------------------------------
 //! CUDA runtime error checking with log and exception.
 #    define ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cmd) ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(cmd)
 

--- a/include/alpaka/core/Unroll.hpp
+++ b/include/alpaka/core/Unroll.hpp
@@ -11,7 +11,6 @@
 
 #include <alpaka/core/BoostPredef.hpp>
 
-//-----------------------------------------------------------------------------
 //! Suggests unrolling of the directly following loop to the compiler.
 //!
 //! Usage:

--- a/include/alpaka/core/Utility.hpp
+++ b/include/alpaka/core/Utility.hpp
@@ -20,13 +20,11 @@ namespace alpaka
 {
     namespace core
     {
-        //-----------------------------------------------------------------------------
         //! convert any type to a reverence type
         //
         // This function is equivalent to std::declval() but can be used
         // within an alpaka accelerator kernel too.
         // This function can be used only within std::decltype().
-        //-----------------------------------------------------------------------------
 #if BOOST_LANG_CUDA && BOOST_COMP_CLANG_CUDA || BOOST_COMP_HIP
         template<class T>
         ALPAKA_FN_HOST_ACC std::add_rvalue_reference_t<T> declval();

--- a/include/alpaka/core/Vectorize.hpp
+++ b/include/alpaka/core/Vectorize.hpp
@@ -14,7 +14,6 @@
 #include <cstddef>
 #include <cstdint>
 
-//-----------------------------------------------------------------------------
 //! Suggests vectorization of the directly following loop to the compiler.
 //!
 //! Usage:
@@ -40,7 +39,6 @@ namespace alpaka
     {
         namespace vectorization
         {
-            //-----------------------------------------------------------------------------
             // The alignment required to enable optimal performance dependant on the target architecture.
             constexpr std::size_t defaultAlignment =
 #if defined(__AVX512BW__) || defined(__AVX512F__) || defined(__MIC__)
@@ -52,7 +50,6 @@ namespace alpaka
 #endif
                 ;
 
-            //-----------------------------------------------------------------------------
             // Number of elements of the given type that can be processed in parallel in a vector register.
             // By default there is no vectorization.
             template<typename TElem>
@@ -61,7 +58,6 @@ namespace alpaka
                 static constexpr std::size_t value = 1u;
             };
 
-            //-----------------------------------------------------------------------------
             // Number of elements of the given type that can be processed in parallel in a vector register.
             template<>
             struct GetVectorizationSizeElems<double>
@@ -91,7 +87,6 @@ namespace alpaka
                     1u;
 #endif
             };
-            //-----------------------------------------------------------------------------
             // Number of elements of the given type that can be processed in parallel in a vector register.
             template<>
             struct GetVectorizationSizeElems<float>
@@ -120,7 +115,6 @@ namespace alpaka
                     1u;
 #endif
             };
-            //-----------------------------------------------------------------------------
             // Number of elements of the given type that can be processed in parallel in a vector register.
             template<>
             struct GetVectorizationSizeElems<std::int8_t>
@@ -154,7 +148,6 @@ namespace alpaka
                     1u;
 #endif
             };
-            //-----------------------------------------------------------------------------
             // Number of elements of the given type that can be processed in parallel in a vector register.
             template<>
             struct GetVectorizationSizeElems<std::uint8_t>
@@ -188,7 +181,6 @@ namespace alpaka
                     1u;
 #endif
             };
-            //-----------------------------------------------------------------------------
             // Number of elements of the given type that can be processed in parallel in a vector register.
             template<>
             struct GetVectorizationSizeElems<std::int16_t>
@@ -222,7 +214,6 @@ namespace alpaka
                     1u;
 #endif
             };
-            //-----------------------------------------------------------------------------
             // Number of elements of the given type that can be processed in parallel in a vector register.
             template<>
             struct GetVectorizationSizeElems<std::uint16_t>
@@ -256,7 +247,6 @@ namespace alpaka
                     1u;
 #endif
             };
-            //-----------------------------------------------------------------------------
             // Number of elements of the given type that can be processed in parallel in a vector register.
             template<>
             struct GetVectorizationSizeElems<std::int32_t>
@@ -285,7 +275,6 @@ namespace alpaka
                     1u;
 #endif
             };
-            //-----------------------------------------------------------------------------
             // Number of elements of the given type that can be processed in parallel in a vector register.
             template<>
             struct GetVectorizationSizeElems<std::uint32_t>
@@ -314,7 +303,6 @@ namespace alpaka
                     1u;
 #endif
             };
-            //-----------------------------------------------------------------------------
             // Number of elements of the given type that can be processed in parallel in a vector register.
             template<>
             struct GetVectorizationSizeElems<std::int64_t>
@@ -341,7 +329,6 @@ namespace alpaka
                     1u;
 #endif
             };
-            //-----------------------------------------------------------------------------
             // Number of elements of the given type that can be processed in parallel in a vector register.
             template<>
             struct GetVectorizationSizeElems<std::uint64_t>

--- a/include/alpaka/ctx/block/CtxBlockOacc.hpp
+++ b/include/alpaka/ctx/block/CtxBlockOacc.hpp
@@ -33,7 +33,6 @@ namespace alpaka
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelOacc;
 
-    //#############################################################################
     //! The OpenACC block context.
     template<typename TDim, typename TIdx>
     class CtxBlockOacc final
@@ -50,7 +49,6 @@ namespace alpaka
         friend class ::alpaka::TaskKernelOacc;
 
     protected:
-        //-----------------------------------------------------------------------------
         CtxBlockOacc(
             Vec<TDim, TIdx> const& gridBlockExtent,
             Vec<TDim, TIdx> const& blockThreadExtent,
@@ -68,25 +66,18 @@ namespace alpaka
         }
 
     public:
-        //-----------------------------------------------------------------------------
         CtxBlockOacc(CtxBlockOacc const&) = delete;
-        //-----------------------------------------------------------------------------
         CtxBlockOacc(CtxBlockOacc&&) = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(CtxBlockOacc const&) -> CtxBlockOacc& = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(CtxBlockOacc&&) -> CtxBlockOacc& = delete;
-        //-----------------------------------------------------------------------------
         ~CtxBlockOacc() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         template<typename TDim, typename TIdx>
         struct SyncBlockThreads<CtxBlockOacc<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             //! Execute op with single thread (any idx, last thread to
             //! arrive at barrier executes) syncing before and after
             template<typename TOp>
@@ -132,7 +123,6 @@ namespace alpaka
                 }
             }
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto syncBlockThreads(CtxBlockOacc<TDim, TIdx> const& acc) -> void
             {
                 masterOpBlockThreads<>(acc, []() {});
@@ -143,10 +133,8 @@ namespace alpaka
         {
             namespace detail
             {
-                //#############################################################################
                 template<typename TOp>
                 struct AtomicOp;
-                //#############################################################################
                 template<>
                 struct AtomicOp<BlockCount>
                 {
@@ -156,7 +144,6 @@ namespace alpaka
                         result += static_cast<int>(value);
                     }
                 };
-                //#############################################################################
                 template<>
                 struct AtomicOp<BlockAnd>
                 {
@@ -166,7 +153,6 @@ namespace alpaka
                         result &= static_cast<int>(value);
                     }
                 };
-                //#############################################################################
                 template<>
                 struct AtomicOp<BlockOr>
                 {
@@ -179,11 +165,9 @@ namespace alpaka
             } // namespace detail
         } // namespace oacc
 
-        //#############################################################################
         template<typename TOp, typename TDim, typename TIdx>
         struct SyncBlockThreadsPredicate<TOp, CtxBlockOacc<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(
                 CtxBlockOacc<TDim, TIdx> const& blockSync,
@@ -205,7 +189,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC accelerator dimension getter trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<CtxBlockOacc<TDim, TIdx>>
@@ -213,7 +196,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The OpenACC accelerator idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<CtxBlockOacc<TDim, TIdx>>
@@ -221,11 +203,9 @@ namespace alpaka
             using type = TIdx;
         };
 
-        //#############################################################################
         template<typename T, typename TDim, typename TIdx, std::size_t TuniqueId>
         struct DeclareSharedVar<T, TuniqueId, CtxBlockOacc<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             static auto declareVar(CtxBlockOacc<TDim, TIdx> const& smem) -> T&
             {
                 auto* data = smem.template getVarPtr<T>(TuniqueId);
@@ -242,11 +222,9 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         template<typename TDim, typename TIdx>
         struct FreeSharedVars<CtxBlockOacc<TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             static auto freeVars(CtxBlockOacc<TDim, TIdx> const&) -> void
             {
                 // Nothing to do. Block shared memory is automatically freed when all threads left the block.

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -41,31 +41,22 @@ namespace alpaka
     }
     class PltfCpu;
 
-    //-----------------------------------------------------------------------------
     //! The CPU device.
     namespace cpu
     {
         namespace detail
         {
-            //#############################################################################
             //! The CPU device implementation.
             class DevCpuImpl
             {
             public:
-                //-----------------------------------------------------------------------------
                 DevCpuImpl() = default;
-                //-----------------------------------------------------------------------------
                 DevCpuImpl(DevCpuImpl const&) = delete;
-                //-----------------------------------------------------------------------------
                 DevCpuImpl(DevCpuImpl&&) = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(DevCpuImpl const&) -> DevCpuImpl& = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(DevCpuImpl&&) -> DevCpuImpl& = delete;
-                //-----------------------------------------------------------------------------
                 ~DevCpuImpl() = default;
 
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST auto getAllExistingQueues() const -> std::vector<std::shared_ptr<cpu::ICpuQueue>>
                 {
                     std::vector<std::shared_ptr<cpu::ICpuQueue>> vspQueues;
@@ -89,7 +80,6 @@ namespace alpaka
                     return vspQueues;
                 }
 
-                //-----------------------------------------------------------------------------
                 //! Registers the given queue on this device.
                 //! NOTE: Every queue has to be registered for correct functionality of device wait operations!
                 ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<cpu::ICpuQueue> spQueue) const -> void
@@ -107,7 +97,6 @@ namespace alpaka
         } // namespace detail
     } // namespace cpu
 
-    //#############################################################################
     //! The CPU device handle.
     class DevCpu
         : public concepts::Implements<ConceptCurrentThreadWaitFor, DevCpu>
@@ -116,31 +105,23 @@ namespace alpaka
         friend struct traits::GetDevByIdx<PltfCpu>;
 
     protected:
-        //-----------------------------------------------------------------------------
         DevCpu() : m_spDevCpuImpl(std::make_shared<cpu::detail::DevCpuImpl>())
         {
         }
 
     public:
-        //-----------------------------------------------------------------------------
         DevCpu(DevCpu const&) = default;
-        //-----------------------------------------------------------------------------
         DevCpu(DevCpu&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(DevCpu const&) -> DevCpu& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(DevCpu&&) -> DevCpu& = default;
-        //-----------------------------------------------------------------------------
         auto operator==(DevCpu const&) const -> bool
         {
             return true;
         }
-        //-----------------------------------------------------------------------------
         auto operator!=(DevCpu const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        //-----------------------------------------------------------------------------
         ~DevCpu() = default;
 
         ALPAKA_FN_HOST auto getAllQueues() const -> std::vector<std::shared_ptr<cpu::ICpuQueue>>
@@ -148,7 +129,6 @@ namespace alpaka
             return m_spDevCpuImpl->getAllExistingQueues();
         }
 
-        //-----------------------------------------------------------------------------
         //! Registers the given queue on this device.
         //! NOTE: Every queue has to be registered for correct functionality of device wait operations!
         ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<cpu::ICpuQueue> spQueue) const -> void
@@ -162,12 +142,10 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU device name get trait specialization.
         template<>
         struct GetName<DevCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getName(DevCpu const& dev) -> std::string
             {
                 alpaka::ignore_unused(dev);
@@ -176,12 +154,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU device available memory get trait specialization.
         template<>
         struct GetMemBytes<DevCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getMemBytes(DevCpu const& dev) -> std::size_t
             {
                 alpaka::ignore_unused(dev);
@@ -190,12 +166,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU device free memory get trait specialization.
         template<>
         struct GetFreeMemBytes<DevCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevCpu const& dev) -> std::size_t
             {
                 alpaka::ignore_unused(dev);
@@ -204,12 +178,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU device warp size get trait specialization.
         template<>
         struct GetWarpSize<DevCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getWarpSize(DevCpu const& dev) -> std::size_t
             {
                 alpaka::ignore_unused(dev);
@@ -218,12 +190,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU device reset trait specialization.
         template<>
         struct Reset<DevCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto reset(DevCpu const& dev) -> void
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -240,7 +210,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU device memory buffer type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct BufType<DevCpu, TElem, TDim, TIdx>
@@ -248,7 +217,6 @@ namespace alpaka
             using type = BufCpu<TElem, TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The CPU device platform type trait specialization.
         template<>
         struct PltfType<DevCpu>

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -42,27 +42,19 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             //! The OpenACC device implementation.
             class DevOaccImpl
             {
             public:
-                //-----------------------------------------------------------------------------
                 DevOaccImpl(int iDevice) noexcept : m_deviceType(::acc_get_device_type()), m_iDevice(iDevice)
                 {
                 }
-                //-----------------------------------------------------------------------------
                 DevOaccImpl(DevOaccImpl const&) = delete;
-                //-----------------------------------------------------------------------------
                 DevOaccImpl(DevOaccImpl&&) = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(DevOaccImpl const&) -> DevOaccImpl& = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(DevOaccImpl&&) -> DevOaccImpl& = delete;
-                //-----------------------------------------------------------------------------
                 ~DevOaccImpl() = default;
 
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST auto getAllExistingQueues() const
                     -> std::vector<std::shared_ptr<IGenericThreadsQueue<DevOacc>>>
                 {
@@ -87,7 +79,6 @@ namespace alpaka
                     return vspQueues;
                 }
 
-                //-----------------------------------------------------------------------------
                 //! Registers the given queue on this device.
                 //! NOTE: Every queue has to be registered for correct functionality of device wait operations!
                 ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<IGenericThreadsQueue<DevOacc>> spQueue) -> void
@@ -115,7 +106,6 @@ namespace alpaka
             };
         } // namespace detail
     } // namespace oacc
-    //#############################################################################
     //! The OpenACC device handle.
     class DevOacc
         : public concepts::Implements<ConceptCurrentThreadWaitFor, DevOacc>
@@ -124,31 +114,23 @@ namespace alpaka
         friend struct traits::GetDevByIdx<PltfOacc>;
 
     protected:
-        //-----------------------------------------------------------------------------
         DevOacc(int iDevice) : m_spDevOaccImpl(std::make_shared<oacc::detail::DevOaccImpl>(iDevice))
         {
         }
 
     public:
-        //-----------------------------------------------------------------------------
         DevOacc(DevOacc const&) = default;
-        //-----------------------------------------------------------------------------
         DevOacc(DevOacc&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(DevOacc const&) -> DevOacc& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(DevOacc&&) -> DevOacc& = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator==(DevOacc const& rhs) const -> bool
         {
             return m_spDevOaccImpl->iDevice() == rhs.m_spDevOaccImpl->iDevice();
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator!=(DevOacc const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        //-----------------------------------------------------------------------------
         ~DevOacc() = default;
         int iDevice() const
         {
@@ -171,7 +153,6 @@ namespace alpaka
             return m_spDevOaccImpl->getAllExistingQueues();
         }
 
-        //-----------------------------------------------------------------------------
         //! Registers the given queue on this device.
         //! NOTE: Every queue has to be registered for correct functionality of device wait operations!
         ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<IGenericThreadsQueue<DevOacc>> spQueue) const -> void
@@ -185,48 +166,40 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The OpenACC device name get trait specialization.
         template<>
         struct GetName<DevOacc>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getName(DevOacc const&) -> std::string
             {
                 return std::string("OpenACC target");
             }
         };
 
-        //#############################################################################
         //! The OpenACC device available memory get trait specialization.
         template<>
         struct GetMemBytes<DevOacc>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getMemBytes(DevOacc const& dev) -> std::size_t
             {
                 return acc_get_property(dev.iDevice(), dev.deviceType(), acc_property_memory);
             }
         };
 
-        //#############################################################################
         //! The OpenACC device free memory get trait specialization.
         template<>
         struct GetFreeMemBytes<DevOacc>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevOacc const& dev) -> std::size_t
             {
                 return acc_get_property(dev.iDevice(), dev.deviceType(), acc_property_free_memory);
             }
         };
 
-        //#############################################################################
         //! The OpenACC device warp size get trait specialization.
         template<>
         struct GetWarpSize<DevOacc>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getWarpSize(DevOacc const& dev) -> std::size_t
             {
                 alpaka::ignore_unused(dev);
@@ -235,12 +208,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC device reset trait specialization.
         template<>
         struct Reset<DevOacc>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto reset(DevOacc const& dev) -> void
             {
                 alpaka::ignore_unused(dev); //! \TODO
@@ -253,7 +224,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The OpenACC device memory buffer type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct BufType<DevOacc, TElem, TDim, TIdx>
@@ -261,7 +231,6 @@ namespace alpaka
             using type = BufOacc<TElem, TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The OpenACC device platform type trait specialization.
         template<>
         struct PltfType<DevOacc>
@@ -287,7 +256,6 @@ namespace alpaka
             using type = QueueOaccNonBlocking;
         };
 
-        //#############################################################################
         //! The thread OpenACC device wait specialization.
         //!
         //! Blocks until the device has completed all preceding requested tasks.
@@ -295,7 +263,6 @@ namespace alpaka
         template<>
         struct CurrentThreadWaitFor<DevOacc>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto currentThreadWaitFor(DevOacc const& dev) -> void
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -40,27 +40,19 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             //! The Omp5 device implementation.
             class DevOmp5Impl
             {
             public:
-                //-----------------------------------------------------------------------------
                 DevOmp5Impl(int iDevice) noexcept : m_iDevice(iDevice)
                 {
                 }
-                //-----------------------------------------------------------------------------
                 DevOmp5Impl(DevOmp5Impl const&) = delete;
-                //-----------------------------------------------------------------------------
                 DevOmp5Impl(DevOmp5Impl&&) = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(DevOmp5Impl const&) -> DevOmp5Impl& = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(DevOmp5Impl&&) -> DevOmp5Impl& = delete;
-                //-----------------------------------------------------------------------------
                 ~DevOmp5Impl() = default;
 
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST auto getAllExistingQueues() const
                     -> std::vector<std::shared_ptr<IGenericThreadsQueue<DevOmp5>>>
                 {
@@ -85,7 +77,6 @@ namespace alpaka
                     return vspQueues;
                 }
 
-                //-----------------------------------------------------------------------------
                 //! Registers the given queue on this device.
                 //! NOTE: Every queue has to be registered for correct functionality of device wait operations!
                 ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<IGenericThreadsQueue<DevOmp5>> spQueue) -> void
@@ -108,7 +99,6 @@ namespace alpaka
             };
         } // namespace detail
     } // namespace omp5
-    //#############################################################################
     //! The Omp5 device handle.
     class DevOmp5
         : public concepts::Implements<ConceptCurrentThreadWaitFor, DevOmp5>
@@ -116,31 +106,23 @@ namespace alpaka
     {
         friend struct traits::GetDevByIdx<PltfOmp5>;
 
-        //-----------------------------------------------------------------------------
         DevOmp5(int iDevice) : m_spDevOmp5Impl(std::make_shared<omp5::detail::DevOmp5Impl>(iDevice))
         {
         }
 
     public:
-        //-----------------------------------------------------------------------------
         DevOmp5(DevOmp5 const&) = default;
-        //-----------------------------------------------------------------------------
         DevOmp5(DevOmp5&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(DevOmp5 const&) -> DevOmp5& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(DevOmp5&&) -> DevOmp5& = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator==(DevOmp5 const& rhs) const -> bool
         {
             return m_spDevOmp5Impl->iDevice() == rhs.m_spDevOmp5Impl->iDevice();
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator!=(DevOmp5 const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        //-----------------------------------------------------------------------------
         ~DevOmp5() = default;
         int iDevice() const
         {
@@ -152,7 +134,6 @@ namespace alpaka
             return m_spDevOmp5Impl->getAllExistingQueues();
         }
 
-        //-----------------------------------------------------------------------------
         //! Registers the given queue on this device.
         //! NOTE: Every queue has to be registered for correct functionality of device wait operations!
         ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<IGenericThreadsQueue<DevOmp5>> spQueue) const -> void
@@ -166,26 +147,22 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The OpenMP 5.0 device name get trait specialization.
         template<>
         struct GetName<DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getName(DevOmp5 const&) -> std::string
             {
                 return std::string("OMP5 target");
             }
         };
 
-        //#############################################################################
         //! The OpenMP 5.0 device available memory get trait specialization.
         //!
         //! Returns 0, because querying target mem is not supported by OpenMP
         template<>
         struct GetMemBytes<DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getMemBytes(DevOmp5 const& dev) -> std::size_t
             {
                 alpaka::ignore_unused(dev); //! \todo query device .. somehow
@@ -194,14 +171,12 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenMP 5.0 device free memory get trait specialization.
         //!
         //! Returns 0, because querying free target mem is not supported by OpenMP
         template<>
         struct GetFreeMemBytes<DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevOmp5 const& dev) -> std::size_t
             {
                 alpaka::ignore_unused(dev);
@@ -210,12 +185,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenMP 5.0 device warp size get trait specialization.
         template<>
         struct GetWarpSize<DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getWarpSize(DevOmp5 const& dev) -> std::size_t
             {
                 alpaka::ignore_unused(dev);
@@ -224,12 +197,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenMP 5.0 device reset trait specialization.
         template<>
         struct Reset<DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto reset(DevOmp5 const& dev) -> void
             {
                 alpaka::ignore_unused(dev); //! \TODO
@@ -242,7 +213,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The OpenMP 5.0 device memory buffer type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct BufType<DevOmp5, TElem, TDim, TIdx>
@@ -250,7 +220,6 @@ namespace alpaka
             using type = BufOmp5<TElem, TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The OpenMP 5.0 device platform type trait specialization.
         template<>
         struct PltfType<DevOmp5>
@@ -275,7 +244,6 @@ namespace alpaka
             using type = QueueOmp5NonBlocking;
         };
 
-        //#############################################################################
         //! The thread Omp5 device wait specialization.
         //!
         //! Blocks until the device has completed all preceding requested tasks.
@@ -283,7 +251,6 @@ namespace alpaka
         template<>
         struct CurrentThreadWaitFor<DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto currentThreadWaitFor(DevOmp5 const& dev) -> void
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -46,7 +46,6 @@ namespace alpaka
     class QueueUniformCudaHipRtBlocking;
     class QueueUniformCudaHipRtNonBlocking;
 
-    //#############################################################################
     //! The CUDA/HIP RT device handle.
     class DevUniformCudaHipRt
         : public concepts::Implements<ConceptCurrentThreadWaitFor, DevUniformCudaHipRt>
@@ -55,29 +54,21 @@ namespace alpaka
         friend struct traits::GetDevByIdx<PltfUniformCudaHipRt>;
 
     protected:
-        //-----------------------------------------------------------------------------
         DevUniformCudaHipRt() = default;
 
     public:
-        //-----------------------------------------------------------------------------
         DevUniformCudaHipRt(DevUniformCudaHipRt const&) = default;
-        //-----------------------------------------------------------------------------
         DevUniformCudaHipRt(DevUniformCudaHipRt&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(DevUniformCudaHipRt const&) -> DevUniformCudaHipRt& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(DevUniformCudaHipRt&&) -> DevUniformCudaHipRt& = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator==(DevUniformCudaHipRt const& rhs) const -> bool
         {
             return m_iDevice == rhs.m_iDevice;
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator!=(DevUniformCudaHipRt const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        //-----------------------------------------------------------------------------
         ~DevUniformCudaHipRt() = default;
 
     public:
@@ -93,12 +84,10 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CUDA/HIP RT device name get trait specialization.
         template<>
         struct GetName<DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getName(DevUniformCudaHipRt const& dev) -> std::string
             {
                 // There is cuda/hip-DeviceGetAttribute as faster alternative to cuda/hip-GetDeviceProperties to get a
@@ -114,12 +103,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT device available memory get trait specialization.
         template<>
         struct GetMemBytes<DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt const& dev) -> std::size_t
             {
                 // Set the current device to wait for.
@@ -134,12 +121,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT device free memory get trait specialization.
         template<>
         struct GetFreeMemBytes<DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevUniformCudaHipRt const& dev) -> std::size_t
             {
                 // Set the current device to wait for.
@@ -154,12 +139,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT device warp size get trait specialization.
         template<>
         struct GetWarpSize<DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getWarpSize(DevUniformCudaHipRt const& dev) -> std::size_t
             {
 #    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
@@ -173,12 +156,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT device reset trait specialization.
         template<>
         struct Reset<DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto reset(DevUniformCudaHipRt const& dev) -> void
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -195,7 +176,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CUDA/HIP RT device memory buffer type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct BufType<DevUniformCudaHipRt, TElem, TDim, TIdx>
@@ -203,7 +183,6 @@ namespace alpaka
             using type = BufUniformCudaHipRt<TElem, TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT device platform type trait specialization.
         template<>
         struct PltfType<DevUniformCudaHipRt>
@@ -211,7 +190,6 @@ namespace alpaka
             using type = PltfUniformCudaHipRt;
         };
 
-        //#############################################################################
         //! The thread CUDA/HIP device wait specialization.
         //!
         //! Blocks until the device has completed all preceding requested tasks.
@@ -219,7 +197,6 @@ namespace alpaka
         template<>
         struct CurrentThreadWaitFor<DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto currentThreadWaitFor(DevUniformCudaHipRt const& dev) -> void
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;

--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -14,47 +14,38 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The device traits.
     namespace traits
     {
-        //#############################################################################
         //! The device type trait.
         template<typename T, typename TSfinae = void>
         struct DevType;
 
-        //#############################################################################
         //! The device get trait.
         template<typename T, typename TSfinae = void>
         struct GetDev;
 
-        //#############################################################################
         //! The device name get trait.
         template<typename TDev, typename TSfinae = void>
         struct GetName;
 
-        //#############################################################################
         //! The device memory size get trait.
         template<typename TDev, typename TSfinae = void>
         struct GetMemBytes;
 
-        //#############################################################################
         //! The device free memory size get trait.
         template<typename T, typename TSfinae = void>
         struct GetFreeMemBytes;
 
-        //#############################################################################
         //! The device warp size get trait.
         template<typename T, typename TSfinae = void>
         struct GetWarpSize;
 
-        //#############################################################################
         //! The device reset trait.
         template<typename T, typename TSfinae = void>
         struct Reset;
     } // namespace traits
 
-    //#############################################################################
     //! The device type trait alias template to remove the ::type.
     template<typename T>
     using Dev = typename traits::DevType<T>::type;
@@ -63,7 +54,6 @@ namespace alpaka
 
     struct ConceptDev;
 
-    //-----------------------------------------------------------------------------
     //! \return The device this object is bound to.
     template<typename T>
     ALPAKA_FN_HOST auto getDev(T const& t)
@@ -72,7 +62,6 @@ namespace alpaka
         return traits::GetDev<ImplementationBase>::getDev(t);
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The device name.
     template<typename TDev>
     ALPAKA_FN_HOST auto getName(TDev const& dev) -> std::string
@@ -80,7 +69,6 @@ namespace alpaka
         return traits::GetName<TDev>::getName(dev);
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The memory on the device in Bytes. Returns 0 if querying memory
     //!  is not supported.
     template<typename TDev>
@@ -89,7 +77,6 @@ namespace alpaka
         return traits::GetMemBytes<TDev>::getMemBytes(dev);
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The free memory on the device in Bytes.
     //
     //! \note Do not use this query if getMemBytes returned 0.
@@ -99,7 +86,6 @@ namespace alpaka
         return traits::GetFreeMemBytes<TDev>::getFreeMemBytes(dev);
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The warp size on the device in number of threads.
     template<typename TDev>
     ALPAKA_FN_HOST auto getWarpSize(TDev const& dev) -> std::size_t
@@ -107,7 +93,6 @@ namespace alpaka
         return traits::GetWarpSize<TDev>::getWarpSize(dev);
     }
 
-    //-----------------------------------------------------------------------------
     //! Resets the device.
     //! What this method does is dependent on the accelerator.
     template<typename TDev>
@@ -118,7 +103,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! Get device type
         template<typename TDev>
         struct DevType<TDev, typename std::enable_if<concepts::ImplementsConcept<ConceptDev, TDev>::value>::type>

--- a/include/alpaka/dev/cpu/SysInfo.hpp
+++ b/include/alpaka/dev/cpu/SysInfo.hpp
@@ -52,7 +52,6 @@ namespace alpaka
 #    if BOOST_COMP_GNUC || BOOST_COMP_CLANG || (!BOOST_COMP_MSVC_EMULATED && defined(__INTEL_COMPILER))               \
         || BOOST_COMP_PGI
 #        include <cpuid.h>
-            //-----------------------------------------------------------------------------
             inline auto cpuid(std::uint32_t const level, std::uint32_t const subfunction, std::uint32_t ex[4]) -> void
             {
                 __cpuid_count(level, subfunction, ex[0], ex[1], ex[2], ex[3]);
@@ -60,13 +59,11 @@ namespace alpaka
 
 #    elif BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED) || defined(__INTEL_COMPILER)
 #        include <intrin.h>
-            //-----------------------------------------------------------------------------
             inline auto cpuid(std::uint32_t const level, std::uint32_t const subfunction, std::uint32_t ex[4]) -> void
             {
                 __cpuidex(reinterpret_cast<int*>(ex), level, subfunction);
             }
 #    else
-            //-----------------------------------------------------------------------------
             inline auto cpuid(std::uint32_t const level, std::uint32_t const subfunction, std::uint32_t ex[4]) -> void
             {
                 ex[0] = ex[2] = ex[3] = NO_CPUID;
@@ -80,7 +77,6 @@ namespace alpaka
                 ex[1] = UNKNOWN_CPU;
             }
 #endif
-            //-----------------------------------------------------------------------------
             //! \return The name of the CPU the code is running on.
             inline auto getCpuName() -> std::string
             {
@@ -127,7 +123,6 @@ namespace alpaka
                 return std::string("unknown");
 #endif
             }
-            //-----------------------------------------------------------------------------
             //! \return The total number of bytes of global memory.
             //! Adapted from David Robert Nadeau:
             //! http://nadeausoftware.com/articles/2012/09/c_c_tip_how_get_physical_memory_size_system
@@ -200,7 +195,6 @@ namespace alpaka
 #    error "getTotalGlobalMemSizeBytes not implemented for this system!"
 #endif
             } // namespace detail
-            //-----------------------------------------------------------------------------
             //! \return The free number of bytes of global memory.
             //! \throws std::logic_error if not implemented on the system and std::runtime_error on other errors.
             inline auto getFreeGlobalMemSizeBytes() -> std::size_t

--- a/include/alpaka/dev/cpu/Wait.hpp
+++ b/include/alpaka/dev/cpu/Wait.hpp
@@ -17,7 +17,6 @@ namespace alpaka
 {
     namespace traits
     {
-        //#############################################################################
         //! The CPU device thread wait specialization.
         //!
         //! Blocks until the device has completed all preceding requested tasks.
@@ -25,7 +24,6 @@ namespace alpaka
         template<>
         struct CurrentThreadWaitFor<DevCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto currentThreadWaitFor(DevCpu const& dev) -> void
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;

--- a/include/alpaka/dim/DimArithmetic.hpp
+++ b/include/alpaka/dim/DimArithmetic.hpp
@@ -15,11 +15,9 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     // Trait specializations for unsigned integral types.
     namespace traits
     {
-        //#############################################################################
         //! The arithmetic type dimension getter trait specialization.
         template<typename T>
         struct DimType<T, std::enable_if_t<std::is_arithmetic<T>::value>>

--- a/include/alpaka/dim/DimIntegralConst.hpp
+++ b/include/alpaka/dim/DimIntegralConst.hpp
@@ -15,7 +15,6 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     // N(th) dimension(s).
     template<std::size_t N>
     using DimInt = std::integral_constant<std::size_t, N>;

--- a/include/alpaka/dim/Traits.hpp
+++ b/include/alpaka/dim/Traits.hpp
@@ -11,17 +11,14 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The dimension traits.
     namespace traits
     {
-        //#############################################################################
         //! The dimension getter type trait.
         template<typename T, typename TSfinae = void>
         struct DimType;
     } // namespace traits
 
-    //#############################################################################
     //! The dimension type trait alias template to remove the ::type.
     template<typename T>
     using Dim = typename traits::DimType<T>::type;

--- a/include/alpaka/elem/Traits.hpp
+++ b/include/alpaka/elem/Traits.hpp
@@ -13,26 +13,21 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The element traits.
     namespace traits
     {
-        //#############################################################################
         //! The element type trait.
         template<typename TView, typename TSfinae = void>
         struct ElemType;
     } // namespace traits
 
-    //#############################################################################
     //! The element type trait alias template to remove the ::type.
     template<typename TView>
     using Elem = std::remove_volatile_t<typename traits::ElemType<TView>::type>;
 
-    //-----------------------------------------------------------------------------
     // Trait specializations for unsigned integral types.
     namespace traits
     {
-        //#############################################################################
         //! The fundamental type elem type trait specialization.
         template<typename T>
         struct ElemType<T, std::enable_if_t<std::is_fundamental<T>::value>>

--- a/include/alpaka/event/EventGenericThreads.hpp
+++ b/include/alpaka/event/EventGenericThreads.hpp
@@ -31,14 +31,12 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             //! The CPU device event implementation.
             template<typename TDev>
             class EventGenericThreadsImpl final
                 : public concepts::Implements<ConceptCurrentThreadWaitFor, EventGenericThreadsImpl<TDev>>
             {
             public:
-                //-----------------------------------------------------------------------------
                 EventGenericThreadsImpl(TDev const& dev) noexcept
                     : m_dev(dev)
                     , m_mutex()
@@ -46,24 +44,17 @@ namespace alpaka
                     , m_LastReadyEnqueueCount(0u)
                 {
                 }
-                //-----------------------------------------------------------------------------
                 EventGenericThreadsImpl(EventGenericThreadsImpl<TDev> const&) = delete;
-                //-----------------------------------------------------------------------------
                 EventGenericThreadsImpl(EventGenericThreadsImpl<TDev>&&) = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(EventGenericThreadsImpl<TDev> const&) -> EventGenericThreadsImpl<TDev>& = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(EventGenericThreadsImpl<TDev>&&) -> EventGenericThreadsImpl<TDev>& = delete;
-                //-----------------------------------------------------------------------------
                 ~EventGenericThreadsImpl() noexcept = default;
 
-                //-----------------------------------------------------------------------------
                 auto isReady() noexcept -> bool
                 {
                     return (m_LastReadyEnqueueCount == m_enqueueCount);
                 }
 
-                //-----------------------------------------------------------------------------
                 auto wait(std::size_t const& enqueueCount, std::unique_lock<std::mutex>& lk) const noexcept -> void
                 {
                     ALPAKA_ASSERT(enqueueCount <= m_enqueueCount);
@@ -91,7 +82,6 @@ namespace alpaka
         } // namespace detail
     } // namespace generic
 
-    //#############################################################################
     //! The CPU device event.
     template<typename TDev>
     class EventGenericThreads final
@@ -99,32 +89,24 @@ namespace alpaka
         , public concepts::Implements<ConceptGetDev, EventGenericThreads<TDev>>
     {
     public:
-        //-----------------------------------------------------------------------------
         //! \param bBusyWaiting Unused. EventGenericThreads never does busy waiting.
         EventGenericThreads(TDev const& dev, bool bBusyWaiting = true)
             : m_spEventImpl(std::make_shared<generic::detail::EventGenericThreadsImpl<TDev>>(dev))
         {
             alpaka::ignore_unused(bBusyWaiting);
         }
-        //-----------------------------------------------------------------------------
         EventGenericThreads(EventGenericThreads<TDev> const&) = default;
-        //-----------------------------------------------------------------------------
         EventGenericThreads(EventGenericThreads<TDev>&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(EventGenericThreads<TDev> const&) -> EventGenericThreads<TDev>& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(EventGenericThreads<TDev>&&) -> EventGenericThreads<TDev>& = default;
-        //-----------------------------------------------------------------------------
         auto operator==(EventGenericThreads<TDev> const& rhs) const -> bool
         {
             return (m_spEventImpl == rhs.m_spEventImpl);
         }
-        //-----------------------------------------------------------------------------
         auto operator!=(EventGenericThreads<TDev> const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        //-----------------------------------------------------------------------------
         ~EventGenericThreads() = default;
 
     public:
@@ -132,24 +114,20 @@ namespace alpaka
     };
     namespace traits
     {
-        //#############################################################################
         //! The CPU device event device get trait specialization.
         template<typename TDev>
         struct GetDev<EventGenericThreads<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDev(EventGenericThreads<TDev> const& event) -> TDev
             {
                 return event.m_spEventImpl->m_dev;
             }
         };
 
-        //#############################################################################
         //! The CPU device event test trait specialization.
         template<typename TDev>
         struct IsComplete<EventGenericThreads<TDev>>
         {
-            //-----------------------------------------------------------------------------
             //! \return If the event is not waiting within a queue (not enqueued or already handled).
             ALPAKA_FN_HOST static auto isComplete(EventGenericThreads<TDev> const& event) -> bool
             {
@@ -159,12 +137,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU non-blocking device queue enqueue trait specialization.
         template<typename TDev>
         struct Enqueue<alpaka::generic::detail::QueueGenericThreadsNonBlockingImpl<TDev>, EventGenericThreads<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 alpaka::generic::detail::QueueGenericThreadsNonBlockingImpl<TDev>& queueImpl,
                 EventGenericThreads<TDev>& event) -> void
@@ -201,12 +177,10 @@ namespace alpaka
 #endif
             }
         };
-        //#############################################################################
         //! The CPU non-blocking device queue enqueue trait specialization.
         template<typename TDev>
         struct Enqueue<QueueGenericThreadsNonBlocking<TDev>, EventGenericThreads<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueGenericThreadsNonBlocking<TDev>& queue,
                 EventGenericThreads<TDev>& event) -> void
@@ -216,12 +190,10 @@ namespace alpaka
                 alpaka::enqueue(*queue.m_spQueueImpl, event);
             }
         };
-        //#############################################################################
         //! The CPU blocking device queue enqueue trait specialization.
         template<typename TDev>
         struct Enqueue<alpaka::generic::detail::QueueGenericThreadsBlockingImpl<TDev>, EventGenericThreads<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 alpaka::generic::detail::QueueGenericThreadsBlockingImpl<TDev>& queueImpl,
                 EventGenericThreads<TDev>& event) -> void
@@ -252,12 +224,10 @@ namespace alpaka
                 promise.set_value();
             }
         };
-        //#############################################################################
         //! The CPU blocking device queue enqueue trait specialization.
         template<typename TDev>
         struct Enqueue<QueueGenericThreadsBlocking<TDev>, EventGenericThreads<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueGenericThreadsBlocking<TDev>& queue,
                 EventGenericThreads<TDev>& event) -> void
@@ -295,7 +265,6 @@ namespace alpaka
             }
         } // namespace generic
 
-        //#############################################################################
         //! The CPU device event thread wait trait specialization.
         //!
         //! Waits until the event itself and therefore all tasks preceding it in the queue it is enqueued to have been
@@ -303,13 +272,11 @@ namespace alpaka
         template<typename TDev>
         struct CurrentThreadWaitFor<EventGenericThreads<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto currentThreadWaitFor(EventGenericThreads<TDev> const& event) -> void
             {
                 wait(*event.m_spEventImpl);
             }
         };
-        //#############################################################################
         //! The CPU device event implementation thread wait trait specialization.
         //!
         //! Waits until the event itself and therefore all tasks preceding it in the queue it is enqueued to have been
@@ -319,7 +286,6 @@ namespace alpaka
         template<typename TDev>
         struct CurrentThreadWaitFor<alpaka::generic::detail::EventGenericThreadsImpl<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto currentThreadWaitFor(
                 alpaka::generic::detail::EventGenericThreadsImpl<TDev> const& eventImpl) -> void
             {
@@ -329,14 +295,12 @@ namespace alpaka
                 eventImpl.wait(enqueueCount, lk);
             }
         };
-        //#############################################################################
         //! The CPU non-blocking device queue event wait trait specialization.
         template<typename TDev>
         struct WaiterWaitFor<
             alpaka::generic::detail::QueueGenericThreadsNonBlockingImpl<TDev>,
             EventGenericThreads<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto waiterWaitFor(
 #if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_PTX)
                 alpaka::generic::detail::QueueGenericThreadsNonBlockingImpl<TDev>& queueImpl,
@@ -367,12 +331,10 @@ namespace alpaka
                 }
             }
         };
-        //#############################################################################
         //! The CPU non-blocking device queue event wait trait specialization.
         template<typename TDev>
         struct WaiterWaitFor<QueueGenericThreadsNonBlocking<TDev>, EventGenericThreads<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto waiterWaitFor(
                 QueueGenericThreadsNonBlocking<TDev>& queue,
                 EventGenericThreads<TDev> const& event) -> void
@@ -380,12 +342,10 @@ namespace alpaka
                 wait(*queue.m_spQueueImpl, event);
             }
         };
-        //#############################################################################
         //! The CPU blocking device queue event wait trait specialization.
         template<typename TDev>
         struct WaiterWaitFor<alpaka::generic::detail::QueueGenericThreadsBlockingImpl<TDev>, EventGenericThreads<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto waiterWaitFor(
                 alpaka::generic::detail::QueueGenericThreadsBlockingImpl<TDev>& queueImpl,
                 EventGenericThreads<TDev> const& event) -> void
@@ -396,12 +356,10 @@ namespace alpaka
                 wait(*event.m_spEventImpl);
             }
         };
-        //#############################################################################
         //! The CPU blocking device queue event wait trait specialization.
         template<typename TDev>
         struct WaiterWaitFor<QueueGenericThreadsBlocking<TDev>, EventGenericThreads<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto waiterWaitFor(
                 QueueGenericThreadsBlocking<TDev>& queue,
                 EventGenericThreads<TDev> const& event) -> void
@@ -409,7 +367,6 @@ namespace alpaka
                 wait(*queue.m_spQueueImpl, event);
             }
         };
-        //#############################################################################
         //! The CPU non-blocking device event wait trait specialization.
         //!
         //! Any future work submitted in any queue of this device will wait for event to complete before beginning
@@ -417,7 +374,6 @@ namespace alpaka
         template<typename TDev>
         struct WaiterWaitFor<TDev, EventGenericThreads<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto waiterWaitFor(TDev& dev, EventGenericThreads<TDev> const& event) -> void
             {
                 // Get all the queues on the device at the time of invocation.
@@ -434,7 +390,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU non-blocking device queue thread wait trait specialization.
         //!
         //! Blocks execution of the calling thread until the queue has finished processing all previously requested
@@ -442,7 +397,6 @@ namespace alpaka
         template<typename TDev>
         struct CurrentThreadWaitFor<QueueGenericThreadsNonBlocking<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto currentThreadWaitFor(QueueGenericThreadsNonBlocking<TDev> const& queue) -> void
             {
                 EventGenericThreads<TDev> event(getDev(queue));

--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -46,12 +46,10 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             //! The CUDA/HIP RT device event implementation.
             class EventUniformCudaHipImpl final
             {
             public:
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST EventUniformCudaHipImpl(DevUniformCudaHipRt const& dev, bool bBusyWait)
                     : m_dev(dev)
                     , m_UniformCudaHipEvent()
@@ -75,15 +73,10 @@ namespace alpaka
                         (bBusyWait ? ALPAKA_API_PREFIX(EventDefault) : ALPAKA_API_PREFIX(EventBlockingSync))
                             | ALPAKA_API_PREFIX(EventDisableTiming)));
                 }
-                //-----------------------------------------------------------------------------
                 EventUniformCudaHipImpl(EventUniformCudaHipImpl const&) = delete;
-                //-----------------------------------------------------------------------------
                 EventUniformCudaHipImpl(EventUniformCudaHipImpl&&) = default;
-                //-----------------------------------------------------------------------------
                 auto operator=(EventUniformCudaHipImpl const&) -> EventUniformCudaHipImpl& = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(EventUniformCudaHipImpl&&) -> EventUniformCudaHipImpl& = delete;
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST ~EventUniformCudaHipImpl()
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -107,38 +100,29 @@ namespace alpaka
         } // namespace detail
     } // namespace uniform_cuda_hip
 
-    //#############################################################################
     //! The CUDA/HIP RT device event.
     class EventUniformCudaHipRt final
         : public concepts::Implements<ConceptCurrentThreadWaitFor, EventUniformCudaHipRt>
         , public concepts::Implements<ConceptGetDev, EventUniformCudaHipRt>
     {
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST EventUniformCudaHipRt(DevUniformCudaHipRt const& dev, bool bBusyWait = true)
             : m_spEventImpl(std::make_shared<uniform_cuda_hip::detail::EventUniformCudaHipImpl>(dev, bBusyWait))
         {
             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
         }
-        //-----------------------------------------------------------------------------
         EventUniformCudaHipRt(EventUniformCudaHipRt const&) = default;
-        //-----------------------------------------------------------------------------
         EventUniformCudaHipRt(EventUniformCudaHipRt&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(EventUniformCudaHipRt const&) -> EventUniformCudaHipRt& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(EventUniformCudaHipRt&&) -> EventUniformCudaHipRt& = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator==(EventUniformCudaHipRt const& rhs) const -> bool
         {
             return (m_spEventImpl == rhs.m_spEventImpl);
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator!=(EventUniformCudaHipRt const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        //-----------------------------------------------------------------------------
         ~EventUniformCudaHipRt() = default;
 
     public:
@@ -146,24 +130,20 @@ namespace alpaka
     };
     namespace traits
     {
-        //#############################################################################
         //! The CUDA/HIP RT device event device get trait specialization.
         template<>
         struct GetDev<EventUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDev(EventUniformCudaHipRt const& event) -> DevUniformCudaHipRt
             {
                 return event.m_spEventImpl->m_dev;
             }
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT device event test trait specialization.
         template<>
         struct IsComplete<EventUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto isComplete(EventUniformCudaHipRt const& event) -> bool
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -177,12 +157,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT queue enqueue trait specialization.
         template<>
         struct Enqueue<QueueUniformCudaHipRtNonBlocking, EventUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(QueueUniformCudaHipRtNonBlocking& queue, EventUniformCudaHipRt& event)
                 -> void
             {
@@ -193,12 +171,10 @@ namespace alpaka
                     queue.m_spQueueImpl->m_UniformCudaHipQueue));
             }
         };
-        //#############################################################################
         //! The CUDA/HIP RT queue enqueue trait specialization.
         template<>
         struct Enqueue<QueueUniformCudaHipRtBlocking, EventUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(QueueUniformCudaHipRtBlocking& queue, EventUniformCudaHipRt& event)
                 -> void
             {
@@ -210,7 +186,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT device event thread wait trait specialization.
         //!
         //! Waits until the event itself and therefore all tasks preceding it in the queue it is enqueued to have been
@@ -218,7 +193,6 @@ namespace alpaka
         template<>
         struct CurrentThreadWaitFor<EventUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto currentThreadWaitFor(EventUniformCudaHipRt const& event) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -228,12 +202,10 @@ namespace alpaka
                     ALPAKA_API_PREFIX(EventSynchronize)(event.m_spEventImpl->m_UniformCudaHipEvent));
             }
         };
-        //#############################################################################
         //! The CUDA/HIP RT queue event wait trait specialization.
         template<>
         struct WaiterWaitFor<QueueUniformCudaHipRtNonBlocking, EventUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto waiterWaitFor(
                 QueueUniformCudaHipRtNonBlocking& queue,
                 EventUniformCudaHipRt const& event) -> void
@@ -246,12 +218,10 @@ namespace alpaka
                     0));
             }
         };
-        //#############################################################################
         //! The CUDA/HIP RT queue event wait trait specialization.
         template<>
         struct WaiterWaitFor<QueueUniformCudaHipRtBlocking, EventUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto waiterWaitFor(
                 QueueUniformCudaHipRtBlocking& queue,
                 EventUniformCudaHipRt const& event) -> void
@@ -264,7 +234,6 @@ namespace alpaka
                     0));
             }
         };
-        //#############################################################################
         //! The CUDA/HIP RT device event wait trait specialization.
         //!
         //! Any future work submitted in any queue of this device will wait for event to complete before beginning
@@ -272,7 +241,6 @@ namespace alpaka
         template<>
         struct WaiterWaitFor<DevUniformCudaHipRt, EventUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto waiterWaitFor(DevUniformCudaHipRt& dev, EventUniformCudaHipRt const& event)
                 -> void
             {

--- a/include/alpaka/event/Traits.hpp
+++ b/include/alpaka/event/Traits.hpp
@@ -14,27 +14,22 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The event management traits.
     namespace traits
     {
-        //#############################################################################
         //! The event type trait.
         template<typename T, typename TSfinae = void>
         struct EventType;
 
-        //#############################################################################
         //! The event tester trait.
         template<typename TEvent, typename TSfinae = void>
         struct IsComplete;
     } // namespace traits
 
-    //#############################################################################
     //! The event type trait alias template to remove the ::type.
     template<typename T>
     using Event = typename traits::EventType<T>::type;
 
-    //-----------------------------------------------------------------------------
     //! Tests if the given event has already been completed.
     //!
     //! \warning This function is allowed to return false negatives. An already completed event can reported as

--- a/include/alpaka/extent/Traits.hpp
+++ b/include/alpaka/extent/Traits.hpp
@@ -21,15 +21,12 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The extent specifics.
     namespace extent
     {
-        //-----------------------------------------------------------------------------
         //! The extent traits.
         namespace traits
         {
-            //#############################################################################
             //! The extent get trait.
             //!
             //! If not specialized explicitly it returns 1.
@@ -43,13 +40,11 @@ namespace alpaka
                 }
             };
 
-            //#############################################################################
             //! The extent set trait.
             template<typename TIdxIntegralConst, typename TExtent, typename TExtentVal, typename TSfinae = void>
             struct SetExtent;
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! \return The extent in the given dimension.
         ALPAKA_NO_HOST_ACC_WARNING
         template<std::size_t Tidx, typename TExtent>
@@ -57,7 +52,6 @@ namespace alpaka
         {
             return traits::GetExtent<DimInt<Tidx>, TExtent>::getExtent(extent);
         }
-        //-----------------------------------------------------------------------------
         //! \return The width.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TExtent>
@@ -65,7 +59,6 @@ namespace alpaka
         {
             return getExtent<Dim<TExtent>::value - 1u>(extent);
         }
-        //-----------------------------------------------------------------------------
         //! \return The height.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TExtent>
@@ -73,7 +66,6 @@ namespace alpaka
         {
             return getExtent<Dim<TExtent>::value - 2u>(extent);
         }
-        //-----------------------------------------------------------------------------
         //! \return The depth.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TExtent>
@@ -84,7 +76,6 @@ namespace alpaka
 
         namespace detail
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename TExtent, size_t... TIndices>
             ALPAKA_FN_HOST_ACC auto getExtentProductInternal(
@@ -97,7 +88,6 @@ namespace alpaka
             }
         } // namespace detail
 
-        //-----------------------------------------------------------------------------
         //! \return The product of the extent.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TExtent>
@@ -107,7 +97,6 @@ namespace alpaka
             return detail::getExtentProductInternal(extent, IdxSequence());
         }
 
-        //-----------------------------------------------------------------------------
         //! Sets the extent in the given dimension.
         ALPAKA_NO_HOST_ACC_WARNING
         template<std::size_t Tidx, typename TExtent, typename TExtentVal>
@@ -115,7 +104,6 @@ namespace alpaka
         {
             traits::SetExtent<DimInt<Tidx>, TExtent, TExtentVal>::setExtent(extent, extentVal);
         }
-        //-----------------------------------------------------------------------------
         //! Sets the width.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TExtent, typename TWidth>
@@ -123,7 +111,6 @@ namespace alpaka
         {
             setExtent<Dim<TExtent>::value - 1u>(extent, width);
         }
-        //-----------------------------------------------------------------------------
         //! Sets the height.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TExtent, typename THeight>
@@ -131,7 +118,6 @@ namespace alpaka
         {
             setExtent<Dim<TExtent>::value - 2u>(extent, height);
         }
-        //-----------------------------------------------------------------------------
         //! Sets the depth.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TExtent, typename TDepth>
@@ -140,11 +126,9 @@ namespace alpaka
             setExtent<Dim<TExtent>::value - 3u>(extent, depth);
         }
 
-        //-----------------------------------------------------------------------------
         // Trait specializations for unsigned integral types.
         namespace traits
         {
-            //#############################################################################
             //! The unsigned integral width get trait specialization.
             template<typename TExtent>
             struct GetExtent<DimInt<0u>, TExtent, std::enable_if_t<std::is_integral<TExtent>::value>>
@@ -155,7 +139,6 @@ namespace alpaka
                     return extent;
                 }
             };
-            //#############################################################################
             //! The unsigned integral width set trait specialization.
             template<typename TExtent, typename TExtentVal>
             struct SetExtent<DimInt<0u>, TExtent, TExtentVal, std::enable_if_t<std::is_integral<TExtent>::value>>

--- a/include/alpaka/idx/Accessors.hpp
+++ b/include/alpaka/idx/Accessors.hpp
@@ -23,7 +23,6 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! Get the indices requested.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TOrigin, typename TUnit, typename TIdx, typename TWorkDiv>
@@ -31,7 +30,6 @@ namespace alpaka
     {
         return traits::GetIdx<TIdx, TOrigin, TUnit>::getIdx(idx, workDiv);
     }
-    //-----------------------------------------------------------------------------
     //! Get the indices requested.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TOrigin, typename TUnit, typename TIdxWorkDiv>
@@ -42,13 +40,11 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The grid block index get trait specialization for classes with IdxGbBase member type.
         template<typename TIdxGb>
         struct GetIdx<TIdxGb, origin::Grid, unit::Blocks>
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptIdxGb, TIdxGb>;
-            //-----------------------------------------------------------------------------
             //! \return The index of the current thread in the grid.
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename TWorkDiv>
@@ -59,13 +55,11 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The block thread index get trait specialization for classes with IdxBtBase member type.
         template<typename TIdxBt>
         struct GetIdx<TIdxBt, origin::Block, unit::Threads>
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptIdxBt, TIdxBt>;
-            //-----------------------------------------------------------------------------
             //! \return The index of the current thread in the grid.
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename TWorkDiv>
@@ -76,12 +70,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The grid thread index get trait specialization.
         template<typename TIdx>
         struct GetIdx<TIdx, origin::Grid, unit::Threads>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current thread in the grid.
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename TWorkDiv>
@@ -93,7 +85,6 @@ namespace alpaka
             }
         };
     } // namespace traits
-    //-----------------------------------------------------------------------------
     //! Get the index of the first element this thread computes.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TIdxWorkDiv, typename TGridThreadIdx, typename TThreadElemExtent>
@@ -106,7 +97,6 @@ namespace alpaka
 
         return gridThreadIdx * threadElemExtent;
     }
-    //-----------------------------------------------------------------------------
     //! Get the index of the first element this thread computes.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TIdxWorkDiv, typename TGridThreadIdx>
@@ -116,7 +106,6 @@ namespace alpaka
         auto const threadElemExtent(alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(idxWorkDiv));
         return getIdxThreadFirstElem(idxWorkDiv, gridThreadIdx, threadElemExtent);
     }
-    //-----------------------------------------------------------------------------
     //! Get the index of the first element this thread computes.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TIdxWorkDiv>

--- a/include/alpaka/idx/MapIdx.hpp
+++ b/include/alpaka/idx/MapIdx.hpp
@@ -19,16 +19,13 @@ namespace alpaka
 {
     namespace detail
     {
-        //#############################################################################
         //! Maps a linear index to a N dimensional index.
         template<std::size_t TidxDimOut, std::size_t TidxDimIn, typename TSfinae = void>
         struct MapIdx;
-        //#############################################################################
         //! Maps a N dimensional index to the same N dimensional index.
         template<std::size_t TidxDim>
         struct MapIdx<TidxDim, TidxDim>
         {
-            //-----------------------------------------------------------------------------
             // \tparam TElem Type of the index values.
             // \param idx Idx to be mapped.
             // \param extent Spatial size to map the index to.
@@ -44,12 +41,10 @@ namespace alpaka
                 return idx;
             }
         };
-        //#############################################################################
         //! Maps a 1 dimensional index to a N dimensional index.
         template<std::size_t TidxDimOut>
         struct MapIdx<TidxDimOut, 1u, std::enable_if_t<TidxDimOut != 1u>>
         {
-            //-----------------------------------------------------------------------------
             // \tparam TElem Type of the index values.
             // \param idx Idx to be mapped.
             // \param extent Spatial size to map the index to
@@ -82,12 +77,10 @@ namespace alpaka
                 return idxNd;
             }
         };
-        //#############################################################################
         //! Maps a N dimensional index to a 1 dimensional index.
         template<std::size_t TidxDimIn>
         struct MapIdx<1u, TidxDimIn, std::enable_if_t<TidxDimIn != 1u>>
         {
-            //-----------------------------------------------------------------------------
             // \tparam TElem Type of the index values.
             // \param idx Idx to be mapped.
             // \param extent Spatial size to map the index to.
@@ -108,7 +101,6 @@ namespace alpaka
         };
     } // namespace detail
 
-    //#############################################################################
     //! Maps a N dimensional index to a N dimensional position.
     //!
     //! \tparam TidxDimOut Dimension of the index vector to map to.
@@ -129,16 +121,13 @@ namespace alpaka
 
     namespace detail
     {
-        //#############################################################################
         //! Maps a linear index to a N dimensional index assuming a buffer wihtout padding.
         template<std::size_t TidxDimOut, std::size_t TidxDimIn, typename TSfinae = void>
         struct MapIdxPitchBytes;
-        //#############################################################################
         //! Maps a N dimensional index to the same N dimensional index assuming a buffer wihtout padding.
         template<std::size_t TidxDim>
         struct MapIdxPitchBytes<TidxDim, TidxDim>
         {
-            //-----------------------------------------------------------------------------
             // \tparam TElem Type of the index values.
             // \param idx Idx to be mapped.
             // \param pitch Spatial pitch (in elems) to map the index to
@@ -154,12 +143,10 @@ namespace alpaka
                 return idx;
             }
         };
-        //#############################################################################
         //! Maps a 1 dimensional index to a N dimensional index assuming a buffer wihtout padding.
         template<std::size_t TidxDimOut>
         struct MapIdxPitchBytes<TidxDimOut, 1u, typename std::enable_if<TidxDimOut != 1u>::type>
         {
-            //-----------------------------------------------------------------------------
             // \tparam TElem Type of the index values.
             // \param idx Idx to be mapped.
             // \param pitch Spatial pitch (in elems) to map the index to
@@ -185,12 +172,10 @@ namespace alpaka
                 return idxNd;
             }
         };
-        //#############################################################################
         //! Maps a N dimensional index to a 1 dimensional index assuming a buffer wihtout padding.
         template<std::size_t TidxDimIn>
         struct MapIdxPitchBytes<1u, TidxDimIn, typename std::enable_if<TidxDimIn != 1u>::type>
         {
-            //-----------------------------------------------------------------------------
             // \tparam TElem Type of the index values.
             // \param idx Idx to be mapped.
             // \param pitch Spatial pitch (in elems) to map the index to
@@ -212,7 +197,6 @@ namespace alpaka
         };
     } // namespace detail
 
-    //#############################################################################
     //! Maps a N dimensional index to a N dimensional position based on
     //! pitch in a buffer without padding or a byte buffer.
     //!

--- a/include/alpaka/idx/Traits.hpp
+++ b/include/alpaka/idx/Traits.hpp
@@ -21,11 +21,9 @@ namespace alpaka
     {
     };
 
-    //-----------------------------------------------------------------------------
     //! The idx traits.
     namespace traits
     {
-        //#############################################################################
         //! The idx type trait.
         template<typename T, typename TSfinae = void>
         struct IdxType;
@@ -36,7 +34,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The arithmetic idx type trait specialization.
         template<typename T>
         struct IdxType<T, std::enable_if_t<std::is_arithmetic<T>::value>>
@@ -44,7 +41,6 @@ namespace alpaka
             using type = std::decay_t<T>;
         };
 
-        //#############################################################################
         //! The index get trait.
         template<typename TIdx, typename TOrigin, typename TUnit, typename TSfinae = void>
         struct GetIdx;

--- a/include/alpaka/idx/bt/IdxBtLinear.hpp
+++ b/include/alpaka/idx/bt/IdxBtLinear.hpp
@@ -21,25 +21,18 @@ namespace alpaka
 {
     namespace bt
     {
-        //#############################################################################
         //! General ND bt index provider based on a linear index.
         template<typename TDim, typename TIdx>
         class IdxBtLinear : public concepts::Implements<ConceptIdxBt, IdxBtLinear<TDim, TIdx>>
         {
         public:
-            //-----------------------------------------------------------------------------
             IdxBtLinear(TIdx blockThreadIdx) : m_blockThreadIdx(blockThreadIdx)
             {
             }
-            //-----------------------------------------------------------------------------
             IdxBtLinear(IdxBtLinear const&) = delete;
-            //-----------------------------------------------------------------------------
             IdxBtLinear(IdxBtLinear&&) = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(IdxBtLinear const&) -> IdxBtLinear& = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(IdxBtLinear&&) -> IdxBtLinear& = delete;
-            //-----------------------------------------------------------------------------
             ~IdxBtLinear() = default;
 
             const TIdx m_blockThreadIdx;
@@ -48,7 +41,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The IdxBtLinear index dimension get trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<bt::IdxBtLinear<TDim, TIdx>>
@@ -56,12 +48,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The IdxBtLinear block thread index get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetIdx<bt::IdxBtLinear<TDim, TIdx>, origin::Block, unit::Threads>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current thread in the block.
             template<typename TWorkDiv>
             static auto getIdx(bt::IdxBtLinear<TDim, TIdx> const& idx, TWorkDiv const& workDiv) -> Vec<TDim, TIdx>
@@ -75,7 +65,6 @@ namespace alpaka
         template<typename TIdx>
         struct GetIdx<bt::IdxBtLinear<DimInt<1u>, TIdx>, origin::Block, unit::Threads>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current thread in the block.
             template<typename TWorkDiv>
             static auto getIdx(bt::IdxBtLinear<DimInt<1u>, TIdx> const& idx, TWorkDiv const&) -> Vec<DimInt<1u>, TIdx>
@@ -84,7 +73,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The IdxBtLinear block thread index idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<bt::IdxBtLinear<TDim, TIdx>>

--- a/include/alpaka/idx/bt/IdxBtOmp.hpp
+++ b/include/alpaka/idx/bt/IdxBtOmp.hpp
@@ -26,30 +26,22 @@ namespace alpaka
 {
     namespace bt
     {
-        //#############################################################################
         //! The OpenMP accelerator index provider.
         template<typename TDim, typename TIdx>
         class IdxBtOmp : public concepts::Implements<ConceptIdxBt, IdxBtOmp<TDim, TIdx>>
         {
         public:
-            //-----------------------------------------------------------------------------
             IdxBtOmp() = default;
-            //-----------------------------------------------------------------------------
             IdxBtOmp(IdxBtOmp const&) = delete;
-            //-----------------------------------------------------------------------------
             IdxBtOmp(IdxBtOmp&&) = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(IdxBtOmp const&) -> IdxBtOmp& = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(IdxBtOmp&&) -> IdxBtOmp& = delete;
-            //-----------------------------------------------------------------------------
             /*virtual*/ ~IdxBtOmp() = default;
         };
     } // namespace bt
 
     namespace traits
     {
-        //#############################################################################
         //! The OpenMP accelerator index dimension get trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<bt::IdxBtOmp<TDim, TIdx>>
@@ -57,12 +49,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The OpenMP accelerator block thread index get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetIdx<bt::IdxBtOmp<TDim, TIdx>, origin::Block, unit::Threads>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current thread in the block.
             template<typename TWorkDiv>
             static auto getIdx(bt::IdxBtOmp<TDim, TIdx> const& idx, TWorkDiv const& workDiv) -> Vec<TDim, TIdx>
@@ -80,7 +70,6 @@ namespace alpaka
         template<typename TIdx>
         struct GetIdx<bt::IdxBtOmp<DimInt<1u>, TIdx>, origin::Block, unit::Threads>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current thread in the block.
             template<typename TWorkDiv>
             static auto getIdx(bt::IdxBtOmp<DimInt<1u>, TIdx> const& idx, TWorkDiv const&) -> Vec<DimInt<1u>, TIdx>
@@ -90,7 +79,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenMP accelerator block thread index idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<bt::IdxBtOmp<TDim, TIdx>>

--- a/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 {
     namespace bt
     {
-        //#############################################################################
         //! The fibers accelerator index provider.
         template<typename TDim, typename TIdx>
         class IdxBtRefFiberIdMap : public concepts::Implements<ConceptIdxBt, IdxBtRefFiberIdMap<TDim, TIdx>>
@@ -33,20 +32,14 @@ namespace alpaka
         public:
             using FiberIdToIdxMap = std::map<boost::fibers::fiber::id, Vec<TDim, TIdx>>;
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST IdxBtRefFiberIdMap(FiberIdToIdxMap const& mFibersToIndices)
                 : m_fibersToIndices(mFibersToIndices)
             {
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST IdxBtRefFiberIdMap(IdxBtRefFiberIdMap const&) = delete;
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST IdxBtRefFiberIdMap(IdxBtRefFiberIdMap&&) = delete;
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator=(IdxBtRefFiberIdMap const&) -> IdxBtRefFiberIdMap& = delete;
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator=(IdxBtRefFiberIdMap&&) -> IdxBtRefFiberIdMap& = delete;
-            //-----------------------------------------------------------------------------
             /*virtual*/ ~IdxBtRefFiberIdMap() = default;
 
         public:
@@ -56,7 +49,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU fibers accelerator index dimension get trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<bt::IdxBtRefFiberIdMap<TDim, TIdx>>
@@ -64,12 +56,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU fibers accelerator block thread index get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetIdx<bt::IdxBtRefFiberIdMap<TDim, TIdx>, origin::Block, unit::Threads>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current thread in the block.
             template<typename TWorkDiv>
             ALPAKA_FN_HOST static auto getIdx(bt::IdxBtRefFiberIdMap<TDim, TIdx> const& idx, TWorkDiv const& workDiv)
@@ -83,7 +73,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU fibers accelerator block thread index idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<bt::IdxBtRefFiberIdMap<TDim, TIdx>>

--- a/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 {
     namespace bt
     {
-        //#############################################################################
         //! The threads accelerator index provider.
         template<typename TDim, typename TIdx>
         class IdxBtRefThreadIdMap : public concepts::Implements<ConceptIdxBt, IdxBtRefThreadIdMap<TDim, TIdx>>
@@ -33,20 +32,14 @@ namespace alpaka
         public:
             using ThreadIdToIdxMap = std::map<std::thread::id, Vec<TDim, TIdx>>;
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST IdxBtRefThreadIdMap(ThreadIdToIdxMap const& mThreadToIndices)
                 : m_threadToIndexMap(mThreadToIndices)
             {
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST IdxBtRefThreadIdMap(IdxBtRefThreadIdMap const&) = delete;
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST IdxBtRefThreadIdMap(IdxBtRefThreadIdMap&&) = delete;
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator=(IdxBtRefThreadIdMap const&) -> IdxBtRefThreadIdMap& = delete;
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator=(IdxBtRefThreadIdMap&&) -> IdxBtRefThreadIdMap& = delete;
-            //-----------------------------------------------------------------------------
             /*virtual*/ ~IdxBtRefThreadIdMap() = default;
 
         public:
@@ -56,7 +49,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU threads accelerator index dimension get trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<bt::IdxBtRefThreadIdMap<TDim, TIdx>>
@@ -64,12 +56,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU threads accelerator block thread index get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetIdx<bt::IdxBtRefThreadIdMap<TDim, TIdx>, origin::Block, unit::Threads>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current thread in the block.
             template<typename TWorkDiv>
             ALPAKA_FN_HOST static auto getIdx(bt::IdxBtRefThreadIdMap<TDim, TIdx> const& idx, TWorkDiv const& workDiv)
@@ -83,7 +73,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU threads accelerator block thread index idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<bt::IdxBtRefThreadIdMap<TDim, TIdx>>

--- a/include/alpaka/idx/bt/IdxBtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/idx/bt/IdxBtUniformCudaHipBuiltIn.hpp
@@ -38,31 +38,23 @@ namespace alpaka
 {
     namespace bt
     {
-        //#############################################################################
         //! The CUDA/HIP accelerator ND index provider.
         template<typename TDim, typename TIdx>
         class IdxBtUniformCudaHipBuiltIn
             : public concepts::Implements<ConceptIdxBt, IdxBtUniformCudaHipBuiltIn<TDim, TIdx>>
         {
         public:
-            //-----------------------------------------------------------------------------
             IdxBtUniformCudaHipBuiltIn() = default;
-            //-----------------------------------------------------------------------------
             __device__ IdxBtUniformCudaHipBuiltIn(IdxBtUniformCudaHipBuiltIn const&) = delete;
-            //-----------------------------------------------------------------------------
             __device__ IdxBtUniformCudaHipBuiltIn(IdxBtUniformCudaHipBuiltIn&&) = delete;
-            //-----------------------------------------------------------------------------
             __device__ auto operator=(IdxBtUniformCudaHipBuiltIn const&) -> IdxBtUniformCudaHipBuiltIn& = delete;
-            //-----------------------------------------------------------------------------
             __device__ auto operator=(IdxBtUniformCudaHipBuiltIn&&) -> IdxBtUniformCudaHipBuiltIn& = delete;
-            //-----------------------------------------------------------------------------
             /*virtual*/ ~IdxBtUniformCudaHipBuiltIn() = default;
         };
     } // namespace bt
 
     namespace traits
     {
-        //#############################################################################
         //! The GPU CUDA/HIP accelerator index dimension get trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<bt::IdxBtUniformCudaHipBuiltIn<TDim, TIdx>>
@@ -70,12 +62,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The GPU CUDA/HIP accelerator block thread index get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetIdx<bt::IdxBtUniformCudaHipBuiltIn<TDim, TIdx>, origin::Block, unit::Threads>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current thread in the block.
             template<typename TWorkDiv>
             __device__ static auto getIdx(bt::IdxBtUniformCudaHipBuiltIn<TDim, TIdx> const& idx, TWorkDiv const&)
@@ -93,7 +83,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The GPU CUDA/HIP accelerator block thread index idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<bt::IdxBtUniformCudaHipBuiltIn<TDim, TIdx>>

--- a/include/alpaka/idx/bt/IdxBtZero.hpp
+++ b/include/alpaka/idx/bt/IdxBtZero.hpp
@@ -19,30 +19,22 @@ namespace alpaka
 {
     namespace bt
     {
-        //#############################################################################
         //! A zero block thread index provider.
         template<typename TDim, typename TIdx>
         class IdxBtZero : public concepts::Implements<ConceptIdxBt, IdxBtZero<TDim, TIdx>>
         {
         public:
-            //-----------------------------------------------------------------------------
             IdxBtZero() = default;
-            //-----------------------------------------------------------------------------
             IdxBtZero(IdxBtZero const&) = delete;
-            //-----------------------------------------------------------------------------
             IdxBtZero(IdxBtZero&&) = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(IdxBtZero const&) -> IdxBtZero& = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(IdxBtZero&&) -> IdxBtZero& = delete;
-            //-----------------------------------------------------------------------------
             /*virtual*/ ~IdxBtZero() = default;
         };
     } // namespace bt
 
     namespace traits
     {
-        //#############################################################################
         //! The zero block thread index provider dimension get trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<bt::IdxBtZero<TDim, TIdx>>
@@ -50,12 +42,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The zero block thread index provider block thread index get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetIdx<bt::IdxBtZero<TDim, TIdx>, origin::Block, unit::Threads>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current thread in the block.
             template<typename TWorkDiv>
             ALPAKA_FN_HOST static auto getIdx(bt::IdxBtZero<TDim, TIdx> const& idx, TWorkDiv const& workDiv)
@@ -67,7 +57,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The zero block thread index idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<bt::IdxBtZero<TDim, TIdx>>

--- a/include/alpaka/idx/gb/IdxGbLinear.hpp
+++ b/include/alpaka/idx/gb/IdxGbLinear.hpp
@@ -21,25 +21,18 @@ namespace alpaka
 {
     namespace gb
     {
-        //#############################################################################
         //! General ND index provider based on a linear index.
         template<typename TDim, typename TIdx>
         class IdxGbLinear : public concepts::Implements<ConceptIdxGb, IdxGbLinear<TDim, TIdx>>
         {
         public:
-            //-----------------------------------------------------------------------------
             IdxGbLinear(const TIdx& teamOffset = static_cast<TIdx>(0u)) : m_gridBlockIdx(teamOffset)
             {
             }
-            //-----------------------------------------------------------------------------
             IdxGbLinear(IdxGbLinear const&) = delete;
-            //-----------------------------------------------------------------------------
             IdxGbLinear(IdxGbLinear&&) = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(IdxGbLinear const&) -> IdxGbLinear& = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(IdxGbLinear&&) -> IdxGbLinear& = delete;
-            //-----------------------------------------------------------------------------
             /*virtual*/ ~IdxGbLinear() = default;
 
             TIdx const m_gridBlockIdx;
@@ -48,7 +41,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The IdxGbLinear index dimension get trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<gb::IdxGbLinear<TDim, TIdx>>
@@ -56,12 +48,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The IdxGbLinear grid block index get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetIdx<gb::IdxGbLinear<TDim, TIdx>, origin::Grid, unit::Blocks>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current block in the grid.
             template<typename TWorkDiv>
             static auto getIdx(gb::IdxGbLinear<TDim, TIdx> const& idx, TWorkDiv const& workDiv) -> Vec<TDim, TIdx>
@@ -76,7 +66,6 @@ namespace alpaka
         template<typename TIdx>
         struct GetIdx<gb::IdxGbLinear<DimInt<1u>, TIdx>, origin::Grid, unit::Blocks>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current block in the grid.
             template<typename TWorkDiv>
             static auto getIdx(gb::IdxGbLinear<DimInt<1u>, TIdx> const& idx, TWorkDiv const&) -> Vec<DimInt<1u>, TIdx>
@@ -85,7 +74,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The IdxGbLinear grid block index idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<gb::IdxGbLinear<TDim, TIdx>>

--- a/include/alpaka/idx/gb/IdxGbRef.hpp
+++ b/include/alpaka/idx/gb/IdxGbRef.hpp
@@ -20,25 +20,18 @@ namespace alpaka
 {
     namespace gb
     {
-        //#############################################################################
         //! A IdxGbRef grid block index.
         template<typename TDim, typename TIdx>
         class IdxGbRef : public concepts::Implements<ConceptIdxGb, IdxGbRef<TDim, TIdx>>
         {
         public:
-            //-----------------------------------------------------------------------------
             IdxGbRef(Vec<TDim, TIdx> const& gridBlockIdx) : m_gridBlockIdx(gridBlockIdx)
             {
             }
-            //-----------------------------------------------------------------------------
             IdxGbRef(IdxGbRef const&) = delete;
-            //-----------------------------------------------------------------------------
             IdxGbRef(IdxGbRef&&) = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(IdxGbRef const&) -> IdxGbRef& = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(IdxGbRef&&) -> IdxGbRef& = delete;
-            //-----------------------------------------------------------------------------
             /*virtual*/ ~IdxGbRef() = default;
 
         public:
@@ -48,7 +41,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The IdxGbRef grid block index dimension get trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<gb::IdxGbRef<TDim, TIdx>>
@@ -56,12 +48,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The IdxGbRef grid block index grid block index get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetIdx<gb::IdxGbRef<TDim, TIdx>, origin::Grid, unit::Blocks>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current block in the grid.
             template<typename TWorkDiv>
             ALPAKA_FN_HOST static auto getIdx(gb::IdxGbRef<TDim, TIdx> const& idx, TWorkDiv const& workDiv)
@@ -72,7 +62,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The IdxGbRef grid block index idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<gb::IdxGbRef<TDim, TIdx>>

--- a/include/alpaka/idx/gb/IdxGbUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/idx/gb/IdxGbUniformCudaHipBuiltIn.hpp
@@ -38,31 +38,23 @@ namespace alpaka
 {
     namespace gb
     {
-        //#############################################################################
         //! The CUDA/HIP accelerator ND index provider.
         template<typename TDim, typename TIdx>
         class IdxGbUniformCudaHipBuiltIn
             : public concepts::Implements<ConceptIdxGb, IdxGbUniformCudaHipBuiltIn<TDim, TIdx>>
         {
         public:
-            //-----------------------------------------------------------------------------
             IdxGbUniformCudaHipBuiltIn() = default;
-            //-----------------------------------------------------------------------------
             __device__ IdxGbUniformCudaHipBuiltIn(IdxGbUniformCudaHipBuiltIn const&) = delete;
-            //-----------------------------------------------------------------------------
             __device__ IdxGbUniformCudaHipBuiltIn(IdxGbUniformCudaHipBuiltIn&&) = delete;
-            //-----------------------------------------------------------------------------
             __device__ auto operator=(IdxGbUniformCudaHipBuiltIn const&) -> IdxGbUniformCudaHipBuiltIn& = delete;
-            //-----------------------------------------------------------------------------
             __device__ auto operator=(IdxGbUniformCudaHipBuiltIn&&) -> IdxGbUniformCudaHipBuiltIn& = delete;
-            //-----------------------------------------------------------------------------
             /*virtual*/ ~IdxGbUniformCudaHipBuiltIn() = default;
         };
     } // namespace gb
 
     namespace traits
     {
-        //#############################################################################
         //! The GPU CUDA/HIP accelerator index dimension get trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<gb::IdxGbUniformCudaHipBuiltIn<TDim, TIdx>>
@@ -70,12 +62,10 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The GPU CUDA/HIP accelerator grid block index get trait specialization.
         template<typename TDim, typename TIdx>
         struct GetIdx<gb::IdxGbUniformCudaHipBuiltIn<TDim, TIdx>, origin::Grid, unit::Blocks>
         {
-            //-----------------------------------------------------------------------------
             //! \return The index of the current block in the grid.
             template<typename TWorkDiv>
             __device__ static auto getIdx(gb::IdxGbUniformCudaHipBuiltIn<TDim, TIdx> const& idx, TWorkDiv const&)
@@ -93,7 +83,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The GPU CUDA/HIP accelerator grid block index idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<gb::IdxGbUniformCudaHipBuiltIn<TDim, TIdx>>

--- a/include/alpaka/intrinsic/IntrinsicCpu.hpp
+++ b/include/alpaka/intrinsic/IntrinsicCpu.hpp
@@ -21,32 +21,23 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The CPU intrinsic.
     class IntrinsicCpu : public concepts::Implements<ConceptIntrinsic, IntrinsicCpu>
     {
     public:
-        //-----------------------------------------------------------------------------
         IntrinsicCpu() = default;
-        //-----------------------------------------------------------------------------
         IntrinsicCpu(IntrinsicCpu const&) = delete;
-        //-----------------------------------------------------------------------------
         IntrinsicCpu(IntrinsicCpu&&) = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(IntrinsicCpu const&) -> IntrinsicCpu& = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(IntrinsicCpu&&) -> IntrinsicCpu& = delete;
-        //-----------------------------------------------------------------------------
         ~IntrinsicCpu() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         template<>
         struct Popcount<IntrinsicCpu>
         {
-            //-----------------------------------------------------------------------------
             static auto popcount(IntrinsicCpu const& /*intrinsic*/, std::uint32_t value) -> std::int32_t
             {
 #if BOOST_COMP_GNUC || BOOST_COMP_CLANG || BOOST_COMP_INTEL
@@ -59,7 +50,6 @@ namespace alpaka
 #endif
             }
 
-            //-----------------------------------------------------------------------------
             static auto popcount(IntrinsicCpu const& /*intrinsic*/, std::uint64_t value) -> std::int32_t
             {
 #if BOOST_COMP_GNUC || BOOST_COMP_CLANG || BOOST_COMP_INTEL
@@ -73,11 +63,9 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         template<>
         struct Ffs<IntrinsicCpu>
         {
-            //-----------------------------------------------------------------------------
             static auto ffs(IntrinsicCpu const& /*intrinsic*/, std::int32_t value) -> std::int32_t
             {
 #if BOOST_COMP_GNUC || BOOST_COMP_CLANG || BOOST_COMP_INTEL
@@ -95,7 +83,6 @@ namespace alpaka
 #endif
             }
 
-            //-----------------------------------------------------------------------------
             static auto ffs(IntrinsicCpu const& /*intrinsic*/, std::int64_t value) -> std::int32_t
             {
 #if BOOST_COMP_GNUC || BOOST_COMP_CLANG || BOOST_COMP_INTEL

--- a/include/alpaka/intrinsic/IntrinsicFallback.hpp
+++ b/include/alpaka/intrinsic/IntrinsicFallback.hpp
@@ -15,7 +15,6 @@ namespace alpaka
 {
     namespace detail
     {
-        //#############################################################################
         //! Fallback implementaion of popcount.
         template<typename TValue>
         static auto popcountFallback(TValue value) -> std::int32_t
@@ -29,7 +28,6 @@ namespace alpaka
             return static_cast<std::int32_t>(count);
         }
 
-        //#############################################################################
         //! Fallback implementaion of ffs.
         template<typename TValue>
         static auto ffsFallback(TValue value) -> std::int32_t
@@ -46,55 +44,42 @@ namespace alpaka
         }
     } // namespace detail
 
-    //#############################################################################
     //! The Fallback intrinsic.
     class IntrinsicFallback : public concepts::Implements<ConceptIntrinsic, IntrinsicFallback>
     {
     public:
-        //-----------------------------------------------------------------------------
         IntrinsicFallback() = default;
-        //-----------------------------------------------------------------------------
         IntrinsicFallback(IntrinsicFallback const&) = delete;
-        //-----------------------------------------------------------------------------
         IntrinsicFallback(IntrinsicFallback&&) = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(IntrinsicFallback const&) -> IntrinsicFallback& = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(IntrinsicFallback&&) -> IntrinsicFallback& = delete;
-        //-----------------------------------------------------------------------------
         ~IntrinsicFallback() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         template<>
         struct Popcount<IntrinsicFallback>
         {
-            //-----------------------------------------------------------------------------
             static auto popcount(IntrinsicFallback const& /*intrinsic*/, std::uint32_t value) -> std::int32_t
             {
                 return alpaka::detail::popcountFallback(value);
             }
 
-            //-----------------------------------------------------------------------------
             static auto popcount(IntrinsicFallback const& /*intrinsic*/, std::uint64_t value) -> std::int32_t
             {
                 return alpaka::detail::popcountFallback(value);
             }
         };
 
-        //#############################################################################
         template<>
         struct Ffs<IntrinsicFallback>
         {
-            //-----------------------------------------------------------------------------
             static auto ffs(IntrinsicFallback const& /*intrinsic*/, std::int32_t value) -> std::int32_t
             {
                 return alpaka::detail::ffsFallback(value);
             }
 
-            //-----------------------------------------------------------------------------
             static auto ffs(IntrinsicFallback const& /*intrinsic*/, std::int64_t value) -> std::int32_t
             {
                 return alpaka::detail::ffsFallback(value);

--- a/include/alpaka/intrinsic/IntrinsicUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/intrinsic/IntrinsicUniformCudaHipBuiltIn.hpp
@@ -25,33 +25,24 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The GPU CUDA/HIP intrinsic.
     class IntrinsicUniformCudaHipBuiltIn
         : public concepts::Implements<ConceptIntrinsic, IntrinsicUniformCudaHipBuiltIn>
     {
     public:
-        //-----------------------------------------------------------------------------
         IntrinsicUniformCudaHipBuiltIn() = default;
-        //-----------------------------------------------------------------------------
         __device__ IntrinsicUniformCudaHipBuiltIn(IntrinsicUniformCudaHipBuiltIn const&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ IntrinsicUniformCudaHipBuiltIn(IntrinsicUniformCudaHipBuiltIn&&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(IntrinsicUniformCudaHipBuiltIn const&) -> IntrinsicUniformCudaHipBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(IntrinsicUniformCudaHipBuiltIn&&) -> IntrinsicUniformCudaHipBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         ~IntrinsicUniformCudaHipBuiltIn() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         template<>
         struct Popcount<IntrinsicUniformCudaHipBuiltIn>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto popcount(IntrinsicUniformCudaHipBuiltIn const& /*intrinsic*/, std::uint32_t value)
                 -> std::int32_t
             {
@@ -62,7 +53,6 @@ namespace alpaka
 #    endif
             }
 
-            //-----------------------------------------------------------------------------
             __device__ static auto popcount(IntrinsicUniformCudaHipBuiltIn const& /*intrinsic*/, std::uint64_t value)
                 -> std::int32_t
             {
@@ -74,18 +64,15 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         template<>
         struct Ffs<IntrinsicUniformCudaHipBuiltIn>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto ffs(IntrinsicUniformCudaHipBuiltIn const& /*intrinsic*/, std::int32_t value)
                 -> std::int32_t
             {
                 return __ffs(static_cast<int>(value));
             }
 
-            //-----------------------------------------------------------------------------
             __device__ static auto ffs(IntrinsicUniformCudaHipBuiltIn const& /*intrinsic*/, std::int64_t value)
                 -> std::int32_t
             {

--- a/include/alpaka/intrinsic/Traits.hpp
+++ b/include/alpaka/intrinsic/Traits.hpp
@@ -21,22 +21,18 @@ namespace alpaka
     {
     };
 
-    //-----------------------------------------------------------------------------
     //! The intrinsics traits.
     namespace traits
     {
-        //#############################################################################
         //! The popcount trait.
         template<typename TWarp, typename TSfinae = void>
         struct Popcount;
 
-        //#############################################################################
         //! The ffs trait.
         template<typename TWarp, typename TSfinae = void>
         struct Ffs;
     } // namespace traits
 
-    //-----------------------------------------------------------------------------
     //! Returns the number of 1 bits in the given 32-bit value.
     //!
     //! \tparam TIntrinsic The intrinsic implementation type.
@@ -50,7 +46,6 @@ namespace alpaka
         return traits::Popcount<ImplementationBase>::popcount(intrinsic, value);
     }
 
-    //-----------------------------------------------------------------------------
     //! Returns the number of 1 bits in the given 64-bit value.
     //!
     //! \tparam TIntrinsic The intrinsic implementation type.
@@ -64,7 +59,6 @@ namespace alpaka
         return traits::Popcount<ImplementationBase>::popcount(intrinsic, value);
     }
 
-    //-----------------------------------------------------------------------------
     //! Returns the 1-based position of the least significant bit set to 1
     //! in the given 32-bit value. Returns 0 for input value 0.
     //!
@@ -79,7 +73,6 @@ namespace alpaka
         return traits::Ffs<ImplementationBase>::ffs(intrinsic, value);
     }
 
-    //-----------------------------------------------------------------------------
     //! Returns the 1-based position of the least significant bit set to 1
     //! in the given 64-bit value. Returns 0 for input value 0.
     //!

--- a/include/alpaka/kernel/TaskKernelCpuFibers.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuFibers.hpp
@@ -41,24 +41,20 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The CPU fibers accelerator execution task.
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelCpuFibers final : public WorkDivMembers<TDim, TIdx>
     {
     private:
-        //#############################################################################
         //! The type given to the ConcurrentExecPool for yielding the current fiber.
         struct FiberPoolYield
         {
-            //-----------------------------------------------------------------------------
             //! Yields the current fiber.
             ALPAKA_FN_HOST static auto yield() -> void
             {
                 boost::this_fiber::yield();
             }
         };
-        //#############################################################################
         // Yielding is not faster for fibers. Therefore we use condition variables.
         // It is better to wake them up when the conditions are fulfilled because this does not cost as much as for
         // real threads.
@@ -73,7 +69,6 @@ namespace alpaka
             false>; // If the threads should yield.
 
     public:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST TaskKernelCpuFibers(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
@@ -84,18 +79,12 @@ namespace alpaka
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                 "The work division and the execution task have to be of the same dimensionality!");
         }
-        //-----------------------------------------------------------------------------
         TaskKernelCpuFibers(TaskKernelCpuFibers const&) = default;
-        //-----------------------------------------------------------------------------
         TaskKernelCpuFibers(TaskKernelCpuFibers&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelCpuFibers const&) -> TaskKernelCpuFibers& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelCpuFibers&&) -> TaskKernelCpuFibers& = default;
-        //-----------------------------------------------------------------------------
         ~TaskKernelCpuFibers() = default;
 
-        //-----------------------------------------------------------------------------
         //! Executes the kernel function object.
         ALPAKA_FN_HOST auto operator()() const -> void
         {
@@ -152,7 +141,6 @@ namespace alpaka
         }
 
     private:
-        //-----------------------------------------------------------------------------
         //! The function executed for each grid block.
         ALPAKA_FN_HOST static auto gridBlockExecHost(
             AccCpuFibers<TDim, TIdx>& acc,
@@ -192,7 +180,6 @@ namespace alpaka
             // After a block has been processed, the shared memory has to be deleted.
             freeSharedVars(acc);
         }
-        //-----------------------------------------------------------------------------
         //! The function executed for each block thread.
         ALPAKA_FN_HOST static auto blockThreadExecHost(
             AccCpuFibers<TDim, TIdx>& acc,
@@ -221,7 +208,6 @@ namespace alpaka
             (void) boundBlockThreadExecAcc;
 #    endif
         }
-        //-----------------------------------------------------------------------------
         //! The fiber entry point.
         ALPAKA_FN_HOST static auto blockThreadFiberFn(
             AccCpuFibers<TDim, TIdx>& acc,
@@ -259,7 +245,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU fibers execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct AccType<TaskKernelCpuFibers<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -267,7 +252,6 @@ namespace alpaka
             using type = AccCpuFibers<TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The CPU fibers execution task device type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DevType<TaskKernelCpuFibers<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -275,7 +259,6 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The CPU fibers execution task dimension getter trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DimType<TaskKernelCpuFibers<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -283,7 +266,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU fibers execution task platform type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct PltfType<TaskKernelCpuFibers<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -291,7 +273,6 @@ namespace alpaka
             using type = PltfCpu;
         };
 
-        //#############################################################################
         //! The CPU fibers execution task idx type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct IdxType<TaskKernelCpuFibers<TDim, TIdx, TKernelFnObj, TArgs...>>

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -44,13 +44,11 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The CPU OpenMP 2.0 block accelerator execution task.
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelCpuOmp2Blocks final : public WorkDivMembers<TDim, TIdx>
     {
     public:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST TaskKernelCpuOmp2Blocks(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
@@ -61,18 +59,12 @@ namespace alpaka
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                 "The work division and the execution task have to be of the same dimensionality!");
         }
-        //-----------------------------------------------------------------------------
         TaskKernelCpuOmp2Blocks(TaskKernelCpuOmp2Blocks const&) = default;
-        //-----------------------------------------------------------------------------
         TaskKernelCpuOmp2Blocks(TaskKernelCpuOmp2Blocks&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelCpuOmp2Blocks const&) -> TaskKernelCpuOmp2Blocks& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelCpuOmp2Blocks&&) -> TaskKernelCpuOmp2Blocks& = default;
-        //-----------------------------------------------------------------------------
         ~TaskKernelCpuOmp2Blocks() = default;
 
-        //-----------------------------------------------------------------------------
         //! Executes the kernel function object.
         ALPAKA_FN_HOST auto operator()() const -> void
         {
@@ -227,7 +219,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU OpenMP 2.0 grid block execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct AccType<TaskKernelCpuOmp2Blocks<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -235,7 +226,6 @@ namespace alpaka
             using type = AccCpuOmp2Blocks<TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 grid block execution task device type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DevType<TaskKernelCpuOmp2Blocks<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -243,7 +233,6 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 grid block execution task dimension getter trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DimType<TaskKernelCpuOmp2Blocks<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -251,7 +240,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 grid block execution task platform type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct PltfType<TaskKernelCpuOmp2Blocks<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -259,7 +247,6 @@ namespace alpaka
             using type = PltfCpu;
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 block execution task idx type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct IdxType<TaskKernelCpuOmp2Blocks<TDim, TIdx, TKernelFnObj, TArgs...>>

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -44,13 +44,11 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The CPU OpenMP 2.0 thread accelerator execution task.
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelCpuOmp2Threads final : public WorkDivMembers<TDim, TIdx>
     {
     public:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST TaskKernelCpuOmp2Threads(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
@@ -61,18 +59,12 @@ namespace alpaka
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                 "The work division and the execution task have to be of the same dimensionality!");
         }
-        //-----------------------------------------------------------------------------
         TaskKernelCpuOmp2Threads(TaskKernelCpuOmp2Threads const&) = default;
-        //-----------------------------------------------------------------------------
         TaskKernelCpuOmp2Threads(TaskKernelCpuOmp2Threads&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelCpuOmp2Threads const&) -> TaskKernelCpuOmp2Threads& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelCpuOmp2Threads&&) -> TaskKernelCpuOmp2Threads& = default;
-        //-----------------------------------------------------------------------------
         ~TaskKernelCpuOmp2Threads() = default;
 
-        //-----------------------------------------------------------------------------
         //! Executes the kernel function object.
         ALPAKA_FN_HOST auto operator()() const -> void
         {
@@ -177,7 +169,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU OpenMP 2.0 block thread execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct AccType<TaskKernelCpuOmp2Threads<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -185,7 +176,6 @@ namespace alpaka
             using type = AccCpuOmp2Threads<TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 block thread execution task device type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DevType<TaskKernelCpuOmp2Threads<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -193,7 +183,6 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 block thread execution task dimension getter trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DimType<TaskKernelCpuOmp2Threads<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -201,7 +190,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 block thread execution task platform type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct PltfType<TaskKernelCpuOmp2Threads<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -209,7 +197,6 @@ namespace alpaka
             using type = PltfCpu;
         };
 
-        //#############################################################################
         //! The CPU OpenMP 2.0 block thread execution task idx type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct IdxType<TaskKernelCpuOmp2Threads<TDim, TIdx, TKernelFnObj, TArgs...>>

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -37,13 +37,11 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The CPU serial execution task implementation.
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelCpuSerial final : public WorkDivMembers<TDim, TIdx>
     {
     public:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST TaskKernelCpuSerial(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
@@ -54,18 +52,12 @@ namespace alpaka
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                 "The work division and the execution task have to be of the same dimensionality!");
         }
-        //-----------------------------------------------------------------------------
         TaskKernelCpuSerial(TaskKernelCpuSerial const&) = default;
-        //-----------------------------------------------------------------------------
         TaskKernelCpuSerial(TaskKernelCpuSerial&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelCpuSerial const&) -> TaskKernelCpuSerial& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelCpuSerial&&) -> TaskKernelCpuSerial& = default;
-        //-----------------------------------------------------------------------------
         ~TaskKernelCpuSerial() = default;
 
-        //-----------------------------------------------------------------------------
         //! Executes the kernel function object.
         ALPAKA_FN_HOST auto operator()() const -> void
         {
@@ -125,7 +117,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU serial execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct AccType<TaskKernelCpuSerial<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -133,7 +124,6 @@ namespace alpaka
             using type = AccCpuSerial<TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The CPU serial execution task device type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DevType<TaskKernelCpuSerial<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -141,7 +131,6 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The CPU serial execution task dimension getter trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DimType<TaskKernelCpuSerial<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -149,7 +138,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU serial execution task platform type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct PltfType<TaskKernelCpuSerial<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -157,7 +145,6 @@ namespace alpaka
             using type = PltfCpu;
         };
 
-        //#############################################################################
         //! The CPU serial execution task idx type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct IdxType<TaskKernelCpuSerial<TDim, TIdx, TKernelFnObj, TArgs...>>

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -42,13 +42,11 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The CPU TBB block accelerator execution task.
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelCpuTbbBlocks final : public WorkDivMembers<TDim, TIdx>
     {
     public:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST TaskKernelCpuTbbBlocks(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
@@ -59,18 +57,12 @@ namespace alpaka
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                 "The work division and the execution task have to be of the same dimensionality!");
         }
-        //-----------------------------------------------------------------------------
         TaskKernelCpuTbbBlocks(TaskKernelCpuTbbBlocks const&) = default;
-        //-----------------------------------------------------------------------------
         TaskKernelCpuTbbBlocks(TaskKernelCpuTbbBlocks&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelCpuTbbBlocks const&) -> TaskKernelCpuTbbBlocks& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelCpuTbbBlocks&&) -> TaskKernelCpuTbbBlocks& = default;
-        //-----------------------------------------------------------------------------
         ~TaskKernelCpuTbbBlocks() = default;
 
-        //-----------------------------------------------------------------------------
         //! Executes the kernel function object.
         ALPAKA_FN_HOST auto operator()() const -> void
         {
@@ -131,7 +123,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU TBB block execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct AccType<TaskKernelCpuTbbBlocks<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -139,7 +130,6 @@ namespace alpaka
             using type = AccCpuTbbBlocks<TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The CPU TBB block execution task device type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DevType<TaskKernelCpuTbbBlocks<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -147,7 +137,6 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The CPU TBB block execution task dimension getter trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DimType<TaskKernelCpuTbbBlocks<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -155,7 +144,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU TBB block execution task platform type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct PltfType<TaskKernelCpuTbbBlocks<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -163,7 +151,6 @@ namespace alpaka
             using type = PltfCpu;
         };
 
-        //#############################################################################
         //! The CPU TBB block execution task idx type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct IdxType<TaskKernelCpuTbbBlocks<TDim, TIdx, TKernelFnObj, TArgs...>>

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -42,24 +42,20 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The CPU threads execution task.
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelCpuThreads final : public WorkDivMembers<TDim, TIdx>
     {
     private:
-        //#############################################################################
         //! The type given to the ConcurrentExecPool for yielding the current thread.
         struct ThreadPoolYield
         {
-            //-----------------------------------------------------------------------------
             //! Yields the current thread.
             ALPAKA_FN_HOST static auto yield() -> void
             {
                 std::this_thread::yield();
             }
         };
-        //#############################################################################
         // When using the thread pool the threads are yielding because this is faster.
         // Using condition variables and going to sleep is very costly for real threads.
         // Especially when the time to wait is really short (syncBlockThreads) yielding is much faster.
@@ -70,7 +66,6 @@ namespace alpaka
             ThreadPoolYield>; // The type yielding the current concurrent execution.
 
     public:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST TaskKernelCpuThreads(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
@@ -81,18 +76,12 @@ namespace alpaka
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                 "The work division and the execution task have to be of the same dimensionality!");
         }
-        //-----------------------------------------------------------------------------
         TaskKernelCpuThreads(TaskKernelCpuThreads const&) = default;
-        //-----------------------------------------------------------------------------
         TaskKernelCpuThreads(TaskKernelCpuThreads&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelCpuThreads const&) -> TaskKernelCpuThreads& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelCpuThreads&&) -> TaskKernelCpuThreads& = default;
-        //-----------------------------------------------------------------------------
         ~TaskKernelCpuThreads() = default;
 
-        //-----------------------------------------------------------------------------
         //! Executes the kernel function object.
         ALPAKA_FN_HOST auto operator()() const -> void
         {
@@ -143,7 +132,6 @@ namespace alpaka
         }
 
     private:
-        //-----------------------------------------------------------------------------
         //! The function executed for each grid block.
         ALPAKA_FN_HOST static auto gridBlockExecHost(
             AccCpuThreads<TDim, TIdx>& acc,
@@ -183,7 +171,6 @@ namespace alpaka
             // After a block has been processed, the shared memory has to be deleted.
             freeSharedVars(acc);
         }
-        //-----------------------------------------------------------------------------
         //! The function executed for each block thread on the host.
         ALPAKA_FN_HOST static auto blockThreadExecHost(
             AccCpuThreads<TDim, TIdx>& acc,
@@ -212,7 +199,6 @@ namespace alpaka
             (void) boundBlockThreadExecAcc;
 #    endif
         }
-        //-----------------------------------------------------------------------------
         //! The thread entry point on the accelerator.
         ALPAKA_FN_HOST static auto blockThreadExecAcc(
             AccCpuThreads<TDim, TIdx>& acc,
@@ -255,7 +241,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU threads execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct AccType<TaskKernelCpuThreads<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -263,7 +248,6 @@ namespace alpaka
             using type = AccCpuThreads<TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The CPU threads execution task device type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DevType<TaskKernelCpuThreads<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -271,7 +255,6 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The CPU threads execution task dimension getter trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DimType<TaskKernelCpuThreads<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -279,7 +262,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU threads execution task platform type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct PltfType<TaskKernelCpuThreads<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -287,7 +269,6 @@ namespace alpaka
             using type = PltfCpu;
         };
 
-        //#############################################################################
         //! The CPU threads execution task idx type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct IdxType<TaskKernelCpuThreads<TDim, TIdx, TKernelFnObj, TArgs...>>

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -68,7 +68,6 @@ namespace alpaka
     {
         namespace detail
         {
-            //-----------------------------------------------------------------------------
             //! The GPU CUDA/HIP kernel entry point.
             // \NOTE: 'A __global__ function or function template cannot have a trailing return type.'
             template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
@@ -92,7 +91,6 @@ namespace alpaka
                 kernelFnObj(const_cast<TAcc const&>(acc), args...);
             }
 
-            //-----------------------------------------------------------------------------
             template<typename TDim, typename TIdx>
             ALPAKA_FN_HOST auto checkVecOnly3Dim(Vec<TDim, TIdx> const& vec) -> void
             {
@@ -106,7 +104,6 @@ namespace alpaka
                 }
             }
 
-            //-----------------------------------------------------------------------------
             template<typename TDim, typename TIdx>
             ALPAKA_FN_HOST auto convertVecToUniformCudaHipDim(Vec<TDim, TIdx> const& vec) -> dim3
             {
@@ -123,13 +120,11 @@ namespace alpaka
         } // namespace detail
     } // namespace uniform_cuda_hip
 
-    //#############################################################################
     //! The GPU CUDA/HIP accelerator execution task.
     template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelGpuUniformCudaHipRt final : public WorkDivMembers<TDim, TIdx>
     {
     public:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST TaskKernelGpuUniformCudaHipRt(
             TWorkDiv&& workDiv,
@@ -143,15 +138,10 @@ namespace alpaka
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                 "The work division and the execution task have to be of the same dimensionality!");
         }
-        //-----------------------------------------------------------------------------
         TaskKernelGpuUniformCudaHipRt(TaskKernelGpuUniformCudaHipRt const&) = default;
-        //-----------------------------------------------------------------------------
         TaskKernelGpuUniformCudaHipRt(TaskKernelGpuUniformCudaHipRt&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelGpuUniformCudaHipRt const&) -> TaskKernelGpuUniformCudaHipRt& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelGpuUniformCudaHipRt&&) -> TaskKernelGpuUniformCudaHipRt& = default;
-        //-----------------------------------------------------------------------------
         ~TaskKernelGpuUniformCudaHipRt() = default;
 
         TKernelFnObj m_kernelFnObj;
@@ -160,7 +150,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The GPU CUDA/HIP execution task accelerator type trait specialization.
         template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct AccType<TaskKernelGpuUniformCudaHipRt<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -168,7 +157,6 @@ namespace alpaka
             using type = AccGpuUniformCudaHipRt<TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The GPU CUDA/HIP execution task device type trait specialization.
         template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DevType<TaskKernelGpuUniformCudaHipRt<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -176,7 +164,6 @@ namespace alpaka
             using type = DevUniformCudaHipRt;
         };
 
-        //#############################################################################
         //! The GPU CUDA/HIP execution task dimension getter trait specialization.
         template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DimType<TaskKernelGpuUniformCudaHipRt<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -184,7 +171,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The CPU CUDA/HIP execution task platform type trait specialization.
         template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct PltfType<TaskKernelGpuUniformCudaHipRt<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -192,7 +178,6 @@ namespace alpaka
             using type = PltfUniformCudaHipRt;
         };
 
-        //#############################################################################
         //! The GPU CUDA/HIP execution task idx type trait specialization.
         template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct IdxType<TaskKernelGpuUniformCudaHipRt<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -200,14 +185,12 @@ namespace alpaka
             using type = TIdx;
         };
 
-        //#############################################################################
         //! The CUDA/HIP non-blocking kernel enqueue trait specialization.
         template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct Enqueue<
             QueueUniformCudaHipRtNonBlocking,
             TaskKernelGpuUniformCudaHipRt<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtNonBlocking& queue,
                 TaskKernelGpuUniformCudaHipRt<TAcc, TDim, TIdx, TKernelFnObj, TArgs...> const& task) -> void
@@ -324,14 +307,12 @@ namespace alpaka
 #    endif
             }
         };
-        //#############################################################################
         //! The CUDA/HIP synchronous kernel enqueue trait specialization.
         template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct Enqueue<
             QueueUniformCudaHipRtBlocking,
             TaskKernelGpuUniformCudaHipRt<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtBlocking& queue,
                 TaskKernelGpuUniformCudaHipRt<TAcc, TDim, TIdx, TKernelFnObj, TArgs...> const& task) -> void

--- a/include/alpaka/kernel/TaskKernelOacc.hpp
+++ b/include/alpaka/kernel/TaskKernelOacc.hpp
@@ -43,13 +43,11 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The OpenACC accelerator execution task.
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelOacc final : public WorkDivMembers<TDim, TIdx>
     {
     public:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST TaskKernelOacc(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
@@ -60,18 +58,12 @@ namespace alpaka
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                 "The work division and the execution task have to be of the same dimensionality!");
         }
-        //-----------------------------------------------------------------------------
         TaskKernelOacc(TaskKernelOacc const& other) = default;
-        //-----------------------------------------------------------------------------
         TaskKernelOacc(TaskKernelOacc&& other) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelOacc const&) -> TaskKernelOacc& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelOacc&&) -> TaskKernelOacc& = default;
-        //-----------------------------------------------------------------------------
         ~TaskKernelOacc() = default;
 
-        //-----------------------------------------------------------------------------
         //! Executes the kernel function object.
         ALPAKA_FN_HOST auto operator()(const DevOacc& dev) const -> void
         {
@@ -169,7 +161,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The OpenACC execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct AccType<TaskKernelOacc<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -177,7 +168,6 @@ namespace alpaka
             using type = AccOacc<TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The OpenACC execution task device type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DevType<TaskKernelOacc<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -185,7 +175,6 @@ namespace alpaka
             using type = DevOacc;
         };
 
-        //#############################################################################
         //! The OpenACC execution task dimension getter trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DimType<TaskKernelOacc<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -193,7 +182,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The OpenACC execution task platform type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct PltfType<TaskKernelOacc<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -201,7 +189,6 @@ namespace alpaka
             using type = PltfOacc;
         };
 
-        //#############################################################################
         //! The OpenACC execution task idx type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct IdxType<TaskKernelOacc<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -229,7 +216,6 @@ namespace alpaka
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct Enqueue<QueueOaccNonBlocking, TaskKernelOacc<TDim, TIdx, TKernelFnObj, TArgs...>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueOaccNonBlocking& queue,
                 TaskKernelOacc<TDim, TIdx, TKernelFnObj, TArgs...> const& task) -> void

--- a/include/alpaka/kernel/TaskKernelOmp5.hpp
+++ b/include/alpaka/kernel/TaskKernelOmp5.hpp
@@ -44,13 +44,11 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The OpenMP 5.0 accelerator execution task.
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelOmp5 final : public WorkDivMembers<TDim, TIdx>
     {
     public:
-        //-----------------------------------------------------------------------------
         template<typename TWorkDiv>
         ALPAKA_FN_HOST TaskKernelOmp5(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
@@ -61,18 +59,12 @@ namespace alpaka
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,
                 "The work division and the execution task have to be of the same dimensionality!");
         }
-        //-----------------------------------------------------------------------------
         TaskKernelOmp5(TaskKernelOmp5 const& other) = default;
-        //-----------------------------------------------------------------------------
         TaskKernelOmp5(TaskKernelOmp5&& other) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelOmp5 const&) -> TaskKernelOmp5& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(TaskKernelOmp5&&) -> TaskKernelOmp5& = default;
-        //-----------------------------------------------------------------------------
         ~TaskKernelOmp5() = default;
 
-        //-----------------------------------------------------------------------------
         //! Executes the kernel function object.
         ALPAKA_FN_HOST auto operator()(const DevOmp5& dev) const -> void
         {
@@ -215,7 +207,6 @@ namespace alpaka
     };
     namespace traits
     {
-        //#############################################################################
         //! The OpenMP 5.0 execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct AccType<TaskKernelOmp5<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -223,7 +214,6 @@ namespace alpaka
             using type = AccOmp5<TDim, TIdx>;
         };
 
-        //#############################################################################
         //! The OpenMP 5.0 execution task device type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DevType<TaskKernelOmp5<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -231,7 +221,6 @@ namespace alpaka
             using type = DevOmp5;
         };
 
-        //#############################################################################
         //! The OpenMP 5.0 execution task dimension getter trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct DimType<TaskKernelOmp5<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -239,7 +228,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The OpenMP 5.0 execution task platform type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct PltfType<TaskKernelOmp5<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -247,7 +235,6 @@ namespace alpaka
             using type = PltfOmp5;
         };
 
-        //#############################################################################
         //! The OpenMP 5.0 execution task idx type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct IdxType<TaskKernelOmp5<TDim, TIdx, TKernelFnObj, TArgs...>>
@@ -275,7 +262,6 @@ namespace alpaka
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
         struct Enqueue<QueueOmp5NonBlocking, TaskKernelOmp5<TDim, TIdx, TKernelFnObj, TArgs...>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueOmp5NonBlocking& queue,
                 TaskKernelOmp5<TDim, TIdx, TKernelFnObj, TArgs...> const& task) -> void

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -25,15 +25,12 @@
 
 #include <type_traits>
 
-//-----------------------------------------------------------------------------
 //! The alpaka accelerator library.
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The kernel traits.
     namespace traits
     {
-        //#############################################################################
         //! The kernel execution task creation trait.
         template<
             typename TAcc,
@@ -43,7 +40,6 @@ namespace alpaka
             typename TSfinae = void*/>
         struct CreateTaskKernel;
 
-        //#############################################################################
         //! The trait for getting the size of the block shared dynamic memory of a kernel.
         //!
         //! \tparam TKernelFnObj The kernel function object.
@@ -58,7 +54,6 @@ namespace alpaka
 #    pragma clang diagnostic ignored                                                                                  \
         "-Wdocumentation" // clang does not support the syntax for variadic template arguments "args,..."
 #endif
-            //-----------------------------------------------------------------------------
             //! \param kernelFnObj The kernel object for which the block shared memory size should be calculated.
             //! \param blockThreadExtent The block thread extent.
             //! \param threadElemExtent The thread element extent.
@@ -88,7 +83,6 @@ namespace alpaka
 
         namespace detail
         {
-            //#############################################################################
             //! Functor to get OpenMP schedule defined by kernel class.
             //! When no schedule is defined, return a default one.
             template<class TKernel, class = void>
@@ -117,7 +111,6 @@ namespace alpaka
             };
         } // namespace detail
 
-        //#############################################################################
         //! The trait for getting the schedule to use when a kernel is run using
         //! the CpuOmp2Blocks accelerator.
         //!
@@ -141,7 +134,6 @@ namespace alpaka
 #    pragma clang diagnostic ignored                                                                                  \
         "-Wdocumentation" // clang does not support the syntax for variadic template arguments "args,..."
 #endif
-            //-----------------------------------------------------------------------------
             //! \param kernelFnObj The kernel object for which the schedule should be returned.
             //! \param blockThreadExtent The block thread extent.
             //! \param threadElemExtent The thread element extent.
@@ -174,7 +166,6 @@ namespace alpaka
 #    pragma clang diagnostic ignored                                                                                  \
         "-Wdocumentation" // clang does not support the syntax for variadic template arguments "args,..."
 #endif
-    //-----------------------------------------------------------------------------
     //! \tparam TAcc The accelerator type.
     //! \param kernelFnObj The kernel object for which the block shared memory size should be calculated.
     //! \param blockThreadExtent The block thread extent.
@@ -205,7 +196,6 @@ namespace alpaka
 #    pragma clang diagnostic ignored                                                                                  \
         "-Wdocumentation" // clang does not support the syntax for variadic template arguments "args,..."
 #endif
-    //-----------------------------------------------------------------------------
     //! \tparam TAcc The accelerator type.
     //! \param kernelFnObj The kernel object for which the block shared memory size should be calculated.
     //! \param blockThreadExtent The block thread extent.
@@ -237,7 +227,6 @@ namespace alpaka
 
     namespace detail
     {
-        //#############################################################################
         //! Check that the return of TKernelFnObj is void
         template<typename TAcc, typename TSfinae = void>
         struct CheckFnReturnType
@@ -254,7 +243,6 @@ namespace alpaka
             }
         };
     } // namespace detail
-    //-----------------------------------------------------------------------------
     //! Creates a kernel execution task.
     //!
     //! \tparam TAcc The accelerator type.
@@ -293,7 +281,6 @@ namespace alpaka
 #    pragma clang diagnostic ignored                                                                                  \
         "-Wdocumentation" // clang does not support the syntax for variadic template arguments "args,..."
 #endif
-    //-----------------------------------------------------------------------------
     //! Executes the given kernel in the given queue.
     //!
     //! \tparam TAcc The accelerator type.

--- a/include/alpaka/math/MathStdLib.hpp
+++ b/include/alpaka/math/MathStdLib.hpp
@@ -36,11 +36,9 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The mathematical operation specifics.
     namespace math
     {
-        //#############################################################################
         //! The standard library math trait specializations.
         class MathStdLib
             : public AbsStdLib

--- a/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
@@ -63,11 +63,9 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The mathematical operation specifics.
     namespace math
     {
-        //#############################################################################
         //! The standard library math trait specializations.
         class MathUniformCudaHipBuiltIn
             : public AbsUniformCudaHipBuiltIn

--- a/include/alpaka/math/abs/AbsStdLib.hpp
+++ b/include/alpaka/math/abs/AbsStdLib.hpp
@@ -20,7 +20,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library abs.
         class AbsStdLib : public concepts::Implements<ConceptMathAbs, AbsStdLib>
         {
@@ -28,7 +27,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library abs trait specialization.
             template<typename TArg>
             struct Abs<

--- a/include/alpaka/math/abs/AbsUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in abs.
         class AbsUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathAbs, AbsUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA built in abs trait specialization.
             template<typename TArg>
             struct Abs<AbsUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/abs/Traits.hpp
+++ b/include/alpaka/math/abs/Traits.hpp
@@ -23,11 +23,9 @@ namespace alpaka
         {
         };
 
-        //-----------------------------------------------------------------------------
         //! The math traits.
         namespace traits
         {
-            //#############################################################################
             //! The abs trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Abs
@@ -42,7 +40,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the absolute value.
         //!
         //! \tparam T The type of the object specializing Abs.

--- a/include/alpaka/math/acos/AcosStdLib.hpp
+++ b/include/alpaka/math/acos/AcosStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library acos.
         class AcosStdLib : public concepts::Implements<ConceptMathAcos, AcosStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library acos trait specialization.
             template<typename TArg>
             struct Acos<AcosStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/acos/AcosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in acos.
         class AcosUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathAcos, AcosUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA acos trait specialization.
             template<typename TArg>
             struct Acos<AcosUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/acos/Traits.hpp
+++ b/include/alpaka/math/acos/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The acos trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Acos
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the principal value of the arc cosine.
         //!
         //! The valid real argument range is [-1.0, 1.0]. For other values

--- a/include/alpaka/math/asin/AsinStdLib.hpp
+++ b/include/alpaka/math/asin/AsinStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library asin.
         class AsinStdLib : public concepts::Implements<ConceptMathAsin, AsinStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library asin trait specialization.
             template<typename TArg>
             struct Asin<AsinStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/asin/AsinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in asin.
         class AsinUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathAsin, AsinUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA asin trait specialization.
             template<typename TArg>
             struct Asin<AsinUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/asin/Traits.hpp
+++ b/include/alpaka/math/asin/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The asin trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Asin
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the principal value of the arc sine.
         //!
         //! The valid real argument range is [-1.0, 1.0]. For other values

--- a/include/alpaka/math/atan/AtanStdLib.hpp
+++ b/include/alpaka/math/atan/AtanStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library atan.
         class AtanStdLib : public concepts::Implements<ConceptMathAtan, AtanStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library atan trait specialization.
             template<typename TArg>
             struct Atan<AtanStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/atan/AtanUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in atan.
         class AtanUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathAtan, AtanUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA atan trait specialization.
             template<typename TArg>
             struct Atan<AtanUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/atan/Traits.hpp
+++ b/include/alpaka/math/atan/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The atan trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Atan
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the principal value of the arc tangent.
         //!
         //! \tparam TArg The arg type.

--- a/include/alpaka/math/atan2/Atan2StdLib.hpp
+++ b/include/alpaka/math/atan2/Atan2StdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library atan2.
         class Atan2StdLib : public concepts::Implements<ConceptMathAtan2, Atan2StdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library atan2 trait specialization.
             template<typename Ty, typename Tx>
             struct Atan2<

--- a/include/alpaka/math/atan2/Atan2UniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2UniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in atan2.
         class Atan2UniformCudaHipBuiltIn : public concepts::Implements<ConceptMathAtan2, Atan2UniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA atan2 trait specialization.
             template<typename Ty, typename Tx>
             struct Atan2<

--- a/include/alpaka/math/atan2/Traits.hpp
+++ b/include/alpaka/math/atan2/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The atan2 trait.
             template<typename T, typename Ty, typename Tx, typename TSfinae = void>
             struct Atan2
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the arc tangent of y/x using the signs of arguments to determine the correct quadrant.
         //!
         //! \tparam T The type of the object specializing Atan2.

--- a/include/alpaka/math/cbrt/CbrtStdLib.hpp
+++ b/include/alpaka/math/cbrt/CbrtStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library cbrt.
         class CbrtStdLib : public concepts::Implements<ConceptMathCbrt, CbrtStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library cbrt trait specialization.
             template<typename TArg>
             struct Cbrt<CbrtStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/cbrt/CbrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in cbrt.
         class CbrtUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathCbrt, CbrtUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA cbrt trait specialization.
             template<typename TArg>
             struct Cbrt<CbrtUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/cbrt/Traits.hpp
+++ b/include/alpaka/math/cbrt/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The cbrt trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Cbrt
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the cbrt.
         //!
         //! \tparam T The type of the object specializing Cbrt.

--- a/include/alpaka/math/ceil/CeilStdLib.hpp
+++ b/include/alpaka/math/ceil/CeilStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library ceil.
         class CeilStdLib : public concepts::Implements<ConceptMathCeil, CeilStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library ceil trait specialization.
             template<typename TArg>
             struct Ceil<CeilStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/ceil/CeilUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in ceil.
         class CeilUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathCeil, CeilUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA ceil trait specialization.
             template<typename TArg>
             struct Ceil<CeilUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/ceil/Traits.hpp
+++ b/include/alpaka/math/ceil/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The ceil trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Ceil
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the smallest integer value not less than arg.
         //!
         //! \tparam T The type of the object specializing Ceil.

--- a/include/alpaka/math/cos/CosStdLib.hpp
+++ b/include/alpaka/math/cos/CosStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library cos.
         class CosStdLib : public concepts::Implements<ConceptMathCos, CosStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library cos trait specialization.
             template<typename TArg>
             struct Cos<CosStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/cos/CosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in cos.
         class CosUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathCos, CosUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA cos trait specialization.
             template<typename TArg>
             struct Cos<CosUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/cos/Traits.hpp
+++ b/include/alpaka/math/cos/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The cos trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Cos
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the cosine (measured in radians).
         //!
         //! \tparam T The type of the object specializing Cos.

--- a/include/alpaka/math/erf/ErfStdLib.hpp
+++ b/include/alpaka/math/erf/ErfStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library erf.
         class ErfStdLib : public concepts::Implements<ConceptMathErf, ErfStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library erf trait specialization.
             template<typename TArg>
             struct Erf<ErfStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/erf/ErfUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in erf.
         class ErfUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathErf, ErfUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA erf trait specialization.
             template<typename TArg>
             struct Erf<ErfUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/erf/Traits.hpp
+++ b/include/alpaka/math/erf/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The erf trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Erf
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the error function of arg.
         //!
         //! \tparam T The type of the object specializing Erf.

--- a/include/alpaka/math/exp/ExpStdLib.hpp
+++ b/include/alpaka/math/exp/ExpStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library exp.
         class ExpStdLib : public concepts::Implements<ConceptMathExp, ExpStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library exp trait specialization.
             template<typename TArg>
             struct Exp<ExpStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/exp/ExpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in exp.
         class ExpUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathExp, ExpUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA exp trait specialization.
             template<typename TArg>
             struct Exp<ExpUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/exp/Traits.hpp
+++ b/include/alpaka/math/exp/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The exp trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Exp
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the e (Euler's number, 2.7182818) raised to the given power arg.
         //!
         //! \tparam T The type of the object specializing Exp.

--- a/include/alpaka/math/floor/FloorStdLib.hpp
+++ b/include/alpaka/math/floor/FloorStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library floor.
         class FloorStdLib : public concepts::Implements<ConceptMathFloor, FloorStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library floor trait specialization.
             template<typename TArg>
             struct Floor<FloorStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/floor/FloorUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in floor.
         class FloorUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathFloor, FloorUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA floor trait specialization.
             template<typename TArg>
             struct Floor<FloorUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/floor/Traits.hpp
+++ b/include/alpaka/math/floor/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The floor trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Floor
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the largest integer value not greater than arg.
         //!
         //! \tparam T The type of the object specializing Floor.

--- a/include/alpaka/math/fmod/FmodStdLib.hpp
+++ b/include/alpaka/math/fmod/FmodStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library fmod.
         class FmodStdLib : public concepts::Implements<ConceptMathFmod, FmodStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library fmod trait specialization.
             template<typename Tx, typename Ty>
             struct Fmod<

--- a/include/alpaka/math/fmod/FmodUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in fmod.
         class FmodUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathFmod, FmodUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA fmod trait specialization.
             template<typename Tx, typename Ty>
             struct Fmod<

--- a/include/alpaka/math/fmod/Traits.hpp
+++ b/include/alpaka/math/fmod/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The fmod trait.
             template<typename T, typename Tx, typename Ty, typename TSfinae = void>
             struct Fmod
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the floating-point remainder of the division operation x/y.
         //!
         //! \tparam T The type of the object specializing Fmod.

--- a/include/alpaka/math/log/LogStdLib.hpp
+++ b/include/alpaka/math/log/LogStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library log.
         class LogStdLib : public concepts::Implements<ConceptMathLog, LogStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library log trait specialization.
             template<typename TArg>
             struct Log<LogStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/log/LogUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/log/LogUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         // ! The CUDA built in log.
         class LogUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathLog, LogUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA log trait specialization.
             template<typename TArg>
             struct Log<LogUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/log/Traits.hpp
+++ b/include/alpaka/math/log/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The log trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Log
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the the natural (base e) logarithm of arg.
         //!
         //! Valid real arguments are non-negative. For other values the result

--- a/include/alpaka/math/max/MaxStdLib.hpp
+++ b/include/alpaka/math/max/MaxStdLib.hpp
@@ -20,7 +20,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library max.
         class MaxStdLib : public concepts::Implements<ConceptMathMax, MaxStdLib>
         {
@@ -28,7 +27,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library integral max trait specialization.
             template<typename Tx, typename Ty>
             struct Max<MaxStdLib, Tx, Ty, std::enable_if_t<std::is_integral<Tx>::value && std::is_integral<Ty>::value>>
@@ -39,7 +37,6 @@ namespace alpaka
                     return std::max(x, y);
                 }
             };
-            //#############################################################################
             //! The standard library mixed integral floating point max trait specialization.
             template<typename Tx, typename Ty>
             struct Max<

--- a/include/alpaka/math/max/MaxUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxUniformCudaHipBuiltIn.hpp
@@ -45,7 +45,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in max.
         class MaxUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathMax, MaxUniformCudaHipBuiltIn>
         {
@@ -53,7 +52,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library integral max trait specialization.
             template<typename Tx, typename Ty>
             struct Max<
@@ -69,7 +67,6 @@ namespace alpaka
                     return ::max(x, y);
                 }
             };
-            //#############################################################################
             //! The CUDA mixed integral floating point max trait specialization.
             template<typename Tx, typename Ty>
             struct Max<

--- a/include/alpaka/math/max/Traits.hpp
+++ b/include/alpaka/math/max/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The max trait.
             template<typename T, typename Tx, typename Ty, typename TSfinae = void>
             struct Max
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Returns the larger of two arguments.
         //! NaNs are treated as missing data (between a NaN and a numeric value, the numeric value is chosen).
         //!

--- a/include/alpaka/math/min/MinStdLib.hpp
+++ b/include/alpaka/math/min/MinStdLib.hpp
@@ -20,7 +20,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library min.
         class MinStdLib : public concepts::Implements<ConceptMathMin, MinStdLib>
         {
@@ -28,7 +27,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library integral min trait specialization.
             template<typename Tx, typename Ty>
             struct Min<MinStdLib, Tx, Ty, std::enable_if_t<std::is_integral<Tx>::value && std::is_integral<Ty>::value>>
@@ -39,7 +37,6 @@ namespace alpaka
                     return std::min(x, y);
                 }
             };
-            //#############################################################################
             //! The standard library mixed integral floating point min trait specialization.
             template<typename Tx, typename Ty>
             struct Min<

--- a/include/alpaka/math/min/MinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/min/MinUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in min.
         class MinUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathMin, MinUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA integral min trait specialization.
             template<typename Tx, typename Ty>
             struct Min<
@@ -70,7 +68,6 @@ namespace alpaka
                     return ::min(x, y);
                 }
             };
-            //#############################################################################
             //! The standard library mixed integral floating point min trait specialization.
             template<typename Tx, typename Ty>
             struct Min<

--- a/include/alpaka/math/min/Traits.hpp
+++ b/include/alpaka/math/min/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The min trait.
             template<typename T, typename Tx, typename Ty, typename TSfinae = void>
             struct Min
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Returns the smaller of two arguments.
         //! NaNs are treated as missing data (between a NaN and a numeric value, the numeric value is chosen).
         //!

--- a/include/alpaka/math/pow/PowStdLib.hpp
+++ b/include/alpaka/math/pow/PowStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library pow.
         class PowStdLib : public concepts::Implements<ConceptMathPow, PowStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library pow trait specialization.
             template<typename TBase, typename TExp>
             struct Pow<

--- a/include/alpaka/math/pow/PowUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in pow.
         class PowUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathPow, PowUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA pow trait specialization.
             template<typename TBase, typename TExp>
             struct Pow<

--- a/include/alpaka/math/pow/Traits.hpp
+++ b/include/alpaka/math/pow/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The pow trait.
             template<typename T, typename TBase, typename TExp, typename TSfinae = void>
             struct Pow
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the value of base raised to the power exp.
         //!
         //! Valid real arguments for base are non-negative. For other values

--- a/include/alpaka/math/remainder/RemainderStdLib.hpp
+++ b/include/alpaka/math/remainder/RemainderStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library remainder.
         class RemainderStdLib : public concepts::Implements<ConceptMathRemainder, RemainderStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library remainder trait specialization.
             template<typename Tx, typename Ty>
             struct Remainder<

--- a/include/alpaka/math/remainder/RemainderUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA built in remainder.
         class RemainderUniformCudaHipBuiltIn
             : public concepts::Implements<ConceptMathRemainder, RemainderUniformCudaHipBuiltIn>
@@ -55,7 +54,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA remainder trait specialization.
             template<typename Tx, typename Ty>
             struct Remainder<

--- a/include/alpaka/math/remainder/Traits.hpp
+++ b/include/alpaka/math/remainder/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The remainder trait.
             template<typename T, typename Tx, typename Ty, typename TSfinae = void>
             struct Remainder
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the IEEE remainder of the floating point division operation x/y.
         //!
         //! \tparam T The type of the object specializing Remainder.

--- a/include/alpaka/math/round/RoundStdLib.hpp
+++ b/include/alpaka/math/round/RoundStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library round.
         class RoundStdLib : public concepts::Implements<ConceptMathRound, RoundStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library round trait specialization.
             template<typename TArg>
             struct Round<RoundStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
@@ -38,7 +36,6 @@ namespace alpaka
                     return std::round(arg);
                 }
             };
-            //#############################################################################
             //! The standard library round trait specialization.
             template<typename TArg>
             struct Lround<RoundStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
@@ -49,7 +46,6 @@ namespace alpaka
                     return std::lround(arg);
                 }
             };
-            //#############################################################################
             //! The standard library round trait specialization.
             template<typename TArg>
             struct Llround<RoundStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/round/RoundUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA round.
         class RoundUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathRound, RoundUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA round trait specialization.
             template<typename TArg>
             struct Round<RoundUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
@@ -65,7 +63,6 @@ namespace alpaka
                     return ::round(arg);
                 }
             };
-            //#############################################################################
             //! The CUDA lround trait specialization.
             template<typename TArg>
             struct Lround<RoundUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
@@ -76,7 +73,6 @@ namespace alpaka
                     return ::lround(arg);
                 }
             };
-            //#############################################################################
             //! The CUDA llround trait specialization.
             template<typename TArg>
             struct Llround<RoundUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/round/Traits.hpp
+++ b/include/alpaka/math/round/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The round trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Round
@@ -39,7 +38,6 @@ namespace alpaka
                 }
             };
 
-            //#############################################################################
             //! The round trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Lround
@@ -53,7 +51,6 @@ namespace alpaka
                 }
             };
 
-            //#############################################################################
             //! The round trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Llround
@@ -68,7 +65,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the nearest integer value to arg (in floating-point format), rounding halfway cases away from
         //! zero, regardless of the current rounding mode.
         //!
@@ -83,7 +79,6 @@ namespace alpaka
             using ImplementationBase = concepts::ImplementationBase<ConceptMathRound, T>;
             return traits::Round<ImplementationBase, TArg>{}(round_ctx, arg);
         }
-        //-----------------------------------------------------------------------------
         //! Computes the nearest integer value to arg (in integer format), rounding halfway cases away from zero,
         //! regardless of the current rounding mode.
         //!
@@ -98,7 +93,6 @@ namespace alpaka
             using ImplementationBase = concepts::ImplementationBase<ConceptMathRound, T>;
             return traits::Lround<ImplementationBase, TArg>{}(lround_ctx, arg);
         }
-        //-----------------------------------------------------------------------------
         //! Computes the nearest integer value to arg (in integer format), rounding halfway cases away from zero,
         //! regardless of the current rounding mode.
         //!

--- a/include/alpaka/math/rsqrt/RsqrtStdLib.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library rsqrt.
         class RsqrtStdLib : public concepts::Implements<ConceptMathRsqrt, RsqrtStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library rsqrt trait specialization.
             template<typename TArg>
             struct Rsqrt<RsqrtStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/rsqrt/RsqrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA rsqrt.
         class RsqrtUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathRsqrt, RsqrtUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA rsqrt trait specialization.
             template<typename TArg>
             struct Rsqrt<RsqrtUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/rsqrt/Traits.hpp
+++ b/include/alpaka/math/rsqrt/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The rsqrt trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Rsqrt
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the rsqrt.
         //!
         //! Valid real arguments are positive. For other values the result

--- a/include/alpaka/math/sin/SinStdLib.hpp
+++ b/include/alpaka/math/sin/SinStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library sin.
         class SinStdLib : public concepts::Implements<ConceptMathSin, SinStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library sin trait specialization.
             template<typename TArg>
             struct Sin<SinStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/sin/SinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA sin.
         class SinUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathSin, SinUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA sin trait specialization.
             template<typename TArg>
             struct Sin<SinUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/sin/Traits.hpp
+++ b/include/alpaka/math/sin/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The sin trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Sin
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the sine (measured in radians).
         //!
         //! \tparam T The type of the object specializing Sin.

--- a/include/alpaka/math/sincos/SinCosStdLib.hpp
+++ b/include/alpaka/math/sincos/SinCosStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library sincos.
         class SinCosStdLib : public concepts::Implements<ConceptMathSinCos, SinCosStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library sincos trait specialization.
             template<typename TArg>
             struct SinCos<SinCosStdLib, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/sincos/SinCosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sincos/SinCosUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA sincos.
         class SinCosUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathSinCos, SinCosUniformCudaHipBuiltIn>
         {
@@ -54,8 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
-
             //! sincos trait specialization.
             template<>
             struct SinCos<SinCosUniformCudaHipBuiltIn, double>

--- a/include/alpaka/math/sincos/Traits.hpp
+++ b/include/alpaka/math/sincos/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The sincos trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct SinCos
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the sine and cosine (measured in radians).
         //!
         //! \tparam T The type of the object specializing SinCos.

--- a/include/alpaka/math/sqrt/SqrtStdLib.hpp
+++ b/include/alpaka/math/sqrt/SqrtStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library sqrt.
         class SqrtStdLib : public concepts::Implements<ConceptMathSqrt, SqrtStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library sqrt trait specialization.
             template<typename TArg>
             struct Sqrt<SqrtStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/sqrt/SqrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA sqrt.
         class SqrtUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathSqrt, SqrtUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA sqrt trait specialization.
             template<typename TArg>
             struct Sqrt<SqrtUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/sqrt/Traits.hpp
+++ b/include/alpaka/math/sqrt/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The sqrt trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Sqrt
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the square root of arg.
         //!
         //! Valid real arguments are non-negative. For other values the result

--- a/include/alpaka/math/tan/TanStdLib.hpp
+++ b/include/alpaka/math/tan/TanStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library tan.
         class TanStdLib : public concepts::Implements<ConceptMathTan, TanStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library tan trait specialization.
             template<typename TArg>
             struct Tan<TanStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/tan/TanUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA tan.
         class TanUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathTan, TanUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA tan trait specialization.
             template<typename TArg>
             struct Tan<TanUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/math/tan/Traits.hpp
+++ b/include/alpaka/math/tan/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The tan trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Tan
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the tangent (measured in radians).
         //!
         //! \tparam T The type of the object specializing Tan.

--- a/include/alpaka/math/trunc/Traits.hpp
+++ b/include/alpaka/math/trunc/Traits.hpp
@@ -25,7 +25,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The trunc trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Trunc
@@ -40,7 +39,6 @@ namespace alpaka
             };
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Computes the nearest integer not greater in magnitude than arg.
         //!
         //! \tparam T The type of the object specializing Trunc.

--- a/include/alpaka/math/trunc/TruncStdLib.hpp
+++ b/include/alpaka/math/trunc/TruncStdLib.hpp
@@ -19,7 +19,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The standard library trunc.
         class TruncStdLib : public concepts::Implements<ConceptMathTrunc, TruncStdLib>
         {
@@ -27,7 +26,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The standard library trunc trait specialization.
             template<typename TArg>
             struct Trunc<TruncStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>

--- a/include/alpaka/math/trunc/TruncUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncUniformCudaHipBuiltIn.hpp
@@ -46,7 +46,6 @@ namespace alpaka
 {
     namespace math
     {
-        //#############################################################################
         //! The CUDA trunc.
         class TruncUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathTrunc, TruncUniformCudaHipBuiltIn>
         {
@@ -54,7 +53,6 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //! The CUDA trunc trait specialization.
             template<typename TArg>
             struct Trunc<TruncUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>

--- a/include/alpaka/mem/alloc/AllocCpuAligned.hpp
+++ b/include/alpaka/mem/alloc/AllocCpuAligned.hpp
@@ -18,7 +18,6 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The CPU boost aligned allocator.
     //!
     //! \tparam TAlignment An integral constant containing the alignment.
@@ -29,12 +28,10 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU boost aligned allocator memory allocation trait specialization.
         template<typename T, typename TAlignment>
         struct Malloc<T, AllocCpuAligned<TAlignment>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto malloc(AllocCpuAligned<TAlignment> const& alloc, std::size_t const& sizeElems)
                 -> T*
             {
@@ -58,12 +55,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU boost aligned allocator memory free trait specialization.
         template<typename T, typename TAlignment>
         struct Free<T, AllocCpuAligned<TAlignment>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto free(AllocCpuAligned<TAlignment> const& alloc, T const* const ptr) -> void
             {
                 alpaka::ignore_unused(alloc);

--- a/include/alpaka/mem/alloc/AllocCpuNew.hpp
+++ b/include/alpaka/mem/alloc/AllocCpuNew.hpp
@@ -15,7 +15,6 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The CPU new allocator.
     class AllocCpuNew : public concepts::Implements<ConceptMemAlloc, AllocCpuNew>
     {
@@ -23,12 +22,10 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU new allocator memory allocation trait specialization.
         template<typename T>
         struct Malloc<T, AllocCpuNew>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto malloc(AllocCpuNew const& alloc, std::size_t const& sizeElems) -> T*
             {
                 alpaka::ignore_unused(alloc);
@@ -36,12 +33,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU new allocator memory free trait specialization.
         template<typename T>
         struct Free<T, AllocCpuNew>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto free(AllocCpuNew const& alloc, T const* const ptr) -> void
             {
                 alpaka::ignore_unused(alloc);

--- a/include/alpaka/mem/alloc/Traits.hpp
+++ b/include/alpaka/mem/alloc/Traits.hpp
@@ -21,22 +21,18 @@ namespace alpaka
     {
     };
 
-    //-----------------------------------------------------------------------------
     //! The allocator traits.
     namespace traits
     {
-        //#############################################################################
         //! The memory allocation trait.
         template<typename T, typename TAlloc, typename TSfinae = void>
         struct Malloc;
 
-        //#############################################################################
         //! The memory free trait.
         template<typename T, typename TAlloc, typename TSfinae = void>
         struct Free;
     } // namespace traits
 
-    //-----------------------------------------------------------------------------
     //! \return The pointer to the allocated memory.
     template<typename T, typename TAlloc>
     ALPAKA_FN_HOST auto malloc(TAlloc const& alloc, std::size_t const& sizeElems) -> T*
@@ -45,7 +41,6 @@ namespace alpaka
         return traits::Malloc<T, ImplementationBase>::malloc(alloc, sizeElems);
     }
 
-    //-----------------------------------------------------------------------------
     //! Frees the memory identified by the given pointer.
     template<typename TAlloc, typename T>
     ALPAKA_FN_HOST auto free(TAlloc const& alloc, T const* const ptr) -> void

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -33,7 +33,6 @@ namespace alpaka
 {
     namespace detail
     {
-        //#############################################################################
         //! The CPU memory buffer.
         template<typename TElem, typename TDim, typename TIdx>
         class BufCpuImpl final
@@ -46,7 +45,6 @@ namespace alpaka
             static_assert(!std::is_const<TIdx>::value, "The idx type of the buffer can not be const!");
 
         public:
-            //-----------------------------------------------------------------------------
             template<typename TExtent>
             ALPAKA_FN_HOST BufCpuImpl(DevCpu const& dev, TExtent const& extent)
                 : AllocCpuAligned<std::integral_constant<std::size_t, core::vectorization::defaultAlignment>>()
@@ -73,15 +71,10 @@ namespace alpaka
                           << " pitch: " << m_pitchBytes << std::endl;
 #endif
             }
-            //-----------------------------------------------------------------------------
             BufCpuImpl(BufCpuImpl const&) = delete;
-            //-----------------------------------------------------------------------------
             BufCpuImpl(BufCpuImpl&&) = default;
-            //-----------------------------------------------------------------------------
             auto operator=(BufCpuImpl const&) -> BufCpuImpl& = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(BufCpuImpl&&) -> BufCpuImpl& = default;
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST ~BufCpuImpl()
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -95,7 +88,6 @@ namespace alpaka
             }
 
         private:
-            //-----------------------------------------------------------------------------
             //! \return The number of elements to allocate.
             template<typename TExtent>
             ALPAKA_FN_HOST static auto computeElementCount(TExtent const& extent) -> TIdx
@@ -116,27 +108,20 @@ namespace alpaka
         };
     } // namespace detail
 
-    //#############################################################################
     //! The CPU memory buffer.
     template<typename TElem, typename TDim, typename TIdx>
     class BufCpu
     {
     public:
-        //-----------------------------------------------------------------------------
         template<typename TExtent>
         ALPAKA_FN_HOST BufCpu(DevCpu const& dev, TExtent const& extent)
             : m_spBufCpuImpl(std::make_shared<detail::BufCpuImpl<TElem, TDim, TIdx>>(dev, extent))
         {
         }
-        //-----------------------------------------------------------------------------
         BufCpu(BufCpu const&) = default;
-        //-----------------------------------------------------------------------------
         BufCpu(BufCpu&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(BufCpu const&) -> BufCpu& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(BufCpu&&) -> BufCpu& = default;
-        //-----------------------------------------------------------------------------
         ~BufCpu() = default;
 
     public:
@@ -145,14 +130,12 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The BufCpu device type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct DevType<BufCpu<TElem, TDim, TIdx>>
         {
             using type = DevCpu;
         };
-        //#############################################################################
         //! The BufCpu device get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetDev<BufCpu<TElem, TDim, TIdx>>
@@ -163,7 +146,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufCpu dimension getter trait.
         template<typename TElem, typename TDim, typename TIdx>
         struct DimType<BufCpu<TElem, TDim, TIdx>>
@@ -171,7 +153,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The BufCpu memory element type get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct ElemType<BufCpu<TElem, TDim, TIdx>>
@@ -183,7 +164,6 @@ namespace alpaka
     {
         namespace traits
         {
-            //#############################################################################
             //! The BufCpu width get trait specialization.
             template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
             struct GetExtent<
@@ -191,7 +171,6 @@ namespace alpaka
                 BufCpu<TElem, TDim, TIdx>,
                 std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getExtent(BufCpu<TElem, TDim, TIdx> const& extent) -> TIdx
                 {
                     return extent.m_spBufCpuImpl->m_extentElements[TIdxIntegralConst::value];
@@ -201,28 +180,23 @@ namespace alpaka
     } // namespace extent
     namespace traits
     {
-        //#############################################################################
         //! The BufCpu native pointer get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrNative<BufCpu<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrNative(BufCpu<TElem, TDim, TIdx> const& buf) -> TElem const*
             {
                 return buf.m_spBufCpuImpl->m_pMem;
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrNative(BufCpu<TElem, TDim, TIdx>& buf) -> TElem*
             {
                 return buf.m_spBufCpuImpl->m_pMem;
             }
         };
-        //#############################################################################
         //! The BufCpu pointer on device get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrDev<BufCpu<TElem, TDim, TIdx>, DevCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrDev(BufCpu<TElem, TDim, TIdx> const& buf, DevCpu const& dev)
                 -> TElem const*
             {
@@ -235,7 +209,6 @@ namespace alpaka
                     throw std::runtime_error("The buffer is not accessible from the given device!");
                 }
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrDev(BufCpu<TElem, TDim, TIdx>& buf, DevCpu const& dev) -> TElem*
             {
                 if(dev == getDev(buf))
@@ -248,24 +221,20 @@ namespace alpaka
                 }
             }
         };
-        //#############################################################################
         //! The BufCpu pitch get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPitchBytes<DimInt<TDim::value - 1u>, BufCpu<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPitchBytes(BufCpu<TElem, TDim, TIdx> const& pitch) -> TIdx
             {
                 return pitch.m_spBufCpuImpl->m_pitchBytes;
             }
         };
 
-        //#############################################################################
         //! The BufCpu memory allocation trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct BufAlloc<TElem, TDim, TIdx, DevCpu>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent>
             ALPAKA_FN_HOST static auto allocBuf(DevCpu const& dev, TExtent const& extent) -> BufCpu<TElem, TDim, TIdx>
             {
@@ -274,12 +243,10 @@ namespace alpaka
                 return BufCpu<TElem, TDim, TIdx>(dev, extent);
             }
         };
-        //#############################################################################
         //! The BufCpu memory mapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Map<BufCpu<TElem, TDim, TIdx>, DevCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto map(BufCpu<TElem, TDim, TIdx>& buf, DevCpu const& dev) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -291,12 +258,10 @@ namespace alpaka
                 // If it is the same device, nothing has to be mapped.
             }
         };
-        //#############################################################################
         //! The BufCpu memory unmapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Unmap<BufCpu<TElem, TDim, TIdx>, DevCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto unmap(BufCpu<TElem, TDim, TIdx>& buf, DevCpu const& dev) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -308,12 +273,10 @@ namespace alpaka
                 // If it is the same device, nothing has to be mapped.
             }
         };
-        //#############################################################################
         //! The BufCpu memory pinning trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Pin<BufCpu<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto pin(BufCpu<TElem, TDim, TIdx>& buf) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -345,23 +308,19 @@ namespace alpaka
                 }
             }
         };
-        //#############################################################################
         //! The BufCpu memory unpinning trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Unpin<BufCpu<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto unpin(BufCpu<TElem, TDim, TIdx>& buf) -> void
             {
                 alpaka::unpin(*buf.m_spBufCpuImpl.get());
             }
         };
-        //#############################################################################
         //! The BufCpuImpl memory unpinning trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Unpin<alpaka::detail::BufCpuImpl<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto unpin(alpaka::detail::BufCpuImpl<TElem, TDim, TIdx>& bufImpl) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -383,23 +342,19 @@ namespace alpaka
                 }
             }
         };
-        //#############################################################################
         //! The BufCpu memory pin state trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct IsPinned<BufCpu<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto isPinned(BufCpu<TElem, TDim, TIdx> const& buf) -> bool
             {
                 return alpaka::isPinned(*buf.m_spBufCpuImpl.get());
             }
         };
-        //#############################################################################
         //! The BufCpuImpl memory pin state trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct IsPinned<alpaka::detail::BufCpuImpl<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto isPinned(alpaka::detail::BufCpuImpl<TElem, TDim, TIdx> const& bufImpl) -> bool
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -412,12 +367,10 @@ namespace alpaka
 #endif
             }
         };
-        //#############################################################################
         //! The BufCpu memory prepareForAsyncCopy trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct PrepareForAsyncCopy<BufCpu<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto prepareForAsyncCopy(BufCpu<TElem, TDim, TIdx>& buf) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -431,19 +384,16 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufCpu offset get trait specialization.
         template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
         struct GetOffset<TIdxIntegralConst, BufCpu<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getOffset(BufCpu<TElem, TDim, TIdx> const&) -> TIdx
             {
                 return 0u;
             }
         };
 
-        //#############################################################################
         //! The BufCpu idx type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct IdxType<BufCpu<TElem, TDim, TIdx>>

--- a/include/alpaka/mem/buf/BufOacc.hpp
+++ b/include/alpaka/mem/buf/BufOacc.hpp
@@ -38,7 +38,6 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             //! The OpenACC memory buffer detail.
             template<typename TElem, typename TDim, typename TIdx>
             class BufOaccImpl
@@ -52,7 +51,6 @@ namespace alpaka
             private:
                 using Elem = TElem;
                 using Dim = TDim;
-                //-----------------------------------------------------------------------------
                 //! Calculate the pitches purely from the extents.
                 template<typename TExtent>
                 ALPAKA_FN_HOST static auto calculatePitchesFromExtents(TExtent const& extent) -> Vec<TDim, TIdx>
@@ -67,7 +65,6 @@ namespace alpaka
                 }
 
             public:
-                //-----------------------------------------------------------------------------
                 //! Constructor
                 template<typename TExtent>
                 ALPAKA_FN_HOST BufOaccImpl(DevOacc const& dev, TElem* const pMem, TExtent const& extent)
@@ -110,7 +107,6 @@ namespace alpaka
     class BufOacc
     {
     public:
-        //-----------------------------------------------------------------------------
         //! Constructor
         template<typename TExtent>
         ALPAKA_FN_HOST BufOacc(DevOacc const& dev, TElem* const pMem, TExtent const& extent)
@@ -143,14 +139,12 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The BufOacc device type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct DevType<BufOacc<TElem, TDim, TIdx>>
         {
             using type = DevOacc;
         };
-        //#############################################################################
         //! The BufOacc device get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetDev<BufOacc<TElem, TDim, TIdx>>
@@ -161,7 +155,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufOacc dimension getter trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct DimType<BufOacc<TElem, TDim, TIdx>>
@@ -169,7 +162,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The BufOacc memory element type get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct ElemType<BufOacc<TElem, TDim, TIdx>>
@@ -182,7 +174,6 @@ namespace alpaka
     {
         namespace traits
         {
-            //#############################################################################
             //! The BufOacc extent get trait specialization.
             template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
             struct GetExtent<
@@ -190,7 +181,6 @@ namespace alpaka
                 BufOacc<TElem, TDim, TIdx>,
                 typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getExtent(BufOacc<TElem, TDim, TIdx> const& extent) -> TIdx
                 {
                     return extent.extentElements()[TIdxIntegralConst::value];
@@ -201,28 +191,23 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The BufOacc native pointer get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrNative<BufOacc<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrNative(BufOacc<TElem, TDim, TIdx> const& buf) -> TElem const*
             {
                 return (*buf).m_pMem;
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrNative(BufOacc<TElem, TDim, TIdx>& buf) -> TElem*
             {
                 return (*buf).m_pMem;
             }
         };
-        //#############################################################################
         //! The BufOacc pointer on device get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrDev<BufOacc<TElem, TDim, TIdx>, DevOacc>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrDev(BufOacc<TElem, TDim, TIdx> const& buf, DevOacc const& dev)
                 -> TElem const*
             {
@@ -235,7 +220,6 @@ namespace alpaka
                     throw std::runtime_error("The buffer is not accessible from the given device!");
                 }
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrDev(BufOacc<TElem, TDim, TIdx>& buf, DevOacc const& dev) -> TElem*
             {
                 if(dev == getDev(buf))
@@ -248,24 +232,20 @@ namespace alpaka
                 }
             }
         };
-        //#############################################################################
         //! The BufOacc pitch get trait specialization.
         template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
         struct GetPitchBytes<TIdxIntegralConst, BufOacc<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPitchBytes(BufOacc<TElem, TDim, TIdx> const& pitch) -> TIdx
             {
                 return (*pitch).m_pitchBytes[TIdxIntegralConst::value];
             }
         };
 
-        //#############################################################################
         //! The BufOacc 1D memory allocation trait specialization.
         template<typename TElem, typename TIdx>
         struct BufAlloc<TElem, DimInt<1u>, TIdx, DevOacc>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent>
             ALPAKA_FN_HOST static auto allocBuf(DevOacc const& dev, TExtent const& extent)
                 -> BufOacc<TElem, DimInt<1u>, TIdx>
@@ -286,12 +266,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufOacc nD memory allocation trait specialization. \todo Add pitch
         template<typename TElem, typename TDim, typename TIdx>
         struct BufAlloc<TElem, TDim, TIdx, DevOacc>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent>
             ALPAKA_FN_HOST static auto allocBuf(DevOacc const& dev, TExtent const& extent)
                 -> BufOacc<TElem, TDim, TIdx>
@@ -310,12 +288,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufOacc device memory mapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Map<BufOacc<TElem, TDim, TIdx>, DevOacc>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto map(BufOacc<TElem, TDim, TIdx> const& buf, DevOacc const& dev) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -328,12 +304,10 @@ namespace alpaka
                 // If it is already the same device, nothing has to be mapped.
             }
         };
-        //#############################################################################
         //! The BufOacc device memory unmapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Unmap<BufOacc<TElem, TDim, TIdx>, DevOacc>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto unmap(BufOacc<TElem, TDim, TIdx> const& buf, DevOacc const& dev) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -346,12 +320,10 @@ namespace alpaka
                 // If it is already the same device, nothing has to be unmapped.
             }
         };
-        //#############################################################################
         //! The BufOacc memory pinning trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Pin<BufOacc<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto pin(BufOacc<TElem, TDim, TIdx>&) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -359,12 +331,10 @@ namespace alpaka
                 // No explicit pinning in OpenACC? GPU would be pinned anyway.
             }
         };
-        //#############################################################################
         //! The BufOacc memory unpinning trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Unpin<BufOacc<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto unpin(BufOacc<TElem, TDim, TIdx>&) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -372,12 +342,10 @@ namespace alpaka
                 // No explicit pinning in OpenACC? GPU would be pinned anyway.
             }
         };
-        //#############################################################################
         //! The BufOacc memory pin state trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct IsPinned<BufOacc<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto isPinned(BufOacc<TElem, TDim, TIdx> const&) -> bool
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -386,12 +354,10 @@ namespace alpaka
                 return true;
             }
         };
-        //#############################################################################
         //! The BufOacc memory prepareForAsyncCopy trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct PrepareForAsyncCopy<BufOacc<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto prepareForAsyncCopy(BufOacc<TElem, TDim, TIdx>&) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -400,19 +366,16 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufOacc offset get trait specialization.
         template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
         struct GetOffset<TIdxIntegralConst, BufOacc<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getOffset(BufOacc<TElem, TDim, TIdx> const&) -> TIdx
             {
                 return 0u;
             }
         };
 
-        //#############################################################################
         //! The BufOacc idx type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct IdxType<BufOacc<TElem, TDim, TIdx>>
@@ -420,12 +383,10 @@ namespace alpaka
             using type = TIdx;
         };
 
-        //#############################################################################
         //! The BufCpu CUDA device memory mapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Map<BufCpu<TElem, TDim, TIdx>, DevOacc>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto map(BufCpu<TElem, TDim, TIdx>& buf, DevOacc const& dev) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -439,12 +400,10 @@ namespace alpaka
                 // If it is already the same device, nothing has to be mapped.
             }
         };
-        //#############################################################################
         //! The BufCpu CUDA device memory unmapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Unmap<BufCpu<TElem, TDim, TIdx>, DevOacc>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto unmap(BufCpu<TElem, TDim, TIdx>& buf, DevOacc const& dev) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -457,17 +416,14 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufCpu pointer on CUDA device get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrDev<BufCpu<TElem, TDim, TIdx>, DevOacc>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrDev(BufCpu<TElem, TDim, TIdx> const&, DevOacc const&) -> TElem const*
             {
                 throw std::runtime_error("Mapping host memory to OpenACC device not implemented!");
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrDev(BufCpu<TElem, TDim, TIdx>&, DevOacc const&) -> TElem*
             {
                 throw std::runtime_error("Mapping host memory to OpenACC device not implemented!");

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -36,7 +36,6 @@ namespace alpaka
 
     namespace detail
     {
-        //#############################################################################
         //! The OMP5 memory buffer detail.
         template<typename TElem, typename TDim, typename TIdx>
         class BufOmp5Impl
@@ -50,7 +49,6 @@ namespace alpaka
         private:
             using Elem = TElem;
             using Dim = TDim;
-            //-----------------------------------------------------------------------------
             //! Calculate the pitches purely from the extents.
             template<typename TExtent>
             ALPAKA_FN_HOST static auto calculatePitchesFromExtents(TExtent const& extent) -> Vec<TDim, TIdx>
@@ -65,7 +63,6 @@ namespace alpaka
             }
 
         public:
-            //-----------------------------------------------------------------------------
             //! Constructor
             template<typename TExtent>
             ALPAKA_FN_HOST BufOmp5Impl(DevOmp5 const& dev, TElem* const pMem, TExtent const& extent)
@@ -106,7 +103,6 @@ namespace alpaka
     class BufOmp5
     {
     public:
-        //-----------------------------------------------------------------------------
         //! Constructor
         template<typename TExtent>
         ALPAKA_FN_HOST BufOmp5(DevOmp5 const& dev, TElem* const pMem, TExtent const& extent)
@@ -139,14 +135,12 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The BufOmp5 device type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct DevType<BufOmp5<TElem, TDim, TIdx>>
         {
             using type = DevOmp5;
         };
-        //#############################################################################
         //! The BufOmp5 device get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetDev<BufOmp5<TElem, TDim, TIdx>>
@@ -157,7 +151,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufOmp5 dimension getter trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct DimType<BufOmp5<TElem, TDim, TIdx>>
@@ -165,7 +158,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The BufOmp5 memory element type get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct ElemType<BufOmp5<TElem, TDim, TIdx>>
@@ -177,7 +169,6 @@ namespace alpaka
     {
         namespace traits
         {
-            //#############################################################################
             //! The BufOmp5 extent get trait specialization.
             template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
             struct GetExtent<
@@ -185,7 +176,6 @@ namespace alpaka
                 BufOmp5<TElem, TDim, TIdx>,
                 typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getExtent(BufOmp5<TElem, TDim, TIdx> const& extent) -> TIdx
                 {
                     return extent.extentElements()[TIdxIntegralConst::value];
@@ -195,28 +185,23 @@ namespace alpaka
     } // namespace extent
     namespace traits
     {
-        //#############################################################################
         //! The BufOmp5 native pointer get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrNative<BufOmp5<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrNative(BufOmp5<TElem, TDim, TIdx> const& buf) -> TElem const*
             {
                 return (*buf).m_pMem;
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrNative(BufOmp5<TElem, TDim, TIdx>& buf) -> TElem*
             {
                 return (*buf).m_pMem;
             }
         };
-        //#############################################################################
         //! The BufOmp5 pointer on device get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrDev<BufOmp5<TElem, TDim, TIdx>, DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrDev(BufOmp5<TElem, TDim, TIdx> const& buf, DevOmp5 const& dev)
                 -> TElem const*
             {
@@ -229,7 +214,6 @@ namespace alpaka
                     throw std::runtime_error("The buffer is not accessible from the given device!");
                 }
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrDev(BufOmp5<TElem, TDim, TIdx>& buf, DevOmp5 const& dev) -> TElem*
             {
                 if(dev == getDev(buf))
@@ -242,24 +226,20 @@ namespace alpaka
                 }
             }
         };
-        //#############################################################################
         //! The BufOmp5 pitch get trait specialization.
         template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
         struct GetPitchBytes<TIdxIntegralConst, BufOmp5<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPitchBytes(BufOmp5<TElem, TDim, TIdx> const& pitch) -> TIdx
             {
                 return (*pitch).m_pitchBytes[TIdxIntegralConst::value];
             }
         };
 
-        //#############################################################################
         //! The BufOmp5 1D memory allocation trait specialization.
         template<typename TElem, typename TIdx>
         struct BufAlloc<TElem, DimInt<1u>, TIdx, DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent>
             ALPAKA_FN_HOST static auto allocBuf(DevOmp5 const& dev, TExtent const& extent)
                 -> BufOmp5<TElem, DimInt<1u>, TIdx>
@@ -279,12 +259,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufOmp5 nD memory allocation trait specialization. \todo Add pitch
         template<typename TElem, typename TDim, typename TIdx>
         struct BufAlloc<TElem, TDim, TIdx, DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent>
             ALPAKA_FN_HOST static auto allocBuf(DevOmp5 const& dev, TExtent const& extent)
                 -> BufOmp5<TElem, TDim, TIdx>
@@ -303,12 +281,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufOmp5 device memory mapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Map<BufOmp5<TElem, TDim, TIdx>, DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto map(BufOmp5<TElem, TDim, TIdx> const& buf, DevOmp5 const& dev) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -321,12 +297,10 @@ namespace alpaka
                 // If it is already the same device, nothing has to be mapped.
             }
         };
-        //#############################################################################
         //! The BufOmp5 device memory unmapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Unmap<BufOmp5<TElem, TDim, TIdx>, DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto unmap(BufOmp5<TElem, TDim, TIdx> const& buf, DevOmp5 const& dev) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -339,12 +313,10 @@ namespace alpaka
                 // If it is already the same device, nothing has to be unmapped.
             }
         };
-        //#############################################################################
         //! The BufOmp5 memory pinning trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Pin<BufOmp5<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto pin(BufOmp5<TElem, TDim, TIdx>&) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -352,12 +324,10 @@ namespace alpaka
                 // No explicit pinning in OMP5? GPU would be pinned anyway.
             }
         };
-        //#############################################################################
         //! The BufOmp5 memory unpinning trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Unpin<BufOmp5<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto unpin(BufOmp5<TElem, TDim, TIdx>&) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -365,12 +335,10 @@ namespace alpaka
                 // No explicit pinning in OMP5? GPU would be pinned anyway.
             }
         };
-        //#############################################################################
         //! The BufOmp5 memory pin state trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct IsPinned<BufOmp5<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto isPinned(BufOmp5<TElem, TDim, TIdx> const&) -> bool
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -379,12 +347,10 @@ namespace alpaka
                 return true;
             }
         };
-        //#############################################################################
         //! The BufOmp5 memory prepareForAsyncCopy trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct PrepareForAsyncCopy<BufOmp5<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto prepareForAsyncCopy(BufOmp5<TElem, TDim, TIdx>&) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -393,19 +359,16 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufOmp5 offset get trait specialization.
         template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
         struct GetOffset<TIdxIntegralConst, BufOmp5<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getOffset(BufOmp5<TElem, TDim, TIdx> const&) -> TIdx
             {
                 return 0u;
             }
         };
 
-        //#############################################################################
         //! The BufOmp5 idx type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct IdxType<BufOmp5<TElem, TDim, TIdx>>
@@ -413,12 +376,10 @@ namespace alpaka
             using type = TIdx;
         };
 
-        //#############################################################################
         //! The BufCpu CUDA device memory mapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Map<BufCpu<TElem, TDim, TIdx>, DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto map(BufCpu<TElem, TDim, TIdx>& buf, DevOmp5 const& dev) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -432,12 +393,10 @@ namespace alpaka
                 // If it is already the same device, nothing has to be mapped.
             }
         };
-        //#############################################################################
         //! The BufCpu CUDA device memory unmapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Unmap<BufCpu<TElem, TDim, TIdx>, DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto unmap(BufCpu<TElem, TDim, TIdx>& buf, DevOmp5 const& dev) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -450,17 +409,14 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufCpu pointer on CUDA device get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrDev<BufCpu<TElem, TDim, TIdx>, DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrDev(BufCpu<TElem, TDim, TIdx> const&, DevOmp5 const&) -> TElem const*
             {
                 throw std::runtime_error("Mapping host memory to OMP5 device not implemented!");
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrDev(BufCpu<TElem, TDim, TIdx>&, DevOmp5 const&) -> TElem*
             {
                 throw std::runtime_error("Mapping host memory to OMP5 device not implemented!");

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -46,7 +46,6 @@ namespace alpaka
     template<typename TElem, typename TDim, typename TIdx>
     class BufCpu;
 
-    //#############################################################################
     //! The CUDA/HIP memory buffer.
     template<typename TElem, typename TDim, typename TIdx>
     class BufUniformCudaHipRt
@@ -62,7 +61,6 @@ namespace alpaka
         using Dim = TDim;
 
     public:
-        //-----------------------------------------------------------------------------
         //! Constructor
         template<typename TExtent>
         ALPAKA_FN_HOST BufUniformCudaHipRt(
@@ -92,7 +90,6 @@ namespace alpaka
         }
 
     private:
-        //-----------------------------------------------------------------------------
         //! Frees the shared buffer.
         ALPAKA_FN_HOST static auto freeBuffer(TElem* const memPtr, DevUniformCudaHipRt const& dev) -> void
         {
@@ -114,14 +111,12 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The BufUniformCudaHipRt device type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct DevType<BufUniformCudaHipRt<TElem, TDim, TIdx>>
         {
             using type = DevUniformCudaHipRt;
         };
-        //#############################################################################
         //! The BufUniformCudaHipRt device get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetDev<BufUniformCudaHipRt<TElem, TDim, TIdx>>
@@ -132,7 +127,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufUniformCudaHipRt dimension getter trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct DimType<BufUniformCudaHipRt<TElem, TDim, TIdx>>
@@ -140,7 +134,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The BufUniformCudaHipRt memory element type get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct ElemType<BufUniformCudaHipRt<TElem, TDim, TIdx>>
@@ -152,7 +145,6 @@ namespace alpaka
     {
         namespace traits
         {
-            //#############################################################################
             //! The BufUniformCudaHipRt extent get trait specialization.
             template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
             struct GetExtent<
@@ -160,7 +152,6 @@ namespace alpaka
                 BufUniformCudaHipRt<TElem, TDim, TIdx>,
                 std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getExtent(BufUniformCudaHipRt<TElem, TDim, TIdx> const& extent) -> TIdx
                 {
                     return extent.m_extentElements[TIdxIntegralConst::value];
@@ -170,28 +161,23 @@ namespace alpaka
     } // namespace extent
     namespace traits
     {
-        //#############################################################################
         //! The BufUniformCudaHipRt native pointer get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrNative<BufUniformCudaHipRt<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrNative(BufUniformCudaHipRt<TElem, TDim, TIdx> const& buf) -> TElem const*
             {
                 return buf.m_spMem.get();
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrNative(BufUniformCudaHipRt<TElem, TDim, TIdx>& buf) -> TElem*
             {
                 return buf.m_spMem.get();
             }
         };
-        //#############################################################################
         //! The BufUniformCudaHipRt pointer on device get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrDev<BufUniformCudaHipRt<TElem, TDim, TIdx>, DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrDev(
                 BufUniformCudaHipRt<TElem, TDim, TIdx> const& buf,
                 DevUniformCudaHipRt const& dev) -> TElem const*
@@ -205,7 +191,6 @@ namespace alpaka
                     throw std::runtime_error("The buffer is not accessible from the given device!");
                 }
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrDev(
                 BufUniformCudaHipRt<TElem, TDim, TIdx>& buf,
                 DevUniformCudaHipRt const& dev) -> TElem*
@@ -220,24 +205,20 @@ namespace alpaka
                 }
             }
         };
-        //#############################################################################
         //! The BufUniformCudaHipRt pitch get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPitchBytes<DimInt<TDim::value - 1u>, BufUniformCudaHipRt<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPitchBytes(BufUniformCudaHipRt<TElem, TDim, TIdx> const& buf) -> TIdx
             {
                 return buf.m_pitchBytes;
             }
         };
 
-        //#############################################################################
         //! The CUDA/HIP 1D memory allocation trait specialization.
         template<typename TElem, typename TIdx>
         struct BufAlloc<TElem, DimInt<1u>, TIdx, DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent>
             ALPAKA_FN_HOST static auto allocBuf(DevUniformCudaHipRt const& dev, TExtent const& extent)
                 -> BufUniformCudaHipRt<TElem, DimInt<1u>, TIdx>
@@ -264,12 +245,10 @@ namespace alpaka
                     extent);
             }
         };
-        //#############################################################################
         //! The CUDA/HIP 2D memory allocation trait specialization.
         template<typename TElem, typename TIdx>
         struct BufAlloc<TElem, DimInt<2u>, TIdx, DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent>
             ALPAKA_FN_HOST static auto allocBuf(DevUniformCudaHipRt const& dev, TExtent const& extent)
                 -> BufUniformCudaHipRt<TElem, DimInt<2u>, TIdx>
@@ -312,12 +291,10 @@ namespace alpaka
                     extent);
             }
         };
-        //#############################################################################
         //! The CUDA/HIP 3D memory allocation trait specialization.
         template<typename TElem, typename TIdx>
         struct BufAlloc<TElem, DimInt<3u>, TIdx, DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent>
             ALPAKA_FN_HOST static auto allocBuf(DevUniformCudaHipRt const& dev, TExtent const& extent)
                 -> BufUniformCudaHipRt<TElem, DimInt<3u>, TIdx>
@@ -358,12 +335,10 @@ namespace alpaka
                     extent);
             }
         };
-        //#############################################################################
         //! The BufUniformCudaHipRt CUDA/HIP device memory mapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Map<BufUniformCudaHipRt<TElem, TDim, TIdx>, DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto map(
                 BufUniformCudaHipRt<TElem, TDim, TIdx> const& buf,
                 DevUniformCudaHipRt const& dev) -> void
@@ -378,12 +353,10 @@ namespace alpaka
                 // If it is already the same device, nothing has to be mapped.
             }
         };
-        //#############################################################################
         //! The BufUniformCudaHipRt CUDA/HIP device memory unmapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Unmap<BufUniformCudaHipRt<TElem, TDim, TIdx>, DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto unmap(
                 BufUniformCudaHipRt<TElem, TDim, TIdx> const& buf,
                 DevUniformCudaHipRt const& dev) -> void
@@ -398,12 +371,10 @@ namespace alpaka
                 // If it is already the same device, nothing has to be unmapped.
             }
         };
-        //#############################################################################
         //! The BufUniformCudaHipRt memory pinning trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Pin<BufUniformCudaHipRt<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto pin(BufUniformCudaHipRt<TElem, TDim, TIdx>&) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -411,12 +382,10 @@ namespace alpaka
                 // CUDA/HIP device memory is always pinned, it can not be swapped out.
             }
         };
-        //#############################################################################
         //! The BufUniformCudaHipRt memory unpinning trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Unpin<BufUniformCudaHipRt<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto unpin(BufUniformCudaHipRt<TElem, TDim, TIdx>&) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -424,12 +393,10 @@ namespace alpaka
                 // CUDA/HIP device memory is always pinned, it can not be swapped out.
             }
         };
-        //#############################################################################
         //! The BufUniformCudaHipRt memory pin state trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct IsPinned<BufUniformCudaHipRt<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto isPinned(BufUniformCudaHipRt<TElem, TDim, TIdx> const&) -> bool
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -438,12 +405,10 @@ namespace alpaka
                 return true;
             }
         };
-        //#############################################################################
         //! The BufUniformCudaHipRt memory prepareForAsyncCopy trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct PrepareForAsyncCopy<BufUniformCudaHipRt<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto prepareForAsyncCopy(BufUniformCudaHipRt<TElem, TDim, TIdx>&) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -452,19 +417,16 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufUniformCudaHipRt offset get trait specialization.
         template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
         struct GetOffset<TIdxIntegralConst, BufUniformCudaHipRt<TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getOffset(BufUniformCudaHipRt<TElem, TDim, TIdx> const&) -> TIdx
             {
                 return 0u;
             }
         };
 
-        //#############################################################################
         //! The BufUniformCudaHipRt idx type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct IdxType<BufUniformCudaHipRt<TElem, TDim, TIdx>>
@@ -472,12 +434,10 @@ namespace alpaka
             using type = TIdx;
         };
 
-        //#############################################################################
         //! The BufCpu CUDA/HIP device memory mapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Map<BufCpu<TElem, TDim, TIdx>, DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto map(BufCpu<TElem, TDim, TIdx>& buf, DevUniformCudaHipRt const& dev) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -496,12 +456,10 @@ namespace alpaka
                 }
             }
         };
-        //#############################################################################
         //! The BufCpu CUDA/HIP device memory unmapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Unmap<BufCpu<TElem, TDim, TIdx>, DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto unmap(BufCpu<TElem, TDim, TIdx>& buf, DevUniformCudaHipRt const& dev) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -517,12 +475,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The BufCpu pointer on CUDA/HIP device get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrDev<BufCpu<TElem, TDim, TIdx>, DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrDev(BufCpu<TElem, TDim, TIdx> const& buf, DevUniformCudaHipRt const&)
                 -> TElem const*
             {
@@ -536,7 +492,6 @@ namespace alpaka
 
                 return pDev;
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrDev(BufCpu<TElem, TDim, TIdx>& buf, DevUniformCudaHipRt const&) -> TElem*
             {
                 // TODO: Check if the memory is mapped at all!

--- a/include/alpaka/mem/buf/SetKernel.hpp
+++ b/include/alpaka/mem/buf/SetKernel.hpp
@@ -17,12 +17,10 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! any device ND memory set kernel.
     class MemSetKernel
     {
     public:
-        //-----------------------------------------------------------------------------
         //! The kernel entry point.
         //!
         //! All but the last element of threadElemExtent must be one.

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -14,57 +14,46 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The buffer traits.
     namespace traits
     {
-        //#############################################################################
         //! The memory buffer type trait.
         template<typename TDev, typename TElem, typename TDim, typename TIdx, typename TSfinae = void>
         struct BufType;
 
-        //#############################################################################
         //! The memory allocator trait.
         template<typename TElem, typename TDim, typename TIdx, typename TDev, typename TSfinae = void>
         struct BufAlloc;
 
-        //#############################################################################
         //! The memory mapping trait.
         template<typename TBuf, typename TDev, typename TSfinae = void>
         struct Map;
 
-        //#############################################################################
         //! The memory unmapping trait.
         template<typename TBuf, typename TDev, typename TSfinae = void>
         struct Unmap;
 
-        //#############################################################################
         //! The memory pinning trait.
         template<typename TBuf, typename TSfinae = void>
         struct Pin;
 
-        //#############################################################################
         //! The memory unpinning trait.
         template<typename TBuf, typename TSfinae = void>
         struct Unpin;
 
-        //#############################################################################
         //! The memory pin state trait.
         template<typename TBuf, typename TSfinae = void>
         struct IsPinned;
 
-        //#############################################################################
         //! The memory prepareForAsyncCopy trait.
         template<typename TBuf, typename TSfinae = void>
         struct PrepareForAsyncCopy;
     } // namespace traits
 
-    //#############################################################################
     //! The memory buffer type trait alias template to remove the ::type.
     template<typename TDev, typename TElem, typename TDim, typename TIdx>
     using Buf = typename traits::BufType<alpaka::Dev<TDev>, TElem, TDim, TIdx>::type;
 
-    //-----------------------------------------------------------------------------
     //! Allocates memory on the given device.
     //!
     //! \tparam TElem The element type of the returned buffer.
@@ -79,7 +68,6 @@ namespace alpaka
     {
         return traits::BufAlloc<TElem, Dim<TExtent>, TIdx, TDev>::allocBuf(dev, extent);
     }
-    //-----------------------------------------------------------------------------
     //! Maps the buffer into the memory of the given device.
     //!
     //! \tparam TBuf The buffer type.
@@ -90,9 +78,7 @@ namespace alpaka
     ALPAKA_FN_HOST auto map(TBuf& buf, TDev const& dev) -> void
     {
         return traits::Map<TBuf, TDev>::map(buf, dev);
-    }
-    //-----------------------------------------------------------------------------
-    //! Unmaps the buffer from the memory of the given device.
+    }    //! Unmaps the buffer from the memory of the given device.
     //!
     //! \tparam TBuf The buffer type.
     //! \tparam TDev The device type.
@@ -102,9 +88,7 @@ namespace alpaka
     ALPAKA_FN_HOST auto unmap(TBuf& buf, TDev const& dev) -> void
     {
         return traits::Unmap<TBuf, TDev>::unmap(buf, dev);
-    }
-    //-----------------------------------------------------------------------------
-    //! Pins the buffer.
+    }    //! Pins the buffer.
     //!
     //! \tparam TBuf The buffer type.
     //! \param buf The buffer to pin in the device memory.
@@ -113,7 +97,6 @@ namespace alpaka
     {
         return traits::Pin<TBuf>::pin(buf);
     }
-    //-----------------------------------------------------------------------------
     //! Unpins the buffer.
     //!
     //! \tparam TBuf The buffer type.
@@ -123,7 +106,6 @@ namespace alpaka
     {
         return traits::Unpin<TBuf>::unpin(buf);
     }
-    //-----------------------------------------------------------------------------
     //! The pin state of the buffer.
     //!
     //! \tparam TBuf The buffer type.
@@ -133,7 +115,6 @@ namespace alpaka
     {
         return traits::IsPinned<TBuf>::isPinned(buf);
     }
-    //-----------------------------------------------------------------------------
     //! Prepares the buffer for non-blocking copy operations, e.g. pinning if
     //! non-blocking copy between a cpu and a cuda device is wanted
     //!

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -68,6 +68,7 @@ namespace alpaka
     {
         return traits::BufAlloc<TElem, Dim<TExtent>, TIdx, TDev>::allocBuf(dev, extent);
     }
+
     //! Maps the buffer into the memory of the given device.
     //!
     //! \tparam TBuf The buffer type.
@@ -78,7 +79,9 @@ namespace alpaka
     ALPAKA_FN_HOST auto map(TBuf& buf, TDev const& dev) -> void
     {
         return traits::Map<TBuf, TDev>::map(buf, dev);
-    }    //! Unmaps the buffer from the memory of the given device.
+    }
+
+    //! Unmaps the buffer from the memory of the given device.
     //!
     //! \tparam TBuf The buffer type.
     //! \tparam TDev The device type.
@@ -88,7 +91,9 @@ namespace alpaka
     ALPAKA_FN_HOST auto unmap(TBuf& buf, TDev const& dev) -> void
     {
         return traits::Unmap<TBuf, TDev>::unmap(buf, dev);
-    }    //! Pins the buffer.
+    }
+
+    //! Pins the buffer.
     //!
     //! \tparam TBuf The buffer type.
     //! \param buf The buffer to pin in the device memory.
@@ -97,6 +102,7 @@ namespace alpaka
     {
         return traits::Pin<TBuf>::pin(buf);
     }
+
     //! Unpins the buffer.
     //!
     //! \tparam TBuf The buffer type.
@@ -106,6 +112,7 @@ namespace alpaka
     {
         return traits::Unpin<TBuf>::unpin(buf);
     }
+
     //! The pin state of the buffer.
     //!
     //! \tparam TBuf The buffer type.
@@ -115,6 +122,7 @@ namespace alpaka
     {
         return traits::IsPinned<TBuf>::isPinned(buf);
     }
+
     //! Prepares the buffer for non-blocking copy operations, e.g. pinning if
     //! non-blocking copy between a cpu and a cuda device is wanted
     //!

--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -27,7 +27,6 @@ namespace alpaka
 {
     namespace detail
     {
-        //#############################################################################
         //! The CPU device memory copy task base.
         //!
         //! Copies from CPU memory into CPU memory.
@@ -62,7 +61,6 @@ namespace alpaka
                 std::is_same<alpaka::Elem<TViewDst>, std::remove_const_t<alpaka::Elem<TViewSrc>>>::value,
                 "The source and the destination view are required to have the same element type!");
 
-            //-----------------------------------------------------------------------------
             TaskCopyCpuBase(TViewDst& viewDst, TViewSrc const& viewSrc, TExtent const& extent)
                 : m_extent(extent::getExtentVec(extent))
                 , m_extentWidthBytes(m_extent[TDim::value - 1u] * static_cast<ExtentSize>(sizeof(Elem)))
@@ -86,7 +84,6 @@ namespace alpaka
             }
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto printDebug() const -> void
             {
                 std::cout << __func__ << " e: " << m_extent << " ewb: " << this->m_extentWidthBytes
@@ -111,7 +108,6 @@ namespace alpaka
         };
 
 
-        //#############################################################################
         //! The CPU device ND memory copy task.
         template<typename TDim, typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyCpu : public TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>
@@ -121,10 +117,8 @@ namespace alpaka
             using typename TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::DstSize;
             using typename TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::SrcSize;
 
-            //-----------------------------------------------------------------------------
             using TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::TaskCopyCpuBase;
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator()() const -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -157,16 +151,13 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU device 1D memory copy task.
         template<typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyCpu<DimInt<1u>, TViewDst, TViewSrc, TExtent>
             : public TaskCopyCpuBase<DimInt<1u>, TViewDst, TViewSrc, TExtent>
         {
-            //-----------------------------------------------------------------------------
             using TaskCopyCpuBase<DimInt<1u>, TViewDst, TViewSrc, TExtent>::TaskCopyCpuBase;
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator()() const -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -187,14 +178,12 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU device memory copy trait specialization.
         //!
         //! Copies from CPU memory into CPU memory.
         template<typename TDim>
         struct CreateTaskMemcpy<TDim, DevCpu, DevCpu>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent, typename TViewSrc, typename TViewDst>
             ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst& viewDst,

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -24,7 +24,6 @@ namespace alpaka
 
     namespace detail
     {
-        //#############################################################################
         //! The CPU device ND memory set task base.
         template<typename TDim, typename TView, typename TExtent>
         struct TaskSetCpuBase
@@ -46,7 +45,6 @@ namespace alpaka
                 meta::IsIntegralSuperset<DstSize, ExtentSize>::value,
                 "The view and the extent are required to have compatible idx type!");
 
-            //-----------------------------------------------------------------------------
             TaskSetCpuBase(TView& view, std::uint8_t const& byte, TExtent const& extent)
                 : m_byte(byte)
                 , m_extent(extent::getExtentVec(extent))
@@ -64,7 +62,6 @@ namespace alpaka
             }
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto printDebug() const -> void
             {
                 std::cout << __func__ << " e: " << this->m_extent << " ewb: " << this->m_extentWidthBytes
@@ -83,7 +80,6 @@ namespace alpaka
             std::uint8_t* const m_dstMemNative;
         };
 
-        //#############################################################################
         //! The CPU device ND memory set task.
         template<typename TDim, typename TView, typename TExtent>
         struct TaskSetCpu : public TaskSetCpuBase<TDim, TView, TExtent>
@@ -92,10 +88,8 @@ namespace alpaka
             using typename TaskSetCpuBase<TDim, TView, TExtent>::ExtentSize;
             using typename TaskSetCpuBase<TDim, TView, TExtent>::DstSize;
 
-            //-----------------------------------------------------------------------------
             using TaskSetCpuBase<TDim, TView, TExtent>::TaskSetCpuBase;
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator()() const -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -124,15 +118,12 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU device 1D memory set task.
         template<typename TView, typename TExtent>
         struct TaskSetCpu<DimInt<1u>, TView, TExtent> : public TaskSetCpuBase<DimInt<1u>, TView, TExtent>
         {
-            //-----------------------------------------------------------------------------
             using TaskSetCpuBase<DimInt<1u>, TView, TExtent>::TaskSetCpuBase;
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator()() const -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -153,12 +144,10 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU device memory set trait specialization.
         template<typename TDim>
         struct CreateTaskMemset<TDim, DevCpu>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent, typename TView>
             ALPAKA_FN_HOST static auto createTaskMemset(TView& view, std::uint8_t const& byte, TExtent const& extent)
                 -> alpaka::detail::TaskSetCpu<TDim, TView, TExtent>

--- a/include/alpaka/mem/buf/oacc/Copy.hpp
+++ b/include/alpaka/mem/buf/oacc/Copy.hpp
@@ -63,7 +63,6 @@ namespace alpaka
                 return TTask<TDim, TViewDst, TViewSrc, TExtent, TCopyPred>(viewDst, viewSrc, extent, dev, copyPred);
             }
 
-            //#############################################################################
             //! The OpenACC device memory copy task base.
             //!
             template<typename TDim, typename TViewDst, typename TViewSrc, typename TExtent, typename TCopyPred>
@@ -93,7 +92,6 @@ namespace alpaka
 
                 using Idx = alpaka::Idx<TExtent>;
 
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST TaskCopyOaccBase(
                     TViewDst& viewDst,
                     TViewSrc const& viewSrc,
@@ -122,7 +120,6 @@ namespace alpaka
                 }
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST auto printDebug() const -> void
                 {
                     std::cout << __func__ << " dev: " << m_dev.iDevice() << " ew: " << m_extent
@@ -145,7 +142,6 @@ namespace alpaka
                 TCopyPred m_copyPred;
             };
 
-            //#############################################################################
             //! The OpenACC Nd device memory copy task.
             //!
             template<typename TDim, typename TViewDst, typename TViewSrc, typename TExtent, typename TCopyPred>
@@ -156,10 +152,8 @@ namespace alpaka
                 using typename TaskCopyOaccBase<TDim, TViewDst, TViewSrc, TExtent, TCopyPred>::DstSize;
                 using typename TaskCopyOaccBase<TDim, TViewDst, TViewSrc, TExtent, TCopyPred>::SrcSize;
 
-                //-----------------------------------------------------------------------------
                 using TaskCopyOaccBase<TDim, TViewDst, TViewSrc, TExtent, TCopyPred>::TaskCopyOaccBase;
 
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST auto operator()() const -> void
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -189,16 +183,13 @@ namespace alpaka
                 }
             };
 
-            //#############################################################################
             //! The 1d OpenACC memory copy task.
             template<typename TViewDst, typename TViewSrc, typename TExtent, typename TCopyPred>
             struct TaskCopyOacc<DimInt<1>, TViewDst, TViewSrc, TExtent, TCopyPred>
                 : public TaskCopyOaccBase<DimInt<1>, TViewDst, TViewSrc, TExtent, TCopyPred>
             {
-                //-----------------------------------------------------------------------------
                 using TaskCopyOaccBase<DimInt<1u>, TViewDst, TViewSrc, TExtent, TCopyPred>::TaskCopyOaccBase;
 
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST auto operator()() const -> void
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -219,16 +210,13 @@ namespace alpaka
         } // namespace detail
     } // namespace oacc
 
-    //-----------------------------------------------------------------------------
     // Trait specializations for CreateTaskCopy.
     namespace traits
     {
-        //#############################################################################
         //! The CPU to OpenACC memory copy trait specialization.
         template<typename TDim>
         struct CreateTaskMemcpy<TDim, DevOacc, DevCpu>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent, typename TViewSrc, typename TViewDst>
             ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst& viewDst,
@@ -247,12 +235,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC to CPU memory copy trait specialization.
         template<typename TDim>
         struct CreateTaskMemcpy<TDim, DevCpu, DevOacc>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent, typename TViewSrc, typename TViewDst>
             ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst& viewDst,
@@ -271,12 +257,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC to OpenACC memory copy trait specialization.
         template<typename TDim>
         struct CreateTaskMemcpy<TDim, DevOacc, DevOacc>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent, typename TViewSrc, typename TViewDst>
             ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst& viewDst,

--- a/include/alpaka/mem/buf/oacc/Set.hpp
+++ b/include/alpaka/mem/buf/oacc/Set.hpp
@@ -40,12 +40,10 @@ namespace alpaka
 {
     namespace traits
     {
-        //#############################################################################
         //! The OpenACC device memory set trait specialization.
         template<typename TDim>
         struct CreateTaskMemset<TDim, DevOacc>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent, typename TView>
             ALPAKA_FN_HOST static auto createTaskMemset(TView& view, std::uint8_t const& byte, TExtent const& extent)
             {

--- a/include/alpaka/mem/buf/omp5/Copy.hpp
+++ b/include/alpaka/mem/buf/omp5/Copy.hpp
@@ -33,7 +33,6 @@ namespace alpaka
 {
     namespace detail
     {
-        //#############################################################################
         //! The Omp5 memory copy trait.
         template<typename TDim, typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyOmp5
@@ -56,7 +55,6 @@ namespace alpaka
 
             using Idx = alpaka::Idx<TExtent>;
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST TaskCopyOmp5(
                 TViewDst& viewDst,
                 TViewSrc const& viewSrc,
@@ -85,7 +83,6 @@ namespace alpaka
             }
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto printDebug() const -> void
             {
                 std::cout << __func__ << " ddev: " << m_iDstDevice << " ew: " << m_extent
@@ -101,7 +98,6 @@ namespace alpaka
             void* m_dstMemNative;
             void const* m_srcMemNative;
 
-            //-----------------------------------------------------------------------------
             //! Executes the kernel function object.
             ALPAKA_FN_HOST auto operator()() const -> void
             {
@@ -150,7 +146,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The Omp5 memory copy trait.
         template<typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyOmp5<DimInt<1>, TViewDst, TViewSrc, TExtent>
@@ -167,7 +162,6 @@ namespace alpaka
 
             using Idx = alpaka::Idx<TExtent>;
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST TaskCopyOmp5(
                 TViewDst& viewDst,
                 TViewSrc const& viewSrc,
@@ -194,7 +188,6 @@ namespace alpaka
             }
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto printDebug() const -> void
             {
                 std::cout << __func__ << " ddev: " << m_iDstDevice << " ew: " << m_extentWidth
@@ -214,7 +207,6 @@ namespace alpaka
             void* m_dstMemNative;
             void const* m_srcMemNative;
 
-            //-----------------------------------------------------------------------------
             //! Executes the kernel function object.
             ALPAKA_FN_HOST auto operator()() const -> void
             {
@@ -240,18 +232,15 @@ namespace alpaka
         };
     } // namespace detail
 
-    //-----------------------------------------------------------------------------
     // Trait specializations for CreateTaskMemcpy.
     namespace traits
     {
         namespace detail
         {
-            //#############################################################################
             //! The Omp5 memory copy task creation trait detail.
             template<typename TDim, typename TDevDst, typename TDevSrc>
             struct CreateTaskCopyImpl
             {
-                //-----------------------------------------------------------------------------
                 template<typename TExtent, typename TViewSrc, typename TViewDst>
                 ALPAKA_FN_HOST static auto createTaskMemcpy(
                     TViewDst& viewDst,
@@ -272,12 +261,10 @@ namespace alpaka
             };
         } // namespace detail
 
-        //#############################################################################
         //! The CPU to Omp5 memory copy trait specialization.
         template<typename TDim>
         struct CreateTaskMemcpy<TDim, DevOmp5, DevCpu>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent, typename TViewSrc, typename TViewDst>
             ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst& viewDst,
@@ -295,12 +282,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The Omp5 to CPU memory copy trait specialization.
         template<typename TDim>
         struct CreateTaskMemcpy<TDim, DevCpu, DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent, typename TViewSrc, typename TViewDst>
             ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst& viewDst,
@@ -318,12 +303,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The Omp5 to Omp5 memory copy trait specialization.
         template<typename TDim>
         struct CreateTaskMemcpy<TDim, DevOmp5, DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent, typename TViewSrc, typename TViewDst>
             ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst& viewDst,

--- a/include/alpaka/mem/buf/omp5/Set.hpp
+++ b/include/alpaka/mem/buf/omp5/Set.hpp
@@ -37,12 +37,10 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The OMP5 device memory set trait specialization.
         template<typename TDim>
         struct CreateTaskMemset<TDim, DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent, typename TView>
             ALPAKA_FN_HOST static auto createTaskMemset(TView& view, std::uint8_t const& byte, TExtent const& extent)
             {

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -45,7 +45,6 @@ namespace alpaka
 {
     namespace detail
     {
-        //-----------------------------------------------------------------------------
         //! Not being able to enable peer access does not prevent such device to device memory copies.
         //! However, those copies may be slower because the memory is copied via the CPU.
         inline auto enablePeerAccessIfPossible(const int& devSrc, const int& devDst) -> void
@@ -89,12 +88,10 @@ namespace alpaka
             }
         }
 
-        //#############################################################################
         //! The CUDA/HIP memory copy trait.
         template<typename TDim, typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyUniformCudaHip;
 
-        //#############################################################################
         //! The 1D CUDA/HIP memory copy trait.
         template<typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyUniformCudaHip<DimInt<1>, TViewDst, TViewSrc, TExtent>
@@ -116,7 +113,6 @@ namespace alpaka
 
             using Idx = Idx<TExtent>;
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST TaskCopyUniformCudaHip(
                 TViewDst& viewDst,
                 TViewSrc const& viewSrc,
@@ -144,7 +140,6 @@ namespace alpaka
 #    endif
             }
 
-            //-----------------------------------------------------------------------------
             template<typename TQueue>
             auto enqueue(TQueue& queue) const -> void
             {
@@ -187,7 +182,6 @@ namespace alpaka
 
         private:
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto printDebug() const -> void
             {
                 std::cout << __func__ << " ddev: " << m_iDstDevice << " ew: " << m_extentWidth
@@ -209,7 +203,6 @@ namespace alpaka
             void* m_dstMemNative;
             void const* m_srcMemNative;
         };
-        //#############################################################################
         //! The 2D CUDA/HIP memory copy trait.
         template<typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyUniformCudaHip<DimInt<2>, TViewDst, TViewSrc, TExtent>
@@ -231,7 +224,6 @@ namespace alpaka
 
             using Idx = Idx<TExtent>;
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST TaskCopyUniformCudaHip(
                 TViewDst& viewDst,
                 TViewSrc const& viewSrc,
@@ -280,7 +272,6 @@ namespace alpaka
 #    endif
             }
 
-            //-----------------------------------------------------------------------------
             template<typename TQueue>
             auto enqueue(TQueue& queue) const -> void
             {
@@ -324,7 +315,6 @@ namespace alpaka
 
         private:
 #    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto buildCudaMemcpy3DPeerParms() const -> cudaMemcpy3DPeerParms
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -356,7 +346,6 @@ namespace alpaka
             }
 #    endif
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto printDebug() const -> void
             {
                 std::cout << __func__ << " ew: " << m_extentWidth << " eh: " << m_extentHeight
@@ -391,7 +380,6 @@ namespace alpaka
             void* m_dstMemNative;
             void const* m_srcMemNative;
         };
-        //#############################################################################
         //! The 3D CUDA/HIP memory copy trait.
         template<typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyUniformCudaHip<DimInt<3>, TViewDst, TViewSrc, TExtent>
@@ -413,7 +401,6 @@ namespace alpaka
 
             using Idx = Idx<TExtent>;
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST TaskCopyUniformCudaHip(
                 TViewDst& viewDst,
                 TViewSrc const& viewSrc,
@@ -468,7 +455,6 @@ namespace alpaka
 #    endif
             }
 
-            //-----------------------------------------------------------------------------
             template<typename TQueue>
             auto enqueue(TQueue& queue) const -> void
             {
@@ -506,7 +492,6 @@ namespace alpaka
             }
 
         private:
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto buildUniformCudaHipMemcpy3DParms() const -> ALPAKA_API_PREFIX(Memcpy3DParms)
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -542,7 +527,6 @@ namespace alpaka
             }
 
 #    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto buildCudaMemcpy3DPeerParms() const -> cudaMemcpy3DPeerParms
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -574,7 +558,6 @@ namespace alpaka
             }
 #    endif
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto printDebug() const -> void
             {
                 std::cout << __func__ << " ew: " << m_extentWidth << " eh: " << m_extentHeight
@@ -614,16 +597,13 @@ namespace alpaka
         };
     } // namespace detail
 
-    //-----------------------------------------------------------------------------
     // Trait specializations for CreateTaskMemcpy.
     namespace traits
     {
-        //#############################################################################
         //! The CUDA/HIP to CPU memory copy trait specialization.
         template<typename TDim>
         struct CreateTaskMemcpy<TDim, DevCpu, DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent, typename TViewSrc, typename TViewDst>
             ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst& viewDst,
@@ -643,12 +623,10 @@ namespace alpaka
                     iDevice);
             }
         };
-        //#############################################################################
         //! The CPU to CUDA/HIP memory copy trait specialization.
         template<typename TDim>
         struct CreateTaskMemcpy<TDim, DevUniformCudaHipRt, DevCpu>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent, typename TViewSrc, typename TViewDst>
             ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst& viewDst,
@@ -668,12 +646,10 @@ namespace alpaka
                     iDevice);
             }
         };
-        //#############################################################################
         //! The CUDA/HIP to CUDA/HIP memory copy trait specialization.
         template<typename TDim>
         struct CreateTaskMemcpy<TDim, DevUniformCudaHipRt, DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent, typename TViewSrc, typename TViewDst>
             ALPAKA_FN_HOST static auto createTaskMemcpy(
                 TViewDst& viewDst,
@@ -692,14 +668,12 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CUDA/HIP non-blocking device queue 1D copy enqueue trait specialization.
         template<typename TExtent, typename TViewSrc, typename TViewDst>
         struct Enqueue<
             QueueUniformCudaHipRtNonBlocking,
             alpaka::detail::TaskCopyUniformCudaHip<DimInt<1u>, TViewDst, TViewSrc, TExtent>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtNonBlocking& queue,
                 alpaka::detail::TaskCopyUniformCudaHip<DimInt<1u>, TViewDst, TViewSrc, TExtent> const& task) -> void
@@ -709,14 +683,12 @@ namespace alpaka
                 task.enqueue(queue);
             }
         };
-        //#############################################################################
         //! The CUDA/HIP blocking device queue 1D copy enqueue trait specialization.
         template<typename TExtent, typename TViewSrc, typename TViewDst>
         struct Enqueue<
             QueueUniformCudaHipRtBlocking,
             alpaka::detail::TaskCopyUniformCudaHip<DimInt<1u>, TViewDst, TViewSrc, TExtent>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtBlocking& queue,
                 alpaka::detail::TaskCopyUniformCudaHip<DimInt<1u>, TViewDst, TViewSrc, TExtent> const& task) -> void
@@ -729,14 +701,12 @@ namespace alpaka
                     ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->m_UniformCudaHipQueue));
             }
         };
-        //#############################################################################
         //! The CUDA/HIP non-blocking device queue 2D copy enqueue trait specialization.
         template<typename TExtent, typename TViewSrc, typename TViewDst>
         struct Enqueue<
             QueueUniformCudaHipRtNonBlocking,
             alpaka::detail::TaskCopyUniformCudaHip<DimInt<2u>, TViewDst, TViewSrc, TExtent>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtNonBlocking& queue,
                 alpaka::detail::TaskCopyUniformCudaHip<DimInt<2u>, TViewDst, TViewSrc, TExtent> const& task) -> void
@@ -746,14 +716,12 @@ namespace alpaka
                 task.enqueue(queue);
             }
         };
-        //#############################################################################
         //! The CUDA/HIP blocking device queue 2D copy enqueue trait specialization.
         template<typename TExtent, typename TViewSrc, typename TViewDst>
         struct Enqueue<
             QueueUniformCudaHipRtBlocking,
             alpaka::detail::TaskCopyUniformCudaHip<DimInt<2u>, TViewDst, TViewSrc, TExtent>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtBlocking& queue,
                 alpaka::detail::TaskCopyUniformCudaHip<DimInt<2u>, TViewDst, TViewSrc, TExtent> const& task) -> void
@@ -766,14 +734,12 @@ namespace alpaka
                     ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->m_UniformCudaHipQueue));
             }
         };
-        //#############################################################################
         //! The CUDA/HIP non-blocking device queue 3D copy enqueue trait specialization.
         template<typename TExtent, typename TViewSrc, typename TViewDst>
         struct Enqueue<
             QueueUniformCudaHipRtNonBlocking,
             alpaka::detail::TaskCopyUniformCudaHip<DimInt<3u>, TViewDst, TViewSrc, TExtent>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtNonBlocking& queue,
                 alpaka::detail::TaskCopyUniformCudaHip<DimInt<3u>, TViewDst, TViewSrc, TExtent> const& task) -> void
@@ -783,14 +749,12 @@ namespace alpaka
                 task.enqueue(queue);
             }
         };
-        //#############################################################################
         //! The CUDA/HIP blocking device queue 3D copy enqueue trait specialization.
         template<typename TExtent, typename TViewSrc, typename TViewDst>
         struct Enqueue<
             QueueUniformCudaHipRtBlocking,
             alpaka::detail::TaskCopyUniformCudaHip<DimInt<3u>, TViewDst, TViewSrc, TExtent>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtBlocking& queue,
                 alpaka::detail::TaskCopyUniformCudaHip<DimInt<3u>, TViewDst, TViewSrc, TExtent> const& task) -> void

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -41,12 +41,10 @@ namespace alpaka
 
     namespace detail
     {
-        //#############################################################################
         //! The CUDA/HIP memory set task base.
         template<typename TDim, typename TView, typename TExtent>
         struct TaskSetUniformCudaHipBase
         {
-            //-----------------------------------------------------------------------------
             TaskSetUniformCudaHipBase(TView& view, std::uint8_t const& byte, TExtent const& extent)
                 : m_view(view)
                 , m_byte(byte)
@@ -67,24 +65,20 @@ namespace alpaka
             std::int32_t const m_iDevice;
         };
 
-        //#############################################################################
         //! The CUDA/HIP memory set task.
         template<typename TDim, typename TView, typename TExtent>
         struct TaskSetUniformCudaHip;
 
-        //#############################################################################
         //! The 1D CUDA/HIP memory set task.
         template<typename TView, typename TExtent>
         struct TaskSetUniformCudaHip<DimInt<1>, TView, TExtent>
             : public TaskSetUniformCudaHipBase<DimInt<1>, TView, TExtent>
         {
-            //-----------------------------------------------------------------------------
             TaskSetUniformCudaHip(TView& view, std::uint8_t const& byte, TExtent const& extent)
                 : TaskSetUniformCudaHipBase<DimInt<1>, TView, TExtent>(view, byte, extent)
             {
             }
 
-            //-----------------------------------------------------------------------------
             template<typename TQueue>
             auto enqueue(TQueue& queue) const -> void
             {
@@ -124,19 +118,16 @@ namespace alpaka
                     queue.m_spQueueImpl->m_UniformCudaHipQueue));
             }
         };
-        //#############################################################################
         //! The 2D CUDA/HIP memory set task.
         template<typename TView, typename TExtent>
         struct TaskSetUniformCudaHip<DimInt<2>, TView, TExtent>
             : public TaskSetUniformCudaHipBase<DimInt<2>, TView, TExtent>
         {
-            //-----------------------------------------------------------------------------
             TaskSetUniformCudaHip(TView& view, std::uint8_t const& byte, TExtent const& extent)
                 : TaskSetUniformCudaHipBase<DimInt<2>, TView, TExtent>(view, byte, extent)
             {
             }
 
-            //-----------------------------------------------------------------------------
             template<typename TQueue>
             auto enqueue(TQueue& queue) const -> void
             {
@@ -183,19 +174,16 @@ namespace alpaka
                     queue.m_spQueueImpl->m_UniformCudaHipQueue));
             }
         };
-        //#############################################################################
         //! The 3D CUDA/HIP memory set task.
         template<typename TView, typename TExtent>
         struct TaskSetUniformCudaHip<DimInt<3>, TView, TExtent>
             : public TaskSetUniformCudaHipBase<DimInt<3>, TView, TExtent>
         {
-            //-----------------------------------------------------------------------------
             TaskSetUniformCudaHip(TView& view, std::uint8_t const& byte, TExtent const& extent)
                 : TaskSetUniformCudaHipBase<DimInt<3>, TView, TExtent>(view, byte, extent)
             {
             }
 
-            //-----------------------------------------------------------------------------
             template<typename TQueue>
             auto enqueue(TQueue& queue) const -> void
             {
@@ -262,12 +250,10 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CUDA device memory set trait specialization.
         template<typename TDim>
         struct CreateTaskMemset<TDim, DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             template<typename TExtent, typename TView>
             ALPAKA_FN_HOST static auto createTaskMemset(TView& view, std::uint8_t const& byte, TExtent const& extent)
                 -> alpaka::detail::TaskSetUniformCudaHip<TDim, TView, TExtent>
@@ -276,14 +262,12 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CUDA non-blocking device queue 1D set enqueue trait specialization.
         template<typename TView, typename TExtent>
         struct Enqueue<
             QueueUniformCudaHipRtNonBlocking,
             alpaka::detail::TaskSetUniformCudaHip<DimInt<1u>, TView, TExtent>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtNonBlocking& queue,
                 alpaka::detail::TaskSetUniformCudaHip<DimInt<1u>, TView, TExtent> const& task) -> void
@@ -293,14 +277,12 @@ namespace alpaka
                 task.enqueue(queue);
             }
         };
-        //#############################################################################
         //! The CUDA blocking device queue 1D set enqueue trait specialization.
         template<typename TView, typename TExtent>
         struct Enqueue<
             QueueUniformCudaHipRtBlocking,
             alpaka::detail::TaskSetUniformCudaHip<DimInt<1u>, TView, TExtent>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtBlocking& queue,
                 alpaka::detail::TaskSetUniformCudaHip<DimInt<1u>, TView, TExtent> const& task) -> void
@@ -312,14 +294,12 @@ namespace alpaka
                 wait(queue);
             }
         };
-        //#############################################################################
         //! The CUDA non-blocking device queue 2D set enqueue trait specialization.
         template<typename TView, typename TExtent>
         struct Enqueue<
             QueueUniformCudaHipRtNonBlocking,
             alpaka::detail::TaskSetUniformCudaHip<DimInt<2u>, TView, TExtent>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtNonBlocking& queue,
                 alpaka::detail::TaskSetUniformCudaHip<DimInt<2u>, TView, TExtent> const& task) -> void
@@ -329,14 +309,12 @@ namespace alpaka
                 task.enqueue(queue);
             }
         };
-        //#############################################################################
         //! The CUDA blocking device queue 2D set enqueue trait specialization.
         template<typename TView, typename TExtent>
         struct Enqueue<
             QueueUniformCudaHipRtBlocking,
             alpaka::detail::TaskSetUniformCudaHip<DimInt<2u>, TView, TExtent>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtBlocking& queue,
                 alpaka::detail::TaskSetUniformCudaHip<DimInt<2u>, TView, TExtent> const& task) -> void
@@ -348,14 +326,12 @@ namespace alpaka
                 wait(queue);
             }
         };
-        //#############################################################################
         //! The CUDA non-blocking device queue 3D set enqueue trait specialization.
         template<typename TView, typename TExtent>
         struct Enqueue<
             QueueUniformCudaHipRtNonBlocking,
             alpaka::detail::TaskSetUniformCudaHip<DimInt<3u>, TView, TExtent>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtNonBlocking& queue,
                 alpaka::detail::TaskSetUniformCudaHip<DimInt<3u>, TView, TExtent> const& task) -> void
@@ -365,14 +341,12 @@ namespace alpaka
                 task.enqueue(queue);
             }
         };
-        //#############################################################################
         //! The CUDA blocking device queue 3D set enqueue trait specialization.
         template<typename TView, typename TExtent>
         struct Enqueue<
             QueueUniformCudaHipRtBlocking,
             alpaka::detail::TaskSetUniformCudaHip<DimInt<3u>, TView, TExtent>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtBlocking& queue,
                 alpaka::detail::TaskSetUniformCudaHip<DimInt<3u>, TView, TExtent> const& task) -> void

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -25,28 +25,23 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The view traits.
     namespace traits
     {
-        //#############################################################################
         //! The native pointer get trait.
         template<typename TView, typename TSfinae = void>
         struct GetPtrNative;
 
-        //#############################################################################
         //! The pointer on device get trait.
         template<typename TView, typename TDev, typename TSfinae = void>
         struct GetPtrDev;
 
         namespace detail
         {
-            //#############################################################################
             template<typename TIdx, typename TView, typename TSfinae = void>
             struct GetPitchBytesDefault;
         } // namespace detail
 
-        //#############################################################################
         //! The pitch in bytes.
         //! This is the distance in bytes in the linear memory between two consecutive elements in the next higher
         //! dimension (TIdx-1).
@@ -55,7 +50,6 @@ namespace alpaka
         template<typename TIdx, typename TView, typename TSfinae = void>
         struct GetPitchBytes
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPitchBytes(TView const& view) -> Idx<TView>
             {
                 return detail::GetPitchBytesDefault<TIdx, TView>::getPitchBytesDefault(view);
@@ -64,33 +58,27 @@ namespace alpaka
 
         namespace detail
         {
-            //#############################################################################
             template<typename TIdx, typename TView>
                 struct GetPitchBytesDefault < TIdx,
                 TView, std::enable_if_t<TIdx::value<(Dim<TView>::value - 1)>>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getPitchBytesDefault(TView const& view) -> Idx<TView>
                 {
                     return extent::getExtent<TIdx::value>(view)
                         * GetPitchBytes<DimInt<TIdx::value + 1>, TView>::getPitchBytes(view);
                 }
             };
-            //#############################################################################
             template<typename TView>
             struct GetPitchBytesDefault<DimInt<Dim<TView>::value - 1u>, TView>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getPitchBytesDefault(TView const& view) -> Idx<TView>
                 {
                     return extent::getExtent<Dim<TView>::value - 1u>(view) * sizeof(Elem<TView>);
                 }
             };
-            //#############################################################################
             template<typename TView>
             struct GetPitchBytesDefault<DimInt<Dim<TView>::value>, TView>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getPitchBytesDefault(TView const&) -> Idx<TView>
                 {
                     return sizeof(Elem<TView>);
@@ -98,27 +86,23 @@ namespace alpaka
             };
         } // namespace detail
 
-        //#############################################################################
         //! The memory set task trait.
         //!
         //! Fills the view with data.
         template<typename TDim, typename TDev, typename TSfinae = void>
         struct CreateTaskMemset;
 
-        //#############################################################################
         //! The memory copy task trait.
         //!
         //! Copies memory from one view into another view possibly on a different device.
         template<typename TDim, typename TDevDst, typename TDevSrc, typename TSfinae = void>
         struct CreateTaskMemcpy;
 
-        //#############################################################################
         //! The static device memory view creation trait.
         template<typename TDev, typename TSfinae = void>
         struct CreateStaticDevMemView;
     } // namespace traits
 
-    //-----------------------------------------------------------------------------
     //! Gets the native pointer of the memory view.
     //!
     //! \param view The memory view.
@@ -128,7 +112,6 @@ namespace alpaka
     {
         return traits::GetPtrNative<TView>::getPtrNative(view);
     }
-    //-----------------------------------------------------------------------------
     //! Gets the native pointer of the memory view.
     //!
     //! \param view The memory view.
@@ -139,7 +122,6 @@ namespace alpaka
         return traits::GetPtrNative<TView>::getPtrNative(view);
     }
 
-    //-----------------------------------------------------------------------------
     //! Gets the pointer to the view on the given device.
     //!
     //! \param view The memory view.
@@ -150,7 +132,6 @@ namespace alpaka
     {
         return traits::GetPtrDev<TView, TDev>::getPtrDev(view, dev);
     }
-    //-----------------------------------------------------------------------------
     //! Gets the pointer to the view on the given device.
     //!
     //! \param view The memory view.
@@ -162,7 +143,6 @@ namespace alpaka
         return traits::GetPtrDev<TView, TDev>::getPtrDev(view, dev);
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The pitch in bytes. This is the distance in bytes between two consecutive elements in the given
     //! dimension.
     ALPAKA_NO_HOST_ACC_WARNING
@@ -172,7 +152,6 @@ namespace alpaka
         return traits::GetPitchBytes<DimInt<Tidx>, TView>::getPitchBytes(view);
     }
 
-    //-----------------------------------------------------------------------------
     //! Create a memory set task.
     //!
     //! \param view The memory view to fill.
@@ -188,7 +167,6 @@ namespace alpaka
         return traits::CreateTaskMemset<Dim<TView>, Dev<TView>>::createTaskMemset(view, byte, extent);
     }
 
-    //-----------------------------------------------------------------------------
     //! Sets the memory to the given value.
     //!
     //! \param queue The queue to enqueue the view fill task into.
@@ -201,7 +179,6 @@ namespace alpaka
         enqueue(queue, createTaskMemset(view, byte, extent));
     }
 
-    //-----------------------------------------------------------------------------
     //! Creates a memory copy task.
     //!
     //! \param viewDst The destination memory view.
@@ -226,7 +203,6 @@ namespace alpaka
             extent);
     }
 
-    //-----------------------------------------------------------------------------
     //! Copies memory possibly between different memory spaces.
     //!
     //! \param queue The queue to enqueue the view copy task into.
@@ -242,7 +218,6 @@ namespace alpaka
 
     namespace detail
     {
-        //-----------------------------------------------------------------------------
         template<typename TDim, typename TView>
         struct Print
         {
@@ -282,7 +257,6 @@ namespace alpaka
                 os << rowSuffix;
             }
         };
-        //-----------------------------------------------------------------------------
         template<typename TView>
         struct Print<DimInt<Dim<TView>::value - 1u>, TView>
         {
@@ -318,7 +292,6 @@ namespace alpaka
             }
         };
     } // namespace detail
-    //-----------------------------------------------------------------------------
     //! Prints the content of the view to the given queue.
     // \TODO: Add precision flag.
     // \TODO: Add column alignment flag.
@@ -344,12 +317,10 @@ namespace alpaka
 
     namespace detail
     {
-        //#############################################################################
         //! A class with a create method that returns the pitch for each index.
         template<std::size_t Tidx>
         struct CreatePitchBytes
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename TPitch>
             ALPAKA_FN_HOST_ACC static auto create(TPitch const& pitch) -> Idx<TPitch>
@@ -358,14 +329,12 @@ namespace alpaka
             }
         };
     } // namespace detail
-    //-----------------------------------------------------------------------------
     //! \return The pitch vector.
     template<typename TPitch>
     auto getPitchBytesVec(TPitch const& pitch = TPitch()) -> Vec<Dim<TPitch>, Idx<TPitch>>
     {
         return createVecFromIndexedFn<Dim<TPitch>, detail::CreatePitchBytes>(pitch);
     }
-    //-----------------------------------------------------------------------------
     //! \return The pitch but only the last N elements.
     template<typename TDim, typename TPitch>
     ALPAKA_FN_HOST auto getPitchBytesVecEnd(TPitch const& pitch = TPitch()) -> Vec<TDim, Idx<TPitch>>
@@ -376,7 +345,6 @@ namespace alpaka
         return createVecFromIndexedFnOffset<TDim, detail::CreatePitchBytes, IdxOffset>(pitch);
     }
 
-    //-----------------------------------------------------------------------------
     //! \return A view to static device memory.
     template<typename TElem, typename TDev, typename TExtent>
     auto createStaticDevMemView(TElem* pMem, TDev const& dev, TExtent const& extent)

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -112,6 +112,7 @@ namespace alpaka
     {
         return traits::GetPtrNative<TView>::getPtrNative(view);
     }
+
     //! Gets the native pointer of the memory view.
     //!
     //! \param view The memory view.
@@ -132,6 +133,7 @@ namespace alpaka
     {
         return traits::GetPtrDev<TView, TDev>::getPtrDev(view, dev);
     }
+
     //! Gets the pointer to the view on the given device.
     //!
     //! \param view The memory view.

--- a/include/alpaka/mem/view/ViewCompileTimeArray.hpp
+++ b/include/alpaka/mem/view/ViewCompileTimeArray.hpp
@@ -19,13 +19,11 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     // Trait specializations for fixed idx arrays.
     //
     // This allows the usage of multidimensional compile time arrays e.g. int[4][3] as argument to memory ops.
     /*namespace traits
     {
-        //#############################################################################
         //! The fixed idx array device type trait specialization.
         template<
             typename TFixedSizeArray>
@@ -36,7 +34,6 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The fixed idx array device get trait specialization.
         template<
             typename TFixedSizeArray>
@@ -44,7 +41,6 @@ namespace alpaka
             TFixedSizeArray,
             std::enable_if_t<std::is_array<TFixedSizeArray>::value>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDev(
                 TFixedSizeArray const & view)
             -> DevCpu
@@ -54,7 +50,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The fixed idx array dimension getter trait specialization.
         template<
             typename TFixedSizeArray>
@@ -65,7 +60,6 @@ namespace alpaka
             using type = DimInt<std::rank<TFixedSizeArray>::value>;
         };
 
-        //#############################################################################
         //! The fixed idx array memory element type get trait specialization.
         template<
             typename TFixedSizeArray>
@@ -81,7 +75,6 @@ namespace alpaka
     {
         namespace traits
         {
-            //#############################################################################
             //! The fixed idx array width get trait specialization.
             template<
                 typename TIdxIntegralConst,
@@ -94,7 +87,6 @@ namespace alpaka
                     && (std::rank<TFixedSizeArray>::value > TIdxIntegralConst::value)
                     && (std::extent<TFixedSizeArray, TIdxIntegralConst::value>::value > 0u)>>
             {
-                //-----------------------------------------------------------------------------
                 static constexpr auto getExtent(
                     TFixedSizeArray const & extent
                 )
@@ -108,7 +100,6 @@ namespace alpaka
     }
     namespace traits
     {
-        //#############################################################################
         //! The fixed idx array native pointer get trait specialization.
         template<
             typename TFixedSizeArray>
@@ -119,14 +110,12 @@ namespace alpaka
         {
             using TElem = std::remove_all_extent_t<TFixedSizeArray>;
 
-            //-----------------------------------------------------------------------------
             static auto getPtrNative(
                 TFixedSizeArray const & view)
             -> TElem const *
             {
                 return view;
             }
-            //-----------------------------------------------------------------------------
             static auto getPtrNative(
                 TFixedSizeArray & view)
             -> TElem *
@@ -135,7 +124,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The fixed idx array pitch get trait specialization.
         template<
             typename TFixedSizeArray>
@@ -148,7 +136,6 @@ namespace alpaka
         {
             using TElem = std::remove_all_extent_t<TFixedSizeArray>;
 
-            //-----------------------------------------------------------------------------
             static constexpr auto getPitchBytes(
                 TFixedSizeArray const &)
             -> Idx<TFixedSizeArray>
@@ -157,7 +144,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The fixed idx array offset get trait specialization.
         template<
             typename TIdx,
@@ -167,7 +153,6 @@ namespace alpaka
             TFixedSizeArray,
             std::enable_if_t<std::is_array<TFixedSizeArray>::value>>
         {
-            //-----------------------------------------------------------------------------
             static auto getOffset(
                 TFixedSizeArray const &)
             -> Idx<TFixedSizeArray>
@@ -176,7 +161,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The std::vector idx type trait specialization.
         template<
             typename TFixedSizeArray>

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -20,7 +20,6 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The memory view to wrap plain pointers.
     template<typename TDev, typename TElem, typename TDim, typename TIdx>
     class ViewPlainPtr final
@@ -30,7 +29,6 @@ namespace alpaka
         using Dev = alpaka::Dev<TDev>;
 
     public:
-        //-----------------------------------------------------------------------------
         template<typename TExtent>
         ALPAKA_FN_HOST ViewPlainPtr(TElem* pMem, Dev const& dev, TExtent const& extent = TExtent())
             : m_pMem(pMem)
@@ -40,7 +38,6 @@ namespace alpaka
         {
         }
 
-        //-----------------------------------------------------------------------------
         template<typename TExtent, typename TPitch>
         ALPAKA_FN_HOST ViewPlainPtr(TElem* pMem, Dev const dev, TExtent const& extent, TPitch const& pitchBytes)
             : m_pMem(pMem)
@@ -50,10 +47,8 @@ namespace alpaka
         {
         }
 
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST
         ViewPlainPtr(ViewPlainPtr const&) = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST
         ViewPlainPtr(ViewPlainPtr&& other) noexcept
             : m_pMem(other.m_pMem)
@@ -62,17 +57,13 @@ namespace alpaka
             , m_pitchBytes(other.m_pitchBytes)
         {
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST
         auto operator=(ViewPlainPtr const&) -> ViewPlainPtr& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST
         auto operator=(ViewPlainPtr&&) -> ViewPlainPtr& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST ~ViewPlainPtr() = default;
 
     private:
-        //-----------------------------------------------------------------------------
         //! Calculate the pitches purely from the extents.
         template<typename TExtent>
         ALPAKA_FN_HOST static auto calculatePitchesFromExtents(TExtent const& extent) -> Vec<TDim, TIdx>
@@ -93,11 +84,9 @@ namespace alpaka
         Vec<TDim, TIdx> const m_pitchBytes;
     };
 
-    //-----------------------------------------------------------------------------
     // Trait specializations for ViewPlainPtr.
     namespace traits
     {
-        //#############################################################################
         //! The ViewPlainPtr device type trait specialization.
         template<typename TDev, typename TElem, typename TDim, typename TIdx>
         struct DevType<ViewPlainPtr<TDev, TElem, TDim, TIdx>>
@@ -105,7 +94,6 @@ namespace alpaka
             using type = alpaka::Dev<TDev>;
         };
 
-        //#############################################################################
         //! The ViewPlainPtr device get trait specialization.
         template<typename TDev, typename TElem, typename TDim, typename TIdx>
         struct GetDev<ViewPlainPtr<TDev, TElem, TDim, TIdx>>
@@ -116,7 +104,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The ViewPlainPtr dimension getter trait.
         template<typename TDev, typename TElem, typename TDim, typename TIdx>
         struct DimType<ViewPlainPtr<TDev, TElem, TDim, TIdx>>
@@ -124,7 +111,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The ViewPlainPtr memory element type get trait specialization.
         template<typename TDev, typename TElem, typename TDim, typename TIdx>
         struct ElemType<ViewPlainPtr<TDev, TElem, TDim, TIdx>>
@@ -136,7 +122,6 @@ namespace alpaka
     {
         namespace traits
         {
-            //#############################################################################
             //! The ViewPlainPtr width get trait specialization.
             template<typename TIdxIntegralConst, typename TDev, typename TElem, typename TDim, typename TIdx>
             struct GetExtent<
@@ -156,7 +141,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The ViewPlainPtr native pointer get trait specialization.
         template<typename TDev, typename TElem, typename TDim, typename TIdx>
         struct GetPtrNative<ViewPlainPtr<TDev, TElem, TDim, TIdx>>
@@ -171,7 +155,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The ViewPlainPtr memory pitch get trait specialization.
         template<typename TIdxIntegralConst, typename TDev, typename TElem, typename TDim, typename TIdx>
             struct GetPitchBytes < TIdxIntegralConst,
@@ -183,12 +166,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU device CreateStaticDevMemView trait specialization.
         template<>
         struct CreateStaticDevMemView<DevCpu>
         {
-            //-----------------------------------------------------------------------------
             template<typename TElem, typename TExtent>
             static auto createStaticDevMemView(TElem* pMem, DevCpu const& dev, TExtent const& extent)
             {
@@ -200,12 +181,10 @@ namespace alpaka
         };
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-        //#############################################################################
         //! The CUDA/HIP RT device CreateStaticDevMemView trait specialization.
         template<>
         struct CreateStaticDevMemView<DevUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             template<typename TElem, typename TExtent>
             static auto createStaticDevMemView(TElem* pMem, DevUniformCudaHipRt const& dev, TExtent const& extent)
             {
@@ -232,13 +211,11 @@ namespace alpaka
 #endif
 
 #ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-        //#############################################################################
         //! The Omp5 device CreateStaticDevMemView trait specialization.
         //! \todo What ist this for? Does this exist in OMP5?
         template<>
         struct CreateStaticDevMemView<DevOmp5>
         {
-            //-----------------------------------------------------------------------------
             template<typename TElem, typename TExtent>
             static auto createStaticDevMemView(TElem* pMem, DevOmp5 const& dev, TExtent const& extent)
             {
@@ -251,12 +228,10 @@ namespace alpaka
 #endif
 
 #ifdef ALPAKA_ACC_ANY_BT_OACC_ENABLED
-        //#############################################################################
         //! The Oacc device CreateStaticDevMemView trait specialization.
         template<>
         struct CreateStaticDevMemView<DevOacc>
         {
-            //-----------------------------------------------------------------------------
             template<typename TElem, typename TExtent>
             static auto createStaticDevMemView(TElem* pMem, DevOacc const& dev, TExtent const& extent)
             {
@@ -268,12 +243,10 @@ namespace alpaka
         };
 #endif
 
-        //#############################################################################
         //! The ViewPlainPtr offset get trait specialization.
         template<typename TIdxIntegralConst, typename TDev, typename TElem, typename TDim, typename TIdx>
         struct GetOffset<TIdxIntegralConst, ViewPlainPtr<TDev, TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST_ACC
             static auto getOffset(ViewPlainPtr<TDev, TElem, TDim, TIdx> const&) -> TIdx
@@ -282,7 +255,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The ViewPlainPtr idx type trait specialization.
         template<typename TDev, typename TElem, typename TDim, typename TIdx>
         struct IdxType<ViewPlainPtr<TDev, TElem, TDim, TIdx>>

--- a/include/alpaka/mem/view/ViewStdArray.hpp
+++ b/include/alpaka/mem/view/ViewStdArray.hpp
@@ -21,7 +21,6 @@ namespace alpaka
 {
     namespace traits
     {
-        //#############################################################################
         //! The std::array device type trait specialization.
         template<typename TElem, std::size_t Tsize>
         struct DevType<std::array<TElem, Tsize>>
@@ -29,12 +28,10 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The std::array device get trait specialization.
         template<typename TElem, std::size_t Tsize>
         struct GetDev<std::array<TElem, Tsize>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDev(std::array<TElem, Tsize> const& view) -> DevCpu
             {
                 alpaka::ignore_unused(view);
@@ -42,7 +39,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The std::array dimension getter trait specialization.
         template<typename TElem, std::size_t Tsize>
         struct DimType<std::array<TElem, Tsize>>
@@ -50,7 +46,6 @@ namespace alpaka
             using type = DimInt<1u>;
         };
 
-        //#############################################################################
         //! The std::array memory element type get trait specialization.
         template<typename TElem, std::size_t Tsize>
         struct ElemType<std::array<TElem, Tsize>>
@@ -62,12 +57,10 @@ namespace alpaka
     {
         namespace traits
         {
-            //#############################################################################
             //! The std::array width get trait specialization.
             template<typename TElem, std::size_t Tsize>
             struct GetExtent<DimInt<0u>, std::array<TElem, Tsize>>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static constexpr auto getExtent(std::array<TElem, Tsize> const& extent)
                     -> Idx<std::array<TElem, Tsize>>
                 {
@@ -80,29 +73,24 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The std::array native pointer get trait specialization.
         template<typename TElem, std::size_t Tsize>
         struct GetPtrNative<std::array<TElem, Tsize>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrNative(std::array<TElem, Tsize> const& view) -> TElem const*
             {
                 return view.data();
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrNative(std::array<TElem, Tsize>& view) -> TElem*
             {
                 return view.data();
             }
         };
 
-        //#############################################################################
         //! The std::array pitch get trait specialization.
         template<typename TElem, std::size_t Tsize>
         struct GetPitchBytes<DimInt<0u>, std::array<TElem, Tsize>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPitchBytes(std::array<TElem, Tsize> const& pitch)
                 -> Idx<std::array<TElem, Tsize>>
             {
@@ -110,19 +98,16 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The std::array offset get trait specialization.
         template<typename TIdx, typename TElem, std::size_t Tsize>
         struct GetOffset<TIdx, std::array<TElem, Tsize>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getOffset(std::array<TElem, Tsize> const&) -> Idx<std::array<TElem, Tsize>>
             {
                 return 0u;
             }
         };
 
-        //#############################################################################
         //! The std::vector idx type trait specialization.
         template<typename TElem, std::size_t Tsize>
         struct IdxType<std::array<TElem, Tsize>>

--- a/include/alpaka/mem/view/ViewStdVector.hpp
+++ b/include/alpaka/mem/view/ViewStdVector.hpp
@@ -21,7 +21,6 @@ namespace alpaka
 {
     namespace traits
     {
-        //#############################################################################
         //! The std::vector device type trait specialization.
         template<typename TElem, typename TAllocator>
         struct DevType<std::vector<TElem, TAllocator>>
@@ -29,12 +28,10 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The std::vector device get trait specialization.
         template<typename TElem, typename TAllocator>
         struct GetDev<std::vector<TElem, TAllocator>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDev(std::vector<TElem, TAllocator> const& view) -> DevCpu
             {
                 alpaka::ignore_unused(view);
@@ -42,7 +39,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The std::vector dimension getter trait specialization.
         template<typename TElem, typename TAllocator>
         struct DimType<std::vector<TElem, TAllocator>>
@@ -50,7 +46,6 @@ namespace alpaka
             using type = DimInt<1u>;
         };
 
-        //#############################################################################
         //! The std::vector memory element type get trait specialization.
         template<typename TElem, typename TAllocator>
         struct ElemType<std::vector<TElem, TAllocator>>
@@ -62,12 +57,10 @@ namespace alpaka
     {
         namespace traits
         {
-            //#############################################################################
             //! The std::vector width get trait specialization.
             template<typename TElem, typename TAllocator>
             struct GetExtent<DimInt<0u>, std::vector<TElem, TAllocator>>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getExtent(std::vector<TElem, TAllocator> const& extent)
                     -> Idx<std::vector<TElem, TAllocator>>
                 {
@@ -78,29 +71,24 @@ namespace alpaka
     } // namespace extent
     namespace traits
     {
-        //#############################################################################
         //! The std::vector native pointer get trait specialization.
         template<typename TElem, typename TAllocator>
         struct GetPtrNative<std::vector<TElem, TAllocator>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrNative(std::vector<TElem, TAllocator> const& view) -> TElem const*
             {
                 return view.data();
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrNative(std::vector<TElem, TAllocator>& view) -> TElem*
             {
                 return view.data();
             }
         };
 
-        //#############################################################################
         //! The std::vector pitch get trait specialization.
         template<typename TElem, typename TAllocator>
         struct GetPitchBytes<DimInt<0u>, std::vector<TElem, TAllocator>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPitchBytes(std::vector<TElem, TAllocator> const& pitch)
                 -> Idx<std::vector<TElem, TAllocator>>
             {
@@ -108,12 +96,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The std::vector offset get trait specialization.
         template<typename TIdx, typename TElem, typename TAllocator>
         struct GetOffset<TIdx, std::vector<TElem, TAllocator>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getOffset(std::vector<TElem, TAllocator> const&)
                 -> Idx<std::vector<TElem, TAllocator>>
             {
@@ -121,7 +107,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The std::vector idx type trait specialization.
         template<typename TElem, typename TAllocator>
         struct IdxType<std::vector<TElem, TAllocator>>

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -25,7 +25,6 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! A sub-view to a view.
     template<typename TDev, typename TElem, typename TDim, typename TIdx>
     class ViewSubView
@@ -35,7 +34,6 @@ namespace alpaka
         using Dev = alpaka::Dev<TDev>;
 
     public:
-        //-----------------------------------------------------------------------------
         //! Constructor.
         //! \param view The view this view is a sub-view of.
         //! \param extentElements The extent in elements.
@@ -78,7 +76,6 @@ namespace alpaka
             ALPAKA_ASSERT(((m_offsetsElements + m_extentElements) <= extent::getExtentVec(view))
                               .foldrAll(std::logical_and<bool>()));
         }
-        //-----------------------------------------------------------------------------
         //! Constructor.
         //! \param view The view this view is a sub-view of.
         //! \param extentElements The extent in elements.
@@ -119,7 +116,6 @@ namespace alpaka
                               .foldrAll(std::logical_and<bool>()));
         }
 
-        //-----------------------------------------------------------------------------
         //! \param view The view this view is a sub-view of.
         template<typename TView>
         explicit ViewSubView(TView const& view) : ViewSubView(view, view, Vec<TDim, TIdx>::all(0))
@@ -127,7 +123,6 @@ namespace alpaka
             ALPAKA_DEBUG_FULL_LOG_SCOPE;
         }
 
-        //-----------------------------------------------------------------------------
         //! \param view The view this view is a sub-view of.
         template<typename TView>
         explicit ViewSubView(TView& view) : ViewSubView(view, view, Vec<TDim, TIdx>::all(0))
@@ -141,11 +136,9 @@ namespace alpaka
         Vec<TDim, TIdx> m_offsetsElements; // The offset relative to the parent view.
     };
 
-    //-----------------------------------------------------------------------------
     // Trait specializations for ViewSubView.
     namespace traits
     {
-        //#############################################################################
         //! The ViewSubView device type trait specialization.
         template<typename TElem, typename TDim, typename TDev, typename TIdx>
         struct DevType<ViewSubView<TDev, TElem, TDim, TIdx>>
@@ -153,19 +146,16 @@ namespace alpaka
             using type = alpaka::Dev<TDev>;
         };
 
-        //#############################################################################
         //! The ViewSubView device get trait specialization.
         template<typename TElem, typename TDim, typename TDev, typename TIdx>
         struct GetDev<ViewSubView<TDev, TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDev(ViewSubView<TDev, TElem, TDim, TIdx> const& view) -> alpaka::Dev<TDev>
             {
                 return alpaka::getDev(view.m_viewParentView);
             }
         };
 
-        //#############################################################################
         //! The ViewSubView dimension getter trait specialization.
         template<typename TElem, typename TDim, typename TDev, typename TIdx>
         struct DimType<ViewSubView<TDev, TElem, TDim, TIdx>>
@@ -173,7 +163,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The ViewSubView memory element type get trait specialization.
         template<typename TElem, typename TDim, typename TDev, typename TIdx>
         struct ElemType<ViewSubView<TDev, TElem, TDim, TIdx>>
@@ -185,7 +174,6 @@ namespace alpaka
     {
         namespace traits
         {
-            //#############################################################################
             //! The ViewSubView width get trait specialization.
             template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TDev, typename TIdx>
             struct GetExtent<
@@ -193,7 +181,6 @@ namespace alpaka
                 ViewSubView<TDev, TElem, TDim, TIdx>,
                 std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto getExtent(ViewSubView<TDev, TElem, TDim, TIdx> const& extent) -> TIdx
                 {
                     return extent.m_extentElements[TIdxIntegralConst::value];
@@ -208,7 +195,6 @@ namespace alpaka
 #    pragma GCC diagnostic ignored                                                                                    \
         "-Wcast-align" // "cast from 'std::uint8_t*' to 'TElem*' increases required alignment of target type"
 #endif
-        //#############################################################################
         //! The ViewSubView native pointer get trait specialization.
         template<typename TElem, typename TDim, typename TDev, typename TIdx>
         struct GetPtrNative<ViewSubView<TDev, TElem, TDim, TIdx>>
@@ -217,7 +203,6 @@ namespace alpaka
             using IdxSequence = std::make_index_sequence<TDim::value>;
 
         public:
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrNative(ViewSubView<TDev, TElem, TDim, TIdx> const& view) -> TElem const*
             {
                 // \TODO: pre-calculate this pointer for faster execution.
@@ -225,7 +210,6 @@ namespace alpaka
                     reinterpret_cast<std::uint8_t const*>(alpaka::getPtrNative(view.m_viewParentView))
                     + pitchedOffsetBytes(view, IdxSequence()));
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPtrNative(ViewSubView<TDev, TElem, TDim, TIdx>& view) -> TElem*
             {
                 // \TODO: pre-calculate this pointer for faster execution.
@@ -235,7 +219,6 @@ namespace alpaka
             }
 
         private:
-            //-----------------------------------------------------------------------------
             //! For a 3D vector this calculates:
             //!
             //! getOffset<0u>(view) * getPitchBytes<1u>(view)
@@ -248,7 +231,6 @@ namespace alpaka
             {
                 return meta::foldr(std::plus<TIdx>(), pitchedOffsetBytesDim<TIndices>(view)...);
             }
-            //-----------------------------------------------------------------------------
             template<std::size_t Tidx, typename TView>
             ALPAKA_FN_HOST static auto pitchedOffsetBytesDim(TView const& view) -> TIdx
             {
@@ -259,19 +241,16 @@ namespace alpaka
 #    pragma GCC diagnostic pop
 #endif
 
-        //#############################################################################
         //! The ViewSubView pitch get trait specialization.
         template<typename TIdxIntegralConst, typename TDev, typename TElem, typename TDim, typename TIdx>
         struct GetPitchBytes<TIdxIntegralConst, ViewSubView<TDev, TElem, TDim, TIdx>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getPitchBytes(ViewSubView<TDev, TElem, TDim, TIdx> const& view) -> TIdx
             {
                 return alpaka::getPitchBytes<TIdxIntegralConst::value>(view.m_viewParentView);
             }
         };
 
-        //#############################################################################
         //! The ViewSubView x offset get trait specialization.
         template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TDev, typename TIdx>
         struct GetOffset<
@@ -279,14 +258,12 @@ namespace alpaka
             ViewSubView<TDev, TElem, TDim, TIdx>,
             std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getOffset(ViewSubView<TDev, TElem, TDim, TIdx> const& offset) -> TIdx
             {
                 return offset.m_offsetsElements[TIdxIntegralConst::value];
             }
         };
 
-        //#############################################################################
         //! The ViewSubView idx type trait specialization.
         template<typename TElem, typename TDim, typename TDev, typename TIdx>
         struct IdxType<ViewSubView<TDev, TElem, TDim, TIdx>>

--- a/include/alpaka/meta/Apply.hpp
+++ b/include/alpaka/meta/Apply.hpp
@@ -15,17 +15,14 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             template<typename TList, template<typename...> class TApplicant>
             struct ApplyImpl;
-            //#############################################################################
             template<template<typename...> class TList, template<typename...> class TApplicant, typename... T>
             struct ApplyImpl<TList<T...>, TApplicant>
             {
                 using type = TApplicant<T...>;
             };
         } // namespace detail
-        //#############################################################################
         template<typename TList, template<typename...> class TApplicant>
         using Apply = typename detail::ApplyImpl<TList, TApplicant>::type;
     } // namespace meta

--- a/include/alpaka/meta/ApplyTuple.hpp
+++ b/include/alpaka/meta/ApplyTuple.hpp
@@ -20,7 +20,6 @@ namespace alpaka
 {
     namespace meta
     {
-        //-----------------------------------------------------------------------------
         // C++17 std::invoke
         namespace detail
         {
@@ -63,7 +62,6 @@ namespace alpaka
             return detail::invoke_impl(std::forward<F>(f), std::forward<ArgTypes>(args)...);
         }
 
-        //-----------------------------------------------------------------------------
         // C++17 std::apply
         namespace detail
         {

--- a/include/alpaka/meta/CartesianProduct.hpp
+++ b/include/alpaka/meta/CartesianProduct.hpp
@@ -15,44 +15,37 @@ namespace alpaka
 {
     namespace meta
     {
-        //-----------------------------------------------------------------------------
         // This is based on code by Patrick Fromberg.
         // See
         // http://stackoverflow.com/questions/9122028/how-to-create-the-cartesian-product-of-a-type-list/19611856#19611856
         namespace detail
         {
-            //#############################################################################
             template<typename... Ts>
             struct CartesianProductImplHelper;
-            //#############################################################################
             // Stop condition.
             template<template<typename...> class TList, typename... Ts>
             struct CartesianProductImplHelper<TList<Ts...>>
             {
                 using type = TList<Ts...>;
             };
-            //#############################################################################
             // Catches first empty tuple.
             template<template<typename...> class TList, typename... Ts>
             struct CartesianProductImplHelper<TList<TList<>>, Ts...>
             {
                 using type = TList<>;
             };
-            //#############################################################################
             // Catches any empty tuple except first.
             template<template<typename...> class TList, typename... Ts, typename... Rests>
             struct CartesianProductImplHelper<TList<Ts...>, TList<>, Rests...>
             {
                 using type = TList<>;
             };
-            //#############################################################################
             template<template<typename...> class TList, typename... X, typename H, typename... Rests>
             struct CartesianProductImplHelper<TList<X...>, TList<H>, Rests...>
             {
                 using type1 = TList<Concatenate<X, TList<H>>...>;
                 using type = typename CartesianProductImplHelper<type1, Rests...>::type;
             };
-            //#############################################################################
             template<
                 template<typename...>
                 class TList,
@@ -70,17 +63,14 @@ namespace alpaka
                 using type = typename CartesianProductImplHelper<type3, Rests...>::type;
             };
 
-            //#############################################################################
             template<template<typename...> class TList, typename... Ts>
             struct CartesianProductImpl;
-            //#############################################################################
             // The base case for no input returns an empty sequence.
             template<template<typename...> class TList>
             struct CartesianProductImpl<TList>
             {
                 using type = TList<>;
             };
-            //#############################################################################
             // R is the return type, Head<A...> is the first input list
             template<
                 template<typename...>
@@ -95,7 +85,6 @@ namespace alpaka
             };
         } // namespace detail
 
-        //#############################################################################
         template<template<typename...> class TList, typename... Ts>
         using CartesianProduct = typename detail::CartesianProductImpl<TList, Ts...>::type;
     } // namespace meta

--- a/include/alpaka/meta/Concatenate.hpp
+++ b/include/alpaka/meta/Concatenate.hpp
@@ -15,23 +15,19 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             template<typename... T>
             struct ConcatenateImpl;
-            //#############################################################################
             template<typename T>
             struct ConcatenateImpl<T>
             {
                 using type = T;
             };
-            //#############################################################################
             template<template<typename...> class TList, typename... As, typename... Bs, typename... TRest>
             struct ConcatenateImpl<TList<As...>, TList<Bs...>, TRest...>
             {
                 using type = typename ConcatenateImpl<TList<As..., Bs...>, TRest...>::type;
             };
         } // namespace detail
-        //#############################################################################
         template<typename... T>
         using Concatenate = typename detail::ConcatenateImpl<T...>::type;
     } // namespace meta

--- a/include/alpaka/meta/DependentFalseType.hpp
+++ b/include/alpaka/meta/DependentFalseType.hpp
@@ -15,7 +15,6 @@ namespace alpaka
 {
     namespace meta
     {
-        //#############################################################################
         //! A false_type being dependent on a ignored template parameter.
         //! This allows to use static_assert in uninstantiated template specializations without triggering.
         template<typename T>

--- a/include/alpaka/meta/Filter.hpp
+++ b/include/alpaka/meta/Filter.hpp
@@ -19,16 +19,13 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             template<template<typename...> class TList, template<typename> class TPred, typename... Ts>
             struct FilterImplHelper;
-            //#############################################################################
             template<template<typename...> class TList, template<typename> class TPred>
             struct FilterImplHelper<TList, TPred>
             {
                 using type = TList<>;
             };
-            //#############################################################################
             template<template<typename...> class TList, template<typename> class TPred, typename T, typename... Ts>
             struct FilterImplHelper<TList, TPred, T, Ts...>
             {
@@ -38,17 +35,14 @@ namespace alpaka
                     typename FilterImplHelper<TList, TPred, Ts...>::type>;
             };
 
-            //#############################################################################
             template<typename TList, template<typename> class TPred>
             struct FilterImpl;
-            //#############################################################################
             template<template<typename...> class TList, template<typename> class TPred, typename... Ts>
             struct FilterImpl<TList<Ts...>, TPred>
             {
                 using type = typename detail::FilterImplHelper<TList, TPred, Ts...>::type;
             };
         } // namespace detail
-        //#############################################################################
         template<typename TList, template<typename> class TPred>
         using Filter = typename detail::FilterImpl<TList, TPred>::type;
     } // namespace meta

--- a/include/alpaka/meta/Fold.hpp
+++ b/include/alpaka/meta/Fold.hpp
@@ -16,7 +16,6 @@ namespace alpaka
 {
     namespace meta
     {
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TFnObj, typename T>
         ALPAKA_FN_HOST_ACC auto foldr(TFnObj const& f, T const& t) -> T
@@ -25,7 +24,6 @@ namespace alpaka
 
             return t;
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TFnObj, typename T0, typename T1, typename... Ts>
         ALPAKA_FN_HOST_ACC auto foldr(TFnObj const& f, T0 const& t0, T1 const& t1, Ts const&... ts)

--- a/include/alpaka/meta/ForEachType.hpp
+++ b/include/alpaka/meta/ForEachType.hpp
@@ -20,14 +20,11 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             template<typename TList>
             struct ForEachTypeHelper;
-            //#############################################################################
             template<template<typename...> class TList>
             struct ForEachTypeHelper<TList<>>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 template<typename TFnObj, typename... TArgs>
                 ALPAKA_FN_HOST_ACC static auto forEachTypeHelper(TFnObj&& f, TArgs&&... args) -> void
@@ -36,11 +33,9 @@ namespace alpaka
                     alpaka::ignore_unused(args...);
                 }
             };
-            //#############################################################################
             template<template<typename...> class TList, typename T, typename... Ts>
             struct ForEachTypeHelper<TList<T, Ts...>>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 template<typename TFnObj, typename... TArgs>
                 ALPAKA_FN_HOST_ACC static auto forEachTypeHelper(TFnObj&& f, TArgs&&... args) -> void
@@ -53,7 +48,6 @@ namespace alpaka
             };
         } // namespace detail
 
-        //-----------------------------------------------------------------------------
         //! Equivalent to boost::mpl::for_each but does not require the types of the sequence to be default
         //! constructible. This function does not create instances of the types instead it passes the types as template
         //! parameter.

--- a/include/alpaka/meta/IntegerSequence.hpp
+++ b/include/alpaka/meta/IntegerSequence.hpp
@@ -21,29 +21,24 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             template<typename TDstType, typename TIntegerSequence>
             struct ConvertIntegerSequence;
-            //#############################################################################
             template<typename TDstType, typename T, T... Tvals>
             struct ConvertIntegerSequence<TDstType, std::integer_sequence<T, Tvals...>>
             {
                 using type = std::integer_sequence<TDstType, static_cast<TDstType>(Tvals)...>;
             };
         } // namespace detail
-        //#############################################################################
         template<typename TDstType, typename TIntegerSequence>
         using ConvertIntegerSequence = typename detail::ConvertIntegerSequence<TDstType, TIntegerSequence>::type;
 
         namespace detail
         {
-            //#############################################################################
             template<bool TisSizeNegative, bool TbIsBegin, typename T, T Tbegin, typename TIntCon, typename TIntSeq>
             struct MakeIntegerSequenceHelper
             {
                 static_assert(!TisSizeNegative, "MakeIntegerSequence<T, N> requires N to be non-negative.");
             };
-            //#############################################################################
             template<typename T, T Tbegin, T... Tvals>
             struct MakeIntegerSequenceHelper<
                 false,
@@ -55,7 +50,6 @@ namespace alpaka
             {
                 using type = std::integer_sequence<T, Tvals...>;
             };
-            //#############################################################################
             template<typename T, T Tbegin, T TIdx, T... Tvals>
             struct MakeIntegerSequenceHelper<
                 false,
@@ -75,7 +69,6 @@ namespace alpaka
             };
         } // namespace detail
 
-        //#############################################################################
         template<typename T, T Tbegin, T Tsize>
         using MakeIntegerSequenceOffset = typename detail::MakeIntegerSequenceHelper<
             (Tsize < 0),
@@ -85,7 +78,6 @@ namespace alpaka
             std::integral_constant<T, Tbegin + Tsize>,
             std::integer_sequence<T>>::type;
 
-        //#############################################################################
         //! Checks if the integral values are unique.
         template<typename T, T... Tvals>
         struct IntegralValuesUnique
@@ -93,11 +85,9 @@ namespace alpaka
             static constexpr bool value = meta::IsParameterPackSet<std::integral_constant<T, Tvals>...>::value;
         };
 
-        //#############################################################################
         //! Checks if the values in the index sequence are unique.
         template<typename TIntegerSequence>
         struct IntegerSequenceValuesUnique;
-        //#############################################################################
         //! Checks if the values in the index sequence are unique.
         template<typename T, T... Tvals>
         struct IntegerSequenceValuesUnique<std::integer_sequence<T, Tvals...>>
@@ -105,18 +95,15 @@ namespace alpaka
             static constexpr bool value = IntegralValuesUnique<T, Tvals...>::value;
         };
 
-        //#############################################################################
         //! Checks if the integral values are within the given range.
         template<typename T, T Tmin, T Tmax, T... Tvals>
         struct IntegralValuesInRange;
-        //#############################################################################
         //! Checks if the integral values are within the given range.
         template<typename T, T Tmin, T Tmax>
         struct IntegralValuesInRange<T, Tmin, Tmax>
         {
             static constexpr bool value = true;
         };
-        //#############################################################################
         //! Checks if the integral values are within the given range.
         template<typename T, T Tmin, T Tmax, T I, T... Tvals>
         struct IntegralValuesInRange<T, Tmin, Tmax, I, Tvals...>
@@ -125,11 +112,9 @@ namespace alpaka
                 = (I >= Tmin) && (I <= Tmax) && IntegralValuesInRange<T, Tmin, Tmax, Tvals...>::value;
         };
 
-        //#############################################################################
         //! Checks if the values in the index sequence are within the given range.
         template<typename TIntegerSequence, typename T, T Tmin, T Tmax>
         struct IntegerSequenceValuesInRange;
-        //#############################################################################
         //! Checks if the values in the index sequence are within the given range.
         template<typename T, T... Tvals, T Tmin, T Tmax>
         struct IntegerSequenceValuesInRange<std::integer_sequence<T, Tvals...>, T, Tmin, Tmax>

--- a/include/alpaka/meta/Integral.hpp
+++ b/include/alpaka/meta/Integral.hpp
@@ -15,7 +15,6 @@ namespace alpaka
 {
     namespace meta
     {
-        //#############################################################################
         //! The trait is true if all values of TSubset are contained in TSuperset.
         template<typename TSuperset, typename TSubset>
         using IsIntegralSuperset = std::integral_constant<
@@ -29,7 +28,6 @@ namespace alpaka
                     || ((std::is_unsigned<TSuperset>::value != std::is_unsigned<TSubset>::value)
                         && (sizeof(TSuperset) > sizeof(TSubset))))>;
 
-        //#############################################################################
         //! The type that has the higher max value.
         template<typename T0, typename T1>
         using HigherMax = std::conditional_t<
@@ -40,7 +38,6 @@ namespace alpaka
                 T0,
                 T1>>;
 
-        //#############################################################################
         //! The type that has the lower max value.
         template<typename T0, typename T1>
         using LowerMax = std::conditional_t<
@@ -51,7 +48,6 @@ namespace alpaka
                 T0,
                 T1>>;
 
-        //#############################################################################
         //! The type that has the higher min value. If both types have the same min value, the type with the wider
         //! range is chosen.
         template<typename T0, typename T1>
@@ -63,7 +59,6 @@ namespace alpaka
                 std::conditional_t<(sizeof(T0) < sizeof(T1)), T0, T1>>,
             std::conditional_t<std::is_unsigned<T0>::value, T0, T1>>;
 
-        //#############################################################################
         //! The type that has the lower min value. If both types have the same min value, the type with the wider range
         //! is chosen.
         template<typename T0, typename T1>

--- a/include/alpaka/meta/IsStrictBase.hpp
+++ b/include/alpaka/meta/IsStrictBase.hpp
@@ -15,7 +15,6 @@ namespace alpaka
 {
     namespace meta
     {
-        //#############################################################################
         //! The trait is true if TDerived is derived from TBase but is not TBase itself.
         template<typename TBase, typename TDerived>
         using IsStrictBase = std::integral_constant<

--- a/include/alpaka/meta/Metafunctions.hpp
+++ b/include/alpaka/meta/Metafunctions.hpp
@@ -17,55 +17,46 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             // TODO: Replace with C++17 std::conjunction
             template<typename...>
             struct ConjunctionImpl : std::true_type
             {
             };
-            //#############################################################################
             // TODO: Replace with C++17 std::conjunction
             template<typename B1>
             struct ConjunctionImpl<B1> : B1
             {
             };
-            //#############################################################################
             // TODO: Replace with C++17 std::conjunction
             template<typename B1, typename... Bn>
             struct ConjunctionImpl<B1, Bn...> : std::conditional<B1::value != false, ConjunctionImpl<Bn...>, B1>::type
             {
             };
         } // namespace detail
-        //#############################################################################
         template<typename... B>
         using Conjunction = typename detail::ConjunctionImpl<B...>::type;
 
         namespace detail
         {
-            //#############################################################################
             // TODO: Replace with C++17 std::disjunction
             template<typename...>
             struct DisjunctionImpl : std::false_type
             {
             };
-            //#############################################################################
             // TODO: Replace with C++17 std::disjunction
             template<typename B1>
             struct DisjunctionImpl<B1> : B1
             {
             };
-            //#############################################################################
             // TODO: Replace with C++17 std::disjunction
             template<typename B1, typename... Bn>
             struct DisjunctionImpl<B1, Bn...> : std::conditional<B1::value != false, B1, DisjunctionImpl<Bn...>>::type
             {
             };
         } // namespace detail
-        //#############################################################################
         template<typename... B>
         using Disjunction = typename detail::DisjunctionImpl<B...>;
 
-        //#############################################################################
         // TODO: Replace with C++17 std::negation
         template<typename B>
         using Negation = std::integral_constant<bool, !B::value>;

--- a/include/alpaka/meta/NdLoop.hpp
+++ b/include/alpaka/meta/NdLoop.hpp
@@ -22,16 +22,13 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             //! N-dimensional loop iteration template.
             template<typename TIndexSequence>
             struct NdLoop;
-            //#############################################################################
             //! N-dimensional loop iteration template.
             template<>
             struct NdLoop<std::index_sequence<>>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 template<typename TIndex, typename TExtentVec, typename TFnObj>
                 ALPAKA_FN_HOST_ACC static auto ndLoop(TIndex& idx, TExtentVec const& extent, TFnObj const& f) -> void
@@ -41,12 +38,10 @@ namespace alpaka
                     alpaka::ignore_unused(f);
                 }
             };
-            //#############################################################################
             //! N-dimensional loop iteration template.
             template<std::size_t Tdim>
             struct NdLoop<std::index_sequence<Tdim>>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 template<typename TIndex, typename TExtentVec, typename TFnObj>
                 ALPAKA_FN_HOST_ACC static auto ndLoop(TIndex& idx, TExtentVec const& extent, TFnObj const& f) -> void
@@ -67,12 +62,10 @@ namespace alpaka
                     }
                 }
             };
-            //#############################################################################
             //! N-dimensional loop iteration template.
             template<std::size_t Tdim0, std::size_t Tdim1, std::size_t... Tdims>
             struct NdLoop<std::index_sequence<Tdim0, Tdim1, Tdims...>>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 template<typename TIndex, typename TExtentVec, typename TFnObj>
                 ALPAKA_FN_HOST_ACC static auto ndLoop(TIndex& idx, TExtentVec const& extent, TFnObj const& f) -> void
@@ -94,7 +87,6 @@ namespace alpaka
                 }
             };
         } // namespace detail
-        //-----------------------------------------------------------------------------
         //! Loops over an n-dimensional iteration index variable calling f(idx, args...) for each iteration.
         //! The loops are nested in the order given by the index_sequence with the first element being the outermost
         //! and the last index the innermost loop.
@@ -129,7 +121,6 @@ namespace alpaka
 
             detail::NdLoop<std::index_sequence<Tdims...>>::template ndLoop(idx, extent, f);
         }
-        //-----------------------------------------------------------------------------
         //! Loops over an n-dimensional iteration index variable calling f(idx, args...) for each iteration.
         //! The loops are nested from index zero outmost to index (dim-1) innermost.
         //!

--- a/include/alpaka/meta/NdLoop.hpp
+++ b/include/alpaka/meta/NdLoop.hpp
@@ -87,6 +87,7 @@ namespace alpaka
                 }
             };
         } // namespace detail
+
         //! Loops over an n-dimensional iteration index variable calling f(idx, args...) for each iteration.
         //! The loops are nested in the order given by the index_sequence with the first element being the outermost
         //! and the last index the innermost loop.
@@ -121,6 +122,7 @@ namespace alpaka
 
             detail::NdLoop<std::index_sequence<Tdims...>>::template ndLoop(idx, extent, f);
         }
+
         //! Loops over an n-dimensional iteration index variable calling f(idx, args...) for each iteration.
         //! The loops are nested from index zero outmost to index (dim-1) innermost.
         //!

--- a/include/alpaka/meta/Set.hpp
+++ b/include/alpaka/meta/Set.hpp
@@ -17,23 +17,19 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             //! Empty dependent type.
             template<typename T>
             struct Empty
             {
             };
 
-            //#############################################################################
             template<typename... Ts>
             struct IsParameterPackSetImpl;
-            //#############################################################################
             template<>
             struct IsParameterPackSetImpl<>
             {
                 static constexpr bool value = true;
             };
-            //#############################################################################
             // Based on code by Roland Bock: https://gist.github.com/rbock/ad8eedde80c060132a18
             // Linearly inherits from empty<T> and checks if it has already inherited from this type.
             template<typename T, typename... Ts>
@@ -46,24 +42,20 @@ namespace alpaka
                 static constexpr bool value = Base::value && !std::is_base_of<Empty<T>, Base>::value;
             };
         } // namespace detail
-        //#############################################################################
         //! Trait that tells if the parameter pack contains only unique (no equal) types.
         template<typename... Ts>
         using IsParameterPackSet = detail::IsParameterPackSetImpl<Ts...>;
 
         namespace detail
         {
-            //#############################################################################
             template<typename TList>
             struct IsSetImpl;
-            //#############################################################################
             template<template<typename...> class TList, typename... Ts>
             struct IsSetImpl<TList<Ts...>>
             {
                 static constexpr bool value = IsParameterPackSet<Ts...>::value;
             };
         } // namespace detail
-        //#############################################################################
         //! Trait that tells if the template contains only unique (no equal) types.
         template<typename TList>
         using IsSet = detail::IsSetImpl<TList>;

--- a/include/alpaka/meta/Transform.hpp
+++ b/include/alpaka/meta/Transform.hpp
@@ -15,17 +15,14 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             template<typename Ts, template<typename...> class TOp>
             struct TransformImpl;
-            //#############################################################################
             template<template<typename...> class TList, typename... Ts, template<typename...> class TOp>
             struct TransformImpl<TList<Ts...>, TOp>
             {
                 using type = TList<TOp<Ts>...>;
             };
         } // namespace detail
-        //#############################################################################
         template<typename Ts, template<typename...> class TOp>
         using Transform = typename detail::TransformImpl<Ts, TOp>::type;
     } // namespace meta

--- a/include/alpaka/meta/Unique.hpp
+++ b/include/alpaka/meta/Unique.hpp
@@ -44,7 +44,6 @@ namespace alpaka
             };
         } // namespace detail
 
-        //#############################################################################
         //! Trait that returns a list with only unique (no equal) types (a set). Duplicates will be filtered out.
         template<typename TList>
         using Unique = typename detail::UniqueImpl<TList>::type;

--- a/include/alpaka/meta/Void.hpp
+++ b/include/alpaka/meta/Void.hpp
@@ -13,7 +13,6 @@ namespace alpaka
 {
     namespace meta
     {
-        //#############################################################################
         //! Mirror of C++17 std::void_t, maps a sequence of any types to type void
         template<class...>
         using Void = void;

--- a/include/alpaka/offset/Traits.hpp
+++ b/include/alpaka/offset/Traits.hpp
@@ -17,11 +17,9 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The offset traits.
     namespace traits
     {
-        //#############################################################################
         //! The x offset get trait.
         //!
         //! If not specialized explicitly it returns 0.
@@ -35,13 +33,11 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The x offset set trait.
         template<typename TIdx, typename TOffsets, typename TOffset, typename TSfinae = void>
         struct SetOffset;
     } // namespace traits
 
-    //-----------------------------------------------------------------------------
     //! \return The offset in the given dimension.
     ALPAKA_NO_HOST_ACC_WARNING
     template<std::size_t Tidx, typename TOffsets>
@@ -49,7 +45,6 @@ namespace alpaka
     {
         return traits::GetOffset<DimInt<Tidx>, TOffsets>::getOffset(offsets);
     }
-    //-----------------------------------------------------------------------------
     //! \return The offset in x dimension.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TOffsets>
@@ -57,7 +52,6 @@ namespace alpaka
     {
         return getOffset<Dim<TOffsets>::value - 1u>(offsets);
     }
-    //-----------------------------------------------------------------------------
     //! \return The offset in y dimension.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TOffsets>
@@ -65,7 +59,6 @@ namespace alpaka
     {
         return getOffset<Dim<TOffsets>::value - 2u>(offsets);
     }
-    //-----------------------------------------------------------------------------
     //! \return The offset in z dimension.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TOffsets>
@@ -74,7 +67,6 @@ namespace alpaka
         return getOffset<Dim<TOffsets>::value - 3u>(offsets);
     }
 
-    //-----------------------------------------------------------------------------
     //! Sets the offset in the given dimension.
     ALPAKA_NO_HOST_ACC_WARNING
     template<std::size_t Tidx, typename TOffsets, typename TOffset>
@@ -82,7 +74,6 @@ namespace alpaka
     {
         traits::SetOffset<DimInt<Tidx>, TOffsets, TOffset>::setOffset(offsets, offset);
     }
-    //-----------------------------------------------------------------------------
     //! Sets the offset in x dimension.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TOffsets, typename TOffset>
@@ -90,7 +81,6 @@ namespace alpaka
     {
         setOffset<Dim<TOffsets>::value - 1u>(offsets, offset);
     }
-    //-----------------------------------------------------------------------------
     //! Sets the offset in y dimension.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TOffsets, typename TOffset>
@@ -98,7 +88,6 @@ namespace alpaka
     {
         setOffset<Dim<TOffsets>::value - 2u>(offsets, offset);
     }
-    //-----------------------------------------------------------------------------
     //! Sets the offset in z dimension.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TOffsets, typename TOffset>
@@ -107,11 +96,9 @@ namespace alpaka
         setOffset<Dim<TOffsets>::value - 3u>(offsets, offset);
     }
 
-    //-----------------------------------------------------------------------------
     // Trait specializations for unsigned integral types.
     namespace traits
     {
-        //#############################################################################
         //! The unsigned integral x offset get trait specialization.
         template<typename TOffsets>
         struct GetOffset<DimInt<0u>, TOffsets, std::enable_if_t<std::is_integral<TOffsets>::value>>
@@ -122,7 +109,6 @@ namespace alpaka
                 return offset;
             }
         };
-        //#############################################################################
         //! The unsigned integral x offset set trait specialization.
         template<typename TOffsets, typename TOffset>
         struct SetOffset<DimInt<0u>, TOffsets, TOffset, std::enable_if_t<std::is_integral<TOffsets>::value>>

--- a/include/alpaka/pltf/PltfCpu.hpp
+++ b/include/alpaka/pltf/PltfCpu.hpp
@@ -18,18 +18,15 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The CPU device platform.
     class PltfCpu : public concepts::Implements<ConceptPltf, PltfCpu>
     {
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST PltfCpu() = delete;
     };
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU device device type trait specialization.
         template<>
         struct DevType<PltfCpu>
@@ -37,12 +34,10 @@ namespace alpaka
             using type = DevCpu;
         };
 
-        //#############################################################################
         //! The CPU platform device count get trait specialization.
         template<>
         struct GetDevCount<PltfCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDevCount() -> std::size_t
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -51,12 +46,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU platform device get trait specialization.
         template<>
         struct GetDevByIdx<PltfCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDevByIdx(std::size_t const& devIdx) -> DevCpu
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;

--- a/include/alpaka/pltf/PltfOacc.hpp
+++ b/include/alpaka/pltf/PltfOacc.hpp
@@ -24,18 +24,15 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The OpenACC device platform.
     class PltfOacc : public concepts::Implements<ConceptPltf, PltfOacc>
     {
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST PltfOacc() = delete;
     };
 
     namespace traits
     {
-        //#############################################################################
         //! The OpenACC device device type trait specialization.
         template<>
         struct DevType<PltfOacc>
@@ -43,12 +40,10 @@ namespace alpaka
             using type = DevOacc;
         };
 
-        //#############################################################################
         //! The OpenACC platform device count get trait specialization.
         template<>
         struct GetDevCount<PltfOacc>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDevCount() -> std::size_t
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -57,12 +52,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenACC platform device get trait specialization.
         template<>
         struct GetDevByIdx<PltfOacc>
         {
-            //-----------------------------------------------------------------------------
             //! \param devIdx device id, less than GetDevCount
             ALPAKA_FN_HOST static auto getDevByIdx(std::size_t devIdx) -> DevOacc
             {

--- a/include/alpaka/pltf/PltfOmp5.hpp
+++ b/include/alpaka/pltf/PltfOmp5.hpp
@@ -25,18 +25,15 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The OpenMP 5 device platform.
     class PltfOmp5 : public concepts::Implements<ConceptPltf, PltfOmp5>
     {
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST PltfOmp5() = delete;
     };
 
     namespace traits
     {
-        //#############################################################################
         //! The OpenMP 5 device device type trait specialization.
         template<>
         struct DevType<PltfOmp5>
@@ -44,12 +41,10 @@ namespace alpaka
             using type = DevOmp5;
         };
 
-        //#############################################################################
         //! The OpenMP 5 platform device count get trait specialization.
         template<>
         struct GetDevCount<PltfOmp5>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDevCount() -> std::size_t
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -60,12 +55,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The OpenMP 5 platform device get trait specialization.
         template<>
         struct GetDevByIdx<PltfOmp5>
         {
-            //-----------------------------------------------------------------------------
             //! \param devIdx device id, less than GetDevCount or equal, yielding omp_get_initial_device()
             ALPAKA_FN_HOST static auto getDevByIdx(std::size_t devIdx) -> DevOmp5
             {

--- a/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
+++ b/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
@@ -37,18 +37,15 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The CUDA/HIP RT platform.
     class PltfUniformCudaHipRt : public concepts::Implements<ConceptPltf, PltfUniformCudaHipRt>
     {
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST PltfUniformCudaHipRt() = delete;
     };
 
     namespace traits
     {
-        //#############################################################################
         //! The CUDA/HIP RT platform device type trait specialization.
         template<>
         struct DevType<PltfUniformCudaHipRt>
@@ -56,12 +53,10 @@ namespace alpaka
             using type = DevUniformCudaHipRt;
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT platform device count get trait specialization.
         template<>
         struct GetDevCount<PltfUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDevCount() -> std::size_t
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -75,12 +70,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT platform device get trait specialization.
         template<>
         struct GetDevByIdx<PltfUniformCudaHipRt>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDevByIdx(std::size_t const& devIdx) -> DevUniformCudaHipRt
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -126,7 +119,6 @@ namespace alpaka
             }
 
         private:
-            //-----------------------------------------------------------------------------
             //! \return If the device is usable.
             ALPAKA_FN_HOST static auto isDevUsable(std::size_t iDevice) -> bool
             {
@@ -162,7 +154,6 @@ namespace alpaka
             }
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-            //-----------------------------------------------------------------------------
             //! Prints all the device properties to std::cout.
             ALPAKA_FN_HOST static auto printDeviceProperties(
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)

--- a/include/alpaka/pltf/Traits.hpp
+++ b/include/alpaka/pltf/Traits.hpp
@@ -23,11 +23,9 @@ namespace alpaka
     {
     };
 
-    //-----------------------------------------------------------------------------
     //! The platform traits.
     namespace traits
     {
-        //#############################################################################
         //! The platform type trait.
         template<typename T, typename TSfinae = void>
         struct PltfType;
@@ -38,23 +36,19 @@ namespace alpaka
             using type = typename concepts::ImplementationBase<ConceptDev, TPltf>;
         };
 
-        //#############################################################################
         //! The device count get trait.
         template<typename T, typename TSfinae = void>
         struct GetDevCount;
 
-        //#############################################################################
         //! The device get trait.
         template<typename T, typename TSfinae = void>
         struct GetDevByIdx;
     } // namespace traits
 
-    //#############################################################################
     //! The platform type trait alias template to remove the ::type.
     template<typename T>
     using Pltf = typename traits::PltfType<T>::type;
 
-    //-----------------------------------------------------------------------------
     //! \return The device identified by its index.
     template<typename TPltf>
     ALPAKA_FN_HOST auto getDevCount()
@@ -62,7 +56,6 @@ namespace alpaka
         return traits::GetDevCount<Pltf<TPltf>>::getDevCount();
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The device identified by its index.
     template<typename TPltf>
     ALPAKA_FN_HOST auto getDevByIdx(std::size_t const& devIdx)
@@ -70,7 +63,6 @@ namespace alpaka
         return traits::GetDevByIdx<Pltf<TPltf>>::getDevByIdx(devIdx);
     }
 
-    //-----------------------------------------------------------------------------
     //! \return All the devices available on this accelerator.
     template<typename TPltf>
     ALPAKA_FN_HOST auto getDevs() -> std::vector<Dev<Pltf<TPltf>>>

--- a/include/alpaka/queue/Properties.hpp
+++ b/include/alpaka/queue/Properties.hpp
@@ -11,15 +11,12 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! Properties to define queue behavior
     namespace property
     {
-        //#############################################################################
         //! The caller is waiting until the enqueued task is finished
         struct Blocking;
 
-        //#############################################################################
         //! The caller is NOT waiting until the enqueued task is finished
         struct NonBlocking;
     } // namespace property

--- a/include/alpaka/queue/QueueGenericThreadsBlocking.hpp
+++ b/include/alpaka/queue/QueueGenericThreadsBlocking.hpp
@@ -35,7 +35,6 @@ namespace alpaka
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wweak-vtables"
 #endif
-            //#############################################################################
             //! The CPU device queue implementation.
             template<typename TDev>
             class QueueGenericThreadsBlockingImpl final : public IGenericThreadsQueue<TDev>
@@ -44,30 +43,23 @@ namespace alpaka
 #endif
             {
             public:
-                //-----------------------------------------------------------------------------
                 explicit QueueGenericThreadsBlockingImpl(TDev const& dev) noexcept
                     : m_dev(dev)
                     , m_bCurrentlyExecutingTask(false)
                 {
                 }
-                //-----------------------------------------------------------------------------
                 QueueGenericThreadsBlockingImpl(QueueGenericThreadsBlockingImpl<TDev> const&) = delete;
-                //-----------------------------------------------------------------------------
                 QueueGenericThreadsBlockingImpl(QueueGenericThreadsBlockingImpl<TDev>&&) = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(QueueGenericThreadsBlockingImpl<TDev> const&)
                     -> QueueGenericThreadsBlockingImpl<TDev>& = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(QueueGenericThreadsBlockingImpl<TDev>&&)
                     -> QueueGenericThreadsBlockingImpl<TDev>& = delete;
 
-                //-----------------------------------------------------------------------------
                 void enqueue(EventGenericThreads<TDev>& ev) final
                 {
                     alpaka::enqueue(*this, ev);
                 }
 
-                //-----------------------------------------------------------------------------
                 void wait(EventGenericThreads<TDev> const& ev) final
                 {
                     alpaka::wait(*this, ev);
@@ -81,7 +73,6 @@ namespace alpaka
         } // namespace detail
     } // namespace generic
 
-    //#############################################################################
     //! The CPU device queue.
     template<typename TDev>
     class QueueGenericThreadsBlocking final
@@ -90,7 +81,6 @@ namespace alpaka
         , public concepts::Implements<ConceptGetDev, QueueGenericThreadsBlocking<TDev>>
     {
     public:
-        //-----------------------------------------------------------------------------
         explicit QueueGenericThreadsBlocking(TDev const& dev)
             : m_spQueueImpl(std::make_shared<generic::detail::QueueGenericThreadsBlockingImpl<TDev>>(dev))
         {
@@ -98,25 +88,18 @@ namespace alpaka
 
             dev.registerQueue(m_spQueueImpl);
         }
-        //-----------------------------------------------------------------------------
         QueueGenericThreadsBlocking(QueueGenericThreadsBlocking<TDev> const&) = default;
-        //-----------------------------------------------------------------------------
         QueueGenericThreadsBlocking(QueueGenericThreadsBlocking<TDev>&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(QueueGenericThreadsBlocking<TDev> const&) -> QueueGenericThreadsBlocking<TDev>& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(QueueGenericThreadsBlocking<TDev>&&) -> QueueGenericThreadsBlocking<TDev>& = default;
-        //-----------------------------------------------------------------------------
         auto operator==(QueueGenericThreadsBlocking<TDev> const& rhs) const -> bool
         {
             return (m_spQueueImpl == rhs.m_spQueueImpl);
         }
-        //-----------------------------------------------------------------------------
         auto operator!=(QueueGenericThreadsBlocking<TDev> const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        //-----------------------------------------------------------------------------
         ~QueueGenericThreadsBlocking() = default;
 
     public:
@@ -125,26 +108,22 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU blocking device queue device type trait specialization.
         template<typename TDev>
         struct DevType<QueueGenericThreadsBlocking<TDev>>
         {
             using type = TDev;
         };
-        //#############################################################################
         //! The CPU blocking device queue device get trait specialization.
         template<typename TDev>
         struct GetDev<QueueGenericThreadsBlocking<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDev(QueueGenericThreadsBlocking<TDev> const& queue) -> TDev
             {
                 return queue.m_spQueueImpl->m_dev;
             }
         };
 
-        //#############################################################################
         //! The CPU blocking device queue event type trait specialization.
         template<typename TDev>
         struct EventType<QueueGenericThreadsBlocking<TDev>>
@@ -152,13 +131,11 @@ namespace alpaka
             using type = EventGenericThreads<TDev>;
         };
 
-        //#############################################################################
         //! The CPU blocking device queue enqueue trait specialization.
         //! This default implementation for all tasks directly invokes the function call operator of the task.
         template<typename TDev, typename TTask>
         struct Enqueue<QueueGenericThreadsBlocking<TDev>, TTask>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(QueueGenericThreadsBlocking<TDev>& queue, TTask const& task) -> void
             {
                 std::lock_guard<std::mutex> lk(queue.m_spQueueImpl->m_mutex);
@@ -170,19 +147,16 @@ namespace alpaka
                 queue.m_spQueueImpl->m_bCurrentlyExecutingTask = false;
             }
         };
-        //#############################################################################
         //! The CPU blocking device queue test trait specialization.
         template<typename TDev>
         struct Empty<QueueGenericThreadsBlocking<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto empty(QueueGenericThreadsBlocking<TDev> const& queue) -> bool
             {
                 return !queue.m_spQueueImpl->m_bCurrentlyExecutingTask;
             }
         };
 
-        //#############################################################################
         //! The CPU blocking device queue thread wait trait specialization.
         //!
         //! Blocks execution of the calling thread until the queue has finished processing all previously requested
@@ -190,7 +164,6 @@ namespace alpaka
         template<typename TDev>
         struct CurrentThreadWaitFor<QueueGenericThreadsBlocking<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto currentThreadWaitFor(QueueGenericThreadsBlocking<TDev> const& queue) -> void
             {
                 std::lock_guard<std::mutex> lk(queue.m_spQueueImpl->m_mutex);

--- a/include/alpaka/queue/QueueGenericThreadsNonBlocking.hpp
+++ b/include/alpaka/queue/QueueGenericThreadsNonBlocking.hpp
@@ -38,7 +38,6 @@ namespace alpaka
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wweak-vtables"
 #endif
-            //#############################################################################
             //! The CPU device queue implementation.
             template<typename TDev>
             class QueueGenericThreadsNonBlockingImpl final : public IGenericThreadsQueue<TDev>
@@ -47,7 +46,6 @@ namespace alpaka
 #endif
             {
             private:
-                //#############################################################################
                 using ThreadPool = alpaka::core::detail::ConcurrentExecPool<
                     std::size_t,
                     std::thread, // The concurrent execution type.
@@ -59,28 +57,21 @@ namespace alpaka
                     false>; // If the threads should yield.
 
             public:
-                //-----------------------------------------------------------------------------
                 explicit QueueGenericThreadsNonBlockingImpl(TDev const& dev) : m_dev(dev), m_workerThread(1u)
                 {
                 }
-                //-----------------------------------------------------------------------------
                 QueueGenericThreadsNonBlockingImpl(QueueGenericThreadsNonBlockingImpl<TDev> const&) = delete;
-                //-----------------------------------------------------------------------------
                 QueueGenericThreadsNonBlockingImpl(QueueGenericThreadsNonBlockingImpl<TDev>&&) = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(QueueGenericThreadsNonBlockingImpl<TDev> const&)
                     -> QueueGenericThreadsNonBlockingImpl<TDev>& = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(QueueGenericThreadsNonBlockingImpl<TDev>&&)
                     -> QueueGenericThreadsNonBlockingImpl<TDev>& = delete;
 
-                //-----------------------------------------------------------------------------
                 void enqueue(EventGenericThreads<TDev>& ev) final
                 {
                     alpaka::enqueue(*this, ev);
                 }
 
-                //-----------------------------------------------------------------------------
                 void wait(EventGenericThreads<TDev> const& ev) final
                 {
                     alpaka::wait(*this, ev);
@@ -94,7 +85,6 @@ namespace alpaka
         } // namespace detail
     } // namespace generic
 
-    //#############################################################################
     //! The CPU device queue.
     template<typename TDev>
     class QueueGenericThreadsNonBlocking final
@@ -103,7 +93,6 @@ namespace alpaka
         , public concepts::Implements<ConceptGetDev, QueueGenericThreadsNonBlocking<TDev>>
     {
     public:
-        //-----------------------------------------------------------------------------
         explicit QueueGenericThreadsNonBlocking(TDev const& dev)
             : m_spQueueImpl(std::make_shared<generic::detail::QueueGenericThreadsNonBlockingImpl<TDev>>(dev))
         {
@@ -111,25 +100,18 @@ namespace alpaka
 
             dev.registerQueue(m_spQueueImpl);
         }
-        //-----------------------------------------------------------------------------
         QueueGenericThreadsNonBlocking(QueueGenericThreadsNonBlocking<TDev> const&) = default;
-        //-----------------------------------------------------------------------------
         QueueGenericThreadsNonBlocking(QueueGenericThreadsNonBlocking<TDev>&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(QueueGenericThreadsNonBlocking<TDev> const&) -> QueueGenericThreadsNonBlocking<TDev>& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(QueueGenericThreadsNonBlocking<TDev>&&) -> QueueGenericThreadsNonBlocking<TDev>& = default;
-        //-----------------------------------------------------------------------------
         auto operator==(QueueGenericThreadsNonBlocking<TDev> const& rhs) const -> bool
         {
             return (m_spQueueImpl == rhs.m_spQueueImpl);
         }
-        //-----------------------------------------------------------------------------
         auto operator!=(QueueGenericThreadsNonBlocking<TDev> const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        //-----------------------------------------------------------------------------
         ~QueueGenericThreadsNonBlocking() = default;
 
     public:
@@ -138,26 +120,22 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU non-blocking device queue device type trait specialization.
         template<typename TDev>
         struct DevType<QueueGenericThreadsNonBlocking<TDev>>
         {
             using type = TDev;
         };
-        //#############################################################################
         //! The CPU non-blocking device queue device get trait specialization.
         template<typename TDev>
         struct GetDev<QueueGenericThreadsNonBlocking<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDev(QueueGenericThreadsNonBlocking<TDev> const& queue) -> TDev
             {
                 return queue.m_spQueueImpl->m_dev;
             }
         };
 
-        //#############################################################################
         //! The CPU non-blocking device queue event type trait specialization.
         template<typename TDev>
         struct EventType<QueueGenericThreadsNonBlocking<TDev>>
@@ -165,13 +143,11 @@ namespace alpaka
             using type = EventGenericThreads<TDev>;
         };
 
-        //#############################################################################
         //! The CPU non-blocking device queue enqueue trait specialization.
         //! This default implementation for all tasks directly invokes the function call operator of the task.
         template<typename TDev, typename TTask>
         struct Enqueue<QueueGenericThreadsNonBlocking<TDev>, TTask>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(QueueGenericThreadsNonBlocking<TDev>& queue, TTask const& task) -> void
             {
 // Workaround: Clang can not support this when natively compiling device code. See ConcurrentExecPool.hpp.
@@ -183,12 +159,10 @@ namespace alpaka
 #endif
             }
         };
-        //#############################################################################
         //! The CPU non-blocking device queue test trait specialization.
         template<typename TDev>
         struct Empty<QueueGenericThreadsNonBlocking<TDev>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto empty(QueueGenericThreadsNonBlocking<TDev> const& queue) -> bool
             {
                 return queue.m_spQueueImpl->m_workerThread.isIdle();

--- a/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
@@ -47,35 +47,26 @@ namespace alpaka
 {
     class EventUniformCudaHipRt;
 
-    //#############################################################################
     //! The CUDA/HIP RT blocking queue.
     class QueueUniformCudaHipRtBlocking final : public uniform_cuda_hip::detail::QueueUniformCudaHipRtBase
     {
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST QueueUniformCudaHipRtBlocking(DevUniformCudaHipRt const& dev)
             : uniform_cuda_hip::detail::QueueUniformCudaHipRtBase(dev)
         {
         }
-        //-----------------------------------------------------------------------------
         QueueUniformCudaHipRtBlocking(QueueUniformCudaHipRtBlocking const&) = default;
-        //-----------------------------------------------------------------------------
         QueueUniformCudaHipRtBlocking(QueueUniformCudaHipRtBlocking&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(QueueUniformCudaHipRtBlocking const&) -> QueueUniformCudaHipRtBlocking& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(QueueUniformCudaHipRtBlocking&&) -> QueueUniformCudaHipRtBlocking& = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator==(QueueUniformCudaHipRtBlocking const& rhs) const -> bool
         {
             return (m_spQueueImpl == rhs.m_spQueueImpl);
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator!=(QueueUniformCudaHipRtBlocking const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        //-----------------------------------------------------------------------------
         ~QueueUniformCudaHipRtBlocking() = default;
     };
 
@@ -87,7 +78,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CUDA/HIP RT blocking queue device type trait specialization.
         template<>
         struct DevType<QueueUniformCudaHipRtBlocking>
@@ -95,7 +85,6 @@ namespace alpaka
             using type = DevUniformCudaHipRt;
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT blocking queue event type trait specialization.
         template<>
         struct EventType<QueueUniformCudaHipRtBlocking>
@@ -103,12 +92,10 @@ namespace alpaka
             using type = EventUniformCudaHipRt;
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT blocking queue enqueue trait specialization.
         template<typename TTask>
         struct Enqueue<QueueUniformCudaHipRtBlocking, TTask>
         {
-            //#############################################################################
             enum class CallbackState
             {
                 enqueued,
@@ -116,7 +103,6 @@ namespace alpaka
                 finished,
             };
 
-            //#############################################################################
             struct CallbackSynchronizationData : public std::enable_shared_from_this<CallbackSynchronizationData>
             {
                 std::mutex m_mutex;
@@ -124,7 +110,6 @@ namespace alpaka
                 CallbackState state = CallbackState::enqueued;
             };
 
-            //-----------------------------------------------------------------------------
 #    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
             static void CUDART_CB
 #    else
@@ -157,7 +142,6 @@ namespace alpaka
                 }
             }
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(QueueUniformCudaHipRtBlocking& queue, TTask const& task) -> void
             {
                 auto pCallbackSynchronizationData = std::make_shared<CallbackSynchronizationData>();

--- a/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
@@ -47,35 +47,26 @@ namespace alpaka
 {
     class EventUniformCudaHipRt;
 
-    //#############################################################################
     //! The CUDA/HIP RT non-blocking queue.
     class QueueUniformCudaHipRtNonBlocking final : public uniform_cuda_hip::detail::QueueUniformCudaHipRtBase
     {
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST QueueUniformCudaHipRtNonBlocking(DevUniformCudaHipRt const& dev)
             : uniform_cuda_hip::detail::QueueUniformCudaHipRtBase(dev)
         {
         }
-        //-----------------------------------------------------------------------------
         QueueUniformCudaHipRtNonBlocking(QueueUniformCudaHipRtNonBlocking const&) = default;
-        //-----------------------------------------------------------------------------
         QueueUniformCudaHipRtNonBlocking(QueueUniformCudaHipRtNonBlocking&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(QueueUniformCudaHipRtNonBlocking const&) -> QueueUniformCudaHipRtNonBlocking& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(QueueUniformCudaHipRtNonBlocking&&) -> QueueUniformCudaHipRtNonBlocking& = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator==(QueueUniformCudaHipRtNonBlocking const& rhs) const -> bool
         {
             return (m_spQueueImpl == rhs.m_spQueueImpl);
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator!=(QueueUniformCudaHipRtNonBlocking const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        //-----------------------------------------------------------------------------
         ~QueueUniformCudaHipRtNonBlocking() = default;
     };
 
@@ -87,7 +78,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CUDA/HIP RT non-blocking queue device type trait specialization.
         template<>
         struct DevType<QueueUniformCudaHipRtNonBlocking>
@@ -95,7 +85,6 @@ namespace alpaka
             using type = DevUniformCudaHipRt;
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT non-blocking queue event type trait specialization.
         template<>
         struct EventType<QueueUniformCudaHipRtNonBlocking>
@@ -103,12 +92,10 @@ namespace alpaka
             using type = EventUniformCudaHipRt;
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT sync queue enqueue trait specialization.
         template<typename TTask>
         struct Enqueue<QueueUniformCudaHipRtNonBlocking, TTask>
         {
-            //#############################################################################
             enum class CallbackState
             {
                 enqueued,
@@ -116,7 +103,6 @@ namespace alpaka
                 finished,
             };
 
-            //#############################################################################
             struct CallbackSynchronizationData : public std::enable_shared_from_this<CallbackSynchronizationData>
             {
                 std::mutex m_mutex;
@@ -124,7 +110,6 @@ namespace alpaka
                 CallbackState state = CallbackState::enqueued;
             };
 
-            //-----------------------------------------------------------------------------
 #    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
             static void CUDART_CB
 #    else
@@ -157,7 +142,6 @@ namespace alpaka
                 }
             }
 
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(QueueUniformCudaHipRtNonBlocking& queue, TTask const& task) -> void
             {
                 auto pCallbackSynchronizationData = std::make_shared<CallbackSynchronizationData>();

--- a/include/alpaka/queue/Traits.hpp
+++ b/include/alpaka/queue/Traits.hpp
@@ -20,27 +20,22 @@ namespace alpaka
 {
     struct ConceptQueue;
 
-    //-----------------------------------------------------------------------------
     //! The queue traits.
     namespace traits
     {
-        //#############################################################################
         //! The queue enqueue trait.
         template<typename TQueue, typename TTask, typename TSfinae = void>
         struct Enqueue;
 
-        //#############################################################################
         //! The queue empty trait.
         template<typename TQueue, typename TSfinae = void>
         struct Empty;
 
-        //#############################################################################
         //! Queue for an accelerator
         template<typename TAcc, typename TProperty, typename TSfinae = void>
         struct QueueType;
     } // namespace traits
 
-    //-----------------------------------------------------------------------------
     //! Queues the given task in the given queue.
     //!
     //! Special Handling for events:
@@ -53,7 +48,6 @@ namespace alpaka
         traits::Enqueue<TQueue, std::decay_t<TTask>>::enqueue(queue, std::forward<TTask>(task));
     }
 
-    //-----------------------------------------------------------------------------
     //! Tests if the queue is empty (all ops in the given queue have been completed).
     //!
     //! \warning This function is allowed to return false negatives. An empty queue can reported as
@@ -66,7 +60,6 @@ namespace alpaka
         return traits::Empty<ImplementationBase>::empty(queue);
     }
 
-    //-----------------------------------------------------------------------------
     //! Queue based on the environment and a property
     //!
     //! \tparam TEnv Environment type, e.g.  accelerator, device or a platform.

--- a/include/alpaka/queue/cpu/ICpuQueue.hpp
+++ b/include/alpaka/queue/cpu/ICpuQueue.hpp
@@ -16,7 +16,6 @@ namespace alpaka
 {
     namespace cpu
     {
-        //#############################################################################
         //! The CPU queue interface
         using ICpuQueue = IGenericThreadsQueue<DevCpu>;
     } // namespace cpu

--- a/include/alpaka/queue/cpu/IGenericThreadsQueue.hpp
+++ b/include/alpaka/queue/cpu/IGenericThreadsQueue.hpp
@@ -23,19 +23,15 @@ namespace alpaka
 #    pragma clang diagnostic ignored "-Wweak-vtables"
 #endif
 
-    //#############################################################################
     //! The CPU queue interface
     template<typename TDev>
     class IGenericThreadsQueue
     {
     public:
-        //-----------------------------------------------------------------------------
         //! enqueue the event
         virtual void enqueue(EventGenericThreads<TDev>&) = 0;
-        //-----------------------------------------------------------------------------
         //! waiting for the event
         virtual void wait(EventGenericThreads<TDev> const&) = 0;
-        //-----------------------------------------------------------------------------
         virtual ~IGenericThreadsQueue() = default;
     };
 #if BOOST_COMP_CLANG

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -42,12 +42,10 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             //! The CUDA/HIP RT blocking queue implementation.
             class QueueUniformCudaHipRtImpl final
             {
             public:
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(DevUniformCudaHipRt const& dev)
                     : m_dev(dev)
                     , m_UniformCudaHipQueue()
@@ -68,15 +66,10 @@ namespace alpaka
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
                         StreamCreateWithFlags)(&m_UniformCudaHipQueue, ALPAKA_API_PREFIX(StreamNonBlocking)));
                 }
-                //-----------------------------------------------------------------------------
                 QueueUniformCudaHipRtImpl(QueueUniformCudaHipRtImpl const&) = delete;
-                //-----------------------------------------------------------------------------
                 QueueUniformCudaHipRtImpl(QueueUniformCudaHipRtImpl&&) = default;
-                //-----------------------------------------------------------------------------
                 auto operator=(QueueUniformCudaHipRtImpl const&) -> QueueUniformCudaHipRtImpl& = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(QueueUniformCudaHipRtImpl&&) -> QueueUniformCudaHipRtImpl& = delete;
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST ~QueueUniformCudaHipRtImpl()
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -102,7 +95,6 @@ namespace alpaka
                 ALPAKA_API_PREFIX(Stream_t) m_UniformCudaHipQueue;
             };
 
-            //#############################################################################
             //! The CUDA RT blocking queue.
             class QueueUniformCudaHipRtBase
                 : public concepts::Implements<ConceptCurrentThreadWaitFor, QueueUniformCudaHipRtBase>
@@ -110,30 +102,22 @@ namespace alpaka
                 , public concepts::Implements<ConceptGetDev, QueueUniformCudaHipRtBase>
             {
             public:
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST QueueUniformCudaHipRtBase(DevUniformCudaHipRt const& dev)
                     : m_spQueueImpl(std::make_shared<QueueUniformCudaHipRtImpl>(dev))
                 {
                 }
-                //-----------------------------------------------------------------------------
                 QueueUniformCudaHipRtBase(QueueUniformCudaHipRtBase const&) = default;
-                //-----------------------------------------------------------------------------
                 QueueUniformCudaHipRtBase(QueueUniformCudaHipRtBase&&) = default;
-                //-----------------------------------------------------------------------------
                 auto operator=(QueueUniformCudaHipRtBase const&) -> QueueUniformCudaHipRtBase& = default;
-                //-----------------------------------------------------------------------------
                 auto operator=(QueueUniformCudaHipRtBase&&) -> QueueUniformCudaHipRtBase& = default;
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST auto operator==(QueueUniformCudaHipRtBase const& rhs) const -> bool
                 {
                     return (m_spQueueImpl == rhs.m_spQueueImpl);
                 }
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST auto operator!=(QueueUniformCudaHipRtBase const& rhs) const -> bool
                 {
                     return !((*this) == rhs);
                 }
-                //-----------------------------------------------------------------------------
                 ~QueueUniformCudaHipRtBase() = default;
 
             public:
@@ -144,12 +128,10 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CUDA/HIP RT non-blocking queue device get trait specialization.
         template<>
         struct GetDev<uniform_cuda_hip::detail::QueueUniformCudaHipRtBase>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDev(uniform_cuda_hip::detail::QueueUniformCudaHipRtBase const& queue)
                 -> DevUniformCudaHipRt
             {
@@ -157,12 +139,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT blocking queue test trait specialization.
         template<>
         struct Empty<uniform_cuda_hip::detail::QueueUniformCudaHipRtBase>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto empty(uniform_cuda_hip::detail::QueueUniformCudaHipRtBase const& queue) -> bool
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -176,7 +156,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CUDA/HIP RT blocking queue thread wait trait specialization.
         //!
         //! Blocks execution of the calling thread until the queue has finished processing all previously requested
@@ -184,7 +163,6 @@ namespace alpaka
         template<>
         struct CurrentThreadWaitFor<uniform_cuda_hip::detail::QueueUniformCudaHipRtBase>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto currentThreadWaitFor(
                 uniform_cuda_hip::detail::QueueUniformCudaHipRtBase const& queue) -> void
             {

--- a/include/alpaka/rand/RandStdLib.hpp
+++ b/include/alpaka/rand/RandStdLib.hpp
@@ -22,20 +22,17 @@ namespace alpaka
 {
     namespace rand
     {
-        //#############################################################################
         //! "Tiny" state mersenne twister implementation
         class TinyMersenneTwister : public concepts::Implements<ConceptRand, TinyMersenneTwister>
         {
         };
         using RandStdLib = TinyMersenneTwister;
 
-        //#############################################################################
         //! The standard library mersenne twister implementation.
         class MersenneTwister : public concepts::Implements<ConceptRand, MersenneTwister>
         {
         };
 
-        //#############################################################################
         //! The standard library rand device implementation.
         class RandomDevice : public concepts::Implements<ConceptRand, RandomDevice>
         {
@@ -45,17 +42,14 @@ namespace alpaka
         {
             namespace cpu
             {
-                //#############################################################################
                 //! The standard library mersenne twister random number generator.
                 //!
                 //! size of state: 19937 bytes
                 class MersenneTwister
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     MersenneTwister() = default;
 
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST MersenneTwister(
                         std::uint32_t const& seed,
                         std::uint32_t const& subsequence = 0,
@@ -69,7 +63,6 @@ namespace alpaka
                     std::mt19937 m_State;
                 };
 
-                //#############################################################################
                 //! "Tiny" state mersenne twister implementation
                 //!
                 //! repository: github.com/MersenneTwister-Lab/TinyMT
@@ -83,10 +76,8 @@ namespace alpaka
                 class TinyMersenneTwister
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     TinyMersenneTwister() = default;
 
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST TinyMersenneTwister(
                         std::uint32_t const& seed,
                         std::uint32_t const& subsequence = 0,
@@ -100,7 +91,6 @@ namespace alpaka
                     TinyMTengine m_State;
                 };
 
-                //#############################################################################
                 //! The standard library's random device based on the local entropy pool.
                 //!
                 //! Warning: the entropy pool on many devices degrates quickly and performance
@@ -110,13 +100,11 @@ namespace alpaka
                 class RandomDevice
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     RandomDevice() = default;
                     RandomDevice(RandomDevice&&) : m_State{}
                     {
                     }
 
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST RandomDevice(
                         std::uint32_t const&,
                         std::uint32_t const& = 0,
@@ -135,16 +123,13 @@ namespace alpaka
         {
             namespace cpu
             {
-                //#############################################################################
                 //! The CPU random number normal distribution.
                 template<typename T>
                 class NormalReal
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     NormalReal() = default;
 
-                    //-----------------------------------------------------------------------------
                     template<typename TGenerator>
                     ALPAKA_FN_HOST auto operator()(TGenerator& generator) -> T
                     {
@@ -153,16 +138,13 @@ namespace alpaka
                     std::normal_distribution<T> m_dist;
                 };
 
-                //#############################################################################
                 //! The CPU random number uniform distribution.
                 template<typename T>
                 class UniformReal
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     UniformReal() = default;
 
-                    //-----------------------------------------------------------------------------
                     template<typename TGenerator>
                     ALPAKA_FN_HOST auto operator()(TGenerator& generator) -> T
                     {
@@ -171,13 +153,11 @@ namespace alpaka
                     std::uniform_real_distribution<T> m_dist;
                 };
 
-                //#############################################################################
                 //! The CPU random number normal distribution.
                 template<typename T>
                 class UniformUint
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     UniformUint()
                         : m_dist(
                             0, // For signed integer: std::numeric_limits<T>::lowest()
@@ -185,7 +165,6 @@ namespace alpaka
                     {
                     }
 
-                    //-----------------------------------------------------------------------------
                     template<typename TGenerator>
                     ALPAKA_FN_HOST auto operator()(TGenerator& generator) -> T
                     {
@@ -200,12 +179,10 @@ namespace alpaka
         {
             namespace traits
             {
-                //#############################################################################
                 //! The CPU device random number float normal distribution get trait specialization.
                 template<typename T>
                 struct CreateNormalReal<RandStdLib, T, std::enable_if_t<std::is_floating_point<T>::value>>
                 {
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST static auto createNormalReal(RandStdLib const& rand)
                         -> rand::distribution::cpu::NormalReal<T>
                     {
@@ -213,12 +190,10 @@ namespace alpaka
                         return rand::distribution::cpu::NormalReal<T>();
                     }
                 };
-                //#############################################################################
                 //! The CPU device random number float uniform distribution get trait specialization.
                 template<typename T>
                 struct CreateUniformReal<RandStdLib, T, std::enable_if_t<std::is_floating_point<T>::value>>
                 {
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST static auto createUniformReal(RandStdLib const& rand)
                         -> rand::distribution::cpu::UniformReal<T>
                     {
@@ -226,12 +201,10 @@ namespace alpaka
                         return rand::distribution::cpu::UniformReal<T>();
                     }
                 };
-                //#############################################################################
                 //! The CPU device random number integer uniform distribution get trait specialization.
                 template<typename T>
                 struct CreateUniformUint<RandStdLib, T, std::enable_if_t<std::is_integral<T>::value>>
                 {
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST static auto createUniformUint(RandStdLib const& rand)
                         -> rand::distribution::cpu::UniformUint<T>
                     {
@@ -245,12 +218,10 @@ namespace alpaka
         {
             namespace traits
             {
-                //#############################################################################
                 //! The CPU device random number default generator get trait specialization.
                 template<>
                 struct CreateDefault<TinyMersenneTwister>
                 {
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST static auto createDefault(
                         TinyMersenneTwister const& rand,
                         std::uint32_t const& seed,
@@ -264,7 +235,6 @@ namespace alpaka
                 template<>
                 struct CreateDefault<MersenneTwister>
                 {
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST static auto createDefault(
                         MersenneTwister const& rand,
                         std::uint32_t const& seed,
@@ -278,7 +248,6 @@ namespace alpaka
                 template<>
                 struct CreateDefault<RandomDevice>
                 {
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST static auto createDefault(
                         RandomDevice const& rand,
                         std::uint32_t const& seed,

--- a/include/alpaka/rand/RandUniformCudaHipRand.hpp
+++ b/include/alpaka/rand/RandUniformCudaHipRand.hpp
@@ -48,7 +48,6 @@ namespace alpaka
 {
     namespace rand
     {
-        //#############################################################################
         //! The CUDA/HIP rand implementation.
         class RandUniformCudaHipRand : public concepts::Implements<ConceptRand, RandUniformCudaHipRand>
         {
@@ -58,15 +57,12 @@ namespace alpaka
         {
             namespace uniform_cuda_hip
             {
-                //#############################################################################
                 //! The CUDA/HIP Xor random number generator.
                 class Xor
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     // After calling this constructor the instance is not valid initialized and
                     // need to be overwritten with a valid object
-                    //-----------------------------------------------------------------------------
 #    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                     ALPAKA_FN_HOST_ACC Xor() : m_State(curandStateXORWOW_t{})
 #    else
@@ -76,11 +72,9 @@ namespace alpaka
                     }
 
 #    if BOOST_COMP_HIP
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST_ACC ~Xor() = default;
 #    endif
 
-                    //-----------------------------------------------------------------------------
                     __device__ Xor(
                         std::uint32_t const& seed,
                         std::uint32_t const& subsequence = 0,
@@ -106,21 +100,17 @@ namespace alpaka
         {
             namespace uniform_cuda_hip
             {
-                //#############################################################################
                 //! The CUDA/HIP random number floating point normal distribution.
                 template<typename T>
                 class NormalReal;
 
-                //#############################################################################
                 //! The CUDA/HIP random number float normal distribution.
                 template<>
                 class NormalReal<float>
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     NormalReal() = default;
 
-                    //-----------------------------------------------------------------------------
                     template<typename TGenerator>
                     __device__ auto operator()(TGenerator& generator) -> float
                     {
@@ -131,16 +121,13 @@ namespace alpaka
 #    endif
                     }
                 };
-                //#############################################################################
                 //! The CUDA/HIP random number float normal distribution.
                 template<>
                 class NormalReal<double>
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     NormalReal() = default;
 
-                    //-----------------------------------------------------------------------------
                     template<typename TGenerator>
                     __device__ auto operator()(TGenerator& generator) -> double
                     {
@@ -152,21 +139,17 @@ namespace alpaka
                     }
                 };
 
-                //#############################################################################
                 //! The CUDA/HIP random number floating point uniform distribution.
                 template<typename T>
                 class UniformReal;
 
-                //#############################################################################
                 //! The CUDA/HIP random number float uniform distribution.
                 template<>
                 class UniformReal<float>
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     UniformReal() = default;
 
-                    //-----------------------------------------------------------------------------
                     template<typename TGenerator>
                     __device__ auto operator()(TGenerator& generator) -> float
                     {
@@ -181,16 +164,13 @@ namespace alpaka
                         return fUniformRand * static_cast<float>(fUniformRand != 1.0f);
                     }
                 };
-                //#############################################################################
                 //! The CUDA/HIP random number float uniform distribution.
                 template<>
                 class UniformReal<double>
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     UniformReal() = default;
 
-                    //-----------------------------------------------------------------------------
                     template<typename TGenerator>
                     __device__ auto operator()(TGenerator& generator) -> double
                     {
@@ -206,21 +186,17 @@ namespace alpaka
                     }
                 };
 
-                //#############################################################################
                 //! The CUDA/HIP random number integer uniform distribution.
                 template<typename T>
                 class UniformUint;
 
-                //#############################################################################
                 //! The CUDA/HIP random number unsigned integer uniform distribution.
                 template<>
                 class UniformUint<unsigned int>
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     UniformUint() = default;
 
-                    //-----------------------------------------------------------------------------
                     template<typename TGenerator>
                     __device__ auto operator()(TGenerator& generator) -> unsigned int
                     {
@@ -238,36 +214,30 @@ namespace alpaka
         {
             namespace traits
             {
-                //#############################################################################
                 //! The CUDA/HIP random number float normal distribution get trait specialization.
                 template<typename T>
                 struct CreateNormalReal<RandUniformCudaHipRand, T, std::enable_if_t<std::is_floating_point<T>::value>>
                 {
-                    //-----------------------------------------------------------------------------
                     __device__ static auto createNormalReal(RandUniformCudaHipRand const& /*rand*/)
                         -> rand::distribution::uniform_cuda_hip::NormalReal<T>
                     {
                         return rand::distribution::uniform_cuda_hip::NormalReal<T>();
                     }
                 };
-                //#############################################################################
                 //! The CUDA/HIP random number float uniform distribution get trait specialization.
                 template<typename T>
                 struct CreateUniformReal<RandUniformCudaHipRand, T, std::enable_if_t<std::is_floating_point<T>::value>>
                 {
-                    //-----------------------------------------------------------------------------
                     __device__ static auto createUniformReal(RandUniformCudaHipRand const& /*rand*/)
                         -> rand::distribution::uniform_cuda_hip::UniformReal<T>
                     {
                         return rand::distribution::uniform_cuda_hip::UniformReal<T>();
                     }
                 };
-                //#############################################################################
                 //! The CUDA/HIP random number integer uniform distribution get trait specialization.
                 template<typename T>
                 struct CreateUniformUint<RandUniformCudaHipRand, T, std::enable_if_t<std::is_integral<T>::value>>
                 {
-                    //-----------------------------------------------------------------------------
                     __device__ static auto createUniformUint(RandUniformCudaHipRand const& /*rand*/)
                         -> rand::distribution::uniform_cuda_hip::UniformUint<T>
                     {
@@ -280,12 +250,10 @@ namespace alpaka
         {
             namespace traits
             {
-                //#############################################################################
                 //! The CUDA/HIP random number default generator get trait specialization.
                 template<>
                 struct CreateDefault<RandUniformCudaHipRand>
                 {
-                    //-----------------------------------------------------------------------------
                     __device__ static auto createDefault(
                         RandUniformCudaHipRand const& /*rand*/,
                         std::uint32_t const& seed,

--- a/include/alpaka/rand/Traits.hpp
+++ b/include/alpaka/rand/Traits.hpp
@@ -16,7 +16,6 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The random number generation specifics.
     namespace rand
     {
@@ -24,31 +23,25 @@ namespace alpaka
         {
         };
 
-        //-----------------------------------------------------------------------------
         //! The random number generator distribution specifics.
         namespace distribution
         {
-            //-----------------------------------------------------------------------------
             //! The random number generator distribution traits.
             namespace traits
             {
-                //#############################################################################
                 //! The random number float normal distribution get trait.
                 template<typename TRand, typename T, typename TSfinae = void>
                 struct CreateNormalReal;
 
-                //#############################################################################
                 //! The random number float uniform distribution get trait.
                 template<typename TRand, typename T, typename TSfinae = void>
                 struct CreateUniformReal;
 
-                //#############################################################################
                 //! The random number integer uniform distribution get trait.
                 template<typename TRand, typename T, typename TSfinae = void>
                 struct CreateUniformUint;
             } // namespace traits
 
-            //-----------------------------------------------------------------------------
             //! \return A normal float distribution with mean 0.0f and standard deviation 1.0f.
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename T, typename TRand>
@@ -59,7 +52,6 @@ namespace alpaka
                 using ImplementationBase = concepts::ImplementationBase<ConceptRand, TRand>;
                 return traits::CreateNormalReal<ImplementationBase, T>::createNormalReal(rand);
             }
-            //-----------------------------------------------------------------------------
             //! \return A uniform floating point distribution [0.0, 1.0).
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename T, typename TRand>
@@ -70,7 +62,6 @@ namespace alpaka
                 using ImplementationBase = concepts::ImplementationBase<ConceptRand, TRand>;
                 return traits::CreateUniformReal<ImplementationBase, T>::createUniformReal(rand);
             }
-            //-----------------------------------------------------------------------------
             //! \return A uniform integer distribution [0, UINT_MAX].
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename T, typename TRand>
@@ -85,20 +76,16 @@ namespace alpaka
             }
         } // namespace distribution
 
-        //-----------------------------------------------------------------------------
         //! The random number generator specifics.
         namespace generator
         {
-            //-----------------------------------------------------------------------------
             //! The random number generator traits.
             namespace traits
             {
-                //#############################################################################
                 //! The random number default generator get trait.
                 template<typename TRand, typename TSfinae = void>
                 struct CreateDefault;
             } // namespace traits
-            //-----------------------------------------------------------------------------
             //! \return A default random number generator.
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename TRand>

--- a/include/alpaka/time/TimeOmp.hpp
+++ b/include/alpaka/time/TimeOmp.hpp
@@ -19,33 +19,24 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The OpenMP accelerator time implementation.
     class TimeOmp : public concepts::Implements<ConceptTime, TimeOmp>
     {
     public:
-        //-----------------------------------------------------------------------------
         TimeOmp() = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST TimeOmp(TimeOmp const&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST TimeOmp(TimeOmp&&) = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(TimeOmp const&) -> TimeOmp& = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST auto operator=(TimeOmp&&) -> TimeOmp& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~TimeOmp() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         //! The OpenMP accelerator clock operation.
         template<>
         struct Clock<TimeOmp>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto clock(TimeOmp const& time) -> std::uint64_t
             {
                 alpaka::ignore_unused(time);

--- a/include/alpaka/time/TimeStdLib.hpp
+++ b/include/alpaka/time/TimeStdLib.hpp
@@ -17,33 +17,24 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The CPU fibers accelerator time implementation.
     class TimeStdLib : public concepts::Implements<ConceptTime, TimeStdLib>
     {
     public:
-        //-----------------------------------------------------------------------------
         TimeStdLib() = default;
-        //-----------------------------------------------------------------------------
         TimeStdLib(TimeStdLib const&) = delete;
-        //-----------------------------------------------------------------------------
         TimeStdLib(TimeStdLib&&) = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(TimeStdLib const&) -> TimeStdLib& = delete;
-        //-----------------------------------------------------------------------------
         auto operator=(TimeStdLib&&) -> TimeStdLib& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~TimeStdLib() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU fibers accelerator clock operation.
         template<>
         struct Clock<TimeStdLib>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto clock(TimeStdLib const& time) -> std::uint64_t
             {
                 alpaka::ignore_unused(time);

--- a/include/alpaka/time/TimeUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/time/TimeUniformCudaHipBuiltIn.hpp
@@ -25,33 +25,24 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The GPU CUDA accelerator time implementation.
     class TimeUniformCudaHipBuiltIn : public concepts::Implements<ConceptTime, TimeUniformCudaHipBuiltIn>
     {
     public:
-        //-----------------------------------------------------------------------------
         TimeUniformCudaHipBuiltIn() = default;
-        //-----------------------------------------------------------------------------
         __device__ TimeUniformCudaHipBuiltIn(TimeUniformCudaHipBuiltIn const&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ TimeUniformCudaHipBuiltIn(TimeUniformCudaHipBuiltIn&&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(TimeUniformCudaHipBuiltIn const&) -> TimeUniformCudaHipBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(TimeUniformCudaHipBuiltIn&&) -> TimeUniformCudaHipBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~TimeUniformCudaHipBuiltIn() = default;
     };
 
     namespace traits
     {
-        //#############################################################################
         //! The CUDA built-in clock operation.
         template<>
         struct Clock<TimeUniformCudaHipBuiltIn>
         {
-            //-----------------------------------------------------------------------------
             __device__ static auto clock(TimeUniformCudaHipBuiltIn const&) -> std::uint64_t
             {
                 // This can be converted to a wall-clock time in seconds by dividing through the shader clock rate

--- a/include/alpaka/time/Traits.hpp
+++ b/include/alpaka/time/Traits.hpp
@@ -20,17 +20,14 @@ namespace alpaka
     {
     };
 
-    //-----------------------------------------------------------------------------
     //! The time traits.
     namespace traits
     {
-        //#############################################################################
         //! The clock trait.
         template<typename TTime, typename TSfinae = void>
         struct Clock;
     } // namespace traits
 
-    //-----------------------------------------------------------------------------
     //! \return A counter that is increasing every clock cycle.
     //!
     //! \tparam TTime The time implementation type.

--- a/include/alpaka/vec/Traits.hpp
+++ b/include/alpaka/vec/Traits.hpp
@@ -20,32 +20,26 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The vec traits.
     namespace traits
     {
-        //#############################################################################
         //! Trait for selecting a sub-vector.
         template<typename TVec, typename TIndexSequence, typename TSfinae = void>
         struct SubVecFromIndices;
 
-        //#############################################################################
         //! Trait for casting a vector.
         template<typename TVal, typename TVec, typename TSfinae = void>
         struct CastVec;
 
-        //#############################################################################
         //! Trait for reversing a vector.
         template<typename TVec, typename TSfinae = void>
         struct ReverseVec;
 
-        //#############################################################################
         //! Trait for concatenating two vectors.
         template<typename TVecL, typename TVecR, typename TSfinae = void>
         struct ConcatVec;
     } // namespace traits
 
-    //-----------------------------------------------------------------------------
     //! Builds a new vector by selecting the elements of the source vector in the given order.
     //! Repeating and swizzling elements is allowed.
     //! \return The sub-vector consisting of the elements specified by the indices.
@@ -55,7 +49,6 @@ namespace alpaka
     {
         return traits::SubVecFromIndices<TVec, TIndexSequence>::subVecFromIndices(vec);
     }
-    //-----------------------------------------------------------------------------
     //! \tparam TVec has to specialize SubVecFromIndices.
     //! \return The sub-vector consisting of the first N elements of the source vector.
     ALPAKA_NO_HOST_ACC_WARNING
@@ -70,7 +63,6 @@ namespace alpaka
         using IdxSubSequence = std::make_integer_sequence<std::size_t, TSubDim::value>;
         return subVecFromIndices<IdxSubSequence>(vec);
     }
-    //-----------------------------------------------------------------------------
     //! \tparam TVec has to specialize SubVecFromIndices.
     //! \return The sub-vector consisting of the last N elements of the source vector.
     ALPAKA_NO_HOST_ACC_WARNING
@@ -88,7 +80,6 @@ namespace alpaka
         return subVecFromIndices<IdxSubSequence>(vec);
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The casted vector.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TVal, typename TVec>
@@ -97,7 +88,6 @@ namespace alpaka
         return traits::CastVec<TVal, TVec>::castVec(vec);
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The reverseVec vector.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TVec>
@@ -106,7 +96,6 @@ namespace alpaka
         return traits::ReverseVec<TVec>::reverseVec(vec);
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The concatenated vector.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TVecL, typename TVecR>

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -35,7 +35,6 @@ namespace alpaka
     template<typename TDim, typename TVal>
     class Vec;
 
-    //-----------------------------------------------------------------------------
     //! Single value constructor helper.
     ALPAKA_NO_HOST_ACC_WARNING
     template<
@@ -54,7 +53,6 @@ namespace alpaka
         return Vec<TDim, decltype(TTFnObj<0>::create(std::forward<TArgs>(args)...))>(
             (TTFnObj<TIndices>::create(std::forward<TArgs>(args)...))...);
     }
-    //-----------------------------------------------------------------------------
     //! Creator using func<idx>(args...) to initialize all values of the vector.
     //! The idx is in the range [0, TDim].
     ALPAKA_NO_HOST_ACC_WARNING
@@ -64,7 +62,6 @@ namespace alpaka
         using IdxSequence = std::make_integer_sequence<typename TDim::value_type, TDim::value>;
         return createVecFromIndexedFnArbitrary<TDim, TTFnObj>(IdxSequence(), std::forward<TArgs>(args)...);
     }
-    //-----------------------------------------------------------------------------
     //! Creator using func<idx>(args...) to initialize all values of the vector.
     //! The idx is in the range [TIdxOffset, TIdxOffset + TDim].
     ALPAKA_NO_HOST_ACC_WARNING
@@ -76,7 +73,6 @@ namespace alpaka
         return createVecFromIndexedFnArbitrary<TDim, TTFnObj>(IdxSubSequence(), std::forward<TArgs>(args)...);
     }
 
-    //#############################################################################
     //! A n-dimensional vector.
     template<typename TDim, typename TVal>
     class Vec final
@@ -93,7 +89,6 @@ namespace alpaka
         using IdxSequence = std::make_integer_sequence<std::size_t, TDim::value>;
 
     public:
-        //-----------------------------------------------------------------------------
         // The default constructor is only available when the vector is zero-dimensional.
         ALPAKA_NO_HOST_ACC_WARNING
         template<bool B = (TDim::value == 0u), typename = std::enable_if_t<B>>
@@ -102,7 +97,6 @@ namespace alpaka
         }
 
 
-        //-----------------------------------------------------------------------------
         //! Value constructor.
         //! This constructor is only available if the number of parameters matches the vector idx.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -117,33 +111,26 @@ namespace alpaka
         {
         }
 
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC
         Vec(Vec const&) = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC
         Vec(Vec&&) noexcept = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC
         auto operator=(Vec const&) -> Vec& = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC
         auto operator=(Vec&&) noexcept -> Vec& = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC ~Vec() = default;
 
     private:
-        //#############################################################################
         //! A function object that returns the given value for each index.
         template<std::size_t Tidx>
         struct CreateSingleVal
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST_ACC static auto create(TVal const& val) -> TVal
             {
@@ -152,7 +139,6 @@ namespace alpaka
         };
 
     public:
-        //-----------------------------------------------------------------------------
         //! \brief Single value constructor.
         //!
         //! Creates a vector with all values set to val.
@@ -162,14 +148,12 @@ namespace alpaka
         {
             return createVecFromIndexedFn<TDim, CreateSingleVal>(val);
         }
-        //-----------------------------------------------------------------------------
         //! Zero value constructor.
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC static auto zeros() -> Vec<TDim, TVal>
         {
             return all(static_cast<TVal>(0));
         }
-        //-----------------------------------------------------------------------------
         //! One value constructor.
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC static auto ones() -> Vec<TDim, TVal>
@@ -177,7 +161,6 @@ namespace alpaka
             return all(static_cast<TVal>(1));
         }
 
-        //-----------------------------------------------------------------------------
         //! Value reference accessor at the given non-unsigned integer index.
         //! \return A reference to the value at the given index.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -190,7 +173,6 @@ namespace alpaka
             return m_data[idx];
         }
 
-        //-----------------------------------------------------------------------------
         //! Value accessor at the given non-unsigned integer index.
         //! \return The value at the given index.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -203,7 +185,6 @@ namespace alpaka
             return m_data[idx];
         }
 
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC auto operator==(Vec const& rhs) const -> bool
         {
@@ -216,13 +197,11 @@ namespace alpaka
             }
             return true;
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC auto operator!=(Vec const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TFnObj, std::size_t... TIndices>
         ALPAKA_FN_HOST_ACC auto foldrByIndices(
@@ -233,7 +212,6 @@ namespace alpaka
 
             return meta::foldr(f, ((*this)[TIndices])...);
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TFnObj>
         ALPAKA_FN_HOST_ACC auto foldrAll(TFnObj const& f) const
@@ -245,7 +223,6 @@ namespace alpaka
 #    pragma warning(push)
 #    pragma warning(disable : 4702) // unreachable code
 #endif
-        //-----------------------------------------------------------------------------
         //! \return The product of all values.
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC auto prod() const -> TVal
@@ -255,35 +232,30 @@ namespace alpaka
 #if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
 #    pragma warning(pop)
 #endif
-        //-----------------------------------------------------------------------------
         //! \return The sum of all values.
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC auto sum() const -> TVal
         {
             return foldrAll(std::plus<TVal>());
         }
-        //-----------------------------------------------------------------------------
         //! \return The min of all values.
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC auto min() const -> TVal
         {
             return foldrAll(meta::min<TVal>());
         }
-        //-----------------------------------------------------------------------------
         //! \return The max of all values.
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC auto max() const -> TVal
         {
             return foldrAll(meta::max<TVal>());
         }
-        //-----------------------------------------------------------------------------
         //! \return The index of the minimal element.
         ALPAKA_FN_HOST auto minElem() const -> typename TDim::value_type
         {
             return static_cast<typename TDim::value_type>(
                 std::distance(std::begin(m_data), std::min_element(std::begin(m_data), std::end(m_data))));
         }
-        //-----------------------------------------------------------------------------
         //! \return The index of the maximal element.
         ALPAKA_FN_HOST auto maxElem() const -> typename TDim::value_type
         {
@@ -298,13 +270,11 @@ namespace alpaka
 
     namespace detail
     {
-        //#############################################################################
         //! This is used to create a Vec by applying a binary operation onto the corresponding elements of two input
         //! vectors.
         template<template<typename> class TFnObj, std::size_t Tidx>
         struct CreateVecByApplyingBinaryFnToTwoIndexedVecs
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename TDim, typename TVal>
             ALPAKA_FN_HOST_ACC static auto create(Vec<TDim, TVal> const& p, Vec<TDim, TVal> const& q)
@@ -320,7 +290,6 @@ namespace alpaka
         using CreateVecFromTwoIndexedVecsPlus = CreateVecByApplyingBinaryFnToTwoIndexedVecs<std::plus, Tidx>;
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The element-wise sum of two vectors.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TVal>
@@ -335,7 +304,6 @@ namespace alpaka
         using CreateVecFromTwoIndexedVecsMinus = CreateVecByApplyingBinaryFnToTwoIndexedVecs<std::minus, Tidx>;
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The element-wise difference of two vectors.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TVal>
@@ -350,7 +318,6 @@ namespace alpaka
         using CreateVecFromTwoIndexedVecsMul = CreateVecByApplyingBinaryFnToTwoIndexedVecs<std::multiplies, Tidx>;
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The element-wise product of two vectors.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TVal>
@@ -365,7 +332,6 @@ namespace alpaka
         using CreateVecFromTwoIndexedVecsLess = CreateVecByApplyingBinaryFnToTwoIndexedVecs<std::less, Tidx>;
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The element-wise less than relation of two vectors.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TVal>
@@ -381,7 +347,6 @@ namespace alpaka
             = CreateVecByApplyingBinaryFnToTwoIndexedVecs<std::less_equal, Tidx>;
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The element-wise less than or equal relation of two vectors.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TVal>
@@ -397,7 +362,6 @@ namespace alpaka
             = CreateVecByApplyingBinaryFnToTwoIndexedVecs<std::greater_equal, Tidx>;
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The element-wise greater than or equal relation of two vectors.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TVal>
@@ -412,7 +376,6 @@ namespace alpaka
         using CreateVecFromTwoIndexedVecsGreater = CreateVecByApplyingBinaryFnToTwoIndexedVecs<std::greater, Tidx>;
     }
 
-    //-----------------------------------------------------------------------------
     //! \return The element-wise greater than relation of two vectors.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TVal>
@@ -421,7 +384,6 @@ namespace alpaka
         return createVecFromIndexedFn<TDim, detail::CreateVecFromTwoIndexedVecsGreater>(p, q);
     }
 
-    //-----------------------------------------------------------------------------
     //! Stream out operator.
     template<typename TDim, typename TVal>
     ALPAKA_FN_HOST auto operator<<(std::ostream& os, Vec<TDim, TVal> const& v) -> std::ostream&
@@ -442,7 +404,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The Vec dimension get trait specialization.
         template<typename TDim, typename TVal>
         struct DimType<Vec<TDim, TVal>>
@@ -450,7 +411,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The Vec idx type trait specialization.
         template<typename TDim, typename TVal>
         struct IdxType<Vec<TDim, TVal>>
@@ -458,7 +418,6 @@ namespace alpaka
             using type = TVal;
         };
 
-        //#############################################################################
         //! Specialization for selecting a sub-vector.
         template<typename TDim, typename TVal, std::size_t... TIndices>
         struct SubVecFromIndices<
@@ -482,7 +441,6 @@ namespace alpaka
                 return Vec<DimInt<sizeof...(TIndices)>, TVal>(vec[TIndices]...);
             }
         };
-        //#############################################################################
         //! Specialization for selecting the whole vector.
         template<typename TDim, typename TVal, std::size_t... TIndices>
         struct SubVecFromIndices<
@@ -502,12 +460,10 @@ namespace alpaka
 
     namespace detail
     {
-        //#############################################################################
         //! A function object that returns the given value for each index.
         template<std::size_t Tidx>
         struct CreateCast
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename TSizeNew, typename TDim, typename TVal>
             ALPAKA_FN_HOST_ACC static auto create(TSizeNew const& /* valNew*/, Vec<TDim, TVal> const& vec) -> TSizeNew
@@ -518,12 +474,10 @@ namespace alpaka
     } // namespace detail
     namespace traits
     {
-        //#############################################################################
         //! CastVec specialization for Vec.
         template<typename TSizeNew, typename TDim, typename TVal>
         struct CastVec<TSizeNew, Vec<TDim, TVal>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST_ACC static auto castVec(Vec<TDim, TVal> const& vec) -> Vec<TDim, TSizeNew>
             {
@@ -531,13 +485,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! (Non-)CastVec specialization for Vec when src and dst types are identical.
-        //#############################################################################
         template<typename TDim, typename TVal>
         struct CastVec<TVal, Vec<TDim, TVal>>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST_ACC static auto castVec(Vec<TDim, TVal> const& vec) -> Vec<TDim, TVal>
             {
@@ -548,12 +499,10 @@ namespace alpaka
 
     namespace detail
     {
-        //#############################################################################
         //! A function object that returns the value at the index from the back of the vector.
         template<std::size_t Tidx>
         struct CreateReverse
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename TDim, typename TVal>
             ALPAKA_FN_HOST_ACC static auto create(Vec<TDim, TVal> const& vec) -> TVal
@@ -564,7 +513,6 @@ namespace alpaka
     } // namespace detail
     namespace traits
     {
-        //#############################################################################
         //! ReverseVec specialization for Vec.
         template<typename TDim, typename TVal>
         struct ReverseVec<Vec<TDim, TVal>>
@@ -576,7 +524,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! (Non-)ReverseVec specialization for 1D Vec.
         template<typename TVal>
         struct ReverseVec<Vec<DimInt<1u>, TVal>>
@@ -591,12 +538,10 @@ namespace alpaka
 
     namespace detail
     {
-        //#############################################################################
         //! A function object that returns the value at the index from the back of the vector.
         template<std::size_t Tidx>
         struct CreateConcat
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename TDimL, typename TDimR, typename TVal>
             ALPAKA_FN_HOST_ACC static auto create(Vec<TDimL, TVal> const& vecL, Vec<TDimR, TVal> const& vecR) -> TVal
@@ -607,7 +552,6 @@ namespace alpaka
     } // namespace detail
     namespace traits
     {
-        //#############################################################################
         //! Concatenation specialization for Vec.
         template<typename TDimL, typename TDimR, typename TVal>
         struct ConcatVec<Vec<TDimL, TVal>, Vec<TDimR, TVal>>
@@ -627,12 +571,10 @@ namespace alpaka
     {
         namespace detail
         {
-            //#############################################################################
             //! A function object that returns the extent for each index.
             template<std::size_t Tidx>
             struct CreateExtent
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 template<typename TExtent>
                 ALPAKA_FN_HOST_ACC static auto create(TExtent const& extent) -> Idx<TExtent>
@@ -641,7 +583,6 @@ namespace alpaka
                 }
             };
         } // namespace detail
-        //-----------------------------------------------------------------------------
         //! \tparam TExtent has to specialize extent::GetExtent.
         //! \return The extent vector.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -650,7 +591,6 @@ namespace alpaka
         {
             return createVecFromIndexedFn<Dim<TExtent>, detail::CreateExtent>(extent);
         }
-        //-----------------------------------------------------------------------------
         //! \tparam TExtent has to specialize extent::GetExtent.
         //! \return The extent but only the last N elements.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -666,12 +606,10 @@ namespace alpaka
 
     namespace detail
     {
-        //#############################################################################
         //! A function object that returns the offsets for each index.
         template<std::size_t Tidx>
         struct CreateOffset
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename TOffsets>
             ALPAKA_FN_HOST_ACC static auto create(TOffsets const& offsets) -> Idx<TOffsets>
@@ -680,7 +618,6 @@ namespace alpaka
             }
         };
     } // namespace detail
-    //-----------------------------------------------------------------------------
     //! \tparam TOffsets has to specialize GetOffset.
     //! \return The offset vector.
     ALPAKA_NO_HOST_ACC_WARNING
@@ -689,7 +626,6 @@ namespace alpaka
     {
         return createVecFromIndexedFn<Dim<TOffsets>, detail::CreateOffset>(offsets);
     }
-    //-----------------------------------------------------------------------------
     //! \tparam TOffsets has to specialize GetOffset.
     //! \return The offset vector but only the last N elements.
     ALPAKA_NO_HOST_ACC_WARNING
@@ -706,7 +642,6 @@ namespace alpaka
     {
         namespace traits
         {
-            //#############################################################################
             //! The Vec extent get trait specialization.
             template<typename TIdxIntegralConst, typename TDim, typename TVal>
             struct GetExtent<
@@ -720,7 +655,6 @@ namespace alpaka
                     return extent[TIdxIntegralConst::value];
                 }
             };
-            //#############################################################################
             //! The Vec extent set trait specialization.
             template<typename TIdxIntegralConst, typename TDim, typename TVal, typename TExtentVal>
             struct SetExtent<
@@ -739,7 +673,6 @@ namespace alpaka
     } // namespace extent
     namespace traits
     {
-        //#############################################################################
         //! The Vec offset get trait specialization.
         template<typename TIdxIntegralConst, typename TDim, typename TVal>
         struct GetOffset<
@@ -753,7 +686,6 @@ namespace alpaka
                 return offsets[TIdxIntegralConst::value];
             }
         };
-        //#############################################################################
         //! The Vec offset set trait specialization.
         template<typename TIdxIntegralConst, typename TDim, typename TVal, typename TOffset>
         struct SetOffset<

--- a/include/alpaka/wait/Traits.hpp
+++ b/include/alpaka/wait/Traits.hpp
@@ -18,22 +18,18 @@ namespace alpaka
     {
     };
 
-    //-----------------------------------------------------------------------------
     //! The wait traits.
     namespace traits
     {
-        //#############################################################################
         //! The thread wait trait.
         template<typename TAwaited, typename TSfinae = void>
         struct CurrentThreadWaitFor;
 
-        //#############################################################################
         //! The waiter wait trait.
         template<typename TWaiter, typename TAwaited, typename TSfinae = void>
         struct WaiterWaitFor;
     } // namespace traits
 
-    //-----------------------------------------------------------------------------
     //! Waits the thread for the completion of the given awaited action to complete.
     template<typename TAwaited>
     ALPAKA_FN_HOST auto wait(TAwaited const& awaited) -> void
@@ -42,7 +38,6 @@ namespace alpaka
         traits::CurrentThreadWaitFor<ImplementationBase>::currentThreadWaitFor(awaited);
     }
 
-    //-----------------------------------------------------------------------------
     //! The waiter waits for the given awaited action to complete.
     template<typename TWaiter, typename TAwaited>
     ALPAKA_FN_HOST auto wait(TWaiter& waiter, TAwaited const& awaited) -> void

--- a/include/alpaka/warp/Traits.hpp
+++ b/include/alpaka/warp/Traits.hpp
@@ -17,7 +17,6 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The thread warp specifics
     namespace warp
     {
@@ -25,42 +24,34 @@ namespace alpaka
         {
         };
 
-        //-----------------------------------------------------------------------------
         //! The warp traits.
         namespace traits
         {
-            //#############################################################################
             //! The warp size trait.
             template<typename TWarp, typename TSfinae = void>
             struct GetSize;
 
-            //#############################################################################
             //! The all warp vote trait.
             template<typename TWarp, typename TSfinae = void>
             struct All;
 
-            //#############################################################################
             //! The any warp vote trait.
             template<typename TWarp, typename TSfinae = void>
             struct Any;
 
-            //#############################################################################
             //! The ballot warp vote trait.
             template<typename TWarp, typename TSfinae = void>
             struct Ballot;
 
-            //#############################################################################
             //! The shfl warp swizzling trait.
             template<typename TWarp, typename TSfinae = void>
             struct Shfl;
 
-            //#############################################################################
             //! The active mask trait.
             template<typename TWarp, typename TSfinae = void>
             struct Activemask;
         } // namespace traits
 
-        //-----------------------------------------------------------------------------
         //! Returns warp size.
         //!
         //! \tparam TWarp The warp implementation type.
@@ -73,7 +64,6 @@ namespace alpaka
             return traits::GetSize<ImplementationBase>::getSize(warp);
         }
 
-        //-----------------------------------------------------------------------------
         //! Returns a 32- or 64-bit unsigned integer (depending on the
         //! accelerator) whose Nth bit is set if and only if the Nth thread
         //! of the warp is active.
@@ -95,7 +85,6 @@ namespace alpaka
             return traits::Activemask<ImplementationBase>::activemask(warp);
         }
 
-        //-----------------------------------------------------------------------------
         //! Evaluates predicate for all active threads of the warp and returns
         //! non-zero if and only if predicate evaluates to non-zero for all of them.
         //!
@@ -114,7 +103,6 @@ namespace alpaka
             return traits::All<ImplementationBase>::all(warp, predicate);
         }
 
-        //-----------------------------------------------------------------------------
         //! Evaluates predicate for all active threads of the warp and returns
         //! non-zero if and only if predicate evaluates to non-zero for any of them.
         //!
@@ -133,7 +121,6 @@ namespace alpaka
             return traits::Any<ImplementationBase>::any(warp, predicate);
         }
 
-        //-----------------------------------------------------------------------------
         //! Evaluates predicate for all non-exited threads in a warp and returns
         //! a 32- or 64-bit unsigned integer (depending on the accelerator)
         //! whose Nth bit is set if and only if predicate evaluates to non-zero
@@ -156,7 +143,6 @@ namespace alpaka
             return traits::Ballot<ImplementationBase>::ballot(warp, predicate);
         }
 
-        //-----------------------------------------------------------------------------
         //! Exchange data between threads within a warp.
         //!
         //! Effectively executes:
@@ -191,7 +177,6 @@ namespace alpaka
             return traits::Shfl<ImplementationBase>::shfl(warp, value, srcLane, width ? width : getSize(warp));
         }
 
-        //-----------------------------------------------------------------------------
         //! shfl for float vals
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TWarp>

--- a/include/alpaka/warp/WarpSingleThread.hpp
+++ b/include/alpaka/warp/WarpSingleThread.hpp
@@ -17,87 +17,68 @@ namespace alpaka
 {
     namespace warp
     {
-        //#############################################################################
         //! The single-threaded warp to emulate it on CPUs.
         class WarpSingleThread : public concepts::Implements<ConceptWarp, WarpSingleThread>
         {
         public:
-            //-----------------------------------------------------------------------------
             WarpSingleThread() = default;
-            //-----------------------------------------------------------------------------
             WarpSingleThread(WarpSingleThread const&) = delete;
-            //-----------------------------------------------------------------------------
             WarpSingleThread(WarpSingleThread&&) = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(WarpSingleThread const&) -> WarpSingleThread& = delete;
-            //-----------------------------------------------------------------------------
             auto operator=(WarpSingleThread&&) -> WarpSingleThread& = delete;
-            //-----------------------------------------------------------------------------
             ~WarpSingleThread() = default;
         };
 
         namespace traits
         {
-            //#############################################################################
             template<>
             struct GetSize<WarpSingleThread>
             {
-                //-----------------------------------------------------------------------------
                 static auto getSize(warp::WarpSingleThread const& /*warp*/)
                 {
                     return 1;
                 }
             };
 
-            //#############################################################################
             template<>
             struct Activemask<WarpSingleThread>
             {
-                //-----------------------------------------------------------------------------
                 static auto activemask(warp::WarpSingleThread const& /*warp*/)
                 {
                     return 1u;
                 }
             };
 
-            //#############################################################################
             template<>
             struct All<WarpSingleThread>
             {
-                //-----------------------------------------------------------------------------
                 static auto all(warp::WarpSingleThread const& /*warp*/, std::int32_t predicate)
                 {
                     return predicate;
                 }
             };
 
-            //#############################################################################
             template<>
             struct Any<WarpSingleThread>
             {
-                //-----------------------------------------------------------------------------
                 static auto any(warp::WarpSingleThread const& /*warp*/, std::int32_t predicate)
                 {
                     return predicate;
                 }
             };
 
-            //#############################################################################
             template<>
             struct Ballot<WarpSingleThread>
             {
-                //-----------------------------------------------------------------------------
                 static auto ballot(warp::WarpSingleThread const& /*warp*/, std::int32_t predicate)
                 {
                     return predicate ? 1u : 0u;
                 }
             };
 
-            //#################################################################
             template<>
             struct Shfl<WarpSingleThread>
             {
-                //-------------------------------------------------------------
                 static auto shfl(
                     warp::WarpSingleThread const& /*warp*/,
                     std::int32_t val,
@@ -106,7 +87,7 @@ namespace alpaka
                 {
                     return val;
                 }
-                //-------------------------------------------------------------
+
                 static auto shfl(
                     warp::WarpSingleThread const& /*warp*/,
                     float val,

--- a/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
@@ -30,43 +30,32 @@ namespace alpaka
 {
     namespace warp
     {
-        //#############################################################################
         //! The GPU CUDA/HIP warp.
         class WarpUniformCudaHipBuiltIn : public concepts::Implements<ConceptWarp, WarpUniformCudaHipBuiltIn>
         {
         public:
-            //-----------------------------------------------------------------------------
             WarpUniformCudaHipBuiltIn() = default;
-            //-----------------------------------------------------------------------------
             __device__ WarpUniformCudaHipBuiltIn(WarpUniformCudaHipBuiltIn const&) = delete;
-            //-----------------------------------------------------------------------------
             __device__ WarpUniformCudaHipBuiltIn(WarpUniformCudaHipBuiltIn&&) = delete;
-            //-----------------------------------------------------------------------------
             __device__ auto operator=(WarpUniformCudaHipBuiltIn const&) -> WarpUniformCudaHipBuiltIn& = delete;
-            //-----------------------------------------------------------------------------
             __device__ auto operator=(WarpUniformCudaHipBuiltIn&&) -> WarpUniformCudaHipBuiltIn& = delete;
-            //-----------------------------------------------------------------------------
             ~WarpUniformCudaHipBuiltIn() = default;
         };
 
         namespace traits
         {
-            //#############################################################################
             template<>
             struct GetSize<WarpUniformCudaHipBuiltIn>
             {
-                //-----------------------------------------------------------------------------
                 __device__ static auto getSize(warp::WarpUniformCudaHipBuiltIn const& /*warp*/) -> std::int32_t
                 {
                     return warpSize;
                 }
             };
 
-            //#############################################################################
             template<>
             struct Activemask<WarpUniformCudaHipBuiltIn>
             {
-                //-----------------------------------------------------------------------------
                 __device__ static auto activemask(warp::WarpUniformCudaHipBuiltIn const& /*warp*/)
 #    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                     -> std::uint32_t
@@ -90,11 +79,9 @@ namespace alpaka
                 }
             };
 
-            //#############################################################################
             template<>
             struct All<WarpUniformCudaHipBuiltIn>
             {
-                //-----------------------------------------------------------------------------
                 __device__ static auto all(warp::WarpUniformCudaHipBuiltIn const& warp, std::int32_t predicate)
                     -> std::int32_t
                 {
@@ -107,11 +94,9 @@ namespace alpaka
                 }
             };
 
-            //#############################################################################
             template<>
             struct Any<WarpUniformCudaHipBuiltIn>
             {
-                //-----------------------------------------------------------------------------
                 __device__ static auto any(warp::WarpUniformCudaHipBuiltIn const& warp, std::int32_t predicate)
                     -> std::int32_t
                 {
@@ -124,11 +109,9 @@ namespace alpaka
                 }
             };
 
-            //#############################################################################
             template<>
             struct Ballot<WarpUniformCudaHipBuiltIn>
             {
-                //-----------------------------------------------------------------------------
                 __device__ static auto ballot(warp::WarpUniformCudaHipBuiltIn const& warp, std::int32_t predicate)
                 // return type is required by the compiler
 #    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
@@ -146,7 +129,6 @@ namespace alpaka
                 }
             };
 
-            //#################################################################
             template<>
             struct Shfl<WarpUniformCudaHipBuiltIn>
             {

--- a/include/alpaka/workdiv/Traits.hpp
+++ b/include/alpaka/workdiv/Traits.hpp
@@ -24,17 +24,14 @@ namespace alpaka
     {
     };
 
-    //-----------------------------------------------------------------------------
     //! The work division traits.
     namespace traits
     {
-        //#############################################################################
         //! The work div trait.
         template<typename TWorkDiv, typename TOrigin, typename TUnit, typename TSfinae = void>
         struct GetWorkDiv;
     } // namespace traits
 
-    //-----------------------------------------------------------------------------
     //! Get the extent requested.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TOrigin, typename TUnit, typename TWorkDiv>
@@ -46,12 +43,10 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The work div grid thread extent trait specialization.
         template<typename TWorkDiv>
         struct GetWorkDiv<TWorkDiv, origin::Grid, unit::Threads>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST_ACC static auto getWorkDiv(TWorkDiv const& workDiv)
             {
@@ -59,12 +54,10 @@ namespace alpaka
                     * alpaka::getWorkDiv<origin::Block, unit::Threads>(workDiv);
             }
         };
-        //#############################################################################
         //! The work div grid element extent trait specialization.
         template<typename TWorkDiv>
         struct GetWorkDiv<TWorkDiv, origin::Grid, unit::Elems>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST_ACC static auto getWorkDiv(TWorkDiv const& workDiv)
             {
@@ -72,12 +65,10 @@ namespace alpaka
                     * alpaka::getWorkDiv<origin::Thread, unit::Elems>(workDiv);
             }
         };
-        //#############################################################################
         //! The work div block element extent trait specialization.
         template<typename TWorkDiv>
         struct GetWorkDiv<TWorkDiv, origin::Block, unit::Elems>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST_ACC static auto getWorkDiv(TWorkDiv const& workDiv)
             {

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -23,11 +23,9 @@
 #include <set>
 #include <type_traits>
 
-//-----------------------------------------------------------------------------
 //! The alpaka library.
 namespace alpaka
 {
-    //#############################################################################
     //! The grid block extent subdivision restrictions.
     enum class GridBlockExtentSubDivRestrictions
     {
@@ -38,7 +36,6 @@ namespace alpaka
 
     namespace detail
     {
-        //-----------------------------------------------------------------------------
         //! \param maxDivisor The maximum divisor.
         //! \param dividend The dividend.
         //! \return The biggest number that satisfies the following conditions:
@@ -60,7 +57,6 @@ namespace alpaka
 
             return divisor;
         }
-        //-----------------------------------------------------------------------------
         //! \param val The value to find divisors of.
         //! \param maxDivisor The maximum.
         //! \return A list of all divisors less then or equal to the given maximum.
@@ -85,7 +81,6 @@ namespace alpaka
         }
     } // namespace detail
 
-    //-----------------------------------------------------------------------------
     //! \tparam TDim The dimensionality of the accelerator device properties.
     //! \tparam TIdx The idx type of the accelerator device properties.
     //! \param accDevProps The maxima for the work division.
@@ -118,7 +113,6 @@ namespace alpaka
         return true;
     }
 
-    //-----------------------------------------------------------------------------
     //! Subdivides the given grid thread extent into blocks restricted by the maxima allowed.
     //! 1. The the maxima block, thread and element extent and counts
     //! 2. The requirement of the block thread extent to divide the grid thread extent without remainder
@@ -328,7 +322,6 @@ namespace alpaka
         return WorkDivMembers<TDim, TIdx>(gridBlockExtent, blockThreadExtent, threadElemExtent);
     }
 
-    //-----------------------------------------------------------------------------
     //! \tparam TAcc The accelerator for which this work division has to be valid.
     //! \tparam TGridElemExtent The type of the grid element extent.
     //! \tparam TThreadElemExtent The type of the thread element extent.
@@ -377,7 +370,6 @@ namespace alpaka
             gridBlockExtentSubDivRestrictions);
     }
 
-    //-----------------------------------------------------------------------------
     //! \tparam TDim The dimensionality of the accelerator device properties.
     //! \tparam TIdx The idx type of the accelerator device properties.
     //! \tparam TWorkDiv The type of the work division.
@@ -425,7 +417,6 @@ namespace alpaka
 
         return true;
     }
-    //-----------------------------------------------------------------------------
     //! \tparam TAcc The accelerator to test the validity on.
     //! \param dev The device to test the work division for validity on.
     //! \param workDiv The work division to test for validity.

--- a/include/alpaka/workdiv/WorkDivMembers.hpp
+++ b/include/alpaka/workdiv/WorkDivMembers.hpp
@@ -18,15 +18,12 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! A basic class holding the work division as grid block extent, block thread and thread element extent.
     template<typename TDim, typename TIdx>
     class WorkDivMembers : public concepts::Implements<ConceptWorkDiv, WorkDivMembers<TDim, TIdx>>
     {
     public:
-        //-----------------------------------------------------------------------------
         ALPAKA_FN_HOST_ACC WorkDivMembers() = delete;
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TGridBlockExtent, typename TBlockThreadExtent, typename TThreadElemExtent>
         ALPAKA_FN_HOST_ACC explicit WorkDivMembers(
@@ -38,7 +35,6 @@ namespace alpaka
             , m_threadElemExtent(extent::getExtentVecEnd<TDim>(threadElemExtent))
         {
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC explicit WorkDivMembers(WorkDivMembers const& other)
             : m_gridBlockExtent(other.m_gridBlockExtent)
@@ -46,7 +42,6 @@ namespace alpaka
             , m_threadElemExtent(other.m_threadElemExtent)
         {
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TWorkDiv>
         ALPAKA_FN_HOST_ACC explicit WorkDivMembers(TWorkDiv const& other)
@@ -55,19 +50,15 @@ namespace alpaka
             , m_threadElemExtent(subVecEnd<TDim>(getWorkDiv<Thread, Elems>(other)))
         {
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC
         WorkDivMembers(WorkDivMembers&&) = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC
         auto operator=(WorkDivMembers const&) -> WorkDivMembers& = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC
         auto operator=(WorkDivMembers&&) -> WorkDivMembers& = default;
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TWorkDiv>
         ALPAKA_FN_HOST_ACC auto operator=(TWorkDiv const& other) -> WorkDivMembers<TDim, TIdx>&
@@ -77,7 +68,6 @@ namespace alpaka
             m_threadElemExtent = subVecEnd<TDim>(getWorkDiv<Thread, Elems>(other));
             return *this;
         }
-        //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         /*virtual*/ ALPAKA_FN_HOST_ACC ~WorkDivMembers() = default;
 
@@ -87,7 +77,6 @@ namespace alpaka
         Vec<TDim, TIdx> m_threadElemExtent;
     };
 
-    //-----------------------------------------------------------------------------
     template<typename TDim, typename TIdx>
     ALPAKA_FN_HOST auto operator<<(std::ostream& os, WorkDivMembers<TDim, TIdx> const& workDiv) -> std::ostream&
     {
@@ -98,7 +87,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The WorkDivMembers dimension get trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<WorkDivMembers<TDim, TIdx>>
@@ -106,7 +94,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The WorkDivMembers idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<WorkDivMembers<TDim, TIdx>>
@@ -114,12 +101,10 @@ namespace alpaka
             using type = TIdx;
         };
 
-        //#############################################################################
         //! The WorkDivMembers grid block extent trait specialization.
         template<typename TDim, typename TIdx>
         struct GetWorkDiv<WorkDivMembers<TDim, TIdx>, origin::Grid, unit::Blocks>
         {
-            //-----------------------------------------------------------------------------
             //! \return The number of blocks in each dimension of the grid.
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST_ACC static auto getWorkDiv(WorkDivMembers<TDim, TIdx> const& workDiv) -> Vec<TDim, TIdx>
@@ -128,12 +113,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The WorkDivMembers block thread extent trait specialization.
         template<typename TDim, typename TIdx>
         struct GetWorkDiv<WorkDivMembers<TDim, TIdx>, origin::Block, unit::Threads>
         {
-            //-----------------------------------------------------------------------------
             //! \return The number of threads in each dimension of a block.
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST_ACC static auto getWorkDiv(WorkDivMembers<TDim, TIdx> const& workDiv) -> Vec<TDim, TIdx>
@@ -142,12 +125,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The WorkDivMembers thread element extent trait specialization.
         template<typename TDim, typename TIdx>
         struct GetWorkDiv<WorkDivMembers<TDim, TIdx>, origin::Thread, unit::Elems>
         {
-            //-----------------------------------------------------------------------------
             //! \return The number of elements in each dimension of a thread.
             ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST_ACC static auto getWorkDiv(WorkDivMembers<TDim, TIdx> const& workDiv) -> Vec<TDim, TIdx>

--- a/include/alpaka/workdiv/WorkDivUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/workdiv/WorkDivUniformCudaHipBuiltIn.hpp
@@ -35,27 +35,20 @@
 
 namespace alpaka
 {
-    //#############################################################################
     //! The GPU CUDA/HIP accelerator work division.
     template<typename TDim, typename TIdx>
     class WorkDivUniformCudaHipBuiltIn
         : public concepts::Implements<ConceptWorkDiv, WorkDivUniformCudaHipBuiltIn<TDim, TIdx>>
     {
     public:
-        //-----------------------------------------------------------------------------
         __device__ WorkDivUniformCudaHipBuiltIn(Vec<TDim, TIdx> const& threadElemExtent)
             : m_threadElemExtent(threadElemExtent)
         {
         }
-        //-----------------------------------------------------------------------------
         __device__ WorkDivUniformCudaHipBuiltIn(WorkDivUniformCudaHipBuiltIn const&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ WorkDivUniformCudaHipBuiltIn(WorkDivUniformCudaHipBuiltIn&&) = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(WorkDivUniformCudaHipBuiltIn const&) -> WorkDivUniformCudaHipBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         __device__ auto operator=(WorkDivUniformCudaHipBuiltIn&&) -> WorkDivUniformCudaHipBuiltIn& = delete;
-        //-----------------------------------------------------------------------------
         /*virtual*/ ~WorkDivUniformCudaHipBuiltIn() = default;
 
     public:
@@ -67,7 +60,6 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The GPU CUDA/HIP accelerator work division dimension get trait specialization.
         template<typename TDim, typename TIdx>
         struct DimType<WorkDivUniformCudaHipBuiltIn<TDim, TIdx>>
@@ -75,7 +67,6 @@ namespace alpaka
             using type = TDim;
         };
 
-        //#############################################################################
         //! The GPU CUDA/HIP accelerator work division idx type trait specialization.
         template<typename TDim, typename TIdx>
         struct IdxType<WorkDivUniformCudaHipBuiltIn<TDim, TIdx>>
@@ -83,12 +74,10 @@ namespace alpaka
             using type = TIdx;
         };
 
-        //#############################################################################
         //! The GPU CUDA/HIP accelerator work division grid block extent trait specialization.
         template<typename TDim, typename TIdx>
         struct GetWorkDiv<WorkDivUniformCudaHipBuiltIn<TDim, TIdx>, origin::Grid, unit::Blocks>
         {
-            //-----------------------------------------------------------------------------
             //! \return The number of blocks in each dimension of the grid.
             __device__ static auto getWorkDiv(WorkDivUniformCudaHipBuiltIn<TDim, TIdx> const& workDiv)
                 -> Vec<TDim, TIdx>
@@ -105,12 +94,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The GPU CUDA/HIP accelerator work division block thread extent trait specialization.
         template<typename TDim, typename TIdx>
         struct GetWorkDiv<WorkDivUniformCudaHipBuiltIn<TDim, TIdx>, origin::Block, unit::Threads>
         {
-            //-----------------------------------------------------------------------------
             //! \return The number of threads in each dimension of a block.
             __device__ static auto getWorkDiv(WorkDivUniformCudaHipBuiltIn<TDim, TIdx> const& workDiv)
                 -> Vec<TDim, TIdx>
@@ -127,12 +114,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The GPU CUDA/HIP accelerator work division thread element extent trait specialization.
         template<typename TDim, typename TIdx>
         struct GetWorkDiv<WorkDivUniformCudaHipBuiltIn<TDim, TIdx>, origin::Thread, unit::Elems>
         {
-            //-----------------------------------------------------------------------------
             //! \return The number of blocks in each dimension of the grid.
             __device__ static auto getWorkDiv(WorkDivUniformCudaHipBuiltIn<TDim, TIdx> const& workDiv)
                 -> Vec<TDim, TIdx>

--- a/test/common/include/alpaka/test/Array.hpp
+++ b/test/common/include/alpaka/test/Array.hpp
@@ -13,7 +13,6 @@ namespace alpaka
 {
     namespace test
     {
-        //#############################################################################
         template<typename TType, size_t TSize>
         struct Array
         {

--- a/test/common/include/alpaka/test/Extent.hpp
+++ b/test/common/include/alpaka/test/Extent.hpp
@@ -15,14 +15,12 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The test specifics.
     namespace test
     {
         template<typename TIdx>
         struct CreateVecWithIdx
         {
-            //#############################################################################
             //! 1D: (11)
             //! 2D: (11, 10)
             //! 3D: (11, 10, 9)
@@ -30,14 +28,12 @@ namespace alpaka
             template<std::size_t Tidx>
             struct ForExtentBuf
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST_ACC static auto create()
                 {
                     return static_cast<TIdx>(11u - Tidx);
                 }
             };
 
-            //#############################################################################
             //! 1D: (8)
             //! 2D: (8, 6)
             //! 3D: (8, 6, 4)
@@ -45,14 +41,12 @@ namespace alpaka
             template<std::size_t Tidx>
             struct ForExtentSubView
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST_ACC static auto create()
                 {
                     return static_cast<TIdx>(8u - (Tidx * 2u));
                 }
             };
 
-            //#############################################################################
             //! 1D: (2)
             //! 2D: (2, 3)
             //! 3D: (2, 3, 4)
@@ -60,7 +54,6 @@ namespace alpaka
             template<std::size_t Tidx>
             struct ForOffset
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST_ACC static auto create()
                 {
                     return static_cast<TIdx>(2u + Tidx);

--- a/test/common/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/test/common/include/alpaka/test/KernelExecutionFixture.hpp
@@ -17,7 +17,6 @@ namespace alpaka
 {
     namespace test
     {
-        //#############################################################################
         //! The fixture for executing a kernel on a given accelerator.
         template<typename TAcc>
         class KernelExecutionFixture
@@ -32,7 +31,6 @@ namespace alpaka
             using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
 
         public:
-            //-----------------------------------------------------------------------------
             template<typename TExtent>
             KernelExecutionFixture(TExtent const& extent)
                 : m_devHost(alpaka::getDevByIdx<PltfCpu>(0u))
@@ -46,7 +44,6 @@ namespace alpaka
                       alpaka::GridBlockExtentSubDivRestrictions::Unrestricted))
             {
             }
-            //-----------------------------------------------------------------------------
             KernelExecutionFixture(WorkDiv const& workDiv)
                 : m_devHost(alpaka::getDevByIdx<PltfCpu>(0u))
                 , m_devAcc(alpaka::getDevByIdx<PltfAcc>(0u))
@@ -54,7 +51,6 @@ namespace alpaka
                 , m_workDiv(workDiv)
             {
             }
-            //-----------------------------------------------------------------------------
             template<typename TKernelFnObj, typename... TArgs>
             auto operator()(TKernelFnObj const& kernelFnObj, TArgs&&... args) -> bool
             {

--- a/test/common/include/alpaka/test/MeasureKernelRunTime.hpp
+++ b/test/common/include/alpaka/test/MeasureKernelRunTime.hpp
@@ -20,7 +20,6 @@ namespace alpaka
     {
         namespace integ
         {
-            //-----------------------------------------------------------------------------
             //! \return The run time of the given kernel.
             template<typename TQueue, typename TTask>
             auto measureTaskRunTimeMs(TQueue& queue, TTask&& task) -> std::chrono::milliseconds::rep

--- a/test/common/include/alpaka/test/acc/TestAccs.hpp
+++ b/test/common/include/alpaka/test/acc/TestAccs.hpp
@@ -29,11 +29,9 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The test specifics.
     namespace test
     {
-        //-----------------------------------------------------------------------------
         //! The detail namespace is used to separate implementation details from user accessible code.
         namespace detail
         {
@@ -139,7 +137,6 @@ namespace alpaka
             template<typename TDim, typename TIdx>
             using AccGpuHipRtIfAvailableElseInt = int;
 #endif
-            //#############################################################################
             //! A vector containing all available accelerators and void's.
             template<typename TDim, typename TIdx>
             using EnabledAccsElseInt = std::tuple<
@@ -156,14 +153,12 @@ namespace alpaka
                 AccGpuHipRtIfAvailableElseInt<TDim, TIdx>>;
         } // namespace detail
 
-        //#############################################################################
         //! A vector containing all available accelerators.
         template<typename TDim, typename TIdx>
         using EnabledAccs = typename alpaka::meta::Filter<detail::EnabledAccsElseInt<TDim, TIdx>, std::is_class>;
 
         namespace detail
         {
-            //#############################################################################
             //! The accelerator name write wrapper.
             struct StreamOutAccName
             {
@@ -176,7 +171,6 @@ namespace alpaka
             };
         } // namespace detail
 
-        //-----------------------------------------------------------------------------
         //! Writes the enabled accelerators to the given stream.
         template<typename TDim, typename TIdx>
         ALPAKA_FN_HOST auto writeEnabledAccs(std::ostream& os) -> void
@@ -190,7 +184,6 @@ namespace alpaka
 
         namespace detail
         {
-            //#############################################################################
             //! A std::tuple holding multiple std::tuple consisting of a dimension and a idx type.
             //!
             //! TestDimIdxTuples =
@@ -205,7 +198,6 @@ namespace alpaka
             template<typename TList>
             using ApplyEnabledAccs = alpaka::meta::Apply<TList, EnabledAccs>;
 
-            //#############################################################################
             //! A std::tuple containing std::tuple with fully instantiated accelerators.
             //!
             //! TestEnabledAccs =
@@ -217,7 +209,6 @@ namespace alpaka
             using InstantiatedEnabledAccs = alpaka::meta::Transform<TestDimIdxTuples, ApplyEnabledAccs>;
         } // namespace detail
 
-        //#############################################################################
         //! A std::tuple containing fully instantiated accelerators.
         //!
         //! TestAccs =

--- a/test/common/include/alpaka/test/dim/TestDims.hpp
+++ b/test/common/include/alpaka/test/dim/TestDims.hpp
@@ -17,7 +17,6 @@ namespace alpaka
 {
     namespace test
     {
-        //#############################################################################
         //! A std::tuple holding dimensions.
         using TestDims = std::tuple<
             alpaka::DimInt<1u>,

--- a/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -21,10 +21,9 @@ namespace alpaka
     {
         namespace traits
         {
-            //!
             template<typename TDev>
             struct EventHostManualTriggerType;
-            //!
+
             template<typename TDev>
             struct IsEventHostManualTriggerSupported;
         } // namespace traits
@@ -65,7 +64,6 @@ namespace alpaka
                     //! Move assignment operator.
                     auto operator=(EventHostManualTriggerCpuImpl&&) -> EventHostManualTriggerCpuImpl& = delete;
 
-                    //!
                     void trigger()
                     {
                         {
@@ -119,7 +117,6 @@ namespace alpaka
                 return !((*this) == rhs);
             }
 
-            //!
             void trigger()
             {
                 m_spEventImpl->trigger();
@@ -131,21 +128,18 @@ namespace alpaka
 
         namespace traits
         {
-            //!
             template<>
             struct EventHostManualTriggerType<alpaka::DevCpu>
             {
                 using type = alpaka::test::EventHostManualTriggerCpu<DevCpu>;
             };
 #ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-            //!
             template<>
             struct EventHostManualTriggerType<alpaka::DevOmp5>
             {
                 using type = alpaka::test::EventHostManualTriggerCpu<alpaka::DevOmp5>;
             };
 #elif defined(ALPAKA_ACC_ANY_BT_OACC_ENABLED)
-            //!
             template<>
             struct EventHostManualTriggerType<alpaka::DevOacc>
             {
@@ -210,7 +204,6 @@ namespace alpaka
             }
         };
 
-        //!
         template<typename TDev>
         struct Enqueue<QueueGenericThreadsNonBlocking<TDev>, test::EventHostManualTriggerCpu<TDev>>
         {
@@ -256,7 +249,7 @@ namespace alpaka
 #endif
             }
         };
-        //!
+
         template<typename TDev>
         struct Enqueue<QueueGenericThreadsBlocking<TDev>, test::EventHostManualTriggerCpu<TDev>>
         {

--- a/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -16,32 +16,23 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The test specifics.
-    //-----------------------------------------------------------------------------
     namespace test
     {
         namespace traits
         {
-            //#############################################################################
             //!
-            //#############################################################################
             template<typename TDev>
             struct EventHostManualTriggerType;
-            //#############################################################################
             //!
-            //#############################################################################
             template<typename TDev>
             struct IsEventHostManualTriggerSupported;
         } // namespace traits
 
-        //#############################################################################
         //! The event host manual trigger type trait alias template to remove the ::type.
-        //#############################################################################
         template<typename TDev>
         using EventHostManualTrigger = typename traits::EventHostManualTriggerType<TDev>::type;
 
-        //-----------------------------------------------------------------------------
         template<typename TDev>
         ALPAKA_FN_HOST auto isEventHostManualTriggerSupported(TDev const& dev) -> bool
         {
@@ -52,16 +43,12 @@ namespace alpaka
         {
             namespace detail
             {
-                //#############################################################################
                 //! Event that can be enqueued into a queue and can be triggered by the Host.
-                //#############################################################################
                 template<class TDev = DevCpu>
                 class EventHostManualTriggerCpuImpl
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     //! Constructor.
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST EventHostManualTriggerCpuImpl(TDev const& dev) noexcept
                         : m_dev(dev)
                         , m_mutex()
@@ -69,26 +56,16 @@ namespace alpaka
                         , m_bIsReady(true)
                     {
                     }
-                    //-----------------------------------------------------------------------------
                     //! Copy constructor.
-                    //-----------------------------------------------------------------------------
                     EventHostManualTriggerCpuImpl(EventHostManualTriggerCpuImpl const& other) = delete;
-                    //-----------------------------------------------------------------------------
                     //! Move constructor.
-                    //-----------------------------------------------------------------------------
                     EventHostManualTriggerCpuImpl(EventHostManualTriggerCpuImpl&&) = delete;
-                    //-----------------------------------------------------------------------------
                     //! Copy assignment operator.
-                    //-----------------------------------------------------------------------------
                     auto operator=(EventHostManualTriggerCpuImpl const&) -> EventHostManualTriggerCpuImpl& = delete;
-                    //-----------------------------------------------------------------------------
                     //! Move assignment operator.
-                    //-----------------------------------------------------------------------------
                     auto operator=(EventHostManualTriggerCpuImpl&&) -> EventHostManualTriggerCpuImpl& = delete;
 
-                    //-----------------------------------------------------------------------------
                     //!
-                    //-----------------------------------------------------------------------------
                     void trigger()
                     {
                         {
@@ -113,54 +90,36 @@ namespace alpaka
             } // namespace detail
         } // namespace cpu
 
-        //#############################################################################
         //! Event that can be enqueued into a queue and can be triggered by the Host.
-        //#############################################################################
         template<class TDev = DevCpu>
         class EventHostManualTriggerCpu
         {
         public:
-            //-----------------------------------------------------------------------------
             //! Constructor.
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST EventHostManualTriggerCpu(TDev const& dev)
                 : m_spEventImpl(std::make_shared<cpu::detail::EventHostManualTriggerCpuImpl<TDev>>(dev))
             {
             }
-            //-----------------------------------------------------------------------------
             //! Copy constructor.
-            //-----------------------------------------------------------------------------
             EventHostManualTriggerCpu(EventHostManualTriggerCpu const&) = default;
-            //-----------------------------------------------------------------------------
             //! Move constructor.
-            //-----------------------------------------------------------------------------
             EventHostManualTriggerCpu(EventHostManualTriggerCpu&&) = default;
-            //-----------------------------------------------------------------------------
             //! Copy assignment operator.
-            //-----------------------------------------------------------------------------
             auto operator=(EventHostManualTriggerCpu const&) -> EventHostManualTriggerCpu& = default;
-            //-----------------------------------------------------------------------------
             //! Move assignment operator.
-            //-----------------------------------------------------------------------------
             auto operator=(EventHostManualTriggerCpu&&) -> EventHostManualTriggerCpu& = default;
-            //-----------------------------------------------------------------------------
             //! Equality comparison operator.
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator==(EventHostManualTriggerCpu const& rhs) const -> bool
             {
                 return (m_spEventImpl == rhs.m_spEventImpl);
             }
-            //-----------------------------------------------------------------------------
             //! Inequality comparison operator.
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator!=(EventHostManualTriggerCpu const& rhs) const -> bool
             {
                 return !((*this) == rhs);
             }
 
-            //-----------------------------------------------------------------------------
             //!
-            //-----------------------------------------------------------------------------
             void trigger()
             {
                 m_spEventImpl->trigger();
@@ -172,63 +131,51 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             //!
-            //#############################################################################
             template<>
             struct EventHostManualTriggerType<alpaka::DevCpu>
             {
                 using type = alpaka::test::EventHostManualTriggerCpu<DevCpu>;
             };
 #ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-            //#############################################################################
             //!
-            //#############################################################################
             template<>
             struct EventHostManualTriggerType<alpaka::DevOmp5>
             {
                 using type = alpaka::test::EventHostManualTriggerCpu<alpaka::DevOmp5>;
             };
 #elif defined(ALPAKA_ACC_ANY_BT_OACC_ENABLED)
-            //#############################################################################
             //!
-            //#############################################################################
             template<>
             struct EventHostManualTriggerType<alpaka::DevOacc>
             {
                 using type = alpaka::test::EventHostManualTriggerCpu<alpaka::DevOacc>;
             };
 #endif
-            //#############################################################################
             //! The CPU event host manual trigger support get trait specialization.
             template<>
             struct IsEventHostManualTriggerSupported<alpaka::DevCpu>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto isSupported(alpaka::DevCpu const&) -> bool
                 {
                     return true;
                 }
             };
 #ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-            //#############################################################################
             //! The Omp5 event host manual trigger support get trait specialization.
             template<>
             struct IsEventHostManualTriggerSupported<alpaka::DevOmp5>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto isSupported(alpaka::DevOmp5 const&) -> bool
                 {
                     return true;
                 }
             };
 #elif defined(ALPAKA_ACC_ANY_BT_OACC_ENABLED)
-            //#############################################################################
             //! The OpenACC event host manual trigger support get trait specialization.
             template<>
             struct IsEventHostManualTriggerSupported<alpaka::DevOacc>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto isSupported(alpaka::DevOacc const&) -> bool
                 {
                     return true;
@@ -239,30 +186,22 @@ namespace alpaka
     } // namespace test
     namespace traits
     {
-        //#############################################################################
         //! The CPU device event device get trait specialization.
-        //#############################################################################
         template<typename TDev>
         struct GetDev<test::EventHostManualTriggerCpu<TDev>>
         {
-            //-----------------------------------------------------------------------------
             //
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDev(test::EventHostManualTriggerCpu<TDev> const& event) -> TDev
             {
                 return event.m_spEventImpl->m_dev;
             }
         };
 
-        //#############################################################################
         //! The CPU device event test trait specialization.
-        //#############################################################################
         template<typename TDev>
         struct IsComplete<test::EventHostManualTriggerCpu<TDev>>
         {
-            //-----------------------------------------------------------------------------
             //! \return If the event is not waiting within a queue (not enqueued or already handled).
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto isComplete(test::EventHostManualTriggerCpu<TDev> const& event) -> bool
             {
                 std::lock_guard<std::mutex> lk(event.m_spEventImpl->m_mutex);
@@ -271,15 +210,11 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //!
-        //#############################################################################
         template<typename TDev>
         struct Enqueue<QueueGenericThreadsNonBlocking<TDev>, test::EventHostManualTriggerCpu<TDev>>
         {
-            //-----------------------------------------------------------------------------
             //
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
 #if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_PTX)
                 QueueGenericThreadsNonBlocking<TDev>& queue,
@@ -321,15 +256,11 @@ namespace alpaka
 #endif
             }
         };
-        //#############################################################################
         //!
-        //#############################################################################
         template<typename TDev>
         struct Enqueue<QueueGenericThreadsBlocking<TDev>, test::EventHostManualTriggerCpu<TDev>>
         {
-            //-----------------------------------------------------------------------------
             //
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueGenericThreadsBlocking<TDev>&,
                 test::EventHostManualTriggerCpu<TDev>& event) -> void
@@ -382,11 +313,9 @@ namespace alpaka
         {
             namespace detail
             {
-                //#############################################################################
                 class EventHostManualTriggerCudaImpl final
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST EventHostManualTriggerCudaImpl(DevUniformCudaHipRt const& dev)
                         : m_dev(dev)
                         , m_mutex()
@@ -402,15 +331,10 @@ namespace alpaka
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             cudaMemset(m_devMem, static_cast<int>(0u), static_cast<size_t>(sizeof(int32_t))));
                     }
-                    //-----------------------------------------------------------------------------
                     EventHostManualTriggerCudaImpl(EventHostManualTriggerCudaImpl const&) = delete;
-                    //-----------------------------------------------------------------------------
                     EventHostManualTriggerCudaImpl(EventHostManualTriggerCudaImpl&&) = delete;
-                    //-----------------------------------------------------------------------------
                     auto operator=(EventHostManualTriggerCudaImpl const&) -> EventHostManualTriggerCudaImpl& = delete;
-                    //-----------------------------------------------------------------------------
                     auto operator=(EventHostManualTriggerCudaImpl&&) -> EventHostManualTriggerCudaImpl& = delete;
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST ~EventHostManualTriggerCudaImpl()
                     {
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -421,7 +345,6 @@ namespace alpaka
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaFree(m_devMem));
                     }
 
-                    //-----------------------------------------------------------------------------
                     void trigger()
                     {
                         std::unique_lock<std::mutex> lock(m_mutex);
@@ -446,38 +369,28 @@ namespace alpaka
             } // namespace detail
         } // namespace uniform_cuda_hip
 
-        //#############################################################################
         class EventHostManualTriggerCuda final
         {
         public:
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST EventHostManualTriggerCuda(DevUniformCudaHipRt const& dev)
                 : m_spEventImpl(std::make_shared<uniform_cuda_hip::detail::EventHostManualTriggerCudaImpl>(dev))
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
             }
-            //-----------------------------------------------------------------------------
             EventHostManualTriggerCuda(EventHostManualTriggerCuda const&) = default;
-            //-----------------------------------------------------------------------------
             EventHostManualTriggerCuda(EventHostManualTriggerCuda&&) = default;
-            //-----------------------------------------------------------------------------
             auto operator=(EventHostManualTriggerCuda const&) -> EventHostManualTriggerCuda& = default;
-            //-----------------------------------------------------------------------------
             auto operator=(EventHostManualTriggerCuda&&) -> EventHostManualTriggerCuda& = default;
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator==(EventHostManualTriggerCuda const& rhs) const -> bool
             {
                 return (m_spEventImpl == rhs.m_spEventImpl);
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator!=(EventHostManualTriggerCuda const& rhs) const -> bool
             {
                 return !((*this) == rhs);
             }
-            //-----------------------------------------------------------------------------
             ~EventHostManualTriggerCuda() = default;
 
-            //-----------------------------------------------------------------------------
             void trigger()
             {
                 m_spEventImpl->trigger();
@@ -489,18 +402,15 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             template<>
             struct EventHostManualTriggerType<alpaka::DevUniformCudaHipRt>
             {
                 using type = alpaka::test::EventHostManualTriggerCuda;
             };
-            //#############################################################################
             //! The CPU event host manual trigger support get trait specialization.
             template<>
             struct IsEventHostManualTriggerSupported<alpaka::DevUniformCudaHipRt>
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto isSupported(alpaka::DevCudaRt const& dev) -> bool
                 {
                     int result = 0;
@@ -512,24 +422,20 @@ namespace alpaka
     } // namespace test
     namespace traits
     {
-        //#############################################################################
         //! The CPU device event device get trait specialization.
         template<>
         struct GetDev<test::EventHostManualTriggerCuda>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDev(test::EventHostManualTriggerCuda const& event) -> DevUniformCudaHipRt
             {
                 return event.m_spEventImpl->m_dev;
             }
         };
 
-        //#############################################################################
         //! The CPU device event test trait specialization.
         template<>
         struct IsComplete<test::EventHostManualTriggerCuda>
         {
-            //-----------------------------------------------------------------------------
             //! \return If the event is not waiting within a queue (not enqueued or already handled).
             ALPAKA_FN_HOST static auto isComplete(test::EventHostManualTriggerCuda const& event) -> bool
             {
@@ -539,11 +445,9 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         template<>
         struct Enqueue<QueueUniformCudaHipRtNonBlocking, test::EventHostManualTriggerCuda>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtNonBlocking& queue,
                 test::EventHostManualTriggerCuda& event) -> void
@@ -575,11 +479,9 @@ namespace alpaka
                     CU_STREAM_WAIT_VALUE_GEQ));
             }
         };
-        //#############################################################################
         template<>
         struct Enqueue<QueueUniformCudaHipRtBlocking, test::EventHostManualTriggerCuda>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(
                 QueueUniformCudaHipRtBlocking& queue,
                 test::EventHostManualTriggerCuda& event) -> void
@@ -634,11 +536,9 @@ namespace alpaka
         {
             namespace detail
             {
-                //#############################################################################
                 class EventHostManualTriggerHipImpl final
                 {
                 public:
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST EventHostManualTriggerHipImpl(DevHipRt const& dev)
                         : m_dev(dev)
                         , m_mutex()
@@ -654,15 +554,10 @@ namespace alpaka
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             hipMemset(m_devMem, static_cast<int>(0u), static_cast<size_t>(sizeof(int32_t))));
                     }
-                    //-----------------------------------------------------------------------------
                     EventHostManualTriggerHipImpl(EventHostManualTriggerHipImpl const&) = delete;
-                    //-----------------------------------------------------------------------------
                     EventHostManualTriggerHipImpl(EventHostManualTriggerHipImpl&&) = delete;
-                    //-----------------------------------------------------------------------------
                     auto operator=(EventHostManualTriggerHipImpl const&) -> EventHostManualTriggerHipImpl& = delete;
-                    //-----------------------------------------------------------------------------
                     auto operator=(EventHostManualTriggerHipImpl&&) -> EventHostManualTriggerHipImpl& = delete;
-                    //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST ~EventHostManualTriggerHipImpl()
                     {
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -672,7 +567,6 @@ namespace alpaka
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipFree(m_devMem));
                     }
 
-                    //-----------------------------------------------------------------------------
                     void trigger()
                     {
                         std::unique_lock<std::mutex> lock(m_mutex);
@@ -697,38 +591,28 @@ namespace alpaka
             } // namespace detail
         } // namespace hip
 
-        //#############################################################################
         class EventHostManualTriggerHip final
         {
         public:
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST EventHostManualTriggerHip(DevHipRt const& dev)
                 : m_spEventImpl(std::make_shared<hip::detail::EventHostManualTriggerHipImpl>(dev))
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
             }
-            //-----------------------------------------------------------------------------
             EventHostManualTriggerHip(EventHostManualTriggerHip const&) = default;
-            //-----------------------------------------------------------------------------
             EventHostManualTriggerHip(EventHostManualTriggerHip&&) = default;
-            //-----------------------------------------------------------------------------
             auto operator=(EventHostManualTriggerHip const&) -> EventHostManualTriggerHip& = default;
-            //-----------------------------------------------------------------------------
             auto operator=(EventHostManualTriggerHip&&) -> EventHostManualTriggerHip& = default;
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator==(EventHostManualTriggerHip const& rhs) const -> bool
             {
                 return (m_spEventImpl == rhs.m_spEventImpl);
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator!=(EventHostManualTriggerHip const& rhs) const -> bool
             {
                 return !((*this) == rhs);
             }
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST ~EventHostManualTriggerHip() = default;
 
-            //-----------------------------------------------------------------------------
             void trigger()
             {
                 m_spEventImpl->trigger();
@@ -740,19 +624,16 @@ namespace alpaka
 
         namespace traits
         {
-            //#############################################################################
             template<>
             struct EventHostManualTriggerType<alpaka::DevHipRt>
             {
                 using type = alpaka::test::EventHostManualTriggerHip;
             };
 
-            //#############################################################################
             //! The HIP event host manual trigger support get trait specialization.
             template<>
             struct IsEventHostManualTriggerSupported<alpaka::DevHipRt>
             {
-                //-----------------------------------------------------------------------------
                 // TODO: there is no CUDA_VERSION in the HIP compiler path.
                 // TODO: there is a hipDeviceGetAttribute, but there is no pendant for
                 // CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS.
@@ -765,24 +646,20 @@ namespace alpaka
     } // namespace test
     namespace traits
     {
-        //#############################################################################
         //! The CPU device event device get trait specialization.
         template<>
         struct GetDev<test::EventHostManualTriggerHip>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDev(test::EventHostManualTriggerHip const& event) -> DevHipRt
             {
                 return event.m_spEventImpl->m_dev;
             }
         };
 
-        //#############################################################################
         //! The CPU device event test trait specialization.
         template<>
         struct IsComplete<test::EventHostManualTriggerHip>
         {
-            //-----------------------------------------------------------------------------
             //! \return If the event is not waiting within a queue (not enqueued or already handled).
             ALPAKA_FN_HOST static auto isComplete(test::EventHostManualTriggerHip const& event) -> bool
             {
@@ -792,11 +669,9 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         template<>
         struct Enqueue<QueueHipRtNonBlocking, test::EventHostManualTriggerHip>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(QueueHipRtNonBlocking& queue, test::EventHostManualTriggerHip& event)
                 -> void
             {
@@ -836,11 +711,9 @@ namespace alpaka
                 }
             }
         };
-        //#############################################################################
         template<>
         struct Enqueue<QueueHipRtBlocking, test::EventHostManualTriggerHip>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(QueueHipRtBlocking& queue, test::EventHostManualTriggerHip& event)
                 -> void
             {

--- a/test/common/include/alpaka/test/idx/TestIdxs.hpp
+++ b/test/common/include/alpaka/test/idx/TestIdxs.hpp
@@ -14,11 +14,9 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The test specifics.
     namespace test
     {
-        //#############################################################################
         //! A std::tuple holding idx types.
         using TestIdxs = std::tuple<
         // size_t is most probably identical to either std::uint64_t or std::uint32_t.

--- a/test/common/include/alpaka/test/mem/view/Iterator.hpp
+++ b/test/common/include/alpaka/test/mem/view/Iterator.hpp
@@ -15,15 +15,12 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The test specifics.
     namespace test
     {
-        //-----------------------------------------------------------------------------
         //!
         namespace traits
         {
-            //#############################################################################
             // \tparam T Type to conditionally make const.
             // \tparam TSource Type to mimic the constness of.
             template<typename T, typename TSource>
@@ -35,7 +32,6 @@ namespace alpaka
 #    pragma GCC diagnostic ignored                                                                                    \
         "-Wcast-align" // "cast from 'Byte*' to 'Elem*' increases required alignment of target type"
 #endif
-            //#############################################################################
             template<typename TView, typename TSfinae = void>
             class IteratorView
             {
@@ -45,7 +41,6 @@ namespace alpaka
                 using Elem = MimicConst<alpaka::Elem<TViewDecayed>, TView>;
 
             public:
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST IteratorView(TView& view, Idx const idx)
                     : m_nativePtr(alpaka::getPtrNative(view))
                     , m_currentIdx(idx)
@@ -54,26 +49,22 @@ namespace alpaka
                 {
                 }
 
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST IteratorView(TView& view) : IteratorView(view, 0)
                 {
                 }
 
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST_ACC auto operator++() -> IteratorView&
                 {
                     ++m_currentIdx;
                     return *this;
                 }
 
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST_ACC auto operator--() -> IteratorView&
                 {
                     --m_currentIdx;
                     return *this;
                 }
 
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST_ACC auto operator++(int) -> IteratorView
                 {
                     IteratorView iterCopy = *this;
@@ -81,7 +72,6 @@ namespace alpaka
                     return iterCopy;
                 }
 
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST_ACC auto operator--(int) -> IteratorView
                 {
                     IteratorView iterCopy = *this;
@@ -89,21 +79,18 @@ namespace alpaka
                     return iterCopy;
                 }
 
-                //-----------------------------------------------------------------------------
                 template<typename TIter>
                 ALPAKA_FN_HOST_ACC auto operator==(TIter& other) const -> bool
                 {
                     return m_currentIdx == other.m_currentIdx;
                 }
 
-                //-----------------------------------------------------------------------------
                 template<typename TIter>
                 ALPAKA_FN_HOST_ACC auto operator!=(TIter& other) const -> bool
                 {
                     return m_currentIdx != other.m_currentIdx;
                 }
 
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST_ACC auto operator*() const -> Elem&
                 {
                     using Dim1 = alpaka::DimInt<1>;
@@ -149,22 +136,18 @@ namespace alpaka
 #    pragma GCC diagnostic pop
 #endif
 
-            //#############################################################################
             template<typename TView, typename TSfinae = void>
             struct Begin
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto begin(TView& view) -> IteratorView<TView>
                 {
                     return IteratorView<TView>(view);
                 }
             };
 
-            //#############################################################################
             template<typename TView, typename TSfinae = void>
             struct End
             {
-                //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto end(TView& view) -> IteratorView<TView>
                 {
                     auto extents = alpaka::extent::getExtentVec(view);
@@ -173,18 +156,15 @@ namespace alpaka
             };
         } // namespace traits
 
-        //#############################################################################
         template<typename TView>
         using Iterator = traits::IteratorView<TView>;
 
-        //-----------------------------------------------------------------------------
         template<typename TView>
         ALPAKA_FN_HOST auto begin(TView& view) -> Iterator<TView>
         {
             return traits::Begin<TView>::begin(view);
         }
 
-        //-----------------------------------------------------------------------------
         template<typename TView>
         ALPAKA_FN_HOST auto end(TView& view) -> Iterator<TView>
         {

--- a/test/common/include/alpaka/test/mem/view/Iterator.hpp
+++ b/test/common/include/alpaka/test/mem/view/Iterator.hpp
@@ -18,7 +18,6 @@ namespace alpaka
     //! The test specifics.
     namespace test
     {
-        //!
         namespace traits
         {
             // \tparam T Type to conditionally make const.

--- a/test/common/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/test/common/include/alpaka/test/mem/view/ViewTest.hpp
@@ -21,11 +21,9 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The test specifics.
     namespace test
     {
-        //-----------------------------------------------------------------------------
         template<typename TElem, typename TDim, typename TIdx, typename TDev, typename TView>
         ALPAKA_FN_HOST auto testViewImmutable(
             TView const& view,
@@ -33,7 +31,6 @@ namespace alpaka
             alpaka::Vec<TDim, TIdx> const& extent,
             alpaka::Vec<TDim, TIdx> const& offset) -> void
         {
-            //-----------------------------------------------------------------------------
             // alpaka::traits::DevType
             {
                 static_assert(
@@ -41,13 +38,11 @@ namespace alpaka
                     "The device type of the view has to be equal to the specified one.");
             }
 
-            //-----------------------------------------------------------------------------
             // alpaka::traits::GetDev
             {
                 REQUIRE(dev == alpaka::getDev(view));
             }
 
-            //-----------------------------------------------------------------------------
             // alpaka::traits::DimType
             {
                 static_assert(
@@ -55,7 +50,6 @@ namespace alpaka
                     "The dimensionality of the view has to be equal to the specified one.");
             }
 
-            //-----------------------------------------------------------------------------
             // alpaka::traits::ElemType
             {
                 static_assert(
@@ -63,13 +57,11 @@ namespace alpaka
                     "The element type of the view has to be equal to the specified one.");
             }
 
-            //-----------------------------------------------------------------------------
             // alpaka::extent::traits::GetExtent
             {
                 REQUIRE(extent == alpaka::extent::getExtentVec(view));
             }
 
-            //-----------------------------------------------------------------------------
             // alpaka::traits::GetPitchBytes
             {
                 // The pitches have to be at least as large as the values we calculate here.
@@ -90,7 +82,6 @@ namespace alpaka
                 }
             }
 
-            //-----------------------------------------------------------------------------
             // alpaka::traits::GetPtrNative
             {
                 // The view is a const& so the pointer has to point to a const value.
@@ -115,13 +106,11 @@ namespace alpaka
                 }
             }
 
-            //-----------------------------------------------------------------------------
             // alpaka::traits::GetOffset
             {
                 REQUIRE(offset == alpaka::getOffsetVec(view));
             }
 
-            //-----------------------------------------------------------------------------
             // alpaka::traits::IdxType
             {
                 static_assert(
@@ -130,7 +119,6 @@ namespace alpaka
             }
         }
 
-        //#############################################################################
         //! Compares element-wise that all bytes are set to the same value.
         struct VerifyBytesSetKernel
         {
@@ -157,7 +145,6 @@ namespace alpaka
                 }
             }
         };
-        //-----------------------------------------------------------------------------
         template<typename TAcc, typename TView>
         ALPAKA_FN_HOST auto verifyBytesSet(TView const& view, std::uint8_t const& byte) -> void
         {
@@ -171,7 +158,6 @@ namespace alpaka
             REQUIRE(fixture(verifyBytesSet, alpaka::test::begin(view), alpaka::test::end(view), byte));
         }
 
-        //#############################################################################
         //! Compares iterators element-wise
 #if BOOST_COMP_GNUC
 #    pragma GCC diagnostic push
@@ -207,7 +193,6 @@ namespace alpaka
 #    pragma GCC diagnostic pop
 #endif
 
-        //-----------------------------------------------------------------------------
         template<typename TAcc, typename TViewB, typename TViewA>
         ALPAKA_FN_HOST auto verifyViewsEqual(TViewA const& viewA, TViewB const& viewB) -> void
         {
@@ -229,7 +214,6 @@ namespace alpaka
                 alpaka::test::begin(viewB)));
         }
 
-        //-----------------------------------------------------------------------------
         //! Fills the given view with increasing values starting at 0.
         template<typename TView, typename TQueue>
         ALPAKA_FN_HOST auto iotaFillView(TQueue& queue, TView& view) -> void
@@ -259,11 +243,9 @@ namespace alpaka
             alpaka::wait(queue);
         }
 
-        //-----------------------------------------------------------------------------
         template<typename TAcc, typename TView, typename TQueue>
         ALPAKA_FN_HOST auto testViewMutable(TQueue& queue, TView& view) -> void
         {
-            //-----------------------------------------------------------------------------
             // alpaka::traits::GetPtrNative
             {
                 // The view is a non-const so the pointer has to point to a non-const value.
@@ -278,7 +260,6 @@ namespace alpaka
 
             auto const extent(alpaka::extent::getExtentVec(view));
 
-            //-----------------------------------------------------------------------------
             // alpaka::set
             {
                 std::uint8_t const byte(static_cast<uint8_t>(42u));
@@ -287,7 +268,6 @@ namespace alpaka
                 verifyBytesSet<TAcc>(view, byte);
             }
 
-            //-----------------------------------------------------------------------------
             // alpaka::copy
             {
                 using Elem = alpaka::Elem<TView>;
@@ -295,7 +275,6 @@ namespace alpaka
 
                 auto const devAcc = alpaka::getDev(view);
 
-                //-----------------------------------------------------------------------------
                 // alpaka::copy into given view
                 {
                     auto srcBufAcc(alpaka::allocBuf<Elem, Idx>(devAcc, extent));
@@ -305,7 +284,6 @@ namespace alpaka
                     verifyViewsEqual<TAcc>(view, srcBufAcc);
                 }
 
-                //-----------------------------------------------------------------------------
                 // alpaka::copy from given view
                 {
                     auto dstBufAcc(alpaka::allocBuf<Elem, Idx>(devAcc, extent));

--- a/test/common/include/alpaka/test/queue/Queue.hpp
+++ b/test/common/include/alpaka/test/queue/Queue.hpp
@@ -13,18 +13,15 @@
 
 namespace alpaka
 {
-    //-----------------------------------------------------------------------------
     //! The test specifics.
     namespace test
     {
         namespace traits
         {
-            //#############################################################################
             //! The default queue type trait for devices.
             template<typename TDev, typename TSfinae = void>
             struct DefaultQueueType;
 
-            //#############################################################################
             //! The default queue type trait specialization for the CPU device.
             template<>
             struct DefaultQueueType<alpaka::DevCpu>
@@ -38,7 +35,6 @@ namespace alpaka
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-            //#############################################################################
             //! The default queue type trait specialization for the CUDA/HIP device.
             template<>
             struct DefaultQueueType<alpaka::DevUniformCudaHipRt>
@@ -51,19 +47,16 @@ namespace alpaka
             };
 #endif
         } // namespace traits
-        //#############################################################################
         //! The queue type that should be used for the given accelerator.
         template<typename TAcc>
         using DefaultQueue = typename traits::DefaultQueueType<TAcc>::type;
 
         namespace traits
         {
-            //#############################################################################
             //! The blocking queue trait.
             template<typename TQueue, typename TSfinae = void>
             struct IsBlockingQueue;
 
-            //#############################################################################
             //! The blocking queue trait specialization for a blocking CPU queue.
             template<typename TDev>
             struct IsBlockingQueue<alpaka::QueueGenericThreadsBlocking<TDev>>
@@ -71,7 +64,6 @@ namespace alpaka
                 static constexpr bool value = true;
             };
 
-            //#############################################################################
             //! The blocking queue trait specialization for a non-blocking CPU queue.
             template<typename TDev>
             struct IsBlockingQueue<alpaka::QueueGenericThreadsNonBlocking<TDev>>
@@ -81,7 +73,6 @@ namespace alpaka
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-            //#############################################################################
             //! The blocking queue trait specialization for a blocking CUDA/HIP RT queue.
             template<>
             struct IsBlockingQueue<alpaka::QueueUniformCudaHipRtBlocking>
@@ -89,7 +80,6 @@ namespace alpaka
                 static constexpr bool value = true;
             };
 
-            //#############################################################################
             //! The blocking queue trait specialization for a non-blocking CUDA/HIP RT queue.
             template<>
             struct IsBlockingQueue<alpaka::QueueUniformCudaHipRtNonBlocking>
@@ -100,7 +90,6 @@ namespace alpaka
 
 #ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
 
-            //#############################################################################
             //! The default queue type trait specialization for the Omp5 device.
             template<>
             struct DefaultQueueType<alpaka::DevOmp5>
@@ -113,7 +102,6 @@ namespace alpaka
             };
 #elif defined ALPAKA_ACC_ANY_BT_OACC_ENABLED
 
-            //#############################################################################
             //! The default queue type trait specialization for the OMP4 device.
             template<>
             struct DefaultQueueType<alpaka::DevOacc>
@@ -123,12 +111,10 @@ namespace alpaka
 #endif
 
         } // namespace traits
-        //#############################################################################
         //! The queue type that should be used for the given accelerator.
         template<typename TQueue>
         using IsBlockingQueue = traits::IsBlockingQueue<TQueue>;
 
-        //#############################################################################
         //! A std::tuple holding tuples of devices and corresponding queue types.
         using TestQueues = std::tuple<
             std::tuple<alpaka::DevCpu, alpaka::QueueCpuBlocking>,

--- a/test/common/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
+++ b/test/common/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
@@ -45,7 +45,6 @@ namespace alpaka
 #        pragma clang diagnostic push
 #        pragma clang diagnostic ignored "-Wweak-vtables"
 #    endif
-            //#############################################################################
             //! The CPU collective device queue implementation.
             class QueueCpuOmp2CollectiveImpl final : public cpu::ICpuQueue
 #    if BOOST_COMP_CLANG
@@ -53,24 +52,17 @@ namespace alpaka
 #    endif
             {
             public:
-                //-----------------------------------------------------------------------------
                 QueueCpuOmp2CollectiveImpl(DevCpu const& dev) noexcept : m_dev(dev), m_uCurrentlyExecutingTask(0u)
                 {
                 }
-                //-----------------------------------------------------------------------------
                 QueueCpuOmp2CollectiveImpl(QueueCpuOmp2CollectiveImpl const&) = delete;
-                //-----------------------------------------------------------------------------
                 QueueCpuOmp2CollectiveImpl(QueueCpuOmp2CollectiveImpl&&) = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(QueueCpuOmp2CollectiveImpl const&) -> QueueCpuOmp2CollectiveImpl& = delete;
-                //-----------------------------------------------------------------------------
                 auto operator=(QueueCpuOmp2CollectiveImpl&&) -> QueueCpuOmp2CollectiveImpl& = delete;
-                //-----------------------------------------------------------------------------
                 void enqueue(EventCpu& ev) final
                 {
                     alpaka::enqueue(*this, ev);
                 }
-                //-----------------------------------------------------------------------------
                 void wait(EventCpu const& ev) final
                 {
                     alpaka::wait(*this, ev);
@@ -84,7 +76,6 @@ namespace alpaka
         } // namespace detail
     } // namespace cpu
 
-    //#############################################################################
     //! The CPU collective device queue.
     //
     // @attention Queue can only be used together with the accelerator AccCpuOmp2Blocks.
@@ -100,32 +91,24 @@ namespace alpaka
         : public concepts::Implements<ConceptCurrentThreadWaitFor, QueueCpuOmp2Collective>
     {
     public:
-        //-----------------------------------------------------------------------------
         QueueCpuOmp2Collective(DevCpu const& dev)
             : m_spQueueImpl(std::make_shared<cpu::detail::QueueCpuOmp2CollectiveImpl>(dev))
             , m_spBlockingQueue(std::make_shared<QueueCpuBlocking>(dev))
         {
             dev.registerQueue(m_spQueueImpl);
         }
-        //-----------------------------------------------------------------------------
         QueueCpuOmp2Collective(QueueCpuOmp2Collective const&) = default;
-        //-----------------------------------------------------------------------------
         QueueCpuOmp2Collective(QueueCpuOmp2Collective&&) = default;
-        //-----------------------------------------------------------------------------
         auto operator=(QueueCpuOmp2Collective const&) -> QueueCpuOmp2Collective& = default;
-        //-----------------------------------------------------------------------------
         auto operator=(QueueCpuOmp2Collective&&) -> QueueCpuOmp2Collective& = default;
-        //-----------------------------------------------------------------------------
         auto operator==(QueueCpuOmp2Collective const& rhs) const -> bool
         {
             return m_spQueueImpl == rhs.m_spQueueImpl && m_spBlockingQueue == rhs.m_spBlockingQueue;
         }
-        //-----------------------------------------------------------------------------
         auto operator!=(QueueCpuOmp2Collective const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        //-----------------------------------------------------------------------------
         ~QueueCpuOmp2Collective() = default;
 
     public:
@@ -135,26 +118,22 @@ namespace alpaka
 
     namespace traits
     {
-        //#############################################################################
         //! The CPU blocking device queue device type trait specialization.
         template<>
         struct DevType<QueueCpuOmp2Collective>
         {
             using type = DevCpu;
         };
-        //#############################################################################
         //! The CPU blocking device queue device get trait specialization.
         template<>
         struct GetDev<QueueCpuOmp2Collective>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto getDev(QueueCpuOmp2Collective const& queue) -> DevCpu
             {
                 return queue.m_spQueueImpl->m_dev;
             }
         };
 
-        //#############################################################################
         //! The CPU blocking device queue event type trait specialization.
         template<>
         struct EventType<QueueCpuOmp2Collective>
@@ -162,13 +141,11 @@ namespace alpaka
             using type = EventCpu;
         };
 
-        //#############################################################################
         //! The CPU blocking device queue enqueue trait specialization.
         //! This default implementation for all tasks directly invokes the function call operator of the task.
         template<typename TTask>
         struct Enqueue<QueueCpuOmp2Collective, TTask>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(QueueCpuOmp2Collective& queue, TTask const& task) -> void
             {
                 if(::omp_in_parallel() != 0)
@@ -192,24 +169,20 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU blocking device queue test trait specialization.
         template<>
         struct Empty<QueueCpuOmp2Collective>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto empty(QueueCpuOmp2Collective const& queue) -> bool
             {
                 return queue.m_spQueueImpl->m_uCurrentlyExecutingTask == 0u && alpaka::empty(*queue.m_spBlockingQueue);
             }
         };
 
-        //#############################################################################
         //! The CPU OpenMP2 collective device queue enqueue trait specialization.
         template<>
         struct Enqueue<cpu::detail::QueueCpuOmp2CollectiveImpl, EventCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(cpu::detail::QueueCpuOmp2CollectiveImpl&, EventCpu&) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -217,12 +190,10 @@ namespace alpaka
 #    pragma omp barrier
             }
         };
-        //#############################################################################
         //! The CPU OpenMP2 collective device queue enqueue trait specialization.
         template<>
         struct Enqueue<QueueCpuOmp2Collective, EventCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(QueueCpuOmp2Collective& queue, EventCpu& event) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -242,7 +213,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU blocking device queue enqueue trait specialization.
         //! This default implementation for all tasks directly invokes the function call operator of the task.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
@@ -252,7 +222,6 @@ namespace alpaka
             using Task = TaskKernelCpuOmp2Blocks<TDim, TIdx, TKernelFnObj, TArgs...>;
 
         public:
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(QueueCpuOmp2Collective& queue, Task const& task) -> void
             {
                 if(::omp_in_parallel() != 0)
@@ -274,15 +243,10 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
-        //!
-        //#############################################################################
         template<>
         struct Enqueue<QueueCpuOmp2Collective, test::EventHostManualTriggerCpu<>>
         {
-            //-----------------------------------------------------------------------------
             //
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto enqueue(QueueCpuOmp2Collective&, test::EventHostManualTriggerCpu<>&) -> void
             {
                 // EventHostManualTriggerCpu are not supported for together with the queue QueueCpuOmp2Collective
@@ -290,7 +254,6 @@ namespace alpaka
             }
         };
 
-        //#############################################################################
         //! The CPU blocking device queue thread wait trait specialization.
         //!
         //! Blocks execution of the calling thread until the queue has finished processing all previously requested
@@ -298,7 +261,6 @@ namespace alpaka
         template<>
         struct CurrentThreadWaitFor<QueueCpuOmp2Collective>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto currentThreadWaitFor(QueueCpuOmp2Collective const& queue) -> void
             {
                 if(::omp_in_parallel() != 0)
@@ -318,23 +280,19 @@ namespace alpaka
         };
 
 
-        //#############################################################################
         //! The CPU OpenMP2 collective device queue event wait trait specialization.
         template<>
         struct WaiterWaitFor<cpu::detail::QueueCpuOmp2CollectiveImpl, EventCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto waiterWaitFor(cpu::detail::QueueCpuOmp2CollectiveImpl&, EventCpu const&) -> void
             {
 #    pragma omp barrier
             }
         };
-        //#############################################################################
         //! The CPU OpenMP2 collective queue event wait trait specialization.
         template<>
         struct WaiterWaitFor<QueueCpuOmp2Collective, EventCpu>
         {
-            //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto waiterWaitFor(QueueCpuOmp2Collective& queue, EventCpu const& event) -> void
             {
                 if(::omp_in_parallel() != 0)
@@ -350,13 +308,11 @@ namespace alpaka
             }
         };
     } // namespace traits
-    //-----------------------------------------------------------------------------
     //! The test specifics.
     namespace test
     {
         namespace traits
         {
-            //#############################################################################
             //! The blocking queue trait specialization for a OpenMP2 collective CPU queue.
             template<>
             struct IsBlockingQueue<alpaka::QueueCpuOmp2Collective>

--- a/test/common/include/alpaka/test/queue/QueueTestFixture.hpp
+++ b/test/common/include/alpaka/test/queue/QueueTestFixture.hpp
@@ -15,7 +15,6 @@ namespace alpaka
 {
     namespace test
     {
-        //#############################################################################
         template<typename TDevQueue>
         struct QueueTestFixture
         {
@@ -24,7 +23,6 @@ namespace alpaka
 
             using Pltf = alpaka::Pltf<Dev>;
 
-            //-----------------------------------------------------------------------------
             QueueTestFixture() : m_dev(alpaka::getDevByIdx<Pltf>(0u)), m_queue(m_dev)
             {
             }

--- a/test/integ/axpy/src/axpy.cpp
+++ b/test/integ/axpy/src/axpy.cpp
@@ -21,12 +21,10 @@
 #include <random>
 #include <typeinfo>
 
-//#############################################################################
 //! A vector addition kernel.
 class AxpyKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     //! Vector addition Y = alpha * X + Y.
     //!
     //! \tparam TAcc The type of the accelerator the kernel is executed on..

--- a/test/integ/cudaOnly/src/cudaNativeFunctions.cpp
+++ b/test/integ/cudaOnly/src/cudaNativeFunctions.cpp
@@ -14,7 +14,6 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ONLY_MODE) && defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA
 
-//-----------------------------------------------------------------------------
 //! Native CUDA function.
 #    if BOOST_COMP_CLANG
 #        pragma clang diagnostic push
@@ -28,11 +27,9 @@ __device__ auto userDefinedThreadFence() -> void
 #        pragma clang diagnostic pop
 #    endif
 
-//#############################################################################
 class CudaOnlyTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
     {
@@ -48,7 +45,6 @@ public:
 };
 
 
-//-----------------------------------------------------------------------------
 TEST_CASE("cudaOnlyModeWorking", "[cudaOnly]")
 {
     using TAcc = alpaka::AccGpuCudaRt<alpaka::DimInt<1u>, std::uint32_t>;

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -21,43 +21,36 @@
 
 //#define ALPAKA_MANDELBROT_TEST_CONTINOUS_COLOR_MAPPING  // Define this to enable the continuous color mapping.
 
-//#############################################################################
 //! Complex Number.
 template<typename T>
 class SimpleComplex
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_HOST_ACC SimpleComplex(T const& a, T const& b) : r(a), i(b)
     {
     }
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_INLINE
     ALPAKA_FN_HOST_ACC auto absSq() const -> T
     {
         return r * r + i * i;
     }
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_HOST_ACC auto operator*(SimpleComplex const& a) -> SimpleComplex
     {
         return SimpleComplex(r * a.r - i * a.i, i * a.r + r * a.i);
     }
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_HOST_ACC auto operator*(float const& a) -> SimpleComplex
     {
         return SimpleComplex(r * a, i * a);
     }
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_HOST_ACC auto operator+(SimpleComplex const& a) -> SimpleComplex
     {
         return SimpleComplex(r + a.r, i + a.i);
     }
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_HOST_ACC auto operator+(float const& a) -> SimpleComplex
     {
@@ -69,13 +62,11 @@ public:
     T i;
 };
 
-//#############################################################################
 //! A Mandelbrot kernel.
 class MandelbrotKernel
 {
 public:
 #ifndef ALPAKA_MANDELBROT_TEST_CONTINOUS_COLOR_MAPPING
-    //-----------------------------------------------------------------------------
     ALPAKA_FN_HOST_ACC MandelbrotKernel()
     {
         // Banding can be prevented by a continuous color functions.
@@ -98,7 +89,6 @@ public:
     }
 #endif
 
-    //-----------------------------------------------------------------------------
     //! \param acc The accelerator to be executed on.
     //! \param pColors The output image.
     //! \param numRows The number of rows in the image
@@ -146,7 +136,6 @@ public:
 #endif
         }
     }
-    //-----------------------------------------------------------------------------
     //! \return The number of iterations until the Mandelbrot iteration with the given Value reaches the absolute value
     //! of 2.
     //!     Only does maxIterations steps and returns maxIterations if the value would be higher.
@@ -165,7 +154,6 @@ public:
         return maxIterations;
     }
 
-    //-----------------------------------------------------------------------------
     ALPAKA_FN_HOST_ACC static auto convertRgbSingleToBgra(
         std::uint32_t const& r,
         std::uint32_t const& g,
@@ -175,7 +163,6 @@ public:
     }
 
 #ifdef ALPAKA_MANDELBROT_TEST_CONTINOUS_COLOR_MAPPING
-    //-----------------------------------------------------------------------------
     //! This uses a simple mapping from iteration count to colors.
     //! This leads to banding but allows a all pixels to be colored.
     ALPAKA_NO_HOST_ACC_WARNING
@@ -193,7 +180,6 @@ public:
         return convertRgbSingleToBgra(r, g, b);
     }
 #else
-    //-----------------------------------------------------------------------------
     //! This uses a simple mapping from iteration count to colors.
     //! This leads to banding but allows a all pixels to be colored.
     ALPAKA_FN_ACC auto iterationCountToRepeatedColor(std::uint32_t const& iterationCount) const -> std::uint32_t
@@ -205,7 +191,6 @@ public:
 #endif
 };
 
-//-----------------------------------------------------------------------------
 //! Writes the buffer color data to a file.
 template<typename TBuf>
 auto writeTgaColorImage(std::string const& fileName, TBuf const& bufRgba) -> void

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -19,14 +19,12 @@
 #include <typeinfo>
 #include <vector>
 
-//#############################################################################
 //! A matrix multiplication kernel.
 //! Computes C + alpha*A*B + beta*C. LxM * MxN -> LxN
 //! This is an adaption of the algorithm from the CUDA developers guide.
 class MatMulKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     //! \tparam TAcc The accelerator environment to be executed on.
     //! \tparam TElem The matrix element type.
     //! \param acc The accelerator to be executed on.
@@ -138,12 +136,10 @@ namespace alpaka
 {
     namespace traits
     {
-        //#############################################################################
         //! The trait for getting the size of the block shared dynamic memory for a kernel.
         template<typename TAcc>
         struct BlockSharedMemDynSizeBytes<MatMulKernel, TAcc>
         {
-            //-----------------------------------------------------------------------------
             //! \return The size of the shared memory allocated for a block.
             template<typename TVec, typename TIndex, typename TElem>
             ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(

--- a/test/integ/separableCompilation/src/main.cpp
+++ b/test/integ/separableCompilation/src/main.cpp
@@ -18,12 +18,10 @@
 #include <iostream>
 #include <typeinfo>
 
-//#############################################################################
 //! A vector addition kernel.
 class SqrtKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     //! The kernel entry point.
     //!
     //! \tparam TAcc The accelerator environment to be executed on.

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -18,14 +18,12 @@
 #include <typeinfo>
 #include <vector>
 
-//#############################################################################
 //! A kernel using atomicOp, syncBlockThreads, getDynSharedMem, getIdx, getWorkDiv and global memory to compute a
 //! (useless) result. \tparam TnumUselessWork The number of useless calculations done in each kernel execution.
 template<typename TnumUselessWork, typename Val>
 class SharedMemKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, Val* const puiBlockRetVals) const -> void
@@ -93,12 +91,10 @@ namespace alpaka
 {
     namespace traits
     {
-        //#############################################################################
         //! The trait for getting the size of the block shared dynamic memory for a kernel.
         template<typename TnumUselessWork, typename Val, typename TAcc>
         struct BlockSharedMemDynSizeBytes<SharedMemKernel<TnumUselessWork, Val>, TAcc>
         {
-            //-----------------------------------------------------------------------------
             //! \return The size of the shared memory allocated for a block.
             template<typename TVec, typename... TArgs>
             ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(

--- a/test/unit/acc/src/AccDevPropsTest.cpp
+++ b/test/unit/acc/src/AccDevPropsTest.cpp
@@ -13,7 +13,6 @@
 
 #include <catch2/catch.hpp>
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("getAccDevProps", "[acc]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/acc/src/AccNameTest.cpp
+++ b/test/unit/acc/src/AccNameTest.cpp
@@ -14,7 +14,6 @@
 
 #include <iostream>
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("getAccName", "[acc]", alpaka::test::TestAccs)
 {
     std::cout << alpaka::getAccName<TestType>() << std::endl;

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -17,7 +17,6 @@
 #include <climits>
 #include <type_traits>
 
-//-----------------------------------------------------------------------------
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename TAcc, typename T>
 ALPAKA_FN_ACC auto testAtomicAdd(TAcc const& acc, bool* success, T operandOrig) -> void
@@ -39,7 +38,6 @@ ALPAKA_FN_ACC auto testAtomicAdd(TAcc const& acc, bool* success, T operandOrig) 
     }
 }
 
-//-----------------------------------------------------------------------------
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename TAcc, typename T>
 ALPAKA_FN_ACC auto testAtomicSub(TAcc const& acc, bool* success, T operandOrig) -> void
@@ -61,7 +59,6 @@ ALPAKA_FN_ACC auto testAtomicSub(TAcc const& acc, bool* success, T operandOrig) 
     }
 }
 
-//-----------------------------------------------------------------------------
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename TAcc, typename T>
 ALPAKA_FN_ACC auto testAtomicMin(TAcc const& acc, bool* success, T operandOrig) -> void
@@ -83,7 +80,6 @@ ALPAKA_FN_ACC auto testAtomicMin(TAcc const& acc, bool* success, T operandOrig) 
     }
 }
 
-//-----------------------------------------------------------------------------
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename TAcc, typename T>
 ALPAKA_FN_ACC auto testAtomicMax(TAcc const& acc, bool* success, T operandOrig) -> void
@@ -105,7 +101,6 @@ ALPAKA_FN_ACC auto testAtomicMax(TAcc const& acc, bool* success, T operandOrig) 
     }
 }
 
-//-----------------------------------------------------------------------------
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename TAcc, typename T>
 ALPAKA_FN_ACC auto testAtomicExch(TAcc const& acc, bool* success, T operandOrig) -> void
@@ -127,7 +122,6 @@ ALPAKA_FN_ACC auto testAtomicExch(TAcc const& acc, bool* success, T operandOrig)
     }
 }
 
-//-----------------------------------------------------------------------------
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename TAcc, typename T>
 ALPAKA_FN_ACC auto testAtomicInc(TAcc const& acc, bool* success, T operandOrig) -> void
@@ -150,7 +144,6 @@ ALPAKA_FN_ACC auto testAtomicInc(TAcc const& acc, bool* success, T operandOrig) 
     }
 }
 
-//-----------------------------------------------------------------------------
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename TAcc, typename T>
 ALPAKA_FN_ACC auto testAtomicDec(TAcc const& acc, bool* success, T operandOrig) -> void
@@ -173,7 +166,6 @@ ALPAKA_FN_ACC auto testAtomicDec(TAcc const& acc, bool* success, T operandOrig) 
     }
 }
 
-//-----------------------------------------------------------------------------
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename TAcc, typename T>
 ALPAKA_FN_ACC auto testAtomicAnd(TAcc const& acc, bool* success, T operandOrig) -> void
@@ -195,7 +187,6 @@ ALPAKA_FN_ACC auto testAtomicAnd(TAcc const& acc, bool* success, T operandOrig) 
     }
 }
 
-//-----------------------------------------------------------------------------
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename TAcc, typename T>
 ALPAKA_FN_ACC auto testAtomicOr(TAcc const& acc, bool* success, T operandOrig) -> void
@@ -217,7 +208,6 @@ ALPAKA_FN_ACC auto testAtomicOr(TAcc const& acc, bool* success, T operandOrig) -
     }
 }
 
-//-----------------------------------------------------------------------------
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename TAcc, typename T>
 ALPAKA_FN_ACC auto testAtomicXor(TAcc const& acc, bool* success, T operandOrig) -> void
@@ -239,7 +229,6 @@ ALPAKA_FN_ACC auto testAtomicXor(TAcc const& acc, bool* success, T operandOrig) 
     }
 }
 
-//-----------------------------------------------------------------------------
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename TAcc, typename T>
 ALPAKA_FN_ACC auto testAtomicCas(TAcc const& acc, bool* success, T operandOrig) -> void
@@ -247,7 +236,6 @@ ALPAKA_FN_ACC auto testAtomicCas(TAcc const& acc, bool* success, T operandOrig) 
     T const value = static_cast<T>(4);
     auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
 
-    //-----------------------------------------------------------------------------
     // with match
     {
         T const compare = operandOrig;
@@ -266,7 +254,6 @@ ALPAKA_FN_ACC auto testAtomicCas(TAcc const& acc, bool* success, T operandOrig) 
         }
     }
 
-    //-----------------------------------------------------------------------------
     // without match
     {
         T const compare = static_cast<T>(operandOrig + static_cast<T>(1));
@@ -286,12 +273,10 @@ ALPAKA_FN_ACC auto testAtomicCas(TAcc const& acc, bool* success, T operandOrig) 
     }
 }
 
-//#############################################################################
 template<typename TAcc, typename T, typename Sfinae = void>
 class AtomicTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, T operandOrig) const -> void
     {
@@ -315,14 +300,12 @@ public:
 };
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-//#############################################################################
 // Skip all atomic tests for the unified CUDA/HIP backend.
 // CUDA and HIP atomics will be tested separate.
 template<typename T, typename TDim, typename TIdx>
 class AtomicTestKernel<alpaka::AccGpuUniformCudaHipRt<TDim, TIdx>, T>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(alpaka::AccGpuUniformCudaHipRt<TDim, TIdx> const& acc, bool* success, T operandOrig)
         const -> void
@@ -335,12 +318,10 @@ public:
 #endif
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA
-//#############################################################################
 template<typename TDim, typename TIdx>
 class AtomicTestKernel<alpaka::AccGpuCudaRt<TDim, TIdx>, int>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(alpaka::AccGpuCudaRt<TDim, TIdx> const& acc, bool* success, int operandOrig) const
         -> void
@@ -365,13 +346,11 @@ public:
     }
 };
 
-//#############################################################################
 // NOTE: unsigned int is the only type supported by all atomic CUDA operations.
 template<typename TDim, typename TIdx>
 class AtomicTestKernel<alpaka::AccGpuCudaRt<TDim, TIdx>, unsigned int>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(alpaka::AccGpuCudaRt<TDim, TIdx> const& acc, bool* success, unsigned int operandOrig)
         const -> void
@@ -395,12 +374,10 @@ public:
     }
 };
 
-//#############################################################################
 template<typename TDim, typename TIdx>
 class AtomicTestKernel<alpaka::AccGpuCudaRt<TDim, TIdx>, unsigned long int>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(
         alpaka::AccGpuCudaRt<TDim, TIdx> const& acc,
@@ -438,12 +415,10 @@ public:
     }
 };
 
-//#############################################################################
 template<typename TDim, typename TIdx>
 class AtomicTestKernel<alpaka::AccGpuCudaRt<TDim, TIdx>, unsigned long long int>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(
         alpaka::AccGpuCudaRt<TDim, TIdx> const& acc,
@@ -475,12 +450,10 @@ public:
     }
 };
 
-//#############################################################################
 template<typename TDim, typename TIdx>
 class AtomicTestKernel<alpaka::AccGpuCudaRt<TDim, TIdx>, float>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(alpaka::AccGpuCudaRt<TDim, TIdx> const& acc, bool* success, float operandOrig) const
         -> void
@@ -509,12 +482,10 @@ public:
     }
 };
 
-//#############################################################################
 template<typename TDim, typename TIdx>
 class AtomicTestKernel<alpaka::AccGpuCudaRt<TDim, TIdx>, double>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(alpaka::AccGpuCudaRt<TDim, TIdx> const& acc, bool* success, double operandOrig) const
         -> void
@@ -544,7 +515,6 @@ public:
     }
 };
 
-//#############################################################################
 template<typename TDim, typename TIdx, typename T>
 class AtomicTestKernel<
     alpaka::AccGpuCudaRt<TDim, TIdx>,
@@ -555,7 +525,6 @@ class AtomicTestKernel<
         && !std::is_same<float, T>::value && !std::is_same<double, T>::value>>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(alpaka::AccGpuCudaRt<TDim, TIdx> const& acc, bool* success, T operandOrig) const
         -> void
@@ -570,12 +539,10 @@ public:
 #endif
 
 #if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP
-//#############################################################################
 template<typename TDim, typename TIdx>
 class AtomicTestKernel<alpaka::AccGpuHipRt<TDim, TIdx>, int>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(alpaka::AccGpuHipRt<TDim, TIdx> const& acc, bool* success, int operandOrig) const
         -> void
@@ -600,13 +567,11 @@ public:
     }
 };
 
-//#############################################################################
 // NOTE: unsigned int is the only type supported by all atomic HIP operations.
 template<typename TDim, typename TIdx>
 class AtomicTestKernel<alpaka::AccGpuHipRt<TDim, TIdx>, unsigned int>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(alpaka::AccGpuHipRt<TDim, TIdx> const& acc, bool* success, unsigned int operandOrig)
         const -> void
@@ -630,12 +595,10 @@ public:
     }
 };
 
-//#############################################################################
 template<typename TDim, typename TIdx>
 class AtomicTestKernel<alpaka::AccGpuHipRt<TDim, TIdx>, unsigned long int>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(
         alpaka::AccGpuHipRt<TDim, TIdx> const& acc,
@@ -673,12 +636,10 @@ public:
     }
 };
 
-//#############################################################################
 template<typename TDim, typename TIdx>
 class AtomicTestKernel<alpaka::AccGpuHipRt<TDim, TIdx>, unsigned long long int>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(
         alpaka::AccGpuHipRt<TDim, TIdx> const& acc,
@@ -710,12 +671,10 @@ public:
     }
 };
 
-//#############################################################################
 template<typename TDim, typename TIdx>
 class AtomicTestKernel<alpaka::AccGpuHipRt<TDim, TIdx>, float>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(alpaka::AccGpuHipRt<TDim, TIdx> const& acc, bool* success, float operandOrig) const
         -> void
@@ -744,12 +703,10 @@ public:
     }
 };
 
-//#############################################################################
 template<typename TDim, typename TIdx>
 class AtomicTestKernel<alpaka::AccGpuHipRt<TDim, TIdx>, double>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(alpaka::AccGpuHipRt<TDim, TIdx> const& acc, bool* success, double operandOrig) const
         -> void
@@ -779,7 +736,6 @@ public:
     }
 };
 
-//#############################################################################
 template<typename TDim, typename TIdx, typename T>
 class AtomicTestKernel<
     alpaka::AccGpuHipRt<TDim, TIdx>,
@@ -790,7 +746,6 @@ class AtomicTestKernel<
         && !std::is_same<float, T>::value && !std::is_same<double, T>::value>>
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(alpaka::AccGpuHipRt<TDim, TIdx> const& acc, bool* success, T operandOrig) const
         -> void
@@ -805,11 +760,9 @@ public:
 #endif
 
 
-//#############################################################################
 template<typename TAcc, typename T>
 struct TestAtomicOperations
 {
-    //-----------------------------------------------------------------------------
     static auto testAtomicOperations() -> void
     {
         using Dim = alpaka::Dim<TAcc>;
@@ -826,7 +779,6 @@ struct TestAtomicOperations
 
 using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, std::size_t>;
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("atomicOperationsWorking", "[atomic]", TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/block/shared/src/BlockSharedMemDyn.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemDyn.cpp
@@ -14,11 +14,9 @@
 
 #include <catch2/catch.hpp>
 
-//#############################################################################
 class BlockSharedMemDynTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -41,12 +39,10 @@ namespace alpaka
 {
     namespace traits
     {
-        //#############################################################################
         //! The trait for getting the size of the block shared dynamic memory for a kernel.
         template<typename TAcc>
         struct BlockSharedMemDynSizeBytes<BlockSharedMemDynTestKernel, TAcc>
         {
-            //-----------------------------------------------------------------------------
             //! \return The size of the shared memory allocated for a block.
             template<typename TVec>
             ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
@@ -64,7 +60,6 @@ namespace alpaka
     } // namespace traits
 } // namespace alpaka
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("sameNonNullAdress", "[blockSharedMemDyn]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/block/shared/src/BlockSharedMemSt.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemSt.cpp
@@ -15,11 +15,9 @@
 
 #include <catch2/catch.hpp>
 
-//#############################################################################
 class BlockSharedMemStNonNullTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -63,7 +61,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("nonNull", "[blockSharedMemSt]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
@@ -78,11 +75,9 @@ TEMPLATE_LIST_TEST_CASE("nonNull", "[blockSharedMemSt]", alpaka::test::TestAccs)
     REQUIRE(fixture(kernel));
 }
 
-//#############################################################################
 class BlockSharedMemStSameTypeAdressVerificationTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -129,7 +124,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("sameTypeAddressVerification", "[blockSharedMemSt]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/block/sync/src/BlockSync.cpp
+++ b/test/unit/block/sync/src/BlockSync.cpp
@@ -13,13 +13,11 @@
 
 #include <catch2/catch.hpp>
 
-//#############################################################################
 class BlockSyncTestKernel
 {
 public:
     static const std::uint8_t gridThreadExtentPerDim = 4u;
 
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -53,12 +51,10 @@ namespace alpaka
 {
     namespace traits
     {
-        //#############################################################################
         //! The trait for getting the size of the block shared dynamic memory for a kernel.
         template<typename TAcc>
         struct BlockSharedMemDynSizeBytes<BlockSyncTestKernel, TAcc>
         {
-            //-----------------------------------------------------------------------------
             //! \return The size of the shared memory allocated for a block.
             template<typename TVec>
             ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
@@ -78,7 +74,6 @@ namespace alpaka
     } // namespace traits
 } // namespace alpaka
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("synchronize", "[blockSync]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/block/sync/src/BlockSyncPredicate.cpp
+++ b/test/unit/block/sync/src/BlockSyncPredicate.cpp
@@ -13,11 +13,9 @@
 
 #include <catch2/catch.hpp>
 
-//#############################################################################
 class BlockSyncPredicateTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -83,7 +81,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("synchronizePredicate", "[blockSync]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/core/src/BoostPredefTest.cpp
+++ b/test/unit/core/src/BoostPredefTest.cpp
@@ -13,7 +13,6 @@
 
 #include <iostream>
 
-//-----------------------------------------------------------------------------
 TEST_CASE("printDefines", "[core]")
 {
 #if BOOST_LANG_CUDA

--- a/test/unit/core/src/ClipCastTest.cpp
+++ b/test/unit/core/src/ClipCastTest.cpp
@@ -11,7 +11,6 @@
 
 #include <catch2/catch.hpp>
 
-//-----------------------------------------------------------------------------
 TEST_CASE("clipCastNoCastShouldNotChangeTheValue", "[core]")
 {
     CHECK(
@@ -28,7 +27,6 @@ TEST_CASE("clipCastNoCastShouldNotChangeTheValue", "[core]")
         == alpaka::core::clipCast<std::uint64_t>(std::numeric_limits<std::uint64_t>::max()));
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("clipCastUpCastEqualSigndnessShouldNotChangeTheValue", "[core]")
 {
     CHECK(
@@ -42,7 +40,6 @@ TEST_CASE("clipCastUpCastEqualSigndnessShouldNotChangeTheValue", "[core]")
         == alpaka::core::clipCast<std::int64_t>(std::numeric_limits<std::int32_t>::min()));
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("clipCastUpCastDifferentSigndnessShouldNotChangeTheValueForPositives", "[core]")
 {
     CHECK(
@@ -56,7 +53,6 @@ TEST_CASE("clipCastUpCastDifferentSigndnessShouldNotChangeTheValueForPositives",
         == alpaka::core::clipCast<std::uint64_t>(std::numeric_limits<std::int32_t>::max()));
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("clipCastUpCastDifferentSigndnessCanChangeTheValueForNegatives", "[core]")
 {
     CHECK(
@@ -70,7 +66,6 @@ TEST_CASE("clipCastUpCastDifferentSigndnessCanChangeTheValueForNegatives", "[cor
         == alpaka::core::clipCast<std::uint64_t>(std::numeric_limits<std::int32_t>::min()));
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("clipCastDownCastEqualSigndnessCanChangeTheValue", "[core]")
 {
     CHECK(
@@ -87,7 +82,6 @@ TEST_CASE("clipCastDownCastEqualSigndnessCanChangeTheValue", "[core]")
         == alpaka::core::clipCast<std::int8_t>(std::numeric_limits<std::int64_t>::min()));
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("clipCastDownCastDifferentSigndnessCanChangeTheValue", "[core]")
 {
     CHECK(

--- a/test/unit/core/src/ConceptsTest.cpp
+++ b/test/unit/core/src/ConceptsTest.cpp
@@ -66,7 +66,6 @@ struct ImplementerNonMatchingTaggedTaggedToBase
 {
 };
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ImplementerNotTagged", "[core]")
 {
     using ImplementationBase = alpaka::concepts::ImplementationBase<ConceptExample, ImplementerNotTagged>;
@@ -76,7 +75,6 @@ TEST_CASE("ImplementerNotTagged", "[core]")
         "alpaka::concepts::ImplementationBase failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ImplementerNotTaggedButNonMatchingTagged", "[core]")
 {
     using ImplementationBase
@@ -87,7 +85,6 @@ TEST_CASE("ImplementerNotTaggedButNonMatchingTagged", "[core]")
         "alpaka::concepts::ImplementationBase failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ImplementerTagged", "[core]")
 {
     using ImplementationBase = alpaka::concepts::ImplementationBase<ConceptExample, ImplementerTagged>;
@@ -97,7 +94,6 @@ TEST_CASE("ImplementerTagged", "[core]")
         "alpaka::concepts::ImplementationBase failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ImplementerTaggedButAlsoNonMatchingTagged", "[core]")
 {
     using ImplementationBase
@@ -108,7 +104,6 @@ TEST_CASE("ImplementerTaggedButAlsoNonMatchingTagged", "[core]")
         "alpaka::concepts::ImplementationBase failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ImplementerWithTaggedBaseAlsoNonMatchingTagged", "[core]")
 {
     using ImplementationBase
@@ -119,7 +114,6 @@ TEST_CASE("ImplementerWithTaggedBaseAlsoNonMatchingTagged", "[core]")
         "alpaka::concepts::ImplementationBase failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ImplementerWithTaggedBase", "[core]")
 {
     using ImplementationBase = alpaka::concepts::ImplementationBase<ConceptExample, ImplementerWithTaggedBase>;
@@ -129,7 +123,6 @@ TEST_CASE("ImplementerWithTaggedBase", "[core]")
         "alpaka::concepts::ImplementationBase failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ImplementerTaggedToBase", "[core]")
 {
     using ImplementationBase = alpaka::concepts::ImplementationBase<ConceptExample, ImplementerTaggedToBase>;
@@ -139,7 +132,6 @@ TEST_CASE("ImplementerTaggedToBase", "[core]")
         "alpaka::concepts::ImplementationBase failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ImplementerTaggedToBaseAlsoNonMatchingTagged", "[core]")
 {
     using ImplementationBase
@@ -150,7 +142,6 @@ TEST_CASE("ImplementerTaggedToBaseAlsoNonMatchingTagged", "[core]")
         "alpaka::concepts::ImplementationBase failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ImplementerNonMatchingTaggedTaggedToBase", "[core]")
 {
     using ImplementationBase

--- a/test/unit/core/src/OmpScheduleTest.cpp
+++ b/test/unit/core/src/OmpScheduleTest.cpp
@@ -12,14 +12,12 @@
 
 #include <catch2/catch.hpp>
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ompScheduleDefaultConstructor", "[core]")
 {
     auto const schedule = alpaka::omp::Schedule{};
     alpaka::ignore_unused(schedule);
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ompScheduleConstructor", "[core]")
 {
     auto const staticSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Static, 5};
@@ -29,21 +27,18 @@ TEST_CASE("ompScheduleConstructor", "[core]")
     alpaka::ignore_unused(guidedSchedule);
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ompScheduleConstexprConstructor", "[core]")
 {
     constexpr auto schedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Dynamic};
     alpaka::ignore_unused(schedule);
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ompGetSchedule", "[core]")
 {
     auto const schedule = alpaka::omp::getSchedule();
     alpaka::ignore_unused(schedule);
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ompSetSchedule", "[core]")
 {
     auto const expectedSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Dynamic, 3};
@@ -56,7 +51,6 @@ TEST_CASE("ompSetSchedule", "[core]")
 #endif
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("ompSetNoSchedule", "[core]")
 {
     auto const expectedSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Guided, 2};

--- a/test/unit/dev/src/DevWarpSizeTest.cpp
+++ b/test/unit/dev/src/DevWarpSizeTest.cpp
@@ -12,7 +12,6 @@
 
 #include <catch2/catch.hpp>
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("getWarpSize", "[dev]", alpaka::test::TestAccs)
 {
     using Dev = alpaka::Dev<TestType>;

--- a/test/unit/event/src/EventTest.cpp
+++ b/test/unit/event/src/EventTest.cpp
@@ -23,7 +23,6 @@ using TestQueues = alpaka::meta::Concatenate<
 #endif
     >;
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("eventTestShouldInitiallyBeTrue", "[event]", TestQueues)
 {
     using DevQueue = TestType;
@@ -36,7 +35,6 @@ TEMPLATE_LIST_TEST_CASE("eventTestShouldInitiallyBeTrue", "[event]", TestQueues)
     REQUIRE(alpaka::isComplete(event));
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("eventTestShouldBeFalseWhileInQueueAndTrueAfterBeingProcessed", "[event]", TestQueues)
 {
     using DevQueue = TestType;
@@ -76,7 +74,6 @@ TEMPLATE_LIST_TEST_CASE("eventTestShouldBeFalseWhileInQueueAndTrueAfterBeingProc
     }
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfNobodyWaitsFor", "[event]", TestQueues)
 {
     using DevQueue = TestType;
@@ -136,7 +133,6 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfNobodyWaitsFor", "[even
     }
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfSomeoneWaitsFor", "[event]", TestQueues)
 {
     using DevQueue = TestType;
@@ -213,7 +209,6 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfSomeoneWaitsFor", "[eve
 }
 
 
-//-----------------------------------------------------------------------------
 // github issue #388
 TEMPLATE_LIST_TEST_CASE("waitForEventThatAlreadyFinishedShouldBeSkipped", "[event]", TestQueues)
 {

--- a/test/unit/idx/src/MapIdx.cpp
+++ b/test/unit/idx/src/MapIdx.cpp
@@ -15,7 +15,6 @@
 
 #include <catch2/catch.hpp>
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("mapIdx", "[idx]", alpaka::test::TestDims)
 {
     using Dim = TestType;

--- a/test/unit/idx/src/MapIdxPitchBytes.cpp
+++ b/test/unit/idx/src/MapIdxPitchBytes.cpp
@@ -18,7 +18,6 @@
 
 #include <catch2/catch.hpp>
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("mapIdxPitchBytes", "[idx]", alpaka::test::TestDims)
 {
     using Dim = TestType;

--- a/test/unit/intrinsic/src/Ffs.cpp
+++ b/test/unit/intrinsic/src/Ffs.cpp
@@ -17,12 +17,10 @@
 #include <cstdint>
 #include <limits>
 
-//#############################################################################
 template<typename TInput>
 class FfsTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -63,7 +61,6 @@ private:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("ffs", "[intrinsic]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/intrinsic/src/Popcount.cpp
+++ b/test/unit/intrinsic/src/Popcount.cpp
@@ -14,12 +14,10 @@
 
 #include <catch2/catch.hpp>
 
-//#############################################################################
 template<typename TInput>
 class PopcountTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -57,7 +55,6 @@ private:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("popcount", "[intrinsic]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/kernel/src/KernelGenericLambda.cpp
+++ b/test/unit/kernel/src/KernelGenericLambda.cpp
@@ -16,7 +16,6 @@
 // CUDA C Programming guide says: "__host__ __device__ extended lambdas cannot be generic lambdas"
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("genericLambdaKernelIsWorking", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
@@ -34,7 +33,6 @@ TEMPLATE_LIST_TEST_CASE("genericLambdaKernelIsWorking", "[kernel]", alpaka::test
     REQUIRE(fixture(kernel));
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("variadicGenericLambdaKernelIsWorking", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/kernel/src/KernelLambda.cpp
+++ b/test/unit/kernel/src/KernelLambda.cpp
@@ -17,7 +17,6 @@
 
 #    include <catch2/catch.hpp>
 
-//-----------------------------------------------------------------------------
 struct TestTemplateLambda
 {
     template<typename TAcc>
@@ -45,7 +44,6 @@ struct TestTemplateLambda
     }
 };
 
-//-----------------------------------------------------------------------------
 struct TestTemplateArg
 {
     template<typename TAcc>
@@ -67,7 +65,6 @@ struct TestTemplateArg
     }
 };
 
-//-----------------------------------------------------------------------------
 struct TestTemplateCapture
 {
     template<typename TAcc>

--- a/test/unit/kernel/src/KernelStdFunction.cpp
+++ b/test/unit/kernel/src/KernelStdFunction.cpp
@@ -24,7 +24,6 @@ TEST_UNIT_KERNEL_KERNEL_STD_FUNCTION
 #    include <nvfunctional>
 #endif
 
-//-----------------------------------------------------------------------------
 template<typename Acc>
 void ALPAKA_FN_ACC kernelFn(Acc const& acc, bool* success, std::int32_t val)
 {
@@ -35,7 +34,6 @@ void ALPAKA_FN_ACC kernelFn(Acc const& acc, bool* success, std::int32_t val)
 
 // std::function and std::bind is only allowed on CPU
 #if !BOOST_LANG_CUDA && !BOOST_LANG_HIP
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("stdFunctionKernelIsWorking", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
@@ -48,7 +46,6 @@ TEMPLATE_LIST_TEST_CASE("stdFunctionKernelIsWorking", "[kernel]", alpaka::test::
     REQUIRE(fixture(kernel, 42));
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("stdBindKernelIsWorking", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
@@ -68,7 +65,6 @@ TEMPLATE_LIST_TEST_CASE("stdBindKernelIsWorking", "[kernel]", alpaka::test::Test
 // clang as a native CUDA compiler does not seem to support nvstd::function when ALPAKA_ACC_GPU_CUDA_ONLY_MODE is used.
 // error: reference to __device__ function 'kernelFn<alpaka::AccGpuCudaRt<std::__1::integral_constant<unsigned long, 1>, unsigned long> >' in __host__ function const auto kernel = nvstd::function<void(Acc const &, bool *, std::int32_t)>( kernelFn<Acc> );
 #    if !(defined(ALPAKA_ACC_GPU_CUDA_ONLY_MODE) && BOOST_COMP_CLANG_CUDA)
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE( "nvstdFunctionKernelIsWorking", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/kernel/src/KernelWithAdditionalParam.cpp
+++ b/test/unit/kernel/src/KernelWithAdditionalParam.cpp
@@ -14,11 +14,9 @@
 
 #include <catch2/catch.hpp>
 
-//#############################################################################
 class KernelWithAdditionalParamByValue
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, std::int32_t val) const -> void
@@ -29,7 +27,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("KernelWithAdditionalParamByValue", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
@@ -48,11 +45,9 @@ Passing a parameter by reference to non-const is not allowed.
 There is only one single copy of the parameters on the CPU accelerators.
 They are shared between all threads. Therefore they should not be mutated.
 
-//#############################################################################
 class KernelWithAdditionalParamByRef
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template <typename TAcc>
     ALPAKA_FN_ACC auto operator()(
@@ -65,7 +60,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("KernelWithAdditionalParamByRef", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
@@ -80,11 +74,9 @@ TEMPLATE_LIST_TEST_CASE("KernelWithAdditionalParamByRef", "[kernel]", alpaka::te
     REQUIRE(fixture(kernel, 42));
 }*/
 
-//#############################################################################
 class KernelWithAdditionalParamByConstRef
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, std::int32_t const& val) const -> void
@@ -95,7 +87,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("KernelWithAdditionalParamByConstRef", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/kernel/src/KernelWithConstructorAndMember.cpp
+++ b/test/unit/kernel/src/KernelWithConstructorAndMember.cpp
@@ -14,16 +14,13 @@
 
 #include <catch2/catch.hpp>
 
-//#############################################################################
 class KernelWithConstructorAndMember
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_FN_HOST KernelWithConstructorAndMember(std::int32_t const val = 42) : m_val(val)
     {
     }
 
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -37,7 +34,6 @@ private:
     std::int32_t m_val;
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("kernelWithConstructorAndMember", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
@@ -51,7 +47,6 @@ TEMPLATE_LIST_TEST_CASE("kernelWithConstructorAndMember", "[kernel]", alpaka::te
     REQUIRE(fixture(kernel));
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("kernelWithConstructorDefaultParamAndMember", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/kernel/src/KernelWithHostConstexpr.cpp
+++ b/test/unit/kernel/src/KernelWithHostConstexpr.cpp
@@ -16,11 +16,9 @@
 
 #include <limits>
 
-//#############################################################################
 class KernelWithHostConstexpr
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -41,7 +39,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("kernelWithHostConstexpr", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -16,14 +16,12 @@
 
 #include <cstdint>
 
-//#############################################################################
 // Schedule to be used by all kernels in this file
 static constexpr auto expectedSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Dynamic, 10};
 
 // Base kernel, not to be used directly in unit tests
 struct KernelWithOmpScheduleBase
 {
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -120,25 +118,21 @@ void test()
     REQUIRE(fixture(kernel));
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("kernelWithConstexprMemberOmpSchedule", "[kernel]", alpaka::test::TestAccs)
 {
     test<TestType, KernelWithConstexprMemberOmpSchedule>();
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("kernelWithMemberOmpSchedule", "[kernel]", alpaka::test::TestAccs)
 {
     test<TestType, KernelWithMemberOmpSchedule>();
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("kernelWithTraitOmpSchedule", "[kernel]", alpaka::test::TestAccs)
 {
     test<TestType, KernelWithTraitOmpSchedule>();
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("kernelWithMemberAndTraitOmpSchedule", "[kernel]", alpaka::test::TestAccs)
 {
     test<TestType, KernelWithMemberAndTraitOmpSchedule>();

--- a/test/unit/kernel/src/KernelWithTemplate.cpp
+++ b/test/unit/kernel/src/KernelWithTemplate.cpp
@@ -16,12 +16,10 @@
 
 #include <type_traits>
 
-//#############################################################################
 template<typename T>
 class KernelFuntionObjectTemplate
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -34,7 +32,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("kernelFuntionObjectTemplate", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
@@ -48,11 +45,9 @@ TEMPLATE_LIST_TEST_CASE("kernelFuntionObjectTemplate", "[kernel]", alpaka::test:
     REQUIRE(fixture(kernel));
 }
 
-//#############################################################################
 class KernelInvocationWithAdditionalTemplate
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc, typename T>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, T const&) const -> void
@@ -65,7 +60,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("kernelFuntionObjectExtraTemplate", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/kernel/src/KernelWithTemplateArgumentDeduction.cpp
+++ b/test/unit/kernel/src/KernelWithTemplateArgumentDeduction.cpp
@@ -16,12 +16,10 @@
 
 #include <type_traits>
 
-//#############################################################################
 template<typename TExpected>
 class KernelInvocationTemplateDeductionValueSemantics
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename Acc, typename TByValue, typename TByConstValue, typename TByConstReference>
     ALPAKA_FN_ACC auto operator()(
@@ -47,7 +45,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("kernelFuntionObjectTemplateDeductionFromValue", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
@@ -94,12 +91,10 @@ TEMPLATE_LIST_TEST_CASE("kernelFuntionObjectTemplateDeductionFromConstReference"
     REQUIRE(fixture(kernel, constReference, constReference, constReference));
 }
 
-//#############################################################################
 template<typename TExpectedFirst, typename TExpectedSecond = TExpectedFirst>
 class KernelInvocationTemplateDeductionPointerSemantics
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename Acc, typename TByPointer, typename TByPointerToConst>
     ALPAKA_FN_ACC auto operator()(Acc const& acc, bool* success, TByPointer*, TByPointerToConst const*) const -> void
@@ -117,7 +112,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("kernelFuntionObjectTemplateDeductionFromPointer", "[kernel]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/kernel/src/KernelWithoutTemplatedAccParam.cpp
+++ b/test/unit/kernel/src/KernelWithoutTemplatedAccParam.cpp
@@ -12,7 +12,6 @@
 
 #include <catch2/catch.hpp>
 
-//#############################################################################
 //! It is not possible to use a alpaka kernel function object without a templated operator() when the CUDA accelerator
 //! is hard-coded.
 //!
@@ -42,10 +41,8 @@ using AccGpu = alpaka::AccGpuCudaRt<Dim, Idx>;
 #endif
 
 #if defined(ALPAKA_ACC_CPU_SERIAL_ENABLED)
-//#############################################################################
 struct KernelNoTemplateCpu
 {
-    //-----------------------------------------------------------------------------
     ALPAKA_FN_ACC
     auto operator()(AccCpu const& acc, bool* success) const -> void
     {
@@ -55,7 +52,6 @@ struct KernelNoTemplateCpu
     }
 };
 
-//-----------------------------------------------------------------------------
 TEST_CASE("kernelNoTemplateCpu", "[kernel]")
 {
     alpaka::test::KernelExecutionFixture<AccCpu> fixture(alpaka::Vec<Dim, Idx>::ones());
@@ -67,11 +63,9 @@ TEST_CASE("kernelNoTemplateCpu", "[kernel]")
 #endif
 
 /*#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA
-//#############################################################################
 //! DO NOT ENABLE! COMPILATION WILL FAIL!
 struct KernelNoTemplateGpu
 {
-    //-----------------------------------------------------------------------------
     ALPAKA_FN_ACC
     auto operator()(
         AccGpu const & acc,
@@ -84,7 +78,6 @@ struct KernelNoTemplateGpu
     }
 };
 
-//-----------------------------------------------------------------------------
 TEST_CASE("kernelNoTemplateGpu", "[kernel]")
 {
     alpaka::test::KernelExecutionFixture<AccGpu> fixture(
@@ -97,10 +90,8 @@ TEST_CASE("kernelNoTemplateGpu", "[kernel]")
 #endif*/
 
 #if defined(ALPAKA_ACC_CPU_SERIAL_ENABLED)
-//#############################################################################
 struct KernelWithoutTemplateParamCpu
 {
-    //-----------------------------------------------------------------------------
     template<typename TNotUsed = void>
     ALPAKA_FN_ACC auto operator()(AccCpu const& acc, bool* success) const -> void
     {
@@ -110,7 +101,6 @@ struct KernelWithoutTemplateParamCpu
     }
 };
 
-//-----------------------------------------------------------------------------
 TEST_CASE("kernelWithoutTemplateParamCpu", "[kernel]")
 {
     alpaka::test::KernelExecutionFixture<AccCpu> fixture(alpaka::Vec<Dim, Idx>::ones());
@@ -122,10 +112,8 @@ TEST_CASE("kernelWithoutTemplateParamCpu", "[kernel]")
 #endif
 
 #if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
-//#############################################################################
 struct KernelWithoutTemplateParamGpu
 {
-    //-----------------------------------------------------------------------------
     template<typename TNotUsed = void>
     ALPAKA_FN_ACC auto operator()(AccGpu const& acc, bool* success) const -> void
     {
@@ -135,7 +123,6 @@ struct KernelWithoutTemplateParamGpu
     }
 };
 
-//-----------------------------------------------------------------------------
 TEST_CASE("kernelWithoutTemplateParamGpu", "[kernel]")
 {
     alpaka::test::KernelExecutionFixture<AccGpu> fixture(alpaka::Vec<Dim, Idx>::ones());

--- a/test/unit/math/src/math.cpp
+++ b/test/unit/math/src/math.cpp
@@ -46,7 +46,6 @@ struct TestKernel
     }
 };
 
-//#############################################################################
 template<typename TAcc, typename TFunctor>
 struct TestTemplate
 {

--- a/test/unit/math/src/sincos.cpp
+++ b/test/unit/math/src/sincos.cpp
@@ -35,7 +35,6 @@ ALPAKA_FN_ACC std::enable_if_t<!std::numeric_limits<FP>::is_integer, bool> almos
 class SinCosTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc, typename FP>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, FP const arg) const -> void
@@ -55,7 +54,6 @@ public:
 
 using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, std::size_t>;
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("sincos", "[sincos]", TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -18,7 +18,6 @@
 #include <numeric>
 #include <type_traits>
 
-//-----------------------------------------------------------------------------
 template<typename TAcc>
 static auto testBufferMutable(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
 {
@@ -33,19 +32,15 @@ static auto testBufferMutable(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> 
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
     Queue queue(dev);
 
-    //-----------------------------------------------------------------------------
     // alpaka::malloc
     auto buf(alpaka::allocBuf<Elem, Idx>(dev, extent));
 
-    //-----------------------------------------------------------------------------
     auto const offset(alpaka::Vec<Dim, Idx>::zeros());
     alpaka::test::testViewImmutable<Elem>(buf, dev, extent, offset);
 
-    //-----------------------------------------------------------------------------
     alpaka::test::testViewMutable<TAcc>(queue, buf);
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("memBufBasicTest", "[memBuf]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
@@ -58,7 +53,6 @@ TEMPLATE_LIST_TEST_CASE("memBufBasicTest", "[memBuf]", alpaka::test::TestAccs)
     testBufferMutable<Acc>(extent);
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("memBufZeroSizeTest", "[memBuf]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
@@ -71,7 +65,6 @@ TEMPLATE_LIST_TEST_CASE("memBufZeroSizeTest", "[memBuf]", alpaka::test::TestAccs
 }
 
 
-//-----------------------------------------------------------------------------
 template<typename TAcc>
 static auto testBufferImmutable(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
 {
@@ -84,16 +77,13 @@ static auto testBufferImmutable(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>
 
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
-    //-----------------------------------------------------------------------------
     // alpaka::malloc
     auto const buf(alpaka::allocBuf<Elem, Idx>(dev, extent));
 
-    //-----------------------------------------------------------------------------
     auto const offset(alpaka::Vec<Dim, Idx>::zeros());
     alpaka::test::testViewImmutable<Elem>(buf, dev, extent, offset);
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("memBufConstTest", "[memBuf]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/mem/p2p/src/P2P.cpp
+++ b/test/unit/mem/p2p/src/P2P.cpp
@@ -19,7 +19,6 @@
 #include <numeric>
 #include <type_traits>
 
-//-----------------------------------------------------------------------------
 template<typename TAcc>
 static auto testP2P(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
 {
@@ -41,21 +40,17 @@ static auto testP2P(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& ext
     Dev const dev1(alpaka::getDevByIdx<Pltf>(1u));
     Queue queue0(dev0);
 
-    //-----------------------------------------------------------------------------
     auto buf0(alpaka::allocBuf<Elem, Idx>(dev0, extent));
     auto buf1(alpaka::allocBuf<Elem, Idx>(dev1, extent));
 
-    //-----------------------------------------------------------------------------
     std::uint8_t const byte(static_cast<uint8_t>(42u));
     alpaka::memset(queue0, buf0, byte, extent);
 
-    //-----------------------------------------------------------------------------
     alpaka::memcpy(queue0, buf1, buf0, extent);
     alpaka::wait(queue0);
     alpaka::test::verifyBytesSet<TAcc>(buf1, byte);
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("memP2PTest", "[memP2P]", alpaka::test::TestAccs)
 {
 #if defined(ALPAKA_CI) && BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(7, 2, 0)                                            \

--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -30,7 +30,6 @@ namespace alpaka
 {
     namespace test
     {
-        //-----------------------------------------------------------------------------
         template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx>
         auto testViewPlainPtrImmutable(
             alpaka::ViewPlainPtr<TDev, TElem, TDim, TIdx> const& view,
@@ -38,11 +37,9 @@ namespace alpaka
             alpaka::Vec<TDim, TIdx> const& extentView,
             alpaka::Vec<TDim, TIdx> const& offsetView) -> void
         {
-            //-----------------------------------------------------------------------------
             alpaka::test::testViewImmutable<TElem>(view, dev, extentView, offsetView);
         }
 
-        //-----------------------------------------------------------------------------
         template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx>
         auto testViewPlainPtrMutable(
             alpaka::ViewPlainPtr<TDev, TElem, TDim, TIdx>& view,
@@ -50,16 +47,13 @@ namespace alpaka
             alpaka::Vec<TDim, TIdx> const& extentView,
             alpaka::Vec<TDim, TIdx> const& offsetView) -> void
         {
-            //-----------------------------------------------------------------------------
             testViewPlainPtrImmutable<TAcc>(view, dev, extentView, offsetView);
 
             using Queue = alpaka::test::DefaultQueue<TDev>;
             Queue queue(dev);
-            //-----------------------------------------------------------------------------
             alpaka::test::testViewMutable<TAcc>(queue, view);
         }
 
-        //-----------------------------------------------------------------------------
         template<typename TAcc, typename TElem>
         auto testViewPlainPtr() -> void
         {
@@ -87,7 +81,6 @@ namespace alpaka
             alpaka::test::testViewPlainPtrMutable<TAcc>(view, dev, extentView, offsetView);
         }
 
-        //-----------------------------------------------------------------------------
         template<typename TAcc, typename TElem>
         auto testViewPlainPtrConst() -> void
         {
@@ -115,7 +108,6 @@ namespace alpaka
             alpaka::test::testViewPlainPtrImmutable<TAcc>(view, dev, extentView, offsetView);
         }
 
-        //-----------------------------------------------------------------------------
         template<typename TAcc, typename TElem>
         auto testViewPlainPtrOperators() -> void
         {
@@ -150,19 +142,16 @@ namespace alpaka
 #    pragma GCC diagnostic pop
 #endif
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("viewPlainPtrTest", "[memView]", alpaka::test::TestAccs)
 {
     alpaka::test::testViewPlainPtr<TestType, float>();
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("viewPlainPtrConstTest", "[memView]", alpaka::test::TestAccs)
 {
     alpaka::test::testViewPlainPtrConst<TestType, float>();
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("viewPlainPtrOperatorTest", "[memView]", alpaka::test::TestAccs)
 {
     alpaka::test::testViewPlainPtrOperators<TestType, float>();

--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -31,7 +31,6 @@ ALPAKA_STATIC_ACC_MEM_CONSTANT Elem g_constantMemory2DInitialized[3][2] = {{0u, 
 
 ALPAKA_STATIC_ACC_MEM_CONSTANT Elem g_constantMemory2DUninitialized[3][2];
 
-//#############################################################################
 //! Uses static device memory on the accelerator defined globally for the whole compilation unit.
 struct StaticDeviceMemoryTestKernel
 {
@@ -51,7 +50,6 @@ struct StaticDeviceMemoryTestKernel
 
 using TestAccs = alpaka::test::EnabledAccs<Dim, Idx>;
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAccs)
 {
     using Acc = TestType;
@@ -65,7 +63,6 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAc
 
     StaticDeviceMemoryTestKernel kernel;
 
-    //-----------------------------------------------------------------------------
     // FIXME: constant memory in HIP is still not working
 #if !BOOST_COMP_HIP
     // initialized static constant device memory
@@ -75,7 +72,6 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAc
 
         REQUIRE(fixture(kernel, alpaka::getPtrNative(viewConstantMemInitialized)));
     }
-    //-----------------------------------------------------------------------------
     // uninitialized static constant device memory
     {
         using PltfHost = alpaka::PltfCpu;
@@ -109,7 +105,6 @@ ALPAKA_STATIC_ACC_MEM_GLOBAL Elem g_globalMemory2DInitialized[3][2] = {{0u, 1u},
 
 ALPAKA_STATIC_ACC_MEM_GLOBAL Elem g_globalMemory2DUninitialized[3][2];
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryConstant", "[viewStaticAccMem]", TestAccs)
 {
     using Acc = TestType;
@@ -123,7 +118,6 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryConstant", "[viewStaticAccMem]", Test
 
     StaticDeviceMemoryTestKernel kernel;
 
-    //-----------------------------------------------------------------------------
     // FIXME: static device memory in HIP is still not working
 #if !BOOST_COMP_HIP
     // initialized static global device memory
@@ -134,7 +128,6 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryConstant", "[viewStaticAccMem]", Test
         REQUIRE(fixture(kernel, alpaka::getPtrNative(viewGlobalMemInitialized)));
     }
 
-    //-----------------------------------------------------------------------------
     // uninitialized static global device memory
     {
         using PltfHost = alpaka::PltfCpu;

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -29,7 +29,6 @@ namespace alpaka
 {
     namespace test
     {
-        //-----------------------------------------------------------------------------
         template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx, typename TBuf>
         auto testViewSubViewImmutable(
             alpaka::ViewSubView<TDev, TElem, TDim, TIdx> const& view,
@@ -38,10 +37,8 @@ namespace alpaka
             alpaka::Vec<TDim, TIdx> const& extentView,
             alpaka::Vec<TDim, TIdx> const& offsetView) -> void
         {
-            //-----------------------------------------------------------------------------
             alpaka::test::testViewImmutable<TElem>(view, dev, extentView, offsetView);
 
-            //-----------------------------------------------------------------------------
             // alpaka::traits::GetPitchBytes
             // The pitch of the view has to be identical to the pitch of the underlying buffer in all dimensions.
             {
@@ -54,7 +51,6 @@ namespace alpaka
                 }
             }
 
-            //-----------------------------------------------------------------------------
             // alpaka::traits::GetPtrNative
             // The native pointer has to be exactly the value we calculate here.
             {
@@ -70,7 +66,6 @@ namespace alpaka
             }
         }
 
-        //-----------------------------------------------------------------------------
         template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx, typename TBuf>
         auto testViewSubViewMutable(
             alpaka::ViewSubView<TDev, TElem, TDim, TIdx>& view,
@@ -79,16 +74,13 @@ namespace alpaka
             alpaka::Vec<TDim, TIdx> const& extentView,
             alpaka::Vec<TDim, TIdx> const& offsetView) -> void
         {
-            //-----------------------------------------------------------------------------
             testViewSubViewImmutable<TAcc>(view, buf, dev, extentView, offsetView);
 
             using Queue = alpaka::test::DefaultQueue<TDev>;
             Queue queue(dev);
-            //-----------------------------------------------------------------------------
             alpaka::test::testViewMutable<TAcc>(queue, view);
         }
 
-        //-----------------------------------------------------------------------------
         template<typename TAcc, typename TElem>
         auto testViewSubViewNoOffset() -> void
         {
@@ -112,7 +104,6 @@ namespace alpaka
             alpaka::test::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
         }
 
-        //-----------------------------------------------------------------------------
         template<typename TAcc, typename TElem>
         auto testViewSubViewOffset() -> void
         {
@@ -138,7 +129,6 @@ namespace alpaka
             alpaka::test::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
         }
 
-        //-----------------------------------------------------------------------------
         template<typename TAcc, typename TElem>
         auto testViewSubViewOffsetConst() -> void
         {
@@ -169,19 +159,16 @@ namespace alpaka
 #    pragma GCC diagnostic pop
 #endif
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("viewSubViewNoOffsetTest", "[memView]", alpaka::test::TestAccs)
 {
     alpaka::test::testViewSubViewNoOffset<TestType, float>();
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("viewSubViewOffsetTest", "[memView]", alpaka::test::TestAccs)
 {
     alpaka::test::testViewSubViewOffset<TestType, float>();
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("viewSubViewOffsetConstTest", "[memView]", alpaka::test::TestAccs)
 {
     alpaka::test::testViewSubViewOffsetConst<TestType, float>();

--- a/test/unit/meta/src/ApplyTest.cpp
+++ b/test/unit/meta/src/ApplyTest.cpp
@@ -19,7 +19,6 @@ struct TypeList
 {
 };
 
-//-----------------------------------------------------------------------------
 TEST_CASE("apply", "[meta]")
 {
     using ApplyInput = std::tuple<int, float, long>;

--- a/test/unit/meta/src/ApplyTupleTest.cpp
+++ b/test/unit/meta/src/ApplyTupleTest.cpp
@@ -11,7 +11,6 @@
 
 #include <catch2/catch.hpp>
 
-//#############################################################################
 struct Foo
 {
     Foo(int num) : num_(num)
@@ -24,14 +23,12 @@ struct Foo
     int num_;
 };
 
-//-----------------------------------------------------------------------------
 auto abs_num(int i) -> int;
 auto abs_num(int i) -> int
 {
     return std::abs(i);
 }
 
-//#############################################################################
 struct AbsNum
 {
     auto operator()(int i) const -> int
@@ -40,7 +37,6 @@ struct AbsNum
     }
 };
 
-//-----------------------------------------------------------------------------
 TEST_CASE("invoke", "[meta]")
 {
     // invoke a free function
@@ -60,21 +56,18 @@ TEST_CASE("invoke", "[meta]")
     REQUIRE(18 == alpaka::meta::invoke(AbsNum(), -18));
 }
 
-//-----------------------------------------------------------------------------
 auto add(int first, int second) -> int;
 auto add(int first, int second) -> int
 {
     return first + second;
 }
 
-//-----------------------------------------------------------------------------
 template<typename T>
 T add_generic(T first, T second)
 {
     return first + second;
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("applyTuple", "[meta]")
 {
     REQUIRE(3 == alpaka::meta::apply(add, std::make_tuple(1, 2)));

--- a/test/unit/meta/src/CartesianProductTest.cpp
+++ b/test/unit/meta/src/CartesianProductTest.cpp
@@ -15,7 +15,6 @@
 #include <tuple>
 #include <type_traits>
 
-//-----------------------------------------------------------------------------
 TEST_CASE("cartesianProduct", "[meta]")
 {
     using TestDims = std::tuple<alpaka::DimInt<1u>, alpaka::DimInt<2u>, alpaka::DimInt<3u>>;

--- a/test/unit/meta/src/ConcatenateTest.cpp
+++ b/test/unit/meta/src/ConcatenateTest.cpp
@@ -15,7 +15,6 @@
 #include <tuple>
 #include <type_traits>
 
-//-----------------------------------------------------------------------------
 TEST_CASE("concatenate", "[meta]")
 {
     using TestTuple1 = std::tuple<float, int, std::tuple<double, unsigned long>>;

--- a/test/unit/meta/src/FilterTest.cpp
+++ b/test/unit/meta/src/FilterTest.cpp
@@ -14,7 +14,6 @@
 #include <tuple>
 #include <type_traits>
 
-//-----------------------------------------------------------------------------
 TEST_CASE("filter", "[meta]")
 {
     using FilterInput = std::tuple<int, float, long>;

--- a/test/unit/meta/src/IntegralTest.cpp
+++ b/test/unit/meta/src/IntegralTest.cpp
@@ -13,7 +13,6 @@
 
 #include <type_traits>
 
-//-----------------------------------------------------------------------------
 TEST_CASE("isIntegralSupersetTrue", "[meta]")
 {
     // unsigned - unsigned
@@ -131,7 +130,6 @@ TEST_CASE("isIntegralSupersetTrue", "[meta]")
         "alpaka::meta::IsIntegralSuperset failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("isIntegralSupersetNoIntegral", "[meta]")
 {
     static_assert(
@@ -142,7 +140,6 @@ TEST_CASE("isIntegralSupersetNoIntegral", "[meta]")
         "alpaka::meta::IsIntegralSuperset failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("isIntegralSupersetFalse", "[meta]")
 {
     // unsigned - unsigned
@@ -260,7 +257,6 @@ TEST_CASE("isIntegralSupersetFalse", "[meta]")
         "alpaka::meta::IsIntegralSuperset failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("higherMax", "[meta]")
 {
     static_assert(
@@ -464,7 +460,6 @@ TEST_CASE("higherMax", "[meta]")
         "alpaka::meta::HigherMax failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("lowerMax", "[meta]")
 {
     static_assert(
@@ -668,7 +663,6 @@ TEST_CASE("lowerMax", "[meta]")
         "alpaka::meta::LowerMax failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("higherMin", "[meta]")
 {
     static_assert(
@@ -871,7 +865,6 @@ TEST_CASE("higherMin", "[meta]")
         std::is_same<alpaka::meta::HigherMin<std::uint64_t, std::uint64_t>, std::uint64_t>::value,
         "alpaka::meta::HigherMin failed!");
 }
-//-----------------------------------------------------------------------------
 TEST_CASE("lowerMin", "[meta]")
 {
     static_assert(

--- a/test/unit/meta/src/IsStrictBaseTest.cpp
+++ b/test/unit/meta/src/IsStrictBaseTest.cpp
@@ -24,7 +24,6 @@ class C
 {
 };
 
-//-----------------------------------------------------------------------------
 TEST_CASE("isStrictBaseTrue", "[meta]")
 {
     constexpr bool IsStrictBaseResult = alpaka::meta::IsStrictBase<A, B>::value;
@@ -34,7 +33,6 @@ TEST_CASE("isStrictBaseTrue", "[meta]")
     static_assert(IsStrictBaseReference == IsStrictBaseResult, "alpaka::meta::IsStrictBase failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("isStrictBaseIdentity", "[meta]")
 {
     constexpr bool IsStrictBaseResult = alpaka::meta::IsStrictBase<A, A>::value;
@@ -44,7 +42,6 @@ TEST_CASE("isStrictBaseIdentity", "[meta]")
     static_assert(IsStrictBaseReference == IsStrictBaseResult, "alpaka::meta::IsStrictBase failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("isStrictBaseNoInheritance", "[meta]")
 {
     constexpr bool IsStrictBaseResult = alpaka::meta::IsStrictBase<A, C>::value;
@@ -54,7 +51,6 @@ TEST_CASE("isStrictBaseNoInheritance", "[meta]")
     static_assert(IsStrictBaseReference == IsStrictBaseResult, "alpaka::meta::IsStrictBase failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("isStrictBaseWrongOrder", "[meta]")
 {
     constexpr bool IsStrictBaseResult = alpaka::meta::IsStrictBase<B, A>::value;

--- a/test/unit/meta/src/MetafunctionsTest.cpp
+++ b/test/unit/meta/src/MetafunctionsTest.cpp
@@ -14,7 +14,6 @@
 #include <tuple>
 #include <type_traits>
 
-//-----------------------------------------------------------------------------
 TEST_CASE("conjunctionTrue", "[meta]")
 {
     using ConjunctionResult
@@ -23,7 +22,6 @@ TEST_CASE("conjunctionTrue", "[meta]")
     static_assert(ConjunctionResult::value == true, "alpaka::meta::Conjunction failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("conjunctionFalse", "[meta]")
 {
     using ConjunctionResult
@@ -32,7 +30,6 @@ TEST_CASE("conjunctionFalse", "[meta]")
     static_assert(ConjunctionResult::value == false, "alpaka::meta::Conjunction failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("disjunctionTrue", "[meta]")
 {
     using DisjunctionResult
@@ -41,7 +38,6 @@ TEST_CASE("disjunctionTrue", "[meta]")
     static_assert(DisjunctionResult::value == true, "alpaka::meta::Disjunction failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("disjunctionFalse", "[meta]")
 {
     using DisjunctionResult
@@ -50,7 +46,6 @@ TEST_CASE("disjunctionFalse", "[meta]")
     static_assert(DisjunctionResult::value == false, "alpaka::meta::Disjunction failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("negationFalse", "[meta]")
 {
     using NegationResult = alpaka::meta::Negation<std::true_type>;
@@ -60,7 +55,6 @@ TEST_CASE("negationFalse", "[meta]")
     static_assert(std::is_same<NegationReference, NegationResult>::value, "alpaka::meta::Negation failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("negationTrue", "[meta]")
 {
     using NegationResult = alpaka::meta::Negation<std::false_type>;

--- a/test/unit/meta/src/SetTest.cpp
+++ b/test/unit/meta/src/SetTest.cpp
@@ -14,7 +14,6 @@
 #include <tuple>
 #include <type_traits>
 
-//-----------------------------------------------------------------------------
 TEST_CASE("isSetTrue", "[meta]")
 {
     using IsSetInput = std::tuple<int, float, long>;
@@ -26,7 +25,6 @@ TEST_CASE("isSetTrue", "[meta]")
     static_assert(IsSetReference == IsSetResult, "alpaka::meta::IsSet failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("isSetFalse", "[meta]")
 {
     using IsSetInput = std::tuple<int, float, int>;

--- a/test/unit/meta/src/TransformTest.cpp
+++ b/test/unit/meta/src/TransformTest.cpp
@@ -17,7 +17,6 @@
 template<typename T>
 using AddConst = T const;
 
-//-----------------------------------------------------------------------------
 TEST_CASE("transform", "[meta]")
 {
     using TransformInput = std::tuple<int, float, long>;
@@ -29,7 +28,6 @@ TEST_CASE("transform", "[meta]")
     static_assert(std::is_same<TransformReference, TransformResult>::value, "alpaka::meta::Transform failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("transformVariadic", "[meta]")
 {
     using TransformInput = std::tuple<int, float, long>;

--- a/test/unit/meta/src/UniqueTest.cpp
+++ b/test/unit/meta/src/UniqueTest.cpp
@@ -14,7 +14,6 @@
 #include <tuple>
 #include <type_traits>
 
-//-----------------------------------------------------------------------------
 TEST_CASE("uniqueWithDuplicate", "[meta]")
 {
     using UniqueInput = std::tuple<int, float, int, float, float, int>;
@@ -26,7 +25,6 @@ TEST_CASE("uniqueWithDuplicate", "[meta]")
     static_assert(std::is_same<UniqueReference, UniqueResult>::value, "alpaka::meta::Unique failed!");
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("uniqueWithoutDuplicate", "[meta]")
 {
     using UniqueInput = std::tuple<int, float, double>;

--- a/test/unit/meta/src/VoidTest.cpp
+++ b/test/unit/meta/src/VoidTest.cpp
@@ -14,22 +14,18 @@
 #include <type_traits>
 #include <vector>
 
-//-----------------------------------------------------------------------------
 TEST_CASE("voidNonEmpty", "[meta]")
 {
     using Result = alpaka::meta::Void<int, float, int>;
     REQUIRE(std::is_same<void, Result>::value);
 }
 
-//-----------------------------------------------------------------------------
 TEST_CASE("voidEmpty", "[meta]")
 {
     using Result = alpaka::meta::Void<>;
     REQUIRE(std::is_same<void, Result>::value);
 }
 
-//-----------------------------------------------------------------------------
-//#############################################################################
 //! Trait to detect if the given class has a method size().
 //! This illustrates and tests the technique of using Void<> to compile-time
 //! check for methods (and members can be treated similarly).

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -49,7 +49,6 @@ using TestQueues = alpaka::meta::Concatenate<
         CHECK(ret);                                                                                                   \
     } while(0)
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("queueIsInitiallyEmpty", "[queue]", TestQueues)
 {
     using DevQueue = TestType;
@@ -59,7 +58,6 @@ TEMPLATE_LIST_TEST_CASE("queueIsInitiallyEmpty", "[queue]", TestQueues)
     CHECK(alpaka::empty(f.m_queue));
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("queueCallbackIsWorking", "[queue]", TestQueues)
 {
 // Workaround: Clang can not support this when natively compiling device code. See ConcurrentExecPool.hpp.
@@ -76,7 +74,6 @@ TEMPLATE_LIST_TEST_CASE("queueCallbackIsWorking", "[queue]", TestQueues)
 #endif
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("queueWaitShouldWork", "[queue]", TestQueues)
 {
     using DevQueue = TestType;
@@ -93,7 +90,6 @@ TEMPLATE_LIST_TEST_CASE("queueWaitShouldWork", "[queue]", TestQueues)
     CHECK(callbackFinished.load() == true);
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE(
     "queueShouldNotBeEmptyWhenLastTaskIsStillExecutingAndIsEmptyAfterProcessingFinished",
     "[queue]",
@@ -120,7 +116,6 @@ TEMPLATE_LIST_TEST_CASE(
     LOOPED_CHECK(30, 100, alpaka::empty(f.m_queue));
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("queueShouldNotExecuteTasksInParallel", "[queue]", TestQueues)
 {
     using DevQueue = TestType;

--- a/test/unit/rand/src/RandTest.cpp
+++ b/test/unit/rand/src/RandTest.cpp
@@ -13,7 +13,6 @@
 
 #include <catch2/catch.hpp>
 
-//#############################################################################
 class RandTestKernel
 {
     ALPAKA_NO_HOST_ACC_WARNING
@@ -61,7 +60,6 @@ class RandTestKernel
     }
 
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -92,7 +90,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("defaultRandomGeneratorIsWorking", "[rand]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/time/src/ClockTest.cpp
+++ b/test/unit/time/src/ClockTest.cpp
@@ -13,11 +13,9 @@
 
 #include <catch2/catch.hpp>
 
-//#############################################################################
 class ClockTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -34,7 +32,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("clockIsWorking", "[timeClock]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -15,7 +15,6 @@
 
 #include <utility>
 
-//-----------------------------------------------------------------------------
 TEST_CASE("basicVecTraits", "[vec]")
 {
     using Dim = alpaka::DimInt<3u>;
@@ -25,14 +24,12 @@ TEST_CASE("basicVecTraits", "[vec]")
     Vec const vec(static_cast<Idx>(0u), static_cast<Idx>(8u), static_cast<Idx>(15u));
 
 
-    //-----------------------------------------------------------------------------
     // alpaka::Vec zero elements
     {
         using Dim0 = alpaka::DimInt<0u>;
         alpaka::Vec<Dim0, Idx> const vec0{};
     }
 
-    //-----------------------------------------------------------------------------
     // alpaka::subVecFromIndices
     {
         using IdxSequence = std::integer_sequence<std::size_t, 0u, Dim::value - 1u, 0u>;
@@ -43,7 +40,6 @@ TEST_CASE("basicVecTraits", "[vec]")
         REQUIRE(vecSubIndices[2u] == vec[0u]);
     }
 
-    //-----------------------------------------------------------------------------
     // alpaka::subVecBegin
     {
         using DimSubVecEnd = alpaka::DimInt<2u>;
@@ -55,7 +51,6 @@ TEST_CASE("basicVecTraits", "[vec]")
         }
     }
 
-    //-----------------------------------------------------------------------------
     // alpaka::subVecEnd
     {
         using DimSubVecEnd = alpaka::DimInt<2u>;
@@ -67,7 +62,6 @@ TEST_CASE("basicVecTraits", "[vec]")
         }
     }
 
-    //-----------------------------------------------------------------------------
     // alpaka::castVec
     {
         using SizeCast = std::uint16_t;
@@ -88,7 +82,6 @@ TEST_CASE("basicVecTraits", "[vec]")
         }
     }
 
-    //-----------------------------------------------------------------------------
     // alpaka::reverseVec
     {
         auto const vecReverse(alpaka::reverseVec(vec));
@@ -99,7 +92,6 @@ TEST_CASE("basicVecTraits", "[vec]")
         }
     }
 
-    //-----------------------------------------------------------------------------
     // alpaka::concatVec
     {
         using Dim2 = alpaka::DimInt<2u>;
@@ -124,7 +116,6 @@ TEST_CASE("basicVecTraits", "[vec]")
     {
         alpaka::Vec<Dim, Idx> const vec3(static_cast<Idx>(47u), static_cast<Idx>(8u), static_cast<Idx>(3u));
 
-        //-----------------------------------------------------------------------------
         // alpaka::Vec operator +
         {
             auto const vecLessEqual(vec + vec3);
@@ -145,7 +136,6 @@ TEST_CASE("basicVecTraits", "[vec]")
             REQUIRE(referenceVec == vecLessEqual);
         }
 
-        //-----------------------------------------------------------------------------
         // alpaka::Vec operator -
         {
             auto const vecLessEqual(vec - vec3);
@@ -166,7 +156,6 @@ TEST_CASE("basicVecTraits", "[vec]")
             REQUIRE(referenceVec == vecLessEqual);
         }
 
-        //-----------------------------------------------------------------------------
         // alpaka::Vec operator *
         {
             auto const vecLessEqual(vec * vec3);
@@ -187,7 +176,6 @@ TEST_CASE("basicVecTraits", "[vec]")
             REQUIRE(referenceVec == vecLessEqual);
         }
 
-        //-----------------------------------------------------------------------------
         // alpaka::Vec operator <
         {
             auto const vecLessEqual(vec < vec3);
@@ -205,7 +193,6 @@ TEST_CASE("basicVecTraits", "[vec]")
             REQUIRE(referenceVec == vecLessEqual);
         }
 
-        //-----------------------------------------------------------------------------
         // alpaka::Vec operator <=
         {
             auto const vecLessEqual(vec <= vec3);
@@ -223,7 +210,6 @@ TEST_CASE("basicVecTraits", "[vec]")
             REQUIRE(referenceVec == vecLessEqual);
         }
 
-        //-----------------------------------------------------------------------------
         // alpaka::Vec operator >=
         {
             auto const vecLessEqual(vec >= vec3);
@@ -241,7 +227,6 @@ TEST_CASE("basicVecTraits", "[vec]")
             REQUIRE(referenceVec == vecLessEqual);
         }
 
-        //-----------------------------------------------------------------------------
         // alpaka::Vec operator >
         {
             auto const vecLessEqual(vec > vec3);
@@ -261,11 +246,9 @@ TEST_CASE("basicVecTraits", "[vec]")
     }
 }
 
-//#############################################################################
 template<typename TDim, typename TIdx>
 struct NonAlpakaVec
 {
-    //-----------------------------------------------------------------------------
     operator ::alpaka::Vec<TDim, TIdx>() const
     {
         using AlpakaVector = ::alpaka::Vec<TDim, TIdx>;
@@ -278,14 +261,12 @@ struct NonAlpakaVec
 
         return result;
     }
-    //-----------------------------------------------------------------------------
     auto operator[](TIdx /*idx*/) const -> TIdx
     {
         return static_cast<TIdx>(0);
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("vecNDConstructionFromNonAlpakaVec", "[vec]", alpaka::test::TestDims)
 {
     using Dim = TestType;

--- a/test/unit/warp/src/Activemask.cpp
+++ b/test/unit/warp/src/Activemask.cpp
@@ -16,11 +16,9 @@
 
 #include <cstdint>
 
-//#############################################################################
 class ActivemaskSingleThreadWarpTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -32,11 +30,9 @@ public:
     }
 };
 
-//#############################################################################
 class ActivemaskMultipleThreadWarpTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, std::uint64_t inactiveThreadIdx) const -> void
@@ -61,7 +57,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("activemask", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/warp/src/All.cpp
+++ b/test/unit/warp/src/All.cpp
@@ -16,11 +16,9 @@
 
 #include <cstdint>
 
-//#############################################################################
 class AllSingleThreadWarpTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -33,11 +31,9 @@ public:
     }
 };
 
-//#############################################################################
 class AllMultipleThreadWarpTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -68,7 +64,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("all", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/warp/src/Any.cpp
+++ b/test/unit/warp/src/Any.cpp
@@ -16,11 +16,9 @@
 
 #include <cstdint>
 
-//#############################################################################
 class AnySingleThreadWarpTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -33,11 +31,9 @@ public:
     }
 };
 
-//#############################################################################
 class AnyMultipleThreadWarpTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -68,7 +64,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("any", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/warp/src/Ballot.cpp
+++ b/test/unit/warp/src/Ballot.cpp
@@ -16,11 +16,9 @@
 
 #include <cstdint>
 
-//#############################################################################
 class BallotSingleThreadWarpTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -33,11 +31,9 @@ public:
     }
 };
 
-//#############################################################################
 class BallotMultipleThreadWarpTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -71,7 +67,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("ballot", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/warp/src/GetSize.cpp
+++ b/test/unit/warp/src/GetSize.cpp
@@ -16,11 +16,9 @@
 
 #include <cstdint>
 
-//#############################################################################
 class GetSizeTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, std::int32_t expectedWarpSize) const -> void
@@ -30,7 +28,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("getSize", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/warp/src/Shfl.cpp
+++ b/test/unit/warp/src/Shfl.cpp
@@ -17,11 +17,9 @@
 #include <cstdint>
 #include <limits>
 
-//#############################################################################
 class ShflSingleThreadWarpTestKernel
 {
 public:
-    //-------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -36,11 +34,9 @@ public:
     }
 };
 
-//#############################################################################
 class ShflMultipleThreadWarpTestKernel
 {
 public:
-    //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
@@ -91,7 +87,6 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("shfl", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;

--- a/test/unit/workDiv/src/WorkDivHelpersTest.cpp
+++ b/test/unit/workDiv/src/WorkDivHelpersTest.cpp
@@ -15,7 +15,6 @@
 
 #include <catch2/catch.hpp>
 
-//-----------------------------------------------------------------------------
 namespace
 {
     template<typename TAcc>
@@ -39,7 +38,6 @@ namespace
     }
 } // namespace
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("getValidWorkDiv", "[workDiv]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
@@ -48,7 +46,6 @@ TEMPLATE_LIST_TEST_CASE("getValidWorkDiv", "[workDiv]", alpaka::test::TestAccs)
     alpaka::ignore_unused(workDiv);
 }
 
-//-----------------------------------------------------------------------------
 TEMPLATE_LIST_TEST_CASE("isValidWorkDiv", "[workDiv]", alpaka::test::TestAccs)
 {
     using Acc = TestType;


### PR DESCRIPTION
As discussed during the last alpaka VC, this PR is just a mechanical removal of section comments of the patterns:

```c++
//-----------------------------------------------------------------------------
//#############################################################################
```

I did a bit of manual formatting on top.