### PR TITLE
Fix OpenMP schedule support

### DIFF
--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -58,6 +58,7 @@ struct OpenMPScheduleMemberKernel : public OpenMPScheduleDefaultKernel
     static constexpr auto ompScheduleKind = alpaka::omp::Schedule::Static;
 
     //! Member to set OpenMP chunk size, can be non-static and non-constexpr.
+    //! Defining kind as member and not defining chunk will result in default chunk size for the kind.
     static constexpr int ompScheduleChunkSize = 1;
 };
 

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -7,6 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/core/BoostPredef.hpp>
 #include <alpaka/core/OmpSchedule.hpp>
 #include <alpaka/kernel/Traits.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
@@ -37,6 +38,20 @@ struct KernelWithConstexprMemberOmpScheduleKind : KernelWithOmpScheduleBase
     static constexpr auto ompScheduleKind = TKind;
 };
 
+// CI runs show that nvcc 10 on Windows has an issue with the const, but not constexpr static member.
+// While instantiating schedule-related templates, it throws an error
+// error #28: expression must have a constant value
+// saying the value of the member cannot be used as a constant.
+// This seems like a bug in the compiler.
+// Other versions or compilers in CI process it properly.
+#if BOOST_OS_WINDOWS && (BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(10, 0, 0))                                           \
+    && (BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 0, 0))
+// For this combination use constexpr instead of const.
+template<alpaka::omp::Schedule::Kind TKind>
+struct KernelWithMemberOmpScheduleKind : KernelWithConstexprMemberOmpScheduleKind<TKind>
+{
+};
+#else
 // Kernel that sets the schedule kind via non-constexpr ompScheduleKind, but no chunk size.
 template<alpaka::omp::Schedule::Kind TKind>
 struct KernelWithMemberOmpScheduleKind : KernelWithOmpScheduleBase
@@ -46,6 +61,7 @@ struct KernelWithMemberOmpScheduleKind : KernelWithOmpScheduleBase
 // In this case, the member has to be defined externally
 template<alpaka::omp::Schedule::Kind TKind>
 const alpaka::omp::Schedule::Kind KernelWithMemberOmpScheduleKind<TKind>::ompScheduleKind = TKind;
+#endif
 
 // Kernel that sets the schedule chunk size via constexpr ompScheduleChunkSize in addition to schedule kind, but no
 // chunk size. Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -29,65 +29,67 @@ struct KernelWithOmpScheduleBase
     }
 };
 
-// Kernel that sets the schedule kind via constexpr ompScheduleKind.
+// Kernel that sets the schedule kind via constexpr ompScheduleKind, but no chunk size.
 // Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.
+template<alpaka::omp::Schedule::Kind TKind>
 struct KernelWithConstexprMemberOmpScheduleKind : KernelWithOmpScheduleBase
 {
-    static constexpr auto ompScheduleKind = alpaka::omp::Schedule::Static;
+    static constexpr auto ompScheduleKind = TKind;
 };
 
-// Kernel that sets the schedule kind via non-constexpr ompScheduleKind.
+// Kernel that sets the schedule kind via non-constexpr ompScheduleKind, but no chunk size.
+template<alpaka::omp::Schedule::Kind TKind>
 struct KernelWithMemberOmpScheduleKind : KernelWithOmpScheduleBase
 {
     static const alpaka::omp::Schedule::Kind ompScheduleKind;
 };
 // In this case, the member has to be defined externally
-const alpaka::omp::Schedule::Kind KernelWithMemberOmpScheduleKind::ompScheduleKind = alpaka::omp::Schedule::Dynamic;
+template<alpaka::omp::Schedule::Kind TKind>
+const alpaka::omp::Schedule::Kind KernelWithMemberOmpScheduleKind<TKind>::ompScheduleKind = TKind;
 
-// Kernel that sets the schedule chunk size via constexpr ompScheduleChunkSize.
-// Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.
-struct KernelWithConstexprStaticMemberOmpScheduleChunkSize : KernelWithOmpScheduleBase
+// Kernel that sets the schedule chunk size via constexpr ompScheduleChunkSize in addition to schedule kind, but no
+// chunk size. Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.
+template<alpaka::omp::Schedule::Kind TKind>
+struct KernelWithConstexprStaticMemberOmpScheduleChunkSize : KernelWithConstexprMemberOmpScheduleKind<TKind>
 {
     static constexpr int ompScheduleChunkSize = 5;
 };
 
