### PR TITLE
Fix BlockSharedMemStMemberImpl::getVarPtr for last var

### DIFF
--- a/include/alpaka/block/shared/st/detail/BlockSharedMemStMemberImpl.hpp
+++ b/include/alpaka/block/shared/st/detail/BlockSharedMemStMemberImpl.hpp
@@ -111,14 +111,11 @@ namespace alpaka
                     off = metaDataPtr->offset;
 
                     if(metaDataPtr->id == id)
-                        break;
+                        return reinterpret_cast<T*>(&m_mem[off - sizeof(T)]);
                 }
 
                 // Variable not found.
-                if(off >= m_allocdBytes)
-                    return nullptr;
-
-                return reinterpret_cast<T*>(&m_mem[off - sizeof(T)]);
+                return nullptr;
             }
 
             //! Get last allocated variable.

--- a/test/unit/block/shared/src/BlockSharedMemSt.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemSt.cpp
@@ -121,6 +121,10 @@ public:
             auto& b = alpaka::declareSharedVar<alpaka::test::Array<std::uint8_t, 21>, 42>(acc);
             ALPAKA_CHECK(*success, &a == &b);
             ALPAKA_CHECK(*success, &a == &baseAllocation);
+
+            auto& lastAllocation = alpaka::declareSharedVar<alpaka::test::Array<std::uint8_t, 23>, 23>(acc);
+            auto& c = alpaka::declareSharedVar<alpaka::test::Array<std::uint8_t, 23>, 23>(acc);
+            ALPAKA_CHECK(*success, &lastAllocation == &c);
         }
     }
 };


### PR DESCRIPTION
test BlockSharedMemSt: Add check if last allocation is at fixed address

Fixes #1277