### PR TITLE
backport to 0.6.1 - bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.6.1] - 2021-XX-XX
 ### Compatibility Changes:
-- rework implementation of OpenMP schedule support #1279
+- rework implementation of OpenMP schedule support #1279 #1309 #1313
   - `alpaka::omp::Schedule` is replaced by `ompScheduleKind` and `ompScheduleChunkSize`
 ### Bug Fixes:
 - CI: use ubuntu-18.04 for gcc-5 and gcc-6 builds #1252
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - port macOSX CI fix from #1283
 - fix assert in DeclareSharedVar (OpenAcc) #1303
 - CI: disable GCC 10.3 + NVCC tests #1302
+- example: fix warning (NVCC+OpenMP) #1307
+- CMake CUDA: dev compile options not propagated #1294
 
 ### Misc
 - add ALPAKA_ASSERT_OFFLOAD Macro #1260

--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -35,7 +35,7 @@ struct OpenMPScheduleDefaultKernel
 {
     //-----------------------------------------------------------------------------
     template<typename TAcc>
-    ALPAKA_FN_ACC auto operator()(TAcc const& acc) const -> void
+    ALPAKA_FN_HOST auto operator()(TAcc const& acc) const -> void
     {
         // For simplicity assume 1d index space throughout this example
         using Idx = alpaka::Idx<TAcc>;

--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -61,6 +61,7 @@ struct OpenMPScheduleMemberKernel : public OpenMPScheduleDefaultKernel
     static constexpr auto ompScheduleKind = alpaka::omp::Schedule::Static;
 
     //! Member to set OpenMP chunk size, can be non-static and non-constexpr.
+    //! Defining kind as member and not defining chunk will result in default chunk size for the kind.
     static constexpr int ompScheduleChunkSize = 1;
 };
 

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -194,7 +194,7 @@ namespace alpaka
         //!
         //! \tparam TKernel The kernel type.
         template<typename TKernel>
-        using HasScheduleChunkSize = std::enable_if_t<sizeof(std::declval<TKernel&>().ompScheduleChunkSize)>;
+        using HasScheduleChunkSize = alpaka::meta::Void<decltype(TKernel::ompScheduleChunkSize)>;
 
         //! Helper executor of parallel OpenMP loop with the static schedule
         //!

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -51,12 +51,11 @@ namespace alpaka
         //! Executor of parallel OpenMP loop with the given schedule
         //!
         //! Is explicitly specialized for all supported schedule kinds to help code optimization by compilers.
-        //! For the same purpose performs dispatch based on ways of setting chunk size.
         //!
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
         //! \tparam TScheduleKind The schedule kind value.
-        template<typename TKernel, typename TSchedule, omp::Schedule::Kind TScheduleKind, bool TSfinae = true>
+        template<typename TKernel, typename TSchedule, omp::Schedule::Kind TScheduleKind>
         struct ParallelForImpl;
 
         //! Executor of parallel OpenMP loop with no schedule set
@@ -100,6 +99,13 @@ namespace alpaka
             }
         };
 
+        /* Implementations for Static, Dynamic and Guided follow the same pattern.
+         * There are two specializations of ParallelForImpl for compile-time dispatch depending on whether the
+         * OmpSchedule trait is specialized.
+         * The no trait case is further compile-time dispatched with a helper ParallelForStaticImpl.
+         * It is based on whether ompScheduleChunkSize member is available.
+         */
+
         //! Executor of parallel OpenMP loop with the static schedule
         //!
         //! Specialization for kernels specializing the OmpSchedule trait.
@@ -141,74 +147,63 @@ namespace alpaka
             }
         };
 
-        //! Helper type to check if TSchedule is a type originating from OmpSchedule trait definition
+        //! Helper executor of parallel OpenMP loop with the static schedule
         //!
-        //! \tparam TSchedule The schedule type.
-        template<typename TSchedule>
-        using IsOmpScheduleTraitSpecialized
-            = std::integral_constant<bool, std::is_same<TSchedule, omp::Schedule>::value>;
-
-        //! Helper type to check if member ompScheduleChunkSize of TKernel should be used
-        //!
-        //! For that it has to be present, and no OmpSchedule trait specialized.
-        //! Is std::true_type for those types, ill-formed otherwise.
+        //! Generel implementation is for TKernel types without member ompScheduleChunkSize.
         //!
         //! \tparam TKernel The kernel type.
