### PR TITLE
Prefer TBBConfig.cmake over FindTBB.cmake

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -269,12 +269,15 @@ endif()
 #-------------------------------------------------------------------------------
 # Find TBB.
 if(ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE)
-    find_package(TBB)
-    if(TBB_FOUND)
-        target_link_libraries(alpaka INTERFACE TBB::tbb)
-    else()
-        message(FATAL_ERROR "Optional alpaka dependency TBB could not be found!")
+    # Prefer TBB's own TBBConfig.cmake (available in more recent TBB versions)
+    find_package(TBB QUIET CONFIG)
+    
+    if(NOT TBB_FOUND)
+        message(STATUS "TBB not found in config mode. Retrying in module mode.")
+        find_package(TBB REQUIRED MODULE)
     endif()
+
+    target_link_libraries(alpaka INTERFACE TBB::tbb)
 endif()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This is a followup to #1328. Not all supported operating systems have `TBBConfig.cmake`. Thankfully, CMake itself is able to support both versions. This PR adds a preference for `TBBConfig.cmake` and resorts to our own `FindTBB.cmake` if it can't pick up the former.

Once merged, this needs to be backported to 0.6.1 and 0.7.0.