### PR TITLE
Fix CtxBlockOacc: SyncBlockThreads

### DIFF
--- a/include/alpaka/ctx/block/CtxBlockOacc.hpp
+++ b/include/alpaka/ctx/block/CtxBlockOacc.hpp
@@ -113,8 +113,8 @@ namespace alpaka
                 }
 #    pragma acc atomic capture
                 {
-                    ++m_syncCounter[slot];
-                    sum = m_syncCounter[slot];
+                    ++m_syncCounter[slot + 1];
+                    sum = m_syncCounter[slot + 1];
                 }
                 while(sum < workerNum)
                 {


### PR DESCRIPTION
The bug fixed here makes threads skip the seconds wait loop allowing them to run into a later barrier before `m_syncCounter` has been prepared for that by the master thread.