### PR TITLE
backport to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.6.1] - 2021-XX-XX
+## [0.6.1] - 2021-06-24
 ### Compatibility Changes:
-- rework implementation of OpenMP schedule support #1279 #1309 #1313
+- rework implementation of OpenMP schedule support #1279 #1309 #1313 #1341
   - `alpaka::omp::Schedule` is replaced by `ompScheduleKind` and `ompScheduleChunkSize`
 ### Bug Fixes:
 - fix OpenMP 5 shared memory allocation #1254 
@@ -17,10 +17,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - fix assert in DeclareSharedVar (OpenAcc) #1303
 - CMake CUDA: dev compile options not propagated #1294
 - example: fix warning (NVCC+OpenMP) #1307
+- TBB: Add missing <limits> header and fix integer namespace #1327
+- OpenAcc: TaskKernelOacc: copyin(all used local vars) #1342
 - port macOSX CI fix from #1283
 - CI: use ubuntu-18.04 for gcc-5 and gcc-6 builds #1252
 - CI: disable GCC 10.3 + NVCC tests #1302
 - CI: MSVC + nvcc workarounds and fixes #1332
+- CI: fix warp test #1339
 
 ### Misc
 - add ALPAKA_ASSERT_OFFLOAD Macro #1260

--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -30,7 +30,7 @@
 //!
 //! Prints distribution of alpaka thread indices between OpenMP threads.
 //! Its operator() is reused in other kernels of this example.