-// Kernel that sets the schedule chunk size via non-constexpr ompScheduleChunkSize.
-struct KernelWithStaticMemberOmpScheduleChunkSize : KernelWithOmpScheduleBase
+// Kernel that sets the schedule chunk size via non-constexpr ompScheduleChunkSize in addition to schedule kind.
+template<alpaka::omp::Schedule::Kind TKind>
+struct KernelWithStaticMemberOmpScheduleChunkSize : KernelWithMemberOmpScheduleKind<TKind>
 {
     static const int ompScheduleChunkSize;
 };
 // In this case, the member has to be defined externally
-const int KernelWithStaticMemberOmpScheduleChunkSize::ompScheduleChunkSize = 2;
+template<alpaka::omp::Schedule::Kind TKind>
+const int KernelWithStaticMemberOmpScheduleChunkSize<TKind>::ompScheduleChunkSize = 2;
 
-// Kernel that sets the schedule chunk size via non-constexpr non-static ompScheduleChunkSize.
-struct KernelWithMemberOmpScheduleChunkSize : KernelWithOmpScheduleBase
+// Kernel that sets the schedule chunk size via non-constexpr non-static ompScheduleChunkSize in addition to schedule
+// kind.
+template<alpaka::omp::Schedule::Kind TKind>
+struct KernelWithMemberOmpScheduleChunkSize : KernelWithConstexprMemberOmpScheduleKind<TKind>
 {
     int ompScheduleChunkSize = 4;
 };
 
-// Kernel that sets the schedule via partial specialization of a trait
-struct KernelWithTraitOmpSchedule : KernelWithOmpScheduleBase
+// Kernel that copies the given base kernel and adds an OmpSchedule trait on top
+template<typename TBase>
+struct KernelWithTrait : TBase
 {
-};
-
-// Kernel that sets the schedule via both member and partial specialization of a trait.
-// In this case test that the trait is used, not the member.
-struct KernelWithMemberAndTraitOmpSchedule : KernelWithOmpScheduleBase
-{
-    static constexpr auto ompScheduleKind = alpaka::omp::Schedule::Dynamic;
 };
 
 namespace alpaka
 {
     namespace traits
     {
-        // Specialize the trait for all kernels
-        template<typename TKernelFnObj, typename TAcc>
-        struct OmpSchedule<TKernelFnObj, TAcc>
+        // Specialize the trait for kernels of type KernelWithTrait<>
+        template<typename TBase, typename TAcc>
+        struct OmpSchedule<KernelWithTrait<TBase>, TAcc>
         {
             template<typename TDim, typename... TArgs>
             ALPAKA_FN_HOST static auto getOmpSchedule(
-                TKernelFnObj const& kernelFnObj,
+                KernelWithTrait<TBase> const& kernelFnObj,
                 Vec<TDim, Idx<TAcc>> const& blockThreadExtent,
                 Vec<TDim, Idx<TAcc>> const& threadElemExtent,
                 TArgs const&... args) -> alpaka::omp::Schedule
@@ -97,7 +99,7 @@ namespace alpaka
                 alpaka::ignore_unused(threadElemExtent);
                 alpaka::ignore_unused(args...);
 
-                return alpaka::omp::Schedule{alpaka::omp::Schedule::Guided, 2};
+                return alpaka::omp::Schedule{alpaka::omp::Schedule::Static, 4};
             }
         };
     } // namespace traits
@@ -105,7 +107,7 @@ namespace alpaka
 
 // Generic testing routine for the given kernel type
 template<typename TAcc, typename TKernel>
-void test()
+void testKernel()
 {
     using Acc = TAcc;
     using Dim = alpaka::Dim<Acc>;
@@ -113,42 +115,47 @@ void test()
 
     alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::ones());
 
+    // Base version with no OmpSchedule trait
     TKernel kernel;
-
     REQUIRE(fixture(kernel));