-        //! \tparam TSchedule The schedule type.
-        template<typename TKernel, typename TSchedule>
-        using UseScheduleChunkSize = std::enable_if_t<
-            sizeof(std::declval<TKernel&>().ompScheduleChunkSize) && !IsOmpScheduleTraitSpecialized<TSchedule>::value,
-            std::true_type>;
-
-        //! Helper type for NotUseScheduleChunkSize
-        //!
-        //! Is std::true_type when TKernel does not have a public member ompScheduleChunkSize,
-        //! std::false_type otherwise.
-        //!
-        //! \tparam TKernel The kernel type.
-        //! \tparam TSchedule The schedule type.
-        template<typename TKernel, typename TSchedule, bool TSfinae = true>
-        struct NotUseScheduleChunkSizeHelper : std::true_type
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        template<typename TKernel, typename TSchedule, typename TSfinae = void>
+        struct ParallelForStaticImpl
         {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const&,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                TSchedule const&)
+            {
+#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
+                         // header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
+                std::intmax_t i;
+#        pragma omp for nowait schedule(static)
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#    else
+#        pragma omp for nowait schedule(static)
+                for(TIdx i = 0; i < numIterations; ++i)
+#    endif
+                {
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
+                }
+            }
         };
 
-        //! Helper trait for NotUseScheduleChunkSize
+        //! Helper type to check if TKernel has member ompScheduleChunkSize
         //!
-        //! Specialization for kernels with ompScheduleChunkSize member.
-        //!
-        //! \tparam TKernel The kernel type.
-        //! \tparam TSchedule The schedule type.
-        template<typename TKernel, typename TSchedule>
-        struct NotUseScheduleChunkSizeHelper<TKernel, TSchedule, UseScheduleChunkSize<TKernel, TSchedule>::value>
-            : std::false_type
-        {
-        };
-
-        //! Helper type to check if member ompScheduleChunkSize of TKernel should not be used
-        //!
-        //! For that it has to be not present, and no OmpSchedule trait specialized.
-        //! Is std::true_type for those types, ill-formed otherwise.
+        //! Is void for those types, ill-formed otherwise.
         //!
         //! \tparam TKernel The kernel type.
-        //! \tparam TSchedule The schedule type.
-        template<typename TKernel, typename TSchedule>
-        using NotUseScheduleChunkSize = std::enable_if_t<
-            NotUseScheduleChunkSizeHelper<TKernel, TSchedule>::value
-                && !IsOmpScheduleTraitSpecialized<TSchedule>::value,
-            std::true_type>;
+        template<typename TKernel>
+        using HasScheduleChunkSize = std::enable_if_t<sizeof(std::declval<TKernel&>().ompScheduleChunkSize)>;
 
-        //! Executor of parallel OpenMP loop with the static schedule
+        //! Helper executor of parallel OpenMP loop with the static schedule
         //!
         //! Specialization for kernels with ompScheduleChunkSize member.
         //!
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
         template<typename TKernel, typename TSchedule>
-        struct ParallelForImpl<
-            TKernel,
-            TSchedule,
-            omp::Schedule::Static,
-            UseScheduleChunkSize<TKernel, TSchedule>::value>
+        struct ParallelForStaticImpl<TKernel, TSchedule, HasScheduleChunkSize<TKernel>>
         {
             //! Run parallel OpenMP loop
             //!
@@ -245,47 +240,14 @@ namespace alpaka
 
         //! Executor of parallel OpenMP loop with the static schedule
         //!
-        //! Specialization for the kernels that do not set chunk size in any way.
+        //! Specialization for kernels not specializing the OmpSchedule trait.
+        //! Falls back to ParallelForStaticImpl for further dispatch.
         //!
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
         template<typename TKernel, typename TSchedule>
-        struct ParallelForImpl<
-            TKernel,
-            TSchedule,
-            omp::Schedule::Static,
-            NotUseScheduleChunkSize<TKernel, TSchedule>::value>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Static> : ParallelForStaticImpl<TKernel, TSchedule>
         {
-            //! Run parallel OpenMP loop
-            //!
-            //! \tparam TLoopBody The loop body functor type.
-            //! \tparam TIdx The index type.
-            //!
-            //! \param loopBody The loop body functor instance, takes iteration index as input.
-            //! \param numIterations The number of loop iterations.
-            template<typename TLoopBody, typename TIdx>
-            ALPAKA_FN_HOST void operator()(
-                TKernel const&,
-                TLoopBody&& loopBody,
-                TIdx const numIterations,
-                TSchedule const&)
-            {
-#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
-                         // header.
-                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
-                std::intmax_t i;
-#        pragma omp for nowait schedule(static)
-                for(i = 0; i < iNumBlocksInGrid; ++i)
-#    else
-#        pragma omp for nowait schedule(static)
-                for(TIdx i = 0; i < numIterations; ++i)
-#    endif
-                {
-                    // Make another lambda to work around #1288
-                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
-                    wrappedLoopBody(i);
-                }
-            }
         };
 
         //! Executor of parallel OpenMP loop with the dynamic schedule
@@ -329,18 +291,55 @@ namespace alpaka
             }
         };
 
