### PR TITLE
Rework implementation of OpenMP schedule support

### DIFF
--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2020 Benjamin Worpitz, Erik Zenker, Sergei Bastrakov
+/* Copyright 2019-2021 Benjamin Worpitz, Erik Zenker, Sergei Bastrakov
  *
  * This file exemplifies usage of alpaka.
  *
@@ -51,10 +51,14 @@ struct OpenMPScheduleDefaultKernel
 //! We inherit OpenMPScheduleDefaultKernel just to reuse its operator().
 struct OpenMPScheduleMemberKernel : public OpenMPScheduleDefaultKernel
 {
-    //! Static member to set OpenMP schedule to be used by the AccCpuOmp2Blocks accelerator.
-    //! This member is only checked for when the OmpSchedule trait is not specialized for this kernel type.
-    //! Note that constexpr is not required, however otherwise there has to be an external definition.
-    static constexpr auto ompSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Static, 1};
+    //! These two members are only checked for when the OmpSchedule trait is not specialized for this kernel type.
+
+    //! OpenMP schedule kind to be used by the AccCpuOmp2Blocks accelerator,
+    //! has to be static and constexpr.
+    static constexpr auto ompScheduleKind = alpaka::omp::Schedule::Static;
+
+    //! Member to set OpenMP chunk size, can be non-static and non-constexpr.
+    static constexpr int ompScheduleChunkSize = 1;
 };
 
 //! Kernel that sets the schedule via trait specialization.

--- a/include/alpaka/core/OmpSchedule.hpp
+++ b/include/alpaka/core/OmpSchedule.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Sergei Bastrakov
+/* Copyright 2020-2021 Sergei Bastrakov
  *
  * This file is part of Alpaka.
  *
@@ -26,33 +26,33 @@ namespace alpaka
         //! whether OpenMP is enabled.
         struct Schedule
         {
-            //! Special schedule setting which does not change the internal control variables of OpenMP
-            constexpr static std::uint32_t NoSchedule = 0u;
-            //! Integers corresponding to the mandatory OpenMP omp_sched_t enum values as of version 5.0.
-            constexpr static std::uint32_t Static = 1u;
-            constexpr static std::uint32_t Dynamic = 2u;
-            constexpr static std::uint32_t Guided = 3u;
-            constexpr static std::uint32_t Auto = 4u;
-            //! Each schedule value can be combined with monotonic using + or |.
-            constexpr static std::uint32_t Monotonic = 0x80000000u;
+            //! Schedule kinds corresponding to arguments of OpenMP schedule clause
+            //!
+            //! Kinds also present in omp_sched_t enum have the same integer values.
+            //! It is enum, not enum class, for shorter usage as omp::Schedule::[kind] and to keep interface of 0.6.0.
+            enum Kind
+            {
+                // Corresponds to not setting schedule
+                NoSchedule,
+                Static = 1u,
+                Dynamic = 2u,
+                Guided = 3u,
+                // Auto supported since OpenMP 3.0
+#if defined _OPENMP && _OPENMP >= 200805
+                Auto = 4u,
+#endif
+                Runtime
+            };
 
             //! Schedule kind.
-            //!
-            //! We cannot simply use type omp_sched_t since this struct is agnostic of OpenMP. We also cannot create an
-            //! own mirror enum, since OpenMP implementations are allowed to extend the range of values beyond the
-            //! standard ones defined above. So we have to accept and store any uint32_t value, and for non-standard
-            //! values a user has to ensure the underlying implementation supports it.
-            std::uint32_t kind;
+            Kind kind;
 
             //! Chunk size. Same as in OpenMP, value 0 corresponds to default chunk size. Using int and not a
             //! fixed-width type to match OpenMP API.
             int chunkSize;
 
-            //! The provided value myKind has to be supported by the underlying OpenMP implementation.
-            //! It does not have to be one of the constants defined above.
-            //! A default-constructed schedule does not affect internal control variables of OpenMP.
-            //! The constructor is constexpr to simplify creation of static constexpr ompSchedule in user code.
-            ALPAKA_FN_HOST constexpr Schedule(std::uint32_t myKind = NoSchedule, int myChunkSize = 0)
+            //! Create a schedule with the given kind and chunk size
+            ALPAKA_FN_HOST constexpr Schedule(Kind myKind = NoSchedule, int myChunkSize = 0)
                 : kind(myKind)
                 , chunkSize(myChunkSize)
             {
@@ -72,7 +72,7 @@ namespace alpaka
             omp_sched_t ompKind;
             int chunkSize = 0;
             omp_get_schedule(&ompKind, &chunkSize);
-            return Schedule{static_cast<std::uint32_t>(ompKind), chunkSize};
+            return Schedule{static_cast<Schedule::Kind>(ompKind), chunkSize};
 #else
             return Schedule{};
 #endif
@@ -86,7 +86,7 @@ namespace alpaka
         //! Note that calling from inside a parallel region does not have an immediate effect.
         ALPAKA_FN_HOST inline void setSchedule(Schedule schedule)
         {
-            if(schedule.kind != Schedule::NoSchedule)
+            if((schedule.kind != Schedule::NoSchedule) && (schedule.kind != Schedule::Runtime))
             {
 #if defined _OPENMP && _OPENMP >= 200805
                 omp_set_schedule(static_cast<omp_sched_t>(schedule.kind), schedule.chunkSize);

--- a/include/alpaka/core/OmpSchedule.hpp
+++ b/include/alpaka/core/OmpSchedule.hpp
@@ -37,11 +37,11 @@ namespace alpaka
                 Static = 1u,
                 Dynamic = 2u,
                 Guided = 3u,
-                // Auto supported since OpenMP 3.0
+            // Auto supported since OpenMP 3.0
 #if defined _OPENMP && _OPENMP >= 200805
                 Auto = 4u,
 #endif
-                Runtime
+                Runtime = 5u
             };
 
             //! Schedule kind.

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -98,14 +98,25 @@ namespace alpaka
             }
         };
 
+        //! Helper trait to check if TSchedule is not a type originating from OmpSchedule trait definition
+        //!
+        //! Is well-formed for those types (not defining the trait), ill-formed otherwise.
+        //! When well-formed, result in a non-void type to not collide with void-based SFINAE also used.
+        //!
+        //! \tparam TSchedule The schedule type.
+        template<typename TSchedule>
+        using HasOmpScheduleNotDefined = std::enable_if_t<!std::is_same<TSchedule, omp::Schedule>::value, char>;
+
         //! Executor of parallel OpenMP loop with the static schedule
         //!
         //! The default implementation is for the kernels that do not set chunk size in any way.
         //!
+        //! Note: HasOmpScheduleNotDefined<TSchedule> should not be necessary, but is required by some old compilers.
+        //!
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
-        template<typename TKernel, typename TSchedule, typename TSfinae>
-        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Static, TSfinae>
+        template<typename TKernel, typename TSchedule>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Static, HasOmpScheduleNotDefined<TSchedule>>
         {
             //! Run parallel OpenMP loop
             //!
@@ -176,13 +187,19 @@ namespace alpaka
             }
         };
 
-        //! Helper trait to check if TKernel has an public (not necessarily static) member ompScheduleChunkSize
+        //! Helper trait to check if TKernel has not defined OmpSchedule trait and has a public (not necessarily
+        //! static) member ompScheduleChunkSize
         //!
         //! Is well-formed for those types, ill-formed otherwise.
         //!
+        //! Note: HasOmpScheduleNotDefined<TSchedule> part should not be necessary, but is required by some old
+        //! compilers.
+        //!
         //! \tparam TKernel The kernel type.
-        template<typename TKernel>
-        using HasScheduleChunkSize = meta::Void<decltype(std::declval<TKernel&>().ompScheduleChunkSize)>;
+        //! \tparam TSchedule The schedule type.
+        template<typename TKernel, typename TSchedule>
+        using HasScheduleChunkSize
+            = meta::Void<decltype(std::declval<TKernel&>().ompScheduleChunkSize), HasOmpScheduleNotDefined<TSchedule>>;
 
         //! Executor of parallel OpenMP loop with the static schedule
         //!
@@ -191,7 +208,7 @@ namespace alpaka
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
         template<typename TKernel, typename TSchedule>
-        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Static, HasScheduleChunkSize<TKernel>>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Static, HasScheduleChunkSize<TKernel, TSchedule>>
         {
             //! Run parallel OpenMP loop
             //!
@@ -228,10 +245,11 @@ namespace alpaka
         //!
         //! The default implementation is for the kernels that do not set chunk size in any way.
         //!
+        //! Note: HasOmpScheduleNotDefined<TSchedule> should not be necessary, but is required by some old compilers.
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
-        template<typename TKernel, typename TSchedule, typename TSfinae>
-        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Dynamic, TSfinae>
+        template<typename TKernel, typename TSchedule>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Dynamic, HasOmpScheduleNotDefined<TSchedule>>
         {
             //! Run parallel OpenMP loop
             //!
@@ -309,7 +327,7 @@ namespace alpaka
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
         template<typename TKernel, typename TSchedule>
-        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Dynamic, HasScheduleChunkSize<TKernel>>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Dynamic, HasScheduleChunkSize<TKernel, TSchedule>>
         {
             //! Run parallel OpenMP loop
             //!
@@ -346,10 +364,12 @@ namespace alpaka
         //!
         //! The default implementation is for the kernels that do not set chunk size in any way.
         //!
+        //! Note: HasOmpScheduleNotDefined<TSchedule> should not be necessary, but is required by some old compilers.
+        //!
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
-        template<typename TKernel, typename TSchedule, typename TSfinae>
-        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Guided, TSfinae>
+        template<typename TKernel, typename TSchedule>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Guided, HasOmpScheduleNotDefined<TSchedule>>
         {
             //! Run parallel OpenMP loop
             //!
@@ -427,7 +447,7 @@ namespace alpaka
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
         template<typename TKernel, typename TSchedule>
-        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Guided, HasScheduleChunkSize<TKernel>>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Guided, HasScheduleChunkSize<TKernel, TSchedule>>
         {
             //! Run parallel OpenMP loop
             //!
@@ -647,9 +667,13 @@ namespace alpaka
         //!
         //! Is well-formed for those types, ill-formed otherwise.
         //!
+        //! Note: HasOmpScheduleNotDefined<TSchedule> part should not be necessary, but is required by some old
+        //! compilers.
+        //!
         //! \tparam TKernel The kernel type.
-        template<typename TKernel>
-        using HasScheduleKind = meta::Void<decltype(TKernel::ompScheduleKind)>;
+        //! \tparam TSchedule The schedule type.
+        template<typename TKernel, typename TSchedule>
+        using HasScheduleKind = meta::Void<decltype(TKernel::ompScheduleKind), HasOmpScheduleNotDefined<TSchedule>>;
 
         //! Executor of parallel OpenMP loop
         //!
@@ -659,7 +683,7 @@ namespace alpaka
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
         template<typename TKernel, typename TSchedule>
-        struct ParallelFor<TKernel, TSchedule, HasScheduleKind<TKernel>>
+        struct ParallelFor<TKernel, TSchedule, HasScheduleKind<TKernel, TSchedule>>
         {
             //! Run parallel OpenMP loop
             //!

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -93,7 +93,9 @@ namespace alpaka
                 for(TIdx i = 0; i < numIterations; ++i)
 #    endif
                 {
-                    loopBody(i);
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
                 }
             }
         };
@@ -143,7 +145,9 @@ namespace alpaka
                 for(TIdx i = 0; i < numIterations; ++i)
 #    endif
                 {
-                    loopBody(i);
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
                 }
             }
         };
@@ -182,7 +186,9 @@ namespace alpaka
                 for(TIdx i = 0; i < numIterations; ++i)
 #    endif
                 {
-                    loopBody(i);
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
                 }
             }
         };
@@ -236,7 +242,9 @@ namespace alpaka
                 for(TIdx i = 0; i < numIterations; ++i)
 #    endif
                 {
-                    loopBody(i);
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
                 }
             }
         };
@@ -276,7 +284,9 @@ namespace alpaka
                 for(TIdx i = 0; i < numIterations; ++i)
 #    endif
                 {
-                    loopBody(i);
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
                 }
             }
         };
@@ -315,7 +325,9 @@ namespace alpaka
                 for(TIdx i = 0; i < numIterations; ++i)
 #    endif
                 {
-                    loopBody(i);
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
                 }
             }
         };
@@ -355,7 +367,9 @@ namespace alpaka
                 for(TIdx i = 0; i < numIterations; ++i)
 #    endif
                 {
-                    loopBody(i);
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
                 }
             }
         };
@@ -396,7 +410,9 @@ namespace alpaka
                 for(TIdx i = 0; i < numIterations; ++i)
 #    endif
                 {
-                    loopBody(i);
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
                 }
             }
         };
@@ -435,7 +451,9 @@ namespace alpaka
                 for(TIdx i = 0; i < numIterations; ++i)
 #    endif
                 {
-                    loopBody(i);
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
                 }
             }
         };
@@ -475,7 +493,9 @@ namespace alpaka
                 for(TIdx i = 0; i < numIterations; ++i)
 #    endif
                 {
-                    loopBody(i);
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
                 }
             }
         };
@@ -507,7 +527,9 @@ namespace alpaka
 #        pragma omp for nowait schedule(auto)
                 for(TIdx i = 0; i < numIterations; ++i)
                 {
-                    loopBody(i);
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
                 }
             }
         };
@@ -547,7 +569,9 @@ namespace alpaka
                 for(TIdx i = 0; i < numIterations; ++i)
 #    endif
                 {
-                    loopBody(i);
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
                 }
             }
         };

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -623,7 +623,7 @@ namespace alpaka
                         numIterations,
                         schedule);
                     break;
-#    if defined _OPENMP && _OPENMP >= 200805
+#    if _OPENMP >= 200805
                 case omp::Schedule::Auto:
                     ParallelForImpl<TKernel, omp::Schedule, omp::Schedule::Auto>{}(
                         kernel,
@@ -830,12 +830,12 @@ namespace alpaka
 
             // Body of the OpenMP parallel loop to be executed.
             // Index type is auto since we have a difference for OpenMP 2.0 and later ones
-            auto loopBody = [&](auto i) {
+            auto loopBody = [&](auto currentIndex) {
 #    if _OPENMP < 200805
-                auto const i_tidx = static_cast<TIdx>(i); // for issue #840
+                auto const i_tidx = static_cast<TIdx>(currentIndex); // for issue #840
                 auto const index = Vec<DimInt<1u>, TIdx>(i_tidx); // for issue #840
 #    else
-                auto const index = Vec<DimInt<1u>, TIdx>(i); // for issue #840
+                auto const index = Vec<DimInt<1u>, TIdx>(currentIndex); // for issue #840
 #    endif
                 acc.m_gridBlockIdx = mapIdx<TDim::value>(index, gridBlockExtent);
 

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2020 Benjamin Worpitz, Bert Wesarg, René Widera, Sergei Bastrakov
+/* Copyright 2019-2021 Benjamin Worpitz, Bert Wesarg, René Widera, Sergei Bastrakov
  *
  * This file is part of alpaka.
  *
@@ -30,6 +30,7 @@
 #    include <alpaka/idx/MapIdx.hpp>
 #    include <alpaka/kernel/Traits.hpp>
 #    include <alpaka/meta/ApplyTuple.hpp>
+#    include <alpaka/meta/Void.hpp>
 #    include <alpaka/workdiv/WorkDivMembers.hpp>
 
 #    include <omp.h>
@@ -38,12 +39,678 @@
 #    include <stdexcept>
 #    include <tuple>
 #    include <type_traits>
+#    include <utility>
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
 #        include <iostream>
 #    endif
 
 namespace alpaka
 {
+    namespace detail
+    {
+        //! Executor of parallel OpenMP loop with the given schedule
+        //!
+        //! Is explicitly specialized for all supported schedule kinds to help code optimization by compilers.
+        //! For the same purpose performs dispatch based on ways of setting chunk size.
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        //! \tparam TScheduleKind The schedule kind value.
+        template<typename TKernel, typename TSchedule, omp::Schedule::Kind TScheduleKind, typename TSfinae = void>
+        struct ParallelForImpl;
+
+        //! Executor of parallel OpenMP loop with no schedule set
+        //!
+        //! Does not use chunk size.
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        template<typename TKernel, typename TSchedule>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::NoSchedule>
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const&,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                TSchedule const&)
+            {
+#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
+                         // header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
+                std::intmax_t i;
+#        pragma omp for nowait
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#    else
+#        pragma omp for nowait
+                for(TIdx i = 0; i < numIterations; ++i)
+#    endif
+                {
+                    loopBody(i);
+                }
+            }
+        };
+
+        //! Executor of parallel OpenMP loop with the static schedule
+        //!
+        //! The default implementation is for the kernels that do not set chunk size in any way.
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        template<typename TKernel, typename TSchedule, typename TSfinae>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Static, TSfinae>
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const&,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                TSchedule const&)
+            {
+#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
+                         // header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
+                std::intmax_t i;
+#        pragma omp for nowait schedule(static)
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#    else
+#        pragma omp for nowait schedule(static)
+                for(TIdx i = 0; i < numIterations; ++i)
+#    endif
+                {
+                    loopBody(i);
+                }
+            }
+        };
+
+        //! Executor of parallel OpenMP loop with the static schedule
+        //!
+        //! Specialization for kernels specializing the OmpSchedule trait.
+        //!
+        //! \tparam TKernel The kernel type.
+        template<typename TKernel>
+        struct ParallelForImpl<TKernel, omp::Schedule, omp::Schedule::Static>
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            //! \param schedule The schedule object.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const&,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                omp::Schedule const& schedule)
+            {
+#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
+                         // header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
+                std::intmax_t i;
+#        pragma omp for nowait schedule(static, schedule.chunkSize)
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#    else
+#        pragma omp for nowait schedule(static, schedule.chunkSize)
+                for(TIdx i = 0; i < numIterations; ++i)
+#    endif
+                {
+                    loopBody(i);
+                }
+            }
+        };
+
+        //! Helper trait to check if TKernel has an public (not necessarily static) member ompScheduleChunkSize
+        //!
+        //! Is well-formed for those types, ill-formed otherwise.
+        //!
+        //! \tparam TKernel The kernel type.
+        template<typename TKernel>
+        using HasScheduleChunkSize = meta::Void<decltype(std::declval<TKernel&>().ompScheduleChunkSize)>;
+
+        //! Executor of parallel OpenMP loop with the static schedule
+        //!
+        //! Specialization for kernels with ompScheduleChunkSize member.
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        template<typename TKernel, typename TSchedule>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Static, HasScheduleChunkSize<TKernel>>
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param kernel The kernel instance reference
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const& kernel,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                TSchedule const&)
+            {
+#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
+                         // header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
+                std::intmax_t i;
+#        pragma omp for nowait schedule(static, kernel.ompScheduleChunkSize)
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#    else
+#        pragma omp for nowait schedule(static, kernel.ompScheduleChunkSize)
+                for(TIdx i = 0; i < numIterations; ++i)
+#    endif
+                {
+                    loopBody(i);
+                }
+            }
+        };
+
+        //! Executor of parallel OpenMP loop with the dynamic schedule
+        //!
+        //! The default implementation is for the kernels that do not set chunk size in any way.
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        template<typename TKernel, typename TSchedule, typename TSfinae>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Dynamic, TSfinae>
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const&,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                TSchedule const&)
+            {
+#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
+                         // header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
+                std::intmax_t i;
+#        pragma omp for nowait schedule(dynamic)
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#    else
+#        pragma omp for nowait schedule(dynamic)
+                for(TIdx i = 0; i < numIterations; ++i)
+#    endif
+                {
+                    loopBody(i);
+                }
+            }
+        };
+
+        //! Executor of parallel OpenMP loop with the dynamic schedule
+        //!
+        //! Specialization for kernels specializing the OmpSchedule trait.
+        //!
+        //! \tparam TKernel The kernel type.
+        template<typename TKernel>
+        struct ParallelForImpl<TKernel, omp::Schedule, omp::Schedule::Dynamic>
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            //! \param schedule The schedule object.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const&,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                omp::Schedule const& schedule)
+            {
+#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
+                         // header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
+                std::intmax_t i;
+#        pragma omp for nowait schedule(dynamic, schedule.chunkSize)
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#    else
+#        pragma omp for nowait schedule(dynamic, schedule.chunkSize)
+                for(TIdx i = 0; i < numIterations; ++i)
+#    endif
+                {
+                    loopBody(i);
+                }
+            }
+        };
+
+        //! Executor of parallel OpenMP loop with the dynamic schedule
+        //!
+        //! Specialization for kernels with ompScheduleChunkSize member.
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        template<typename TKernel, typename TSchedule>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Dynamic, HasScheduleChunkSize<TKernel>>
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param kernel The kernel instance reference
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const& kernel,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                TSchedule const&)
+            {
+#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
+                         // header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
+                std::intmax_t i;
+#        pragma omp for nowait schedule(dynamic, kernel.ompScheduleChunkSize)
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#    else
+#        pragma omp for nowait schedule(dynamic, kernel.ompScheduleChunkSize)
+                for(TIdx i = 0; i < numIterations; ++i)
+#    endif
+                {
+                    loopBody(i);
+                }
+            }
+        };
+
+        //! Executor of parallel OpenMP loop with the guided schedule
+        //!
+        //! The default implementation is for the kernels that do not set chunk size in any way.
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        template<typename TKernel, typename TSchedule, typename TSfinae>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Guided, TSfinae>
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const&,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                TSchedule const&)
+            {
+#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
+                         // header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
+                std::intmax_t i;
+#        pragma omp for nowait schedule(guided)
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#    else
+#        pragma omp for nowait schedule(guided)
+                for(TIdx i = 0; i < numIterations; ++i)
+#    endif
+                {
+                    loopBody(i);
+                }
+            }
+        };
+
+        //! Executor of parallel OpenMP loop with the guided schedule
+        //!
+        //! Specialization for kernels specializing the OmpSchedule trait.
+        //!
+        //! \tparam TKernel The kernel type.
+        template<typename TKernel>
+        struct ParallelForImpl<TKernel, omp::Schedule, omp::Schedule::Guided>
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            //! \param schedule The schedule object.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const&,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                omp::Schedule const& schedule)
+            {
+#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
+                         // header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
+                std::intmax_t i;
+#        pragma omp for nowait schedule(guided, schedule.chunkSize)
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#    else
+#        pragma omp for nowait schedule(guided, schedule.chunkSize)
+                for(TIdx i = 0; i < numIterations; ++i)
+#    endif
+                {
+                    loopBody(i);
+                }
+            }
+        };
+
+        //! Executor of parallel OpenMP loop with the guided schedule
+        //!
+        //! Specialization for kernels with ompScheduleChunkSize member.
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        template<typename TKernel, typename TSchedule>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Guided, HasScheduleChunkSize<TKernel>>
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param kernel The kernel instance reference
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const& kernel,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                TSchedule const&)
+            {
+#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
+                         // header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
+                std::intmax_t i;
+#        pragma omp for nowait schedule(guided, kernel.ompScheduleChunkSize)
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#    else
+#        pragma omp for nowait schedule(guided, kernel.ompScheduleChunkSize)
+                for(TIdx i = 0; i < numIterations; ++i)
+#    endif
+                {
+                    loopBody(i);
+                }
+            }
+        };
+
+#    if _OPENMP >= 200805
+        //! Executor of parallel OpenMP loop with auto schedule set
+        //!
+        //! Does not use chunk size.
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        template<typename TKernel, typename TSchedule>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Auto>
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const&,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                TSchedule const&)
+            {
+#        pragma omp for nowait schedule(auto)
+                for(TIdx i = 0; i < numIterations; ++i)
+                {
+                    loopBody(i);
+                }
+            }
+        };
+#    endif
+
+        //! Executor of parallel OpenMP loop with runtime schedule set
+        //!
+        //! Does not use chunk size.
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        template<typename TKernel, typename TSchedule>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Runtime>
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const&,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                TSchedule const&)
+            {
+#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
+                         // header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
+                std::intmax_t i;
+#        pragma omp for nowait schedule(runtime)
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#    else
+#        pragma omp for nowait schedule(runtime)
+                for(TIdx i = 0; i < numIterations; ++i)
+#    endif
+                {
+                    loopBody(i);
+                }
+            }
+        };
+
+        //! Executor of parallel OpenMP loop
+        //!
+        //! Performs dispatch based on schedule kind and forwards to the corresponding ParallelForImpl.
+        //! The default implementation is for the kernels that do not set schedule in any way, compile-time dispatch.
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        template<typename TKernel, typename TSchedule, typename TSfinae = void>
+        struct ParallelFor
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param kernel The kernel instance reference
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            //! \param schedule The schedule object.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const& kernel,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                TSchedule const& schedule)
+            {
+                // Forward to ParallelForImpl that performs dispatch by by chunk size
+                ParallelForImpl<TKernel, TSchedule, omp::Schedule::NoSchedule>{}(
+                    kernel,
+                    std::forward<TLoopBody>(loopBody),
+                    numIterations,
+                    schedule);
+            }
+        };
+
+        //! Executor of parallel OpenMP loop
+        //!
+        //! Performs dispatch based on schedule kind and forwards to the corresponding ParallelForImpl.
+        //! Specialization for kernels specializing the OmpSchedule trait, run-time dispatch.
+        //!
+        //! \tparam TKernel The kernel type.
+        template<typename TKernel>
+        struct ParallelFor<TKernel, omp::Schedule>
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param kernel The kernel instance reference
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            //! \param schedule The schedule object.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const& kernel,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                omp::Schedule const& schedule)
+            {
+                // Forward to ParallelForImpl that performs dispatch by by chunk size
+                switch(schedule.kind)
+                {
+                case omp::Schedule::NoSchedule:
+                    ParallelForImpl<TKernel, omp::Schedule, omp::Schedule::NoSchedule>{}(
+                        kernel,
+                        std::forward<TLoopBody>(loopBody),
+                        numIterations,
+                        schedule);
+                    break;
+                case omp::Schedule::Static:
+                    ParallelForImpl<TKernel, omp::Schedule, omp::Schedule::Static>{}(
+                        kernel,
+                        std::forward<TLoopBody>(loopBody),
+                        numIterations,
+                        schedule);
+                    break;
+                case omp::Schedule::Dynamic:
+                    ParallelForImpl<TKernel, omp::Schedule, omp::Schedule::Dynamic>{}(
+                        kernel,
+                        std::forward<TLoopBody>(loopBody),
+                        numIterations,
+                        schedule);
+                    break;
+                case omp::Schedule::Guided:
+                    ParallelForImpl<TKernel, omp::Schedule, omp::Schedule::Guided>{}(
+                        kernel,
+                        std::forward<TLoopBody>(loopBody),
+                        numIterations,
+                        schedule);
+                    break;
+#    if defined _OPENMP && _OPENMP >= 200805
+                case omp::Schedule::Auto:
+                    ParallelForImpl<TKernel, omp::Schedule, omp::Schedule::Auto>{}(
+                        kernel,
+                        std::forward<TLoopBody>(loopBody),
+                        numIterations,
+                        schedule);
+                    break;
+#    endif
+                case omp::Schedule::Runtime:
+                    ParallelForImpl<TKernel, omp::Schedule, omp::Schedule::Runtime>{}(
+                        kernel,
+                        std::forward<TLoopBody>(loopBody),
+                        numIterations,
+                        schedule);
+                    break;
+                }
+            }
+        };
+
+        //! Helper trait to check if TKernel has an public static member ompScheduleKind
+        //!
+        //! Is well-formed for those types, ill-formed otherwise.
+        //!
+        //! \tparam TKernel The kernel type.
+        template<typename TKernel>
+        using HasScheduleKind = meta::Void<decltype(TKernel::ompScheduleKind)>;
+
+        //! Executor of parallel OpenMP loop
+        //!
+        //! Performs dispatch based on schedule kind and forwards to the corresponding ParallelForImpl.
+        //! Specialization for kernels with ompScheduleKind member, compile-time dispatch.
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        template<typename TKernel, typename TSchedule>
+        struct ParallelFor<TKernel, TSchedule, HasScheduleKind<TKernel>>
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param kernel The kernel instance reference
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            //! \param schedule The schedule object.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const& kernel,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                TSchedule const& schedule)
+            {
+                // Forward to ParallelForImpl that performs dispatch by by chunk size
+                ParallelForImpl<TKernel, TSchedule, TKernel::ompScheduleKind>{}(
+                    kernel,
+                    std::forward<TLoopBody>(loopBody),
+                    numIterations,
+                    schedule);
+            }
+        };
+
+        //! Run parallel OpenMP loop
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TLoopBody The loop body functor type.
+        //! \tparam TIdx The index type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        //!
+        //! \param kernel The kernel instance reference,
+        //!        not perfect=forwarded to shorten SFINAE internally.
+        //! \param loopBody The loop body functor instance, takes iteration index as input.
+        //! \param numIterations The number of loop iterations.
+        //! \param schedule The schedule object.
+        template<typename TKernel, typename TLoopBody, typename TIdx, typename TSchedule>
+        ALPAKA_FN_HOST ALPAKA_FN_INLINE void parallelFor(
+            TKernel const& kernel,
+            TLoopBody&& loopBody,
+            TIdx const numIterations,
+            TSchedule const& schedule)
+        {
+            // Forward to ParallelFor that performs first a dispatch by schedule kind, and then by chunk size
+            ParallelFor<TKernel, TSchedule>{}(kernel, std::forward<TLoopBody>(loopBody), numIterations, schedule);
+        }
+
+    } // namespace detail
+
     //! The CPU OpenMP 2.0 block accelerator execution task.
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     class TaskKernelCpuOmp2Blocks final : public WorkDivMembers<TDim, TIdx>
@@ -104,68 +771,42 @@ namespace alpaka
                 throw std::runtime_error("Only one thread per block allowed in the OpenMP 2.0 block accelerator!");
             }
 
+            // Get the OpenMP schedule information for the given kernel and parameter types
+            auto const schedule(meta::apply(
+                [&](ALPAKA_DECAY_T(TArgs) const&... args) {
+                    return getOmpSchedule<AccCpuOmp2Blocks<TDim, TIdx>>(
+                        m_kernelFnObj,
+                        blockThreadExtent,
+                        threadElemExtent,
+                        args...);
+                },
+                m_args));
+
             if(::omp_in_parallel() != 0)
             {
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " already within a parallel region." << std::endl;
 #    endif
-                parallelFn(boundKernelFnObj, blockSharedMemDynSizeBytes, numBlocksInGrid, gridBlockExtent);
+                parallelFn(boundKernelFnObj, blockSharedMemDynSizeBytes, numBlocksInGrid, gridBlockExtent, schedule);
             }
             else
             {
-                //! Set the given OpenMP schedule while this object is alive.
-                //! Restore the old schedule afterwards.
-                class ScheduleGuard
-                {
-                public:
-                    ScheduleGuard(omp::Schedule const schedule) : oldSchedule(omp::getSchedule())
-                    {
-                        omp::setSchedule(schedule);
-                    }
-
-                    ScheduleGuard(ScheduleGuard const&) = default;
-
-                    ~ScheduleGuard()
-                    {
-                        omp::setSchedule(oldSchedule);
-                    }
-
-                private:
-                    omp::Schedule const oldSchedule;
-                };
-
-                // Get the OpenMP schedule.
-                // We only do it when outside of a parallel region, since
-                // otherwise the change of schedule would have no effect.
-                auto const schedule(meta::apply(
-                    [&](ALPAKA_DECAY_T(TArgs) const&... args) {
-                        return getOmpSchedule<AccCpuOmp2Blocks<TDim, TIdx>>(
-                            m_kernelFnObj,
-                            blockThreadExtent,
-                            threadElemExtent,
-                            args...);
-                    },
-                    m_args));
-
-                // Schedule change is a scoped object, so that the old schedule is
-                // also restored in case of exception.
-                auto const scheduleGuard = ScheduleGuard{schedule};
-
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " opening new parallel region." << std::endl;
 #    endif
 #    pragma omp parallel
-                parallelFn(boundKernelFnObj, blockSharedMemDynSizeBytes, numBlocksInGrid, gridBlockExtent);
+                parallelFn(boundKernelFnObj, blockSharedMemDynSizeBytes, numBlocksInGrid, gridBlockExtent, schedule);
             }
         }
 
     private:
-        template<typename FnObj>
+        template<typename FnObj, typename TSchedule>
         ALPAKA_FN_HOST auto parallelFn(
             FnObj const& boundKernelFnObj,
             std::size_t const& blockSharedMemDynSizeBytes,
             TIdx const& numBlocksInGrid,
-            Vec<TDim, TIdx> const& gridBlockExtent) const -> void
+            Vec<TDim, TIdx> const& gridBlockExtent,
+            TSchedule const& schedule) const -> void
         {
 #    pragma omp single nowait
             {
@@ -187,17 +828,9 @@ namespace alpaka
                 *static_cast<WorkDivMembers<TDim, TIdx> const*>(this),
                 blockSharedMemDynSizeBytes);
 
-#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
-                         // header.
-            std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numBlocksInGrid));
-            std::intmax_t i;
-#        pragma omp for nowait schedule(runtime)
-            for(i = 0; i < iNumBlocksInGrid; ++i)
-#    else
-#        pragma omp for nowait schedule(runtime)
-            for(TIdx i = 0; i < numBlocksInGrid; ++i)
-#    endif
-            {
+            // Body of the OpenMP parallel loop to be executed.
+            // Index type is auto since we have a difference for OpenMP 2.0 and later ones
+            auto loopBody = [&](auto i) {
 #    if _OPENMP < 200805
                 auto const i_tidx = static_cast<TIdx>(i); // for issue #840
                 auto const index = Vec<DimInt<1u>, TIdx>(i_tidx); // for issue #840
@@ -210,7 +843,9 @@ namespace alpaka
 
                 // After a block has been processed, the shared memory has to be deleted.
                 freeSharedVars(acc);
-            }
+            };
+
+            detail::parallelFor(m_kernelFnObj, loopBody, numBlocksInGrid, schedule);
         }
 
         TKernelFnObj m_kernelFnObj;

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2020 Axel Huebl, Benjamin Worpitz, René Widera, Sergei Bastrakov
+/* Copyright 2019-2021 Axel Huebl, Benjamin Worpitz, René Widera, Sergei Bastrakov
  *
  * This file is part of alpaka.
  *
@@ -81,54 +81,31 @@ namespace alpaka
             }
         };
 
-        namespace detail
-        {
-            //! Functor to get OpenMP schedule defined by kernel class.
-            //! When no schedule is defined, return a default one.
-            template<class TKernel, class = void>
-            struct GetOmpSchedule
-            {
-                ALPAKA_FN_HOST static auto get()
-                {
-                    return alpaka::omp::Schedule{};
-                }
-            };
-
-            //! Functor to get OpenMP schedule for kernel classes with
-            //! ompSchedule static member.
-            //! That member is never odr-used by alpaka.
-            template<class TKernel>
-            struct GetOmpSchedule<TKernel, meta::Void<decltype(TKernel::ompSchedule)>>
-            {
-                ALPAKA_FN_HOST static auto get()
-                {
-                    // Just having return TKernel::ompSchedule here would be
-                    // a non-odr use of that variable, since it would be an
-                    // argument of the copy constructor. So have to manually
-                    // create a new identical object and then return it.
-                    return alpaka::omp::Schedule{TKernel::ompSchedule.kind, TKernel::ompSchedule.chunkSize};
-                }
-            };
-        } // namespace detail
-
-        //! The trait for getting the schedule to use when a kernel is run using
-        //! the CpuOmp2Blocks accelerator.
+        //! The trait for getting the schedule to use when a kernel is run using the CpuOmp2Blocks accelerator.
         //!
-        //! Has no effect on other accelerators or when run using OpenMP
-        //! implementation not supporting at least version 3.0.
+        //! Has no effect on other accelerators.
         //!
-        //! A user could either specialize this trait for their kernel, or define
-        //! a public static member ompSchedule of type alpaka::omp::Schedule
-        //! inside it, which would be picked up by this implementation.
-        //! In the latter case, alpaka never odr-uses that member.
+        //! A user could either specialize this trait for their kernel, or define a public static member
+        //! ompScheduleKind of type alpaka::omp::Schedule, and additionally also int member ompScheduleChunkSize. In
+        //! the latter case, alpaka never odr-uses these members.
+        //!
+        //! In case schedule kind and chunk size are compile-time constants, setting then inside kernel may benefit
+        //! performance.
         //!
         //! \tparam TKernelFnObj The kernel function object.
         //! \tparam TAcc The accelerator.
         //!
-        //! The default implementation returns 0.
+        //! The default implementation behaves as if the trait was not specialized.
         template<typename TKernelFnObj, typename TAcc, typename TSfinae = void>
         struct OmpSchedule
         {
+        private:
+            //! Type returned when the trait is not specialized
+            struct TraitNotSpecialized
+            {
+            };
+
+        public:
 #if BOOST_COMP_CLANG
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored                                                                                  \
@@ -139,7 +116,8 @@ namespace alpaka
             //! \param threadElemExtent The thread element extent.
             //! \tparam TArgs The kernel invocation argument types pack.
             //! \param args,... The kernel invocation arguments.
-            //! \return The OpenMP schedule information.
+            //! \return The OpenMP schedule information as an alpaka::omp::Schedule object,
+            //!         returning an object of any other type is treated as if the trait is not specialized.
 #if BOOST_COMP_CLANG
 #    pragma clang diagnostic pop
 #endif
@@ -149,14 +127,14 @@ namespace alpaka
                 TKernelFnObj const& kernelFnObj,
                 Vec<TDim, Idx<TAcc>> const& blockThreadExtent,
                 Vec<TDim, Idx<TAcc>> const& threadElemExtent,
-                TArgs const&... args) -> alpaka::omp::Schedule
+                TArgs const&... args) -> TraitNotSpecialized
             {
                 alpaka::ignore_unused(kernelFnObj);
                 alpaka::ignore_unused(blockThreadExtent);
                 alpaka::ignore_unused(threadElemExtent);
                 alpaka::ignore_unused(args...);
 
-                return detail::GetOmpSchedule<TKernelFnObj>::get();
+                return TraitNotSpecialized{};
             }
         };
     } // namespace traits
@@ -201,7 +179,8 @@ namespace alpaka
     //! \param blockThreadExtent The block thread extent.
     //! \param threadElemExtent The thread element extent.
     //! \param args,... The kernel invocation arguments.
-    //! \return The OpenMP schedule information.
+    //! \return The OpenMP schedule information as an alpaka::omp::Schedule object if the kernel specialized the
+    //!         OmpSchedule trait, an object of another type if the kernel didn't specialize the trait.
 #if BOOST_COMP_CLANG
 #    pragma clang diagnostic pop
 #endif
@@ -210,7 +189,7 @@ namespace alpaka
         TKernelFnObj const& kernelFnObj,
         Vec<TDim, Idx<TAcc>> const& blockThreadExtent,
         Vec<TDim, Idx<TAcc>> const& threadElemExtent,
-        TArgs const&... args) -> omp::Schedule
+        TArgs const&... args)
     {
         return traits::OmpSchedule<TKernelFnObj, TAcc>::getOmpSchedule(
             kernelFnObj,

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -48,7 +48,7 @@ const alpaka::omp::Schedule::Kind KernelWithMemberOmpScheduleKind::ompScheduleKi
 // Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.
 struct KernelWithConstexprStaticMemberOmpScheduleChunkSize : KernelWithOmpScheduleBase
 {
-    static constexpr int ompScheduleChiunkSize = 5;
+    static constexpr int ompScheduleChunkSize = 5;
 };
 
 // Kernel that sets the schedule chunk size via non-constexpr ompScheduleChunkSize.

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Sergei Bastrakov
+/* Copyright 2020-2021 Sergei Bastrakov
  *
  * This file is part of alpaka.
  *
@@ -16,9 +16,6 @@
 
 #include <cstdint>
 
-// Schedule to be used by all kernels in this file
-static constexpr auto expectedSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Dynamic, 10};
-
 // Base kernel, not to be used directly in unit tests
 struct KernelWithOmpScheduleBase
 {
@@ -26,43 +23,47 @@ struct KernelWithOmpScheduleBase
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
     {
-        // By default no run-time check is performed
+        // No run-time check is performed
         alpaka::ignore_unused(acc);
         ALPAKA_CHECK(*success, true);
     }
-
-    // Only check when the schedule feature is active
-#if defined _OPENMP && _OPENMP >= 200805 && defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
-    ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TDim, typename TIdx>
-    ALPAKA_FN_ACC auto operator()(alpaka::AccCpuOmp2Blocks<TDim, TIdx> const& acc, bool* success) const -> void
-    {
-        alpaka::ignore_unused(acc);
-        omp_sched_t kind;
-        int actualChunkSize = 0;
-        omp_get_schedule(&kind, &actualChunkSize);
-        auto const actualKind = static_cast<std::uint32_t>(kind);
-        bool result = (expectedSchedule.kind == actualKind) && (expectedSchedule.chunkSize == actualChunkSize);
-        ALPAKA_CHECK(*success, result);
-    }
-#endif
 };
 
-// Kernel that sets the schedule via constexpr ompSchedule.
-// Checks that this variable is only declared and not defined, It also tests that
-// alpaka never odr-uses it.
-struct KernelWithConstexprMemberOmpSchedule : KernelWithOmpScheduleBase
+// Kernel that sets the schedule kind via constexpr ompScheduleKind.
+// Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.
+struct KernelWithConstexprMemberOmpScheduleKind : KernelWithOmpScheduleBase
 {
-    static constexpr auto ompSchedule = expectedSchedule;
+    static constexpr auto ompScheduleKind = alpaka::omp::Schedule::Runtime;
 };
 
-// Kernel that sets the schedule via non-constexpr ompSchedule.
-struct KernelWithMemberOmpSchedule : KernelWithOmpScheduleBase
+// Kernel that sets the schedule kind via non-constexpr ompScheduleKind.
+struct KernelWithMemberOmpScheduleKind : KernelWithOmpScheduleBase
 {
-    static const alpaka::omp::Schedule ompSchedule;
+    static const alpaka::omp::Schedule::Kind ompScheduleKind;
 };
 // In this case, the member has to be defined externally
-const alpaka::omp::Schedule KernelWithMemberOmpSchedule::ompSchedule = expectedSchedule;
+const alpaka::omp::Schedule::Kind KernelWithMemberOmpScheduleKind::ompScheduleKind = alpaka::omp::Schedule::NoSchedule;
+
+// Kernel that sets the schedule chunk size via constexpr ompScheduleChunkSize.
+// Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.
+struct KernelWithConstexprStaticMemberOmpScheduleChunkSize : KernelWithOmpScheduleBase
+{
+    static constexpr int ompScheduleChiunkSize = 5;
+};
+
+// Kernel that sets the schedule chunk size via non-constexpr ompScheduleChunkSize.
+struct KernelWithStaticMemberOmpScheduleChunkSize : KernelWithOmpScheduleBase
+{
+    static const int ompScheduleChunkSize;
+};
+// In this case, the member has to be defined externally
+const int KernelWithStaticMemberOmpScheduleChunkSize::ompScheduleChunkSize = 2;
+
+// Kernel that sets the schedule chunk size via non-constexpr non-static ompScheduleChunkSize.
+struct KernelWithMemberOmpScheduleChunkSize : KernelWithOmpScheduleBase
+{
+    int ompScheduleChunkSize = 4;
+};
 
 // Kernel that sets the schedule via partial specialization of a trait
 struct KernelWithTraitOmpSchedule : KernelWithOmpScheduleBase
@@ -73,8 +74,7 @@ struct KernelWithTraitOmpSchedule : KernelWithOmpScheduleBase
 // In this case test that the trait is used, not the member.
 struct KernelWithMemberAndTraitOmpSchedule : KernelWithOmpScheduleBase
 {
-    // Set to be different from expected so that it this is used the test would fail
-    static constexpr auto ompSchedule = alpaka::omp::Schedule{expectedSchedule.kind, expectedSchedule.chunkSize + 1};
+    static constexpr auto ompScheduleKind = alpaka::omp::Schedule::Dynamic;
 };
 
 namespace alpaka
@@ -97,7 +97,7 @@ namespace alpaka
                 alpaka::ignore_unused(threadElemExtent);
                 alpaka::ignore_unused(args...);
 
-                return expectedSchedule;
+                return alpaka::omp::Schedule{alpaka::omp::Schedule::Guided, 2};
             }
         };
     } // namespace traits
@@ -118,14 +118,29 @@ void test()
     REQUIRE(fixture(kernel));
 }
 
-TEMPLATE_LIST_TEST_CASE("kernelWithConstexprMemberOmpSchedule", "[kernel]", alpaka::test::TestAccs)
+TEMPLATE_LIST_TEST_CASE("kernelWithConstexprMemberOmpScheduleKind", "[kernel]", alpaka::test::TestAccs)
 {
-    test<TestType, KernelWithConstexprMemberOmpSchedule>();
+    test<TestType, KernelWithConstexprMemberOmpScheduleKind>();
 }
 
-TEMPLATE_LIST_TEST_CASE("kernelWithMemberOmpSchedule", "[kernel]", alpaka::test::TestAccs)
+TEMPLATE_LIST_TEST_CASE("kernelWithMemberOmpScheduleKind", "[kernel]", alpaka::test::TestAccs)
 {
-    test<TestType, KernelWithMemberOmpSchedule>();
+    test<TestType, KernelWithMemberOmpScheduleKind>();
+}
+
+TEMPLATE_LIST_TEST_CASE("kernelWithConstexprStaticMemberOmpScheduleChunkSize", "[kernel]", alpaka::test::TestAccs)
+{
+    test<TestType, KernelWithConstexprStaticMemberOmpScheduleChunkSize>();
+}
+
+TEMPLATE_LIST_TEST_CASE("kernelWithStaticMemberOmpScheduleChunkSize", "[kernel]", alpaka::test::TestAccs)
+{
+    test<TestType, KernelWithStaticMemberOmpScheduleChunkSize>();
+}
+
+TEMPLATE_LIST_TEST_CASE("kernelWithMemberOmpScheduleChunkSize", "[kernel]", alpaka::test::TestAccs)
+{
+    test<TestType, KernelWithMemberOmpScheduleChunkSize>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithTraitOmpSchedule", "[kernel]", alpaka::test::TestAccs)


### PR DESCRIPTION
As discussed in #1255, the previous implementation always used schedule(runtime) and called appropriate `omp_set_schedule()`.
This could have been suboptimal for two reasons.
First, it did not give control while inside the parallel section.
Second, it may have hindered some optimizations made by compilers.

The new implementation performs explicit complile-time dispatch into appropriate `schedule()` clauses.
This solves the first shortcoming and hopefully helps the second.

In terms of the user interface, the only change is that when defining as a member in kernel, it is no longer
`ompSchedule` of type `alpaka::omp::Schedule`, but two separate members `ompScheduleKind` and `ompScheduleChunkSize`.
The trait interface is unchanged and still has a higher priority.
See the changes in example and tests.

It is a bit ugly due to combination of copy-pasted implementations for compilte-time dispatch and existing ifdef-guards that were inside and got cloned now. I actually tried a lot to limit the ugliness, but that's how it is now.

@krzikalla is it possible that you test this branch for your codebase?