### PR TITLE
Rename "generator" to "engine" in rand

### DIFF
--- a/example/monteCarloIntegration/src/monteCarloIntegration.cpp
+++ b/example/monteCarloIntegration/src/monteCarloIntegration.cpp
@@ -59,8 +59,8 @@ struct Kernel
         auto const globalThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
         auto const linearizedGlobalThreadIdx = alpaka::mapIdx<1u>(globalThreadIdx, globalThreadExtent)[0];
-        // Setup generator and distribution.
-        auto generator = alpaka::rand::generator::createDefault(
+        // Setup generator engine and distribution.
+        auto engine = alpaka::rand::engine::createDefault(
             acc,
             linearizedGlobalThreadIdx,
             0); // No specific subsequence start.
@@ -71,8 +71,8 @@ struct Kernel
         for(size_t i = linearizedGlobalThreadIdx; i < numPoints; i += globalThreadExtent.prod())
         {
             // Generate a point in the 2D interval.
-            float x = dist(generator);
-            float y = dist(generator);
+            float x = dist(engine);
+            float y = dist(engine);
             // Count every time where the point is "below" the given function.
             if(y <= functor(acc, x))
             {

--- a/include/alpaka/rand/RandStdLib.hpp
+++ b/include/alpaka/rand/RandStdLib.hpp
@@ -130,10 +130,10 @@ namespace alpaka
                 public:
                     NormalReal() = default;
 
-                    template<typename TGenerator>
-                    ALPAKA_FN_HOST auto operator()(TGenerator& generator) -> T
+                    template<typename TEngine>
+                    ALPAKA_FN_HOST auto operator()(TEngine& engine) -> T
                     {
-                        return m_dist(generator.m_State);
+                        return m_dist(engine.m_State);
                     }
                     std::normal_distribution<T> m_dist;
                 };
@@ -145,10 +145,10 @@ namespace alpaka
                 public:
                     UniformReal() = default;
 
-                    template<typename TGenerator>
-                    ALPAKA_FN_HOST auto operator()(TGenerator& generator) -> T
+                    template<typename TEngine>
+                    ALPAKA_FN_HOST auto operator()(TEngine& engine) -> T
                     {
-                        return m_dist(generator.m_State);
+                        return m_dist(engine.m_State);
                     }
                     std::uniform_real_distribution<T> m_dist;
                 };
@@ -165,10 +165,10 @@ namespace alpaka
                     {
                     }
 
-                    template<typename TGenerator>
-                    ALPAKA_FN_HOST auto operator()(TGenerator& generator) -> T
+                    template<typename TEngine>
+                    ALPAKA_FN_HOST auto operator()(TEngine& engine) -> T
                     {
-                        return m_dist(generator.m_State);
+                        return m_dist(engine.m_State);
                     }
                     std::uniform_int_distribution<T> m_dist;
                 };

--- a/include/alpaka/rand/RandStdLib.hpp
+++ b/include/alpaka/rand/RandStdLib.hpp
@@ -38,7 +38,7 @@ namespace alpaka
         {
         };
 
-        namespace generator
+        namespace engine
         {
             namespace cpu
             {
@@ -117,7 +117,7 @@ namespace alpaka
                     std::random_device m_State;
                 };
             } // namespace cpu
-        } // namespace generator
+        } // namespace engine
 
         namespace distribution
         {
@@ -214,7 +214,7 @@ namespace alpaka
                 };
             } // namespace traits
         } // namespace distribution
-        namespace generator
+        namespace engine
         {
             namespace traits
             {
@@ -225,10 +225,10 @@ namespace alpaka
                     ALPAKA_FN_HOST static auto createDefault(
                         TinyMersenneTwister const& rand,
                         std::uint32_t const& seed,
-                        std::uint32_t const& subsequence) -> rand::generator::cpu::TinyMersenneTwister
+                        std::uint32_t const& subsequence) -> rand::engine::cpu::TinyMersenneTwister
                     {
                         alpaka::ignore_unused(rand);
-                        return rand::generator::cpu::TinyMersenneTwister(seed, subsequence);
+                        return rand::engine::cpu::TinyMersenneTwister(seed, subsequence);
                     }
                 };
 
@@ -238,10 +238,10 @@ namespace alpaka
                     ALPAKA_FN_HOST static auto createDefault(
                         MersenneTwister const& rand,
                         std::uint32_t const& seed,
-                        std::uint32_t const& subsequence) -> rand::generator::cpu::MersenneTwister
+                        std::uint32_t const& subsequence) -> rand::engine::cpu::MersenneTwister
                     {
                         alpaka::ignore_unused(rand);
-                        return rand::generator::cpu::MersenneTwister(seed, subsequence);
+                        return rand::engine::cpu::MersenneTwister(seed, subsequence);
                     }
                 };
 
@@ -251,13 +251,13 @@ namespace alpaka
                     ALPAKA_FN_HOST static auto createDefault(
                         RandomDevice const& rand,
                         std::uint32_t const& seed,
-                        std::uint32_t const& subsequence) -> rand::generator::cpu::RandomDevice
+                        std::uint32_t const& subsequence) -> rand::engine::cpu::RandomDevice
                     {
                         alpaka::ignore_unused(rand);
-                        return rand::generator::cpu::RandomDevice(seed, subsequence);
+                        return rand::engine::cpu::RandomDevice(seed, subsequence);
                     }
                 };
             } // namespace traits
-        } // namespace generator
+        } // namespace engine
     } // namespace rand
 } // namespace alpaka

--- a/include/alpaka/rand/RandUniformCudaHipRand.hpp
+++ b/include/alpaka/rand/RandUniformCudaHipRand.hpp
@@ -57,7 +57,7 @@ namespace alpaka
         {
             namespace uniform_cuda_hip
             {
-                //! The CUDA/HIP Xor random number generator.
+                //! The CUDA/HIP Xor random number generator engine.
                 class Xor
                 {
                 public:
@@ -111,13 +111,13 @@ namespace alpaka
                 public:
                     NormalReal() = default;
 
-                    template<typename TGenerator>
-                    __device__ auto operator()(TGenerator& generator) -> float
+                    template<typename TEngine>
+                    __device__ auto operator()(TEngine& engine) -> float
                     {
 #    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                        return curand_normal(&generator.m_State);
+                        return curand_normal(&engine.m_State);
 #    else
-                        return hiprand_normal(&generator.m_State);
+                        return hiprand_normal(&engine.m_State);
 #    endif
                     }
                 };
@@ -128,13 +128,13 @@ namespace alpaka
                 public:
                     NormalReal() = default;
 
-                    template<typename TGenerator>
-                    __device__ auto operator()(TGenerator& generator) -> double
+                    template<typename TEngine>
+                    __device__ auto operator()(TEngine& engine) -> double
                     {
 #    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                        return curand_normal_double(&generator.m_State);
+                        return curand_normal_double(&engine.m_State);
 #    else
-                        return hiprand_normal_double(&generator.m_State);
+                        return hiprand_normal_double(&engine.m_State);
 #    endif
                     }
                 };
@@ -150,14 +150,14 @@ namespace alpaka
                 public:
                     UniformReal() = default;
 
-                    template<typename TGenerator>
-                    __device__ auto operator()(TGenerator& generator) -> float
+                    template<typename TEngine>
+                    __device__ auto operator()(TEngine& engine) -> float
                     {
                         // (0.f, 1.0f]
 #    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                        float const fUniformRand(curand_uniform(&generator.m_State));
+                        float const fUniformRand(curand_uniform(&engine.m_State));
 #    else
-                        float const fUniformRand(hiprand_uniform(&generator.m_State));
+                        float const fUniformRand(hiprand_uniform(&engine.m_State));
 #    endif
                         // NOTE: (1.0f - curand_uniform) does not work, because curand_uniform seems to return
                         // denormalized floats around 0.f. [0.f, 1.0f)
@@ -171,14 +171,14 @@ namespace alpaka
                 public:
                     UniformReal() = default;
 
-                    template<typename TGenerator>
-                    __device__ auto operator()(TGenerator& generator) -> double
+                    template<typename TEngine>
+                    __device__ auto operator()(TEngine& engine) -> double
                     {
                         // (0.f, 1.0f]
 #    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                        double const fUniformRand(curand_uniform_double(&generator.m_State));
+                        double const fUniformRand(curand_uniform_double(&engine.m_State));
 #    else
-                        double const fUniformRand(hiprand_uniform_double(&generator.m_State));
+                        double const fUniformRand(hiprand_uniform_double(&engine.m_State));
 #    endif
                         // NOTE: (1.0f - curand_uniform_double) does not work, because curand_uniform_double seems to
                         // return denormalized floats around 0.f. [0.f, 1.0f)
@@ -197,13 +197,13 @@ namespace alpaka
                 public:
                     UniformUint() = default;
 
-                    template<typename TGenerator>
-                    __device__ auto operator()(TGenerator& generator) -> unsigned int
+                    template<typename TEngine>
+                    __device__ auto operator()(TEngine& engine) -> unsigned int
                     {
 #    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                        return curand(&generator.m_State);
+                        return curand(&engine.m_State);
 #    else
-                        return hiprand(&generator.m_State);
+                        return hiprand(&engine.m_State);
 #    endif
                     }
                 };

--- a/include/alpaka/rand/RandUniformCudaHipRand.hpp
+++ b/include/alpaka/rand/RandUniformCudaHipRand.hpp
@@ -53,7 +53,7 @@ namespace alpaka
         {
         };
 
-        namespace generator
+        namespace engine
         {
             namespace uniform_cuda_hip
             {
@@ -95,7 +95,7 @@ namespace alpaka
 #    endif
                 };
             } // namespace uniform_cuda_hip
-        } // namespace generator
+        } // namespace engine
         namespace distribution
         {
             namespace uniform_cuda_hip
@@ -246,7 +246,7 @@ namespace alpaka
                 };
             } // namespace traits
         } // namespace distribution
-        namespace generator
+        namespace engine
         {
             namespace traits
             {
@@ -257,13 +257,13 @@ namespace alpaka
                     __device__ static auto createDefault(
                         RandUniformCudaHipRand const& /*rand*/,
                         std::uint32_t const& seed,
-                        std::uint32_t const& subsequence) -> rand::generator::uniform_cuda_hip::Xor
+                        std::uint32_t const& subsequence) -> rand::engine::uniform_cuda_hip::Xor
                     {
-                        return rand::generator::uniform_cuda_hip::Xor(seed, subsequence);
+                        return rand::engine::uniform_cuda_hip::Xor(seed, subsequence);
                     }
                 };
             } // namespace traits
-        } // namespace generator
+        } // namespace engine
     } // namespace rand
 } // namespace alpaka
 

--- a/include/alpaka/rand/TinyMT/Engine.hpp
+++ b/include/alpaka/rand/TinyMT/Engine.hpp
@@ -18,7 +18,7 @@ namespace alpaka
 {
     namespace rand
     {
-        namespace generator
+        namespace engine
         {
             namespace cpu
             {
@@ -78,6 +78,6 @@ namespace alpaka
                 };
 
             } // namespace cpu
-        } // namespace generator
+        } // namespace engine
     } // namespace rand
 } // namespace alpaka

--- a/include/alpaka/rand/Traits.hpp
+++ b/include/alpaka/rand/Traits.hpp
@@ -76,17 +76,17 @@ namespace alpaka
             }
         } // namespace distribution
 
-        //! The random number generator specifics.
-        namespace generator
+        //! The random number generator engine specifics.
+        namespace engine
         {
-            //! The random number generator traits.
+            //! The random number generator engine traits.
             namespace traits
             {
-                //! The random number default generator get trait.
+                //! The random number default generator engine get trait.
                 template<typename TRand, typename TSfinae = void>
                 struct CreateDefault;
             } // namespace traits
-            //! \return A default random number generator.
+            //! \return A default random number generator engine.
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename TRand>
             ALPAKA_FN_HOST_ACC auto createDefault(
@@ -97,6 +97,6 @@ namespace alpaka
                 using ImplementationBase = concepts::ImplementationBase<ConceptRand, TRand>;
                 return traits::CreateDefault<ImplementationBase>::createDefault(rand, seed, subsequence);
             }
-        } // namespace generator
+        } // namespace engine
     } // namespace rand
 } // namespace alpaka

--- a/test/unit/rand/src/RandTest.cpp
+++ b/test/unit/rand/src/RandTest.cpp
@@ -77,8 +77,7 @@ public:
         genNumbers(acc, success, genRandomDevice);
 
         // MersenneTwister
-        auto genMersenneTwister
-            = alpaka::rand::engine::createDefault(alpaka::rand::MersenneTwister{}, 12345u, 6789u);
+        auto genMersenneTwister = alpaka::rand::engine::createDefault(alpaka::rand::MersenneTwister{}, 12345u, 6789u);
         genNumbers(acc, success, genMersenneTwister);
 #    endif
 

--- a/test/unit/rand/src/RandTest.cpp
+++ b/test/unit/rand/src/RandTest.cpp
@@ -65,7 +65,7 @@ public:
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
     {
         // default generator for accelerator
-        auto genDefault = alpaka::rand::generator::createDefault(acc, 12345u, 6789u);
+        auto genDefault = alpaka::rand::engine::createDefault(acc, 12345u, 6789u);
         genNumbers(acc, success, genDefault);
 
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED)
@@ -73,18 +73,18 @@ public:
         // TODO: These ifdefs are wrong: They will reduce the test to the
         // smallest common denominator from all enabled backends
         // std::random_device
-        auto genRandomDevice = alpaka::rand::generator::createDefault(alpaka::rand::RandomDevice{}, 12345u, 6789u);
+        auto genRandomDevice = alpaka::rand::engine::createDefault(alpaka::rand::RandomDevice{}, 12345u, 6789u);
         genNumbers(acc, success, genRandomDevice);
 
         // MersenneTwister
         auto genMersenneTwister
-            = alpaka::rand::generator::createDefault(alpaka::rand::MersenneTwister{}, 12345u, 6789u);
+            = alpaka::rand::engine::createDefault(alpaka::rand::MersenneTwister{}, 12345u, 6789u);
         genNumbers(acc, success, genMersenneTwister);
 #    endif
 
         // TinyMersenneTwister
         auto genTinyMersenneTwister
-            = alpaka::rand::generator::createDefault(alpaka::rand::TinyMersenneTwister{}, 12345u, 6789u);
+            = alpaka::rand::engine::createDefault(alpaka::rand::TinyMersenneTwister{}, 12345u, 6789u);
         genNumbers(acc, success, genTinyMersenneTwister);
 #endif
     }


### PR DESCRIPTION
As discussed in an earlier meeting, *engine* is a better name than *generator*. It's also consistent with the STL which refers to these as engines (even though it does not use such a namespace directly).