-        //! Executor of parallel OpenMP loop with the dynamic schedule
+        //! Helper executor of parallel OpenMP loop with the dynamic schedule
+        //!
+        //! Generel implementation is for TKernel types without member ompScheduleChunkSize.
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        template<typename TKernel, typename TSchedule, typename TSfinae = void>
+        struct ParallelForDynamicImpl
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const&,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                TSchedule const&)
+            {
+#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
+                         // header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
+                std::intmax_t i;
+#        pragma omp for nowait schedule(dynamic)
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#    else
+#        pragma omp for nowait schedule(dynamic)
+                for(TIdx i = 0; i < numIterations; ++i)
+#    endif
+                {
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
+                }
+            }
+        };
+
+        //! Helper executor of parallel OpenMP loop with the dynamic schedule
         //!
         //! Specialization for kernels with ompScheduleChunkSize member.
         //!
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
         template<typename TKernel, typename TSchedule>
-        struct ParallelForImpl<
-            TKernel,
-            TSchedule,
-            omp::Schedule::Dynamic,
-            UseScheduleChunkSize<TKernel, TSchedule>::value>
+        struct ParallelForDynamicImpl<TKernel, TSchedule, HasScheduleChunkSize<TKernel>>
         {
             //! Run parallel OpenMP loop
             //!
@@ -377,47 +376,14 @@ namespace alpaka
 
         //! Executor of parallel OpenMP loop with the dynamic schedule
         //!
-        //! Specialization for the kernels that do not set chunk size in any way.
+        //! Specialization for kernels not specializing the OmpSchedule trait.
+        //! Falls back to ParallelForDynamicImpl for further dispatch.
         //!
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
         template<typename TKernel, typename TSchedule>
-        struct ParallelForImpl<
-            TKernel,
-            TSchedule,
-            omp::Schedule::Dynamic,
-            NotUseScheduleChunkSize<TKernel, TSchedule>::value>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Dynamic> : ParallelForDynamicImpl<TKernel, TSchedule>
         {
-            //! Run parallel OpenMP loop
-            //!
-            //! \tparam TLoopBody The loop body functor type.
-            //! \tparam TIdx The index type.
-            //!
-            //! \param loopBody The loop body functor instance, takes iteration index as input.
-            //! \param numIterations The number of loop iterations.
-            template<typename TLoopBody, typename TIdx>
-            ALPAKA_FN_HOST void operator()(
-                TKernel const&,
-                TLoopBody&& loopBody,
-                TIdx const numIterations,
-                TSchedule const&)
-            {
-#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
-                         // header.
-                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
-                std::intmax_t i;
-#        pragma omp for nowait schedule(dynamic)
-                for(i = 0; i < iNumBlocksInGrid; ++i)
-#    else
-#        pragma omp for nowait schedule(dynamic)
-                for(TIdx i = 0; i < numIterations; ++i)
-#    endif
-                {
-                    // Make another lambda to work around #1288
-                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
-                    wrappedLoopBody(i);
-                }
-            }
         };
 
         //! Executor of parallel OpenMP loop with the guided schedule
@@ -461,18 +427,55 @@ namespace alpaka
             }
         };
 