-//! Sets no schedule explicitly, so the default is used, controlled by the OMP_SCHEDULE environment variable.
+//! Sets no schedule explicitly, so no schedule() clause is used.
 struct OpenMPScheduleDefaultKernel
 {
     //-----------------------------------------------------------------------------
@@ -80,9 +80,7 @@ namespace alpaka
     {
         //! Schedule trait specialization for OpenMPScheduleTraitKernel.
         //! This is the most general way to define a schedule.
-        //! In case neither the trait nor the member are provided, alpaka does not set any runtime schedule and the
-        //! schedule used is defined by omp_set_schedule() called on the user side, or otherwise by the OMP_SCHEDULE
-        //! environment variable.
+        //! In case neither the trait nor the member are provided, there will be no schedule() clause.
         template<typename TAcc>
         struct OmpSchedule<OpenMPScheduleTraitKernel, TAcc>
         {
@@ -141,7 +139,6 @@ auto main() -> int
         alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
 
     // Run the kernel setting no schedule explicitly.
-    // In this case the schedule is controlled by the OMP_SCHEDULE environment variable.
     std::cout << "OpenMPScheduleDefaultKernel setting no schedule explicitly:\n";
     alpaka::exec<Acc>(queue, workDiv, OpenMPScheduleDefaultKernel{});
     alpaka::wait(queue);

--- a/include/alpaka/block/shared/st/detail/BlockSharedMemStMemberImpl.hpp
+++ b/include/alpaka/block/shared/st/detail/BlockSharedMemStMemberImpl.hpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <type_traits>
 
 namespace alpaka
@@ -32,25 +33,25 @@ namespace alpaka
             struct MetaData
             {
                 //! Unique id if the next data chunk.
-                uint32_t id = std::numeric_limits<uint32_t>::max();
+                std::uint32_t id = std::numeric_limits<std::uint32_t>::max();
                 //! Offset to the next meta data header, relative to m_mem.
                 //! To access the meta data header the offset must by aligned first.
-                uint32_t offset = 0;
+                std::uint32_t offset = 0;
             };
 
-            static constexpr uint32_t metaDataSize = sizeof(MetaData);
+            static constexpr std::uint32_t metaDataSize = sizeof(MetaData);
 
         public:
             //-----------------------------------------------------------------------------
 #ifndef NDEBUG
-            BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t capacity)
+            BlockSharedMemStMemberImpl(std::uint8_t* mem, std::size_t capacity)
                 : m_mem(mem)
                 , m_capacity(static_cast<std::uint32_t>(capacity))
             {
                 ALPAKA_ASSERT_OFFLOAD((m_mem == nullptr) == (m_capacity == 0u));
             }
 #else
-            BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t) : m_mem(mem)
+            BlockSharedMemStMemberImpl(std::uint8_t* mem, std::size_t) : m_mem(mem)
             {
             }
 #endif
@@ -66,7 +67,7 @@ namespace alpaka
             /*virtual*/ ~BlockSharedMemStMemberImpl() = default;
 
             template<typename T>
-            void alloc(uint32_t id) const
+            void alloc(std::uint32_t id) const
             {
                 // Add meta data chunk in front of the user data
                 m_allocdBytes = varChunkEnd<MetaData>(m_allocdBytes);
@@ -94,19 +95,19 @@ namespace alpaka
             //! @param id unique id of the variable
             //! @return nullptr if variable with id not exists
             template<typename T>
-            T* getVarPtr(uint32_t id) const
+            T* getVarPtr(std::uint32_t id) const
             {
                 // Offset in bytes to the next unaligned meta data header behind the variable.
-                uint32_t off = 0;
+                std::uint32_t off = 0;
 
                 // Iterate over allocated data only
                 while(off < m_allocdBytes)
                 {
                     // Adjust offset to be aligned
-                    uint32_t const alignedMetaDataOffset
-                        = varChunkEnd<MetaData>(off) - static_cast<uint32_t>(sizeof(MetaData));
+                    std::uint32_t const alignedMetaDataOffset
+                        = varChunkEnd<MetaData>(off) - static_cast<std::uint32_t>(sizeof(MetaData));
                     ALPAKA_ASSERT_OFFLOAD(
-                        (alignedMetaDataOffset + static_cast<uint32_t>(sizeof(MetaData))) <= m_allocdBytes);
+                        (alignedMetaDataOffset + static_cast<std::uint32_t>(sizeof(MetaData))) <= m_allocdBytes);
                     MetaData* metaDataPtr = reinterpret_cast<MetaData*>(m_mem + alignedMetaDataOffset);
                     off = metaDataPtr->offset;
 
@@ -140,12 +141,12 @@ namespace alpaka
             //! \param byteOffset Current byte offset.
             //! \result Byte offset to the end of the data chunk, relative to m_mem..
             template<typename T>
-            std::uint32_t varChunkEnd(uint32_t byteOffset) const
+            std::uint32_t varChunkEnd(std::uint32_t byteOffset) const
             {
-                size_t const ptr = reinterpret_cast<size_t>(m_mem + byteOffset);
+                std::size_t const ptr = reinterpret_cast<std::size_t>(m_mem + byteOffset);
                 constexpr size_t align = std::max(TMinDataAlignBytes, alignof(T));
-                size_t const newPtrAdress = ((ptr + align - 1u) / align) * align + sizeof(T);
-                return static_cast<uint32_t>(newPtrAdress - reinterpret_cast<size_t>(m_mem));
+                std::size_t const newPtrAdress = ((ptr + align - 1u) / align) * align + sizeof(T);
+                return static_cast<uint32_t>(newPtrAdress - reinterpret_cast<std::size_t>(m_mem));
             }
 
             //! Offset in bytes relative to m_mem to next free data area.
@@ -155,7 +156,7 @@ namespace alpaka
             //! Memory layout
             //! |Header|Padding|Variable|Padding|Header|....uninitialized Data ....
             //! Size of padding can be zero if data after padding is already aligned.
-            uint8_t* const m_mem;
+            std::uint8_t* const m_mem;
 #ifndef NDEBUG
             const std::uint32_t m_capacity;
 #endif

--- a/include/alpaka/kernel/TaskKernelOacc.hpp
+++ b/include/alpaka/kernel/TaskKernelOacc.hpp
@@ -122,8 +122,13 @@ namespace alpaka
             auto argsD = m_args;
             auto kernelFnObj = m_kernelFnObj;
             dev.makeCurrent();
-#    pragma acc parallel num_workers(blockThreadCount)                                                                \
-        copyin(threadElemExtent, blockThreadExtent, argsD, gridBlockExtent) default(present)
+#    pragma acc parallel num_workers(blockThreadCount) copyin(                                                        \
+        threadElemExtent,                                                                                             \
+        blockThreadExtent,                                                                                            \
+        gridBlockExtent,                                                                                              \
+        argsD,                                                                                                        \
+        blockSharedMemDynSizeBytes,                                                                                   \
+        kernelFnObj) default(present)
             {
                 {
 #    pragma acc loop gang

--- a/test/unit/warp/src/Activemask.cpp
+++ b/test/unit/warp/src/Activemask.cpp
@@ -14,6 +14,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <climits>
 #include <cstdint>
 
 //#############################################################################
@@ -55,7 +56,9 @@ public:
 
         auto const actual = alpaka::warp::activemask(acc);
         using Result = decltype(actual);
-        Result const allActive = (Result{1} << static_cast<Result>(warpExtent)) - 1;
+        Result const allActive = static_cast<size_t>(warpExtent) == sizeof(Result) * CHAR_BIT
+            ? ~Result{0u}
+            : (Result{1} << warpExtent) - 1u;
         Result const expected = allActive & ~(Result{1} << inactiveThreadIdx);
         ALPAKA_CHECK(*success, actual == expected);
     }


### PR DESCRIPTION
This PR backports the last PRs required for the release 0.6.1

- Add missing <limits> header and fix integer namespace #1327
- TaskKernelOacc: copyin(all used local vars) #1342 
- CI: fix warp test #1339
- Fix outdated comments in the OpenMP schedule example #1341
- Update changelog and schedule release date for **24.06.2021**