### PR TITLE
fix HIP compiler options not recognized

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -771,8 +771,8 @@ if(TARGET alpaka)
     endif()
 endif()
 
-# NVCC does not incorporate the COMPILE_OPTIONS of a target but only the CMAKE_CXX_FLAGS
-if(ALPAKA_ACC_GPU_HIP_ENABLE AND ALPAKA_CUDA_COMPILER MATCHES "nvcc")
+# For hipcc we need to propagate the CMAKE_CXX_FLAGS to HIP_HIPCC_FLAGS.
+if(ALPAKA_ACC_GPU_HIP_ENABLE)
     get_property(_ALPAKA_COMPILE_OPTIONS_PUBLIC
                  TARGET alpaka
                  PROPERTY INTERFACE_COMPILE_OPTIONS)
@@ -780,9 +780,13 @@ if(ALPAKA_ACC_GPU_HIP_ENABLE AND ALPAKA_CUDA_COMPILER MATCHES "nvcc")
     alpaka_set_compiler_options(HOST var CMAKE_CXX_FLAGS "${_ALPAKA_COMPILE_OPTIONS_STRING}")
 
     # Append CMAKE_CXX_FLAGS_[Release|Debug|RelWithDebInfo] to CMAKE_CXX_FLAGS
-    # because FindCUDA only propagates the latter to nvcc.
+    # because cmake HIP modules do not use the former variables
     string(TOUPPER "${CMAKE_BUILD_TYPE}" build_config)
     alpaka_set_compiler_options(HOST var CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_${build_config}}")
+
+    # additionally CMAKE_CXX_FLAGS must be propagated to HIP_HIPCC_FLAGS
+    string(REPLACE " " ";" CMAKE_CXX_FLAGS_AS_LIST "${CMAKE_CXX_FLAGS}")
+    alpaka_set_compiler_options(DEVICE list HIP_HIPCC_FLAGS "${CMAKE_CXX_FLAGS_AS_LIST}")
 endif()
 
 if(ALPAKA_COMPILER_OPTIONS_DEVICE OR ALPAKA_COMPILER_OPTIONS_DEVICE)


### PR DESCRIPTION
Compiler options for hipcc must be provided via the cmake variable
HIP_HIPCC_FLAGS. CMAKE_CXX_FLAGS is not taken into account.