### PR TITLE
CI: MSVC + nvcc workarounds and fixes (backport to 0.6.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,12 +210,15 @@ jobs:
         - name: windows_nvcc-11.1_cl-2017_debug_cuda-only
           os: windows-2016
           env: {CXX: cl.exe,  CC: cl.exe, ALPAKA_CI_CL_VER: 2017,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.72.0, ALPAKA_CI_CMAKE_VER: 3.18.5,                     ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "11.1", ALPAKA_CUDA_ARCH: "35;80", ALPAKA_ACC_GPU_CUDA_ONLY_MODE: ON,                                                                ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE: OFF, ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF, ALPAKA_ACC_ANY_BT_OMP5_ENABLE: OFF}
-        - name: windows_nvcc-11.1_cl-2019_release_cuda-only
+
+          ## CUDA 11.2
+          # nvcc + MSVC
+        - name: windows_nvcc-11.2_cl-2019_release_cuda-only_c++17
           os: windows-2019
-          env: {CXX: cl.exe,  CC: cl.exe, ALPAKA_CI_CL_VER: 2019,                                   CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.74.0, ALPAKA_CI_CMAKE_VER: 3.19.0,                     ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "11.1", ALPAKA_CUDA_ARCH: "35;75", ALPAKA_ACC_GPU_CUDA_ONLY_MODE: ON,                                                                ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE: OFF, ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF, ALPAKA_ACC_ANY_BT_OMP5_ENABLE: OFF}
-        - name: windows_nvcc-11.1_cl-2019_debug
+          env: {CXX: cl.exe,  CC: cl.exe, ALPAKA_CI_CL_VER: 2019,                                   CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.74.0, ALPAKA_CI_CMAKE_VER: 3.19.0,                     ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "11.2", ALPAKA_CUDA_ARCH: "35;75", ALPAKA_ACC_GPU_CUDA_ONLY_MODE: ON,                                                                ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE: OFF, ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF, ALPAKA_ACC_ANY_BT_OMP5_ENABLE: OFF, ALPAKA_CXX_STANDARD: 17}
+        - name: windows_nvcc-11.2_cl-2019_debug_c++17
           os: windows-2019
-          env: {CXX: cl.exe,  CC: cl.exe, ALPAKA_CI_CL_VER: 2019,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.68.0, ALPAKA_CI_CMAKE_VER: 3.18.5,                     ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "11.1",                                                                                                                              ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_ACC_CPU_BT_OMP4_ENABLE: OFF, ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF}
+          env: {CXX: cl.exe,  CC: cl.exe, ALPAKA_CI_CL_VER: 2019,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.68.0, ALPAKA_CI_CMAKE_VER: 3.18.5,                     ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CUDA_VERSION: "11.2",                                                                                                                              ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_ACC_CPU_BT_OMP4_ENABLE: OFF, ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, ALPAKA_CXX_STANDARD: 17}
 
         ### Ubuntu
         ## native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - rework implementation of OpenMP schedule support #1279 #1309 #1313
   - `alpaka::omp::Schedule` is replaced by `ompScheduleKind` and `ompScheduleChunkSize`
 ### Bug Fixes:
-- CI: use ubuntu-18.04 for gcc-5 and gcc-6 builds #1252
 - fix OpenMP 5 shared memory allocation #1254 
 - fix static shared memory alignment #1282
 - fix BlockSharedMemStMemberImpl::getVarPtr for last var #1280
 - fix CPU static shared memory implementation #1258
 - unit tests: fix queue test #1266
 - fix CtxBlockOacc: SyncBlockThreads #1291
-- port macOSX CI fix from #1283
 - fix assert in DeclareSharedVar (OpenAcc) #1303
-- CI: disable GCC 10.3 + NVCC tests #1302
-- example: fix warning (NVCC+OpenMP) #1307
 - CMake CUDA: dev compile options not propagated #1294
+- example: fix warning (NVCC+OpenMP) #1307
+- port macOSX CI fix from #1283
+- CI: use ubuntu-18.04 for gcc-5 and gcc-6 builds #1252
+- CI: disable GCC 10.3 + NVCC tests #1302
+- CI: MSVC + nvcc workarounds and fixes #1332
 
 ### Misc
 - add ALPAKA_ASSERT_OFFLOAD Macro #1260

--- a/script/install_cuda.sh
+++ b/script/install_cuda.sh
@@ -130,10 +130,18 @@ then
     then
         ALPAKA_CUDA_PKG_FILE_NAME=cuda_11.1.1_456.81_win10.exe
         ALPAKA_CUDA_PKG_FILE_PATH=https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/${ALPAKA_CUDA_PKG_FILE_NAME}
+    elif [ "${ALPAKA_CUDA_VERSION}" == "11.2" ]
+    then
+        ALPAKA_CUDA_PKG_FILE_NAME=cuda_11.2.2_461.33_win10.exe
+        ALPAKA_CUDA_PKG_FILE_PATH=https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/${ALPAKA_CUDA_PKG_FILE_NAME}
+    elif [ "${ALPAKA_CUDA_VERSION}" == "11.3" ]
+    then
+        ALPAKA_CUDA_PKG_FILE_NAME=cuda_11.3.1_465.89_win10.exe
+        ALPAKA_CUDA_PKG_FILE_PATH=https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/${ALPAKA_CUDA_PKG_FILE_NAME}
     else
-        echo CUDA versions other than 10.0, 10.1, 10.2, 11.0 and 11.1 are not currently supported on Windows!
+        echo CUDA versions other than 10.0, 10.1, 10.2, 11.0, 11.1, 11.2 and 11.3 are not currently supported on Windows!
     fi
 
     curl -L -o cuda_installer.exe ${ALPAKA_CUDA_PKG_FILE_PATH}
-    ./cuda_installer.exe -s "nvcc_${ALPAKA_CUDA_VERSION}" "curand_dev_${ALPAKA_CUDA_VERSION}" "cudart_${ALPAKA_CUDA_VERSION}"
+    ./cuda_installer.exe -s "nvcc_${ALPAKA_CUDA_VERSION}" "curand_dev_${ALPAKA_CUDA_VERSION}" "cudart_${ALPAKA_CUDA_VERSION}" "visual_studio_integration_${ALPAKA_CUDA_VERSION}"
 fi

--- a/script/install_cuda.sh
+++ b/script/install_cuda.sh
@@ -116,8 +116,8 @@ then
         ALPAKA_CUDA_PKG_FILE_PATH=https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers/${ALPAKA_CUDA_PKG_FILE_NAME}
     elif [ "${ALPAKA_CUDA_VERSION}" == "10.1" ]
     then
-        ALPAKA_CUDA_PKG_FILE_NAME=cuda_10.1.168_425.25_win10.exe
-        ALPAKA_CUDA_PKG_FILE_PATH=https://developer.nvidia.com/compute/cuda/10.1/Prod/local_installers/${ALPAKA_CUDA_PKG_FILE_NAME}
+        ALPAKA_CUDA_PKG_FILE_NAME=cuda_10.1.243_426.00_win10.exe
+        ALPAKA_CUDA_PKG_FILE_PATH=https://developer.download.nvidia.com/compute/cuda/10.1/Prod/local_installers/${ALPAKA_CUDA_PKG_FILE_NAME}
     elif [ "${ALPAKA_CUDA_VERSION}" == "10.2" ]
     then
         ALPAKA_CUDA_PKG_FILE_NAME=cuda_10.2.89_441.22_win10.exe
@@ -128,8 +128,8 @@ then
         ALPAKA_CUDA_PKG_FILE_PATH=http://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/${ALPAKA_CUDA_PKG_FILE_NAME}
     elif [ "${ALPAKA_CUDA_VERSION}" == "11.1" ]
     then
-        ALPAKA_CUDA_PKG_FILE_NAME=cuda_11.1.0_456.43_win10.exe
-        ALPAKA_CUDA_PKG_FILE_PATH=http://developer.download.nvidia.com/compute/cuda/11.1.0/local_installers/${ALPAKA_CUDA_PKG_FILE_NAME}
+        ALPAKA_CUDA_PKG_FILE_NAME=cuda_11.1.1_456.81_win10.exe
+        ALPAKA_CUDA_PKG_FILE_PATH=https://developer.download.nvidia.com/compute/cuda/11.1.1/local_installers/${ALPAKA_CUDA_PKG_FILE_NAME}
     else
         echo CUDA versions other than 10.0, 10.1, 10.2, 11.0 and 11.1 are not currently supported on Windows!
     fi


### PR DESCRIPTION
- backport #1332 to 0.6.1
- update changelog
- remove Visual Studio 2019 + CUDA 11.1 tests by CUDA 11.2 to workaround #1331