+
+    // Same members, but with OmpSchedule trait
+    KernelWithTrait<TKernel> kernelWithTrait;
+    REQUIRE(fixture(kernelWithTrait));
+}
+
+// Note: it turned out not possible to test all possible combinations as it causes several compilers to crash in CI.
+// However the following tests should cover all important cases
+
+TEMPLATE_LIST_TEST_CASE("kernelWithOmpScheduleBase", "[kernel]", alpaka::test::TestAccs)
+{
+    testKernel<TestType, KernelWithOmpScheduleBase>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithConstexprMemberOmpScheduleKind", "[kernel]", alpaka::test::TestAccs)
 {
-    test<TestType, KernelWithConstexprMemberOmpScheduleKind>();
+    testKernel<TestType, KernelWithConstexprMemberOmpScheduleKind<alpaka::omp::Schedule::NoSchedule>>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithMemberOmpScheduleKind", "[kernel]", alpaka::test::TestAccs)
 {
-    test<TestType, KernelWithMemberOmpScheduleKind>();
+    testKernel<TestType, KernelWithMemberOmpScheduleKind<alpaka::omp::Schedule::Static>>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithConstexprStaticMemberOmpScheduleChunkSize", "[kernel]", alpaka::test::TestAccs)
 {
-    test<TestType, KernelWithConstexprStaticMemberOmpScheduleChunkSize>();
+    testKernel<TestType, KernelWithConstexprStaticMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Dynamic>>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithStaticMemberOmpScheduleChunkSize", "[kernel]", alpaka::test::TestAccs)
 {
-    test<TestType, KernelWithStaticMemberOmpScheduleChunkSize>();
+    testKernel<TestType, KernelWithStaticMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Guided>>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithMemberOmpScheduleChunkSize", "[kernel]", alpaka::test::TestAccs)
 {
-    test<TestType, KernelWithMemberOmpScheduleChunkSize>();
-}
-
-TEMPLATE_LIST_TEST_CASE("kernelWithTraitOmpSchedule", "[kernel]", alpaka::test::TestAccs)
-{
-    test<TestType, KernelWithTraitOmpSchedule>();
-}
-
-TEMPLATE_LIST_TEST_CASE("kernelWithMemberAndTraitOmpSchedule", "[kernel]", alpaka::test::TestAccs)
-{
-    test<TestType, KernelWithMemberAndTraitOmpSchedule>();
+#if defined _OPENMP && _OPENMP >= 200805
+    testKernel<TestType, KernelWithMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Auto>>();
+#endif
+    testKernel<TestType, KernelWithMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Runtime>>();
 }

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -33,7 +33,7 @@ struct KernelWithOmpScheduleBase
 // Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.
 struct KernelWithConstexprMemberOmpScheduleKind : KernelWithOmpScheduleBase
 {
-    static constexpr auto ompScheduleKind = alpaka::omp::Schedule::Runtime;
+    static constexpr auto ompScheduleKind = alpaka::omp::Schedule::Static;
 };
 
 // Kernel that sets the schedule kind via non-constexpr ompScheduleKind.
@@ -42,7 +42,7 @@ struct KernelWithMemberOmpScheduleKind : KernelWithOmpScheduleBase
     static const alpaka::omp::Schedule::Kind ompScheduleKind;
 };
 // In this case, the member has to be defined externally
-const alpaka::omp::Schedule::Kind KernelWithMemberOmpScheduleKind::ompScheduleKind = alpaka::omp::Schedule::NoSchedule;
+const alpaka::omp::Schedule::Kind KernelWithMemberOmpScheduleKind::ompScheduleKind = alpaka::omp::Schedule::Dynamic;
 
 // Kernel that sets the schedule chunk size via constexpr ompScheduleChunkSize.
 // Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.


### PR DESCRIPTION
There is a bug in #1279 and so currently in `develop` and 0.6.1 release branch, reported by DLR. Faulty template specialization logic results in some valid combinations not compiling. I accidentally introduced it while fighting old compilers in the CI and then the tests were not trying out that combination, so it went through. The code is quite complicated as well and now became even slightly more due to the fix.

This PR in the current state attemps to fix and try how CI likes it. The unit tests need to be extended as well, I will do it in this PR.