-        //! Executor of parallel OpenMP loop with the guided schedule
+        //! Helper executor of parallel OpenMP loop with the guided schedule
+        //!
+        //! Generel implementation is for TKernel types without member ompScheduleChunkSize.
+        //!
+        //! \tparam TKernel The kernel type.
+        //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
+        template<typename TKernel, typename TSchedule, typename TSfinae = void>
+        struct ParallelForGuidedImpl
+        {
+            //! Run parallel OpenMP loop
+            //!
+            //! \tparam TLoopBody The loop body functor type.
+            //! \tparam TIdx The index type.
+            //!
+            //! \param loopBody The loop body functor instance, takes iteration index as input.
+            //! \param numIterations The number of loop iterations.
+            template<typename TLoopBody, typename TIdx>
+            ALPAKA_FN_HOST void operator()(
+                TKernel const&,
+                TLoopBody&& loopBody,
+                TIdx const numIterations,
+                TSchedule const&)
+            {
+#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
+                         // header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
+                std::intmax_t i;
+#        pragma omp for nowait schedule(guided)
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#    else
+#        pragma omp for nowait schedule(guided)
+                for(TIdx i = 0; i < numIterations; ++i)
+#    endif
+                {
+                    // Make another lambda to work around #1288
+                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
+                    wrappedLoopBody(i);
+                }
+            }
+        };
+
+        //! Helper executor of parallel OpenMP loop with the guided schedule
         //!
         //! Specialization for kernels with ompScheduleChunkSize member.
         //!
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
         template<typename TKernel, typename TSchedule>
-        struct ParallelForImpl<
-            TKernel,
-            TSchedule,
-            omp::Schedule::Guided,
-            UseScheduleChunkSize<TKernel, TSchedule>::value>
+        struct ParallelForGuidedImpl<TKernel, TSchedule, HasScheduleChunkSize<TKernel>>
         {
             //! Run parallel OpenMP loop
             //!
@@ -509,47 +512,14 @@ namespace alpaka
 
         //! Executor of parallel OpenMP loop with the guided schedule
         //!
-        //! Specialization for the kernels that do not set chunk size in any way.
+        //! Specialization for kernels not specializing the OmpSchedule trait.
+        //! Falls back to ParallelForGuidedImpl for further dispatch.
         //!
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
         template<typename TKernel, typename TSchedule>
-        struct ParallelForImpl<
-            TKernel,
-            TSchedule,
-            omp::Schedule::Guided,
-            NotUseScheduleChunkSize<TKernel, TSchedule>::value>
+        struct ParallelForImpl<TKernel, TSchedule, omp::Schedule::Guided> : ParallelForGuidedImpl<TKernel, TSchedule>
         {
-            //! Run parallel OpenMP loop
-            //!
-            //! \tparam TLoopBody The loop body functor type.
-            //! \tparam TIdx The index type.
-            //!
-            //! \param loopBody The loop body functor instance, takes iteration index as input.
-            //! \param numIterations The number of loop iterations.
-            template<typename TLoopBody, typename TIdx>
-            ALPAKA_FN_HOST void operator()(
-                TKernel const&,
-                TLoopBody&& loopBody,
-                TIdx const numIterations,
-                TSchedule const&)
-            {
-#    if _OPENMP < 200805 // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop
-                         // header.
-                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numIterations));
-                std::intmax_t i;
-#        pragma omp for nowait schedule(guided)
-                for(i = 0; i < iNumBlocksInGrid; ++i)
-#    else
-#        pragma omp for nowait schedule(guided)
-                for(TIdx i = 0; i < numIterations; ++i)
-#    endif
-                {
-                    // Make another lambda to work around #1288
-                    auto wrappedLoopBody = [&loopBody](auto idx) { loopBody(idx); };
-                    wrappedLoopBody(i);
-                }
-            }
         };
 
 #    if _OPENMP >= 200805
@@ -635,7 +605,7 @@ namespace alpaka
         //!
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
-        template<typename TKernel, typename TSchedule, bool TSfinae = true>
+        template<typename TKernel, typename TSchedule, typename TSfinae = void>
         struct ParallelFor
         {
             //! Run parallel OpenMP loop
@@ -739,17 +709,23 @@ namespace alpaka
             }
         };
 
+        //! Helper type to check if TSchedule is a type originating from OmpSchedule trait definition
+        //!
+        //! \tparam TSchedule The schedule type.
+        template<typename TSchedule>
+        using IsOmpScheduleTraitSpecialized
+            = std::integral_constant<bool, std::is_same<TSchedule, omp::Schedule>::value>;
+
         //! Helper type to check if member ompScheduleKind of TKernel should be used
         //!
         //! For that it has to be present, and no OmpSchedule trait specialized.
-        //! Is std::true_type for those types, ill-formed otherwise.
+        //! Is void for those types, ill-formed otherwise.
         //!
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type.
         template<typename TKernel, typename TSchedule>
