### PR TITLE
Fix outdated comments in the OpenMP schedule example

### DIFF
--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -29,7 +29,7 @@
 //!
 //! Prints distribution of alpaka thread indices between OpenMP threads.
 //! Its operator() is reused in other kernels of this example.
-//! Sets no schedule explicitly, so the default is used, controlled by the OMP_SCHEDULE environment variable.
+//! Sets no schedule explicitly, so no schedule() clause is used.
 struct OpenMPScheduleDefaultKernel
 {
     template<typename TAcc>
@@ -76,9 +76,7 @@ namespace alpaka
     {
         //! Schedule trait specialization for OpenMPScheduleTraitKernel.
         //! This is the most general way to define a schedule.
-        //! In case neither the trait nor the member are provided, alpaka does not set any runtime schedule and the
-        //! schedule used is defined by omp_set_schedule() called on the user side, or otherwise by the OMP_SCHEDULE
-        //! environment variable.
+        //! In case neither the trait nor the member are provided, there will be no schedule() clause.
         template<typename TAcc>
         struct OmpSchedule<OpenMPScheduleTraitKernel, TAcc>
         {
@@ -137,7 +135,6 @@ auto main() -> int
         alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
 
     // Run the kernel setting no schedule explicitly.
-    // In this case the schedule is controlled by the OMP_SCHEDULE environment variable.
     std::cout << "OpenMPScheduleDefaultKernel setting no schedule explicitly:\n";
     alpaka::exec<Acc>(queue, workDiv, OpenMPScheduleDefaultKernel{});
     alpaka::wait(queue);


### PR DESCRIPTION
In the schedule implementation fix #1309, the comments in the example were outdated. Thanks to DLR for reporting this.

Regarding the other reported issue, there is a possible situation that one sets an `ompScheduleChunkSize` member but not `ompScheduleKind`. In this case `ompScheduleChunkSize` would be doing nothing, in accordance to how it is documented. I see that there can be a typo causing it, but I do not see any easy way to check and issue a warning there. Internally, this part is already very complicated, and also compile-time-consuming. So I think it is more practical to keep it as is.