### PR TITLE
example: fix warning (NVCC+OpenMP)

### DIFF
--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -33,7 +33,7 @@
 struct OpenMPScheduleDefaultKernel
 {
     template<typename TAcc>
-    ALPAKA_FN_ACC auto operator()(TAcc const& acc) const -> void
+    ALPAKA_FN_HOST auto operator()(TAcc const& acc) const -> void
     {
         // For simplicity assume 1d index space throughout this example
         using Idx = alpaka::Idx<TAcc>;


### PR DESCRIPTION
Fix warning when enabling OpenMP + CUDA nvcc.
`omp_get_thread_num()` is a host function, therefore the kernel can only be called with a CPU accelerator and the function suffix must be ` ALPAKA_FN_HOST`.

```
alpaka/example/openMPSchedule/src/openMPSchedule.cpp(43): 
warning #20011-D: calling a __host__ function("omp_get_thread_num") from a 
__host__ __device__ function("OpenMPScheduleDefaultKernel::operator ()< 
::alpaka::AccCpuOmp2Blocks<    ::std::integral_constant<unsigned long, (unsigned long)1ul
> , unsigned long> >  const") is not allowed
```