### PR TITLE
Add Front and Contains type list meta functions

### DIFF
--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -146,6 +146,7 @@
 #include <alpaka/meta/NdLoop.hpp>
 #include <alpaka/meta/Set.hpp>
 #include <alpaka/meta/Transform.hpp>
+#include <alpaka/meta/TypeListOps.hpp>
 #include <alpaka/meta/Void.hpp>
 // offset
 #include <alpaka/offset/Traits.hpp>

--- a/include/alpaka/meta/TypeListOps.hpp
+++ b/include/alpaka/meta/TypeListOps.hpp
@@ -1,0 +1,46 @@
+/* Copyright 2021 Bernhard Manfred Gruber
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace alpaka
+{
+    namespace meta
+    {
+        namespace detail
+        {
+            template<typename List>
+            struct Front
+            {
+            };
+
+            template<template<typename...> class List, typename Head, typename... Tail>
+            struct Front<List<Head, Tail...>>
+            {
+                using type = Head;
+            };
+        } // namespace detail
+
+        template<typename List>
+        using Front = typename detail::Front<List>::type;
+
+        template<typename List, typename Value>
+        struct Contains : std::false_type
+        {
+        };
+
+        template<template<typename...> class List, typename Head, typename... Tail, typename Value>
+        struct Contains<List<Head, Tail...>, Value>
+        {
+            static constexpr bool value = std::is_same<Head, Value>::value || Contains<List<Tail...>, Value>::value;
+        };
+    } // namespace meta
+} // namespace alpaka

--- a/test/unit/meta/src/TypeListOpsTest.cpp
+++ b/test/unit/meta/src/TypeListOpsTest.cpp
@@ -1,0 +1,33 @@
+/* Copyright 2021 Bernhard Manfred Gruber
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <alpaka/meta/TypeListOps.hpp>
+
+#include <catch2/catch.hpp>
+
+#include <tuple>
+#include <type_traits>
+
+TEST_CASE("front", "[meta]")
+{
+    STATIC_REQUIRE(std::is_same<alpaka::meta::Front<std::tuple<int>>, int>::value);
+    STATIC_REQUIRE(std::is_same<alpaka::meta::Front<std::tuple<int, int>>, int>::value);
+    STATIC_REQUIRE(std::is_same<alpaka::meta::Front<std::tuple<float, int>>, float>::value);
+    STATIC_REQUIRE(std::is_same<alpaka::meta::Front<std::tuple<short, int, double, float, float>>, short>::value);
+}
+
+TEST_CASE("contains", "[meta]")
+{
+    STATIC_REQUIRE(!alpaka::meta::Contains<std::tuple<>, int>::value);
+    STATIC_REQUIRE(alpaka::meta::Contains<std::tuple<int>, int>::value);
+    STATIC_REQUIRE(alpaka::meta::Contains<std::tuple<short, int, double, float>, short>::value);
+    STATIC_REQUIRE(alpaka::meta::Contains<std::tuple<short, int, double, float>, double>::value);
+    STATIC_REQUIRE(alpaka::meta::Contains<std::tuple<short, int, double, float>, float>::value);
+    STATIC_REQUIRE(!alpaka::meta::Contains<std::tuple<short, int, double, float>, char>::value);
+}


### PR DESCRIPTION
As suggested by @BenjaminW3, this PR splits out the two added meta functions form the accessor PR #1249.