### PR TITLE
CI: fix warp test

### DIFF
--- a/test/unit/warp/src/Activemask.cpp
+++ b/test/unit/warp/src/Activemask.cpp
@@ -14,6 +14,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <climits>
 #include <cstdint>
 
 class ActivemaskSingleThreadWarpTestKernel
@@ -51,7 +52,9 @@ public:
 
         auto const actual = alpaka::warp::activemask(acc);
         using Result = decltype(actual);
-        Result const allActive = (Result{1} << static_cast<Result>(warpExtent)) - 1;
+        Result const allActive = static_cast<size_t>(warpExtent) == sizeof(Result) * CHAR_BIT
+            ? ~Result{0u}
+            : (Result{1} << warpExtent) - 1u;
         Result const expected = allActive & ~(Result{1} << inactiveThreadIdx);
         ALPAKA_CHECK(*success, actual == expected);
     }

--- a/test/unit/warp/src/Ballot.cpp
+++ b/test/unit/warp/src/Ballot.cpp
@@ -14,6 +14,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <climits>
 #include <cstdint>
 
 class BallotSingleThreadWarpTestKernel
@@ -41,7 +42,11 @@ public:
         std::int32_t const warpExtent = alpaka::warp::getSize(acc);
         ALPAKA_CHECK(*success, warpExtent > 1);
 
-        ALPAKA_CHECK(*success, alpaka::warp::ballot(acc, 42) == (std::uint64_t{1} << warpExtent) - 1);
+        using BallotResultType = decltype(alpaka::warp::ballot(acc, 42));
+        BallotResultType const allActive = static_cast<size_t>(warpExtent) == sizeof(BallotResultType) * CHAR_BIT
+            ? ~BallotResultType{0u}
+            : (BallotResultType{1} << warpExtent) - 1u;
+        ALPAKA_CHECK(*success, alpaka::warp::ballot(acc, 42) == allActive);
         ALPAKA_CHECK(*success, alpaka::warp::ballot(acc, 0) == 0u);
 
         // Test relies on having a single warp per thread block


### PR DESCRIPTION
Fix undefined behavior because we shifted `static_cast<T>(1)<<n` where `n == sizeof(T)`.
If `n` is known at compile time the compiler is throwing a warning.
In the case where we use it, we assumed `1<<32` for 32bit is always `0`, this is wrong!

Unfortunately, we need to backport this to 0.6.1 and 0.7.0 :-(