-        using UseScheduleKind = std::enable_if_t<
-            sizeof(TKernel::ompScheduleKind) && !IsOmpScheduleTraitSpecialized<TSchedule>::value,
-            std::true_type>;
+        using UseScheduleKind
+            = std::enable_if_t<sizeof(TKernel::ompScheduleKind) && !IsOmpScheduleTraitSpecialized<TSchedule>::value>;
 
         //! Executor of parallel OpenMP loop
         //!
@@ -759,7 +735,7 @@ namespace alpaka
         //! \tparam TKernel The kernel type.
         //! \tparam TSchedule The schedule type (not necessarily omp::Schedule).
         template<typename TKernel, typename TSchedule>
-        struct ParallelFor<TKernel, TSchedule, UseScheduleKind<TKernel, TSchedule>::value>
+        struct ParallelFor<TKernel, TSchedule, UseScheduleKind<TKernel, TSchedule>>
         {
             //! Run parallel OpenMP loop
             //!
@@ -844,12 +820,12 @@ namespace alpaka
         {
             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-            auto const gridBlockExtent(getWorkDiv<Grid, Blocks>(*this));
-            auto const blockThreadExtent(getWorkDiv<Block, Threads>(*this));
-            auto const threadElemExtent(getWorkDiv<Thread, Elems>(*this));
+            auto const gridBlockExtent = getWorkDiv<Grid, Blocks>(*this);
+            auto const blockThreadExtent = getWorkDiv<Block, Threads>(*this);
+            auto const threadElemExtent = getWorkDiv<Thread, Elems>(*this);
 
             // Get the size of the block shared dynamic memory.
-            auto const blockSharedMemDynSizeBytes(meta::apply(
+            auto const blockSharedMemDynSizeBytes = meta::apply(
                 [&](ALPAKA_DECAY_T(TArgs) const&... args) {
                     return getBlockSharedMemDynSizeBytes<AccCpuOmp2Blocks<TDim, TIdx>>(
                         m_kernelFnObj,
@@ -857,7 +833,7 @@ namespace alpaka
                         threadElemExtent,
                         args...);
                 },
-                m_args));
+                m_args);
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
             std::cout << __func__ << " blockSharedMemDynSizeBytes: " << blockSharedMemDynSizeBytes << " B"
@@ -865,11 +841,11 @@ namespace alpaka
 #    endif
             // Bind all arguments except the accelerator.
             // TODO: With C++14 we could create a perfectly argument forwarding function object within the constructor.
-            auto const boundKernelFnObj(meta::apply(
+            auto const boundKernelFnObj = meta::apply(
                 [this](ALPAKA_DECAY_T(TArgs) const&... args) {
                     return std::bind(std::ref(m_kernelFnObj), std::placeholders::_1, std::ref(args)...);
                 },
-                m_args));
+                m_args);
 
             // The number of blocks in the grid.
             TIdx const numBlocksInGrid(gridBlockExtent.prod());
@@ -879,7 +855,7 @@ namespace alpaka
             }
 
             // Get the OpenMP schedule information for the given kernel and parameter types
-            auto const schedule(meta::apply(
+            auto const schedule = meta::apply(
                 [&](ALPAKA_DECAY_T(TArgs) const&... args) {
                     return getOmpSchedule<AccCpuOmp2Blocks<TDim, TIdx>>(
                         m_kernelFnObj,
@@ -887,7 +863,7 @@ namespace alpaka
                         threadElemExtent,
                         args...);
                 },
-                m_args));
+                m_args);
 
             if(::omp_in_parallel() != 0)
             {

--- a/test/common/devCompileOptions.cmake
+++ b/test/common/devCompileOptions.cmake
@@ -20,6 +20,8 @@ TARGET_INCLUDE_DIRECTORIES(
 
 IF(ALPAKA_ACC_GPU_CUDA_ENABLE AND (ALPAKA_CUDA_COMPILER MATCHES "nvcc") AND (ALPAKA_CUDA_VERSION VERSION_GREATER_EQUAL 11.0))
     LIST(APPEND CUDA_NVCC_FLAGS -Wdefault-stream-launch -Werror=default-stream-launch)
+    # export to parent scope to be visible in all test cases
+    set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} PARENT_SCOPE)
 ENDIF()
 
 #MSVC

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -31,65 +31,67 @@ struct KernelWithOmpScheduleBase
     }
 };
 
-// Kernel that sets the schedule kind via constexpr ompScheduleKind.
+// Kernel that sets the schedule kind via constexpr ompScheduleKind, but no chunk size.
 // Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.
+template<alpaka::omp::Schedule::Kind TKind>
 struct KernelWithConstexprMemberOmpScheduleKind : KernelWithOmpScheduleBase
 {
-    static constexpr auto ompScheduleKind = alpaka::omp::Schedule::Static;
+    static constexpr auto ompScheduleKind = TKind;
 };
 
-// Kernel that sets the schedule kind via non-constexpr ompScheduleKind.
+// Kernel that sets the schedule kind via non-constexpr ompScheduleKind, but no chunk size.
+template<alpaka::omp::Schedule::Kind TKind>
 struct KernelWithMemberOmpScheduleKind : KernelWithOmpScheduleBase
 {
     static const alpaka::omp::Schedule::Kind ompScheduleKind;
 };
 // In this case, the member has to be defined externally
-const alpaka::omp::Schedule::Kind KernelWithMemberOmpScheduleKind::ompScheduleKind = alpaka::omp::Schedule::Dynamic;
+template<alpaka::omp::Schedule::Kind TKind>
+const alpaka::omp::Schedule::Kind KernelWithMemberOmpScheduleKind<TKind>::ompScheduleKind = TKind;
 
-// Kernel that sets the schedule chunk size via constexpr ompScheduleChunkSize.
-// Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.
-struct KernelWithConstexprStaticMemberOmpScheduleChunkSize : KernelWithOmpScheduleBase
+// Kernel that sets the schedule chunk size via constexpr ompScheduleChunkSize in addition to schedule kind, but no
+// chunk size. Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.
+template<alpaka::omp::Schedule::Kind TKind>
+struct KernelWithConstexprStaticMemberOmpScheduleChunkSize : KernelWithConstexprMemberOmpScheduleKind<TKind>
 {
     static constexpr int ompScheduleChunkSize = 5;
 };
 
-// Kernel that sets the schedule chunk size via non-constexpr ompScheduleChunkSize.
-struct KernelWithStaticMemberOmpScheduleChunkSize : KernelWithOmpScheduleBase
+// Kernel that sets the schedule chunk size via non-constexpr ompScheduleChunkSize in addition to schedule kind.
+template<alpaka::omp::Schedule::Kind TKind>
+struct KernelWithStaticMemberOmpScheduleChunkSize : KernelWithMemberOmpScheduleKind<TKind>
 {
     static const int ompScheduleChunkSize;
 };
 // In this case, the member has to be defined externally
-const int KernelWithStaticMemberOmpScheduleChunkSize::ompScheduleChunkSize = 2;
+template<alpaka::omp::Schedule::Kind TKind>
+const int KernelWithStaticMemberOmpScheduleChunkSize<TKind>::ompScheduleChunkSize = 2;
 
-// Kernel that sets the schedule chunk size via non-constexpr non-static ompScheduleChunkSize.
-struct KernelWithMemberOmpScheduleChunkSize : KernelWithOmpScheduleBase
+// Kernel that sets the schedule chunk size via non-constexpr non-static ompScheduleChunkSize in addition to schedule
+// kind.
+template<alpaka::omp::Schedule::Kind TKind>
+struct KernelWithMemberOmpScheduleChunkSize : KernelWithConstexprMemberOmpScheduleKind<TKind>
 {
     int ompScheduleChunkSize = 4;
 };
 
-// Kernel that sets the schedule via partial specialization of a trait
-struct KernelWithTraitOmpSchedule : KernelWithOmpScheduleBase
+// Kernel that copies the given base kernel and adds an OmpSchedule trait on top
+template<typename TBase>
+struct KernelWithTrait : TBase
 {
-};
-
-// Kernel that sets the schedule via both member and partial specialization of a trait.
-// In this case test that the trait is used, not the member.
-struct KernelWithMemberAndTraitOmpSchedule : KernelWithOmpScheduleBase
-{
-    static constexpr auto ompScheduleKind = alpaka::omp::Schedule::Dynamic;
 };
 
 namespace alpaka
 {
     namespace traits
     {
-        // Specialize the trait for all kernels
-        template<typename TKernelFnObj, typename TAcc>
-        struct OmpSchedule<TKernelFnObj, TAcc>
+        // Specialize the trait for kernels of type KernelWithTrait<>
+        template<typename TBase, typename TAcc>
+        struct OmpSchedule<KernelWithTrait<TBase>, TAcc>
         {
             template<typename TDim, typename... TArgs>
             ALPAKA_FN_HOST static auto getOmpSchedule(
-                TKernelFnObj const& kernelFnObj,
+                KernelWithTrait<TBase> const& kernelFnObj,
                 Vec<TDim, Idx<TAcc>> const& blockThreadExtent,
                 Vec<TDim, Idx<TAcc>> const& threadElemExtent,
                 TArgs const&... args) -> alpaka::omp::Schedule
@@ -99,7 +101,7 @@ namespace alpaka
                 alpaka::ignore_unused(threadElemExtent);
                 alpaka::ignore_unused(args...);
 
-                return alpaka::omp::Schedule{alpaka::omp::Schedule::Guided, 2};
+                return alpaka::omp::Schedule{alpaka::omp::Schedule::Static, 4};
             }
         };
     } // namespace traits
@@ -107,7 +109,7 @@ namespace alpaka
 
 // Generic testing routine for the given kernel type
 template<typename TAcc, typename TKernel>
-void test()
+void testKernel()
 {
     using Acc = TAcc;
     using Dim = alpaka::Dim<Acc>;
@@ -115,44 +117,47 @@ void test()
 
     alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::ones());
 
+    // Base version with no OmpSchedule trait
     TKernel kernel;
-
     REQUIRE(fixture(kernel));
+
+    // Same members, but with OmpSchedule trait
+    KernelWithTrait<TKernel> kernelWithTrait;
+    REQUIRE(fixture(kernelWithTrait));
+}
+
+// Note: it turned out not possible to test all possible combinations as it causes several compilers to crash in CI.
+// However the following tests should cover all important cases
+
+TEMPLATE_LIST_TEST_CASE("kernelWithOmpScheduleBase", "[kernel]", alpaka::test::TestAccs)
+{
+    testKernel<TestType, KernelWithOmpScheduleBase>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithConstexprMemberOmpScheduleKind", "[kernel]", alpaka::test::TestAccs)
 {
-    test<TestType, KernelWithConstexprMemberOmpScheduleKind>();
+    testKernel<TestType, KernelWithConstexprMemberOmpScheduleKind<alpaka::omp::Schedule::NoSchedule>>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithMemberOmpScheduleKind", "[kernel]", alpaka::test::TestAccs)
 {
-    test<TestType, KernelWithMemberOmpScheduleKind>();
+    testKernel<TestType, KernelWithMemberOmpScheduleKind<alpaka::omp::Schedule::Static>>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithConstexprStaticMemberOmpScheduleChunkSize", "[kernel]", alpaka::test::TestAccs)
 {
-    test<TestType, KernelWithConstexprStaticMemberOmpScheduleChunkSize>();
+    testKernel<TestType, KernelWithConstexprStaticMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Dynamic>>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithStaticMemberOmpScheduleChunkSize", "[kernel]", alpaka::test::TestAccs)
 {
-    test<TestType, KernelWithStaticMemberOmpScheduleChunkSize>();
+    testKernel<TestType, KernelWithStaticMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Guided>>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithMemberOmpScheduleChunkSize", "[kernel]", alpaka::test::TestAccs)
 {
-    test<TestType, KernelWithMemberOmpScheduleChunkSize>();
-}
-
-//-----------------------------------------------------------------------------
-TEMPLATE_LIST_TEST_CASE("kernelWithTraitOmpSchedule", "[kernel]", alpaka::test::TestAccs)
-{
-    test<TestType, KernelWithTraitOmpSchedule>();
-}
-
-//-----------------------------------------------------------------------------
-TEMPLATE_LIST_TEST_CASE("kernelWithMemberAndTraitOmpSchedule", "[kernel]", alpaka::test::TestAccs)
-{
-    test<TestType, KernelWithMemberAndTraitOmpSchedule>();
+#if defined _OPENMP && _OPENMP >= 200805
+    testKernel<TestType, KernelWithMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Auto>>();
+#endif
+    testKernel<TestType, KernelWithMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Runtime>>();
 }

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -40,30 +40,12 @@ struct KernelWithConstexprMemberOmpScheduleKind : KernelWithOmpScheduleBase
     static constexpr auto ompScheduleKind = TKind;
 };
 
-// CI runs show that nvcc 10 on Windows has an issue with the const, but not constexpr static member.
-// While instantiating schedule-related templates, it throws an error
-// error #28: expression must have a constant value
-// saying the value of the member cannot be used as a constant.
-// This seems like a bug in the compiler.
-// Other versions or compilers in CI process it properly.
-#if BOOST_OS_WINDOWS && (BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(10, 0, 0))                                           \
-    && (BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 0, 0))
-// For this combination use constexpr instead of const.
-template<alpaka::omp::Schedule::Kind TKind>
-struct KernelWithMemberOmpScheduleKind : KernelWithConstexprMemberOmpScheduleKind<TKind>
-{
-};
-#else
 // Kernel that sets the schedule kind via non-constexpr ompScheduleKind, but no chunk size.
 template<alpaka::omp::Schedule::Kind TKind>
 struct KernelWithMemberOmpScheduleKind : KernelWithOmpScheduleBase
 {
-    static const alpaka::omp::Schedule::Kind ompScheduleKind;
+    static const alpaka::omp::Schedule::Kind ompScheduleKind = TKind;
 };
-// In this case, the member has to be defined externally
-template<alpaka::omp::Schedule::Kind TKind>
-const alpaka::omp::Schedule::Kind KernelWithMemberOmpScheduleKind<TKind>::ompScheduleKind = TKind;
-#endif
 
 // Kernel that sets the schedule chunk size via constexpr ompScheduleChunkSize in addition to schedule kind, but no
 // chunk size. Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -35,7 +35,7 @@ struct KernelWithOmpScheduleBase
 // Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.
 struct KernelWithConstexprMemberOmpScheduleKind : KernelWithOmpScheduleBase
 {
-    static constexpr auto ompScheduleKind = alpaka::omp::Schedule::Runtime;
+    static constexpr auto ompScheduleKind = alpaka::omp::Schedule::Static;
 };
 
 // Kernel that sets the schedule kind via non-constexpr ompScheduleKind.
@@ -44,7 +44,7 @@ struct KernelWithMemberOmpScheduleKind : KernelWithOmpScheduleBase
     static const alpaka::omp::Schedule::Kind ompScheduleKind;
 };
 // In this case, the member has to be defined externally
-const alpaka::omp::Schedule::Kind KernelWithMemberOmpScheduleKind::ompScheduleKind = alpaka::omp::Schedule::NoSchedule;
+const alpaka::omp::Schedule::Kind KernelWithMemberOmpScheduleKind::ompScheduleKind = alpaka::omp::Schedule::Dynamic;
 
 // Kernel that sets the schedule chunk size via constexpr ompScheduleChunkSize.
 // Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -7,6 +7,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <alpaka/core/BoostPredef.hpp>
 #include <alpaka/core/OmpSchedule.hpp>
 #include <alpaka/kernel/Traits.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
@@ -39,6 +40,20 @@ struct KernelWithConstexprMemberOmpScheduleKind : KernelWithOmpScheduleBase
     static constexpr auto ompScheduleKind = TKind;
 };
 
+// CI runs show that nvcc 10 on Windows has an issue with the const, but not constexpr static member.
+// While instantiating schedule-related templates, it throws an error
+// error #28: expression must have a constant value
+// saying the value of the member cannot be used as a constant.
+// This seems like a bug in the compiler.
+// Other versions or compilers in CI process it properly.
+#if BOOST_OS_WINDOWS && (BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(10, 0, 0))                                           \
+    && (BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 0, 0))
+// For this combination use constexpr instead of const.
+template<alpaka::omp::Schedule::Kind TKind>
+struct KernelWithMemberOmpScheduleKind : KernelWithConstexprMemberOmpScheduleKind<TKind>
+{
+};
+#else
 // Kernel that sets the schedule kind via non-constexpr ompScheduleKind, but no chunk size.
 template<alpaka::omp::Schedule::Kind TKind>
 struct KernelWithMemberOmpScheduleKind : KernelWithOmpScheduleBase
@@ -48,6 +63,7 @@ struct KernelWithMemberOmpScheduleKind : KernelWithOmpScheduleBase
 // In this case, the member has to be defined externally
 template<alpaka::omp::Schedule::Kind TKind>
 const alpaka::omp::Schedule::Kind KernelWithMemberOmpScheduleKind<TKind>::ompScheduleKind = TKind;
+#endif
 
 // Kernel that sets the schedule chunk size via constexpr ompScheduleChunkSize in addition to schedule kind, but no
 // chunk size. Checks that this variable is only declared and not defined, It also tests that alpaka never odr-uses it.


### PR DESCRIPTION
backport:
- fix OpenMP schedule support #1309 #1313
- example: fix warning (NVCC+OpenMP) #1307
- CMake CUDA: dev compile options not propagated #1294
- update CHANGELOG.md

# Dependency

- [x] this PR already includes #1313, wait with merging until #1313 is merged