### PR TITLE
fix OpenMP schedule support

### DIFF
--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -194,7 +194,7 @@ namespace alpaka
         //!
         //! \tparam TKernel The kernel type.
         template<typename TKernel>
-        using HasScheduleChunkSize = std::enable_if_t<sizeof(std::declval<TKernel&>().ompScheduleChunkSize)>;
+        using HasScheduleChunkSize = alpaka::meta::Void<decltype(TKernel::ompScheduleChunkSize)>;
 
         //! Helper executor of parallel OpenMP loop with the static schedule
         //!


### PR DESCRIPTION
Fix support for MSVC 2017.

```
  D:/a/alpaka/alpaka/include\alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp(251): note: see reference to class template instantiation 'alpaka::detail::ParallelForImpl<TKernel,TSchedule,alpaka::omp::Schedule::Static>' being compiled
D:/a/alpaka/alpaka/include\alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp(375): error C2976: 'alpaka::detail::ParallelForDynamicImpl': too few template arguments
```

Similar issues was fixed during the development of #1309.