### PR TITLE
TaskKernelOacc: copyin(all used local vars)

### DIFF
--- a/include/alpaka/kernel/TaskKernelOacc.hpp
+++ b/include/alpaka/kernel/TaskKernelOacc.hpp
@@ -114,8 +114,13 @@ namespace alpaka
             auto argsD = m_args;
             auto kernelFnObj = m_kernelFnObj;
             dev.makeCurrent();
-#    pragma acc parallel num_workers(blockThreadCount)                                                                \
-        copyin(threadElemExtent, blockThreadExtent, argsD, gridBlockExtent) default(present)
+#    pragma acc parallel num_workers(blockThreadCount) copyin(                                                        \
+        threadElemExtent,                                                                                             \
+        blockThreadExtent,                                                                                            \
+        gridBlockExtent,                                                                                              \
+        argsD,                                                                                                        \
+        blockSharedMemDynSizeBytes,                                                                                   \
+        kernelFnObj) default(present)
             {
                 {
 #    pragma acc loop gang


### PR DESCRIPTION
Because of the `default(present)` clause, which is required, because alpaka device buffer contain device pointer and should not be mapped to device again, all local variables use in the device code must be mapped manually.

Please backport to 0.6.1.