### PR TITLE
fix HIP compiler options not recognized (backport to 0.6.1)

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -853,7 +853,8 @@ if(TARGET alpaka)
 endif()
 
 # NVCC does not incorporate the COMPILE_OPTIONS of a target but only the CMAKE_CXX_FLAGS
-if((ALPAKA_ACC_GPU_CUDA_ENABLE OR ALPAKA_ACC_GPU_HIP_ENABLE) AND ALPAKA_CUDA_COMPILER MATCHES "nvcc")
+# For hipcc we need to propagate the CMAKE_CXX_FLAGS to HIP_HIPCC_FLAGS.
+if((ALPAKA_ACC_GPU_CUDA_ENABLE AND ALPAKA_CUDA_COMPILER MATCHES "nvcc") OR ALPAKA_ACC_GPU_HIP_ENABLE)
     get_property(_ALPAKA_COMPILE_OPTIONS_PUBLIC
                  TARGET alpaka
                  PROPERTY INTERFACE_COMPILE_OPTIONS)
@@ -864,5 +865,9 @@ if((ALPAKA_ACC_GPU_CUDA_ENABLE OR ALPAKA_ACC_GPU_HIP_ENABLE) AND ALPAKA_CUDA_COM
     # because FindCUDA only propagates the latter to nvcc.
     string(TOUPPER "${CMAKE_BUILD_TYPE}" build_config)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${build_config}}")
+    if(ALPAKA_ACC_GPU_HIP_ENABLE)
+        # for hipcc we need to propagate the CMAKE_CXX_FLAGS to HIP_HIPCC_FLAGS
+        list(APPEND HIP_HIPCC_FLAGS ${CMAKE_CXX_FLAGS})
+    endif()
 endif()
 


### PR DESCRIPTION
This PR is against 0.6.1, the fix for dev and 0.7.0-rc1 will follow soon.

Compiler options for hipcc must be provided via the cmake variable HIP_HIPCC_FLAGS. CMAKE_CXX_FLAGS is not taken into account.


Bug was found with PIConGPU: https://github.com/ComputationalRadiationPhysics/picongpu/issues/3624#issuecomment-848517408