### PR TITLE
CMake CUDA: dev compile options not propagated

### DIFF
--- a/test/common/devCompileOptions.cmake
+++ b/test/common/devCompileOptions.cmake
@@ -20,6 +20,8 @@ TARGET_INCLUDE_DIRECTORIES(
 
 IF(ALPAKA_ACC_GPU_CUDA_ENABLE AND (ALPAKA_CUDA_COMPILER MATCHES "nvcc") AND (ALPAKA_CUDA_VERSION VERSION_GREATER_EQUAL 11.0))
     LIST(APPEND CUDA_NVCC_FLAGS -Wdefault-stream-launch -Werror=default-stream-launch)
+    # export to parent scope to be visible in all test cases
+    set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} PARENT_SCOPE)
 ENDIF()
 
 #MSVC


### PR DESCRIPTION
The compile options for the test cases are not propagated to all tests.

Note: I am not sure if this also happens with the other variables for the CPU. 
I have currently no time to check this. 

This fix is required for CUDA 11.3.

Tested with cmake@3.18.4


- [x] rebase against #1302