### PR TITLE
Showcase and discuss CRP clang-tidy 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,156 @@
+Checks: 'bugprone-bool-pointer-implicit-conversion,
+bugprone-copy-constructor-init,
+bugprone-forwarding-reference-overload,
+bugprone-misplaced-widening-cast,
+bugprone-parent-virtual-call,
+bugprone-signed-char-misuse,
+bugprone-suspicious-enum-usage,
+bugprone-swapped-arguments,
+bugprone-undelegated-constructor,
+bugprone-unhandled-self-assignment,
+bugprone-virtual-near-miss,
+cert-dcl50-cpp,
+cert-oop57-cpp,
+cert-oop58-cpp,
+cppcoreguidelines-narrowing-conversions,
+cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+cppcoreguidelines-pro-type-cstyle-cast,
+cppcoreguidelines-pro-type-member-init,
+cppcoreguidelines-pro-type-static-cast-downcast,
+cppcoreguidelines-pro-type-vararg,
+cppcoreguidelines-slicing,
+cppcoreguidelines-special-member-functions,
+google-default-arguments,
+google-explicit-constructor,
+google-readability-casting,
+google-readability-todo,
+hicpp-signed-bitwise,
+misc-misplaced-const,
+misc-unconventional-assign-operator,
+modernize-raw-string-literal,
+modernize-replace-disallow-copy-and-assign-macro,
+modernize-return-braced-init-list,
+modernize-unary-static-assert,
+modernize-use-auto,
+modernize-use-bool-literals,
+modernize-use-default-member-init,
+modernize-use-equals-default,
+modernize-use-equals-delete,
+modernize-use-nullptr,
+modernize-use-override,
+modernize-use-transparent-functors,
+modernize-use-using,
+readability-avoid-const-params-in-decls,
+readability-const-return-type,
+readability-convert-member-functions-to-static,
+readability-deleted-default,
+readability-identifier-naming,
+readability-implicit-bool-conversion,
+readability-isolate-declaration,
+readability-make-member-function-const,
+readability-misplaced-array-index,
+readability-non-const-parameter,
+readability-qualified-auto,
+readability-redundant-access-specifiers,
+readability-redundant-declaration,
+readability-redundant-function-ptr-dereference,
+readability-redundant-member-init,
+readability-redundant-preprocessor,
+readability-simplify-boolean-expr,
+readability-simplify-subscript-expr,
+readability-static-accessed-through-instance'
+CheckOptions:
+  - { key: bugprone-misplaced-widening-cast.CheckImplicitCasts, value: 1}
+  - { key: bugprone-signed-char-misuse.CharTypedefsToIgnore, value: "int8_t;std::int8_t"}
+  - { key: bugprone-signed-char-misuse.DiagnoseSignedUnsignedCharComparisons, value: 1}
+  - { key: bugprone-suspicious-enum-usage.StrictMode, value: 1}
+  - { key: bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField, value: 0}
+  - { key: cppcoreguidelines-narrowing-conversions.WarnOnFloatingPointNarrowingConversion, value: 1}
+  - { key: cppcoreguidelines-narrowing-conversions.WarnWithinTemplateInstantiation, value: 1}
+  - { key: cppcoreguidelines-narrowing-conversions.WarnOnEquivalentBitWidth, value: 1}
+  - { key: cppcoreguidelines-narrowing-conversions.PedanticMode, value: 1}
+  - { key: cppcoreguidelines-pro-type-member-init.IgnoreArrays, value: 0}
+  - { key: cppcoreguidelines-pro-type-member-init.UseAssignment, value: 0}
+  - { key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor, value: 0}
+  - { key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions, value: 0}
+  - { key: cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted, value: 0}
+  - { key: hicpp-signed-bitwise.IgnorePositiveIntegerLiterals, value: false}
+  - { key: modernize-use-auto.MinTypeNameLength, value: 0}
+  - { key: modernize-use-auto.RemoveStars, value: 0}
+  - { key: modernize-use-bool-literals.IgnoreMacros, value: 0}
+  - { key: modernize-use-default-member-init.UseAssignment, value: 0}
+  - { key: modernize-use-default-member-init.IgnoreMacros, value: 0}
+  - { key: modernize-use-equals-default.IgnoreMacros, value: 0}
+  - { key: modernize-use-equals-delete.IgnoreMacros, value: 0}
+  - { key: modernize-use-override.IgnoreDestructors, value: 0}
+  - { key: modernize-use-override.AllowOverrideAndFinal, value: 1}
+  - { key: modernize-use-transparent-functors.SafeMode, value: 1}
+  - { key: modernize-use-using.IgnoreMacros, value: 0}
+  - { key: readability-identifier-naming.AbstractClassCase, value: CamelCase}
+  - { key: readability-identifier-naming.AggressiveDependentMemberLookup, value: 1}
+  - { key: readability-identifier-naming.ClassCase, value: CamelCase}
+  - { key: readability-identifier-naming.ClassConstantCase, value: lower_case}
+  - { key: readability-identifier-naming.ClassMemberCase, value: lower_case}
+  - { key: readability-identifier-naming.ClassMethodCase, value: lower_case}
+  - { key: readability-identifier-naming.ConstantCase, value: lower_case}
+  - { key: readability-identifier-naming.ConstantMemberCase, value: lower_case}
+  - { key: readability-identifier-naming.ConstantMemberPrefix, value: m_}
+  - { key: readability-identifier-naming.ConstantParameterCase, value: lower_case}
+  - { key: readability-identifier-naming.ConstantPointerParameterCase, value: lower_case}
+  - { key: readability-identifier-naming.ConstexprFunctionCase, value: lower_case}
+  - { key: readability-identifier-naming.ConstexprMethodCase, value: lower_case}
+  - { key: readability-identifier-naming.ConstexprVariableCase, value: lower_case}
+  - { key: readability-identifier-naming.EnumCase, value: CamelCase}
+  - { key: readability-identifier-naming.EnumConstantCase, value: lower_case}
+  - { key: readability-identifier-naming.FunctionCase, value: lower_case}
+  - { key: readability-identifier-naming.GlobalConstantCase, value: lower_case}
+  - { key: readability-identifier-naming.GlobalConstantPointerCase, value: lower_case}
+  - { key: readability-identifier-naming.GlobalFunctionCase, value: lower_case}
+  - { key: readability-identifier-naming.GlobalPointerCase, value: lower_case}
+  - { key: readability-identifier-naming.GlobalVariableCase, value: lower_case}
+  - { key: readability-identifier-naming.InlineNamespaceCase, value: lower_case}
+  - { key: readability-identifier-naming.LocalConstantCase, value: lower_case}
+  - { key: readability-identifier-naming.LocalConstantPointerCase, value: lower_case}
+  - { key: readability-identifier-naming.LocalPointerCase, value: lower_case}
+  - { key: readability-identifier-naming.LocalVariableCase, value: lower_case}
+  - { key: readability-identifier-naming.MacroDefinitionCase, value: UPPER_CASE}
+  - { key: readability-identifier-naming.MemberCase, value: lower_case}
+  - { key: readability-identifier-naming.MemberPrefix, value: m_}
+  - { key: readability-identifier-naming.MethodCase, value: lower_case}
+  - { key: readability-identifier-naming.NamespaceCase, value: lower_case}
+  - { key: readability-identifier-naming.ParameterCase, value: lower_case}
+  - { key: readability-identifier-naming.ParameterPackCase, value: lower_case}
+  - { key: readability-identifier-naming.PointerParameterCase, value: lower_case}
+  - { key: readability-identifier-naming.PrivateMemberCase, value: lower_case}
+  - { key: readability-identifier-naming.PrivateMemberPrefix, value: m_}
+  - { key: readability-identifier-naming.PrivateMethodCase, value: lower_case}
+  - { key: readability-identifier-naming.ProtectedMemberCase, value: lower_case}
+  - { key: readability-identifier-naming.ProtectedMemberPrefix, value: m_}
+  - { key: readability-identifier-naming.ProtectedMethodCase, value: lower_case}
+  - { key: readability-identifier-naming.PublicMemberCase, value: lower_case}
+  - { key: readability-identifier-naming.PublicMemberPrefix, value: m_}
+  - { key: readability-identifier-naming.PublicMethodCase, value: lower_case}
+  - { key: readability-identifier-naming.StaticConstantCase, value: lower_case}
+  - { key: readability-identifier-naming.StaticVariableCase, value: lower_case}
+  - { key: readability-identifier-naming.StructCase, value: CamelCase}
+  - { key: readability-identifier-naming.TemplateParameterCase, value: CamelCase}
+  - { key: readability-identifier-naming.TemplateParameterPrefix, value: T}
+  - { key: readability-identifier-naming.TemplateTemplateParameterCase, value: CamelCase}
+  - { key: readability-identifier-naming.TemplateTemplateParameterPrefix, value: T}
+  - { key: readability-identifier-naming.TypeAliasCase, value: CamelCase}
+  - { key: readability-identifier-naming.TypedefCase, value: CamelCase}
+  - { key: readability-identifier-naming.TypeTemplateParameterCase, value: CamelCase}
+  - { key: readability-identifier-naming.TypeTemplateParameterPrefix, value: T}
+  - { key: readability-identifier-naming.UnionCase, value: CamelCase}
+  - { key: readability-identifier-naming.ValueTemplateParameterCase, value: CamelCase}
+  - { key: readability-identifier-naming.ValueTemplateParameterPrefix, value: T}
+  - { key: readability-identifier-naming.VariableCase, value: lower_case}
+  - { key: readability-identifier-naming.VirtualMethodCase, value: lower_case}
+  - { key: readability-implicit-bool-conversion.AllowIntegerConditions, value: 0}
+  - { key: readability-implicit-bool-conversion.AllowPointerConditions, value: 0}
+  - { key: readability-qualified-auto.AddConstToQualified, value: 1}
+  - { key: readability-redundant-access-specifiers.CheckFirstDeclaration, value: 1}
+  - { key: readability-redundant-declaration.IgnoreMacros, value: 0}
+  - { key: readability-redundant-member-init.IgnoreBaseInCopyConstructors, value: 1}
+  - { key: readability-simplify-boolean-expr.ChainedConditionalAssignment, value: 1}
+  - { key: readability-simplify-boolean-expr.ChainedConditionalReturn, value: 1}

--- a/example/helloWorld/src/helloWorld.cpp
+++ b/example/helloWorld/src/helloWorld.cpp
@@ -38,13 +38,13 @@ struct HelloWorldKernel
         // exist overall. These information can be obtained by
         // getIdx() and getWorkDiv(). In this example these
         // values are obtained for a global scope.
-        Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-        Vec const globalThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+        Vec const global_thread_idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+        Vec const global_thread_extent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
         // Map the three dimensional thread index into a
         // one dimensional thread index space. We call it
         // linearize the thread index.
-        Vec1 const linearizedGlobalThreadIdx = alpaka::mapIdx<1u>(globalThreadIdx, globalThreadExtent);
+        Vec1 const linearized_global_thread_idx = alpaka::mapIdx<1u>(global_thread_idx, global_thread_extent);
 
         // Each thread prints a hello world to the terminal
         // together with the global index of the thread in
@@ -53,10 +53,10 @@ struct HelloWorldKernel
         // order [z][y][x] where the last index is the fast one.
         printf(
             "[z:%u, y:%u, x:%u][linear:%u] Hello World\n",
-            static_cast<unsigned>(globalThreadIdx[0u]),
-            static_cast<unsigned>(globalThreadIdx[1u]),
-            static_cast<unsigned>(globalThreadIdx[2u]),
-            static_cast<unsigned>(linearizedGlobalThreadIdx[0u]));
+            static_cast<unsigned>(global_thread_idx[0u]),
+            static_cast<unsigned>(global_thread_idx[1u]),
+            static_cast<unsigned>(global_thread_idx[2u]),
+            static_cast<unsigned>(linearized_global_thread_idx[0u]));
     }
 };
 
@@ -113,7 +113,7 @@ auto main() -> int
     // by id (0 to the number of devices minus 1) or you
     // can also retrieve all devices in a vector (getDevs()).
     // In this example the first devices is choosen.
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const dev_acc = alpaka::getDevByIdx<Acc>(0u);
 
     // Create a queue on the device
     //
@@ -125,7 +125,7 @@ auto main() -> int
     // The example queue is a blocking queue to a cpu device,
     // but it also exists an non-blocking queue for this
     // device (QueueCpuNonBlocking).
-    Queue queue(devAcc);
+    Queue queue(dev_acc);
 
     // Define the work division
     //
@@ -156,13 +156,13 @@ auto main() -> int
     // Thus, a thread can process data element size wise with its
     // vector processing unit.
     using Vec = alpaka::Vec<Dim, Idx>;
-    Vec const elementsPerThread(Vec::all(static_cast<Idx>(1)));
-    Vec const threadsPerGrid(Vec::all(static_cast<Idx>(8)));
+    Vec const elements_per_thread(Vec::all(static_cast<Idx>(1)));
+    Vec const threads_per_grid(Vec::all(static_cast<Idx>(8)));
     using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
-    WorkDiv const workDiv = alpaka::getValidWorkDiv<Acc>(
-        devAcc,
-        threadsPerGrid,
-        elementsPerThread,
+    WorkDiv const work_div = alpaka::getValidWorkDiv<Acc>(
+        dev_acc,
+        threads_per_grid,
+        elements_per_thread,
         false,
         alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
 
@@ -171,7 +171,7 @@ auto main() -> int
     // Kernels can be everything that has a callable operator()
     // and which takes the accelerator as first argument.
     // So a kernel can be a class or struct, a lambda, a std::function, etc.
-    HelloWorldKernel helloWorldKernel;
+    HelloWorldKernel hello_world_kernel;
 
     // Run the kernel
     //
@@ -184,8 +184,8 @@ auto main() -> int
     // Here it is synchronous which means that the kernel is directly executed.
     alpaka::exec<Acc>(
         queue,
-        workDiv,
-        helloWorldKernel
+        work_div,
+        hello_world_kernel
         /* put kernel arguments here */);
     alpaka::wait(queue);
 

--- a/example/helloWorldLambda/src/helloWorldLambda.cpp
+++ b/example/helloWorldLambda/src/helloWorldLambda.cpp
@@ -28,25 +28,25 @@
 //! to lift an existing function into a kernel
 //! function.
 template<typename TAcc>
-void ALPAKA_FN_ACC hiWorldFunction(TAcc const& acc, size_t const nExclamationMarks)
+void ALPAKA_FN_ACC hi_world_function(TAcc const& acc, size_t const n_exclamation_marks)
 {
     using Dim = alpaka::Dim<TAcc>;
     using Idx = alpaka::Idx<TAcc>;
     using Vec = alpaka::Vec<Dim, Idx>;
     using Vec1 = alpaka::Vec<alpaka::DimInt<1u>, Idx>;
 
-    Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-    Vec const globalThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
-    Vec1 const linearizedGlobalThreadIdx = alpaka::mapIdx<1u>(globalThreadIdx, globalThreadExtent);
+    Vec const global_thread_idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+    Vec const global_thread_extent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+    Vec1 const linearized_global_thread_idx = alpaka::mapIdx<1u>(global_thread_idx, global_thread_extent);
 
     printf(
         "[z:%u, y:%u, x:%u][linear:%u] Hi world from a function",
-        static_cast<unsigned>(globalThreadIdx[0]),
-        static_cast<unsigned>(globalThreadIdx[1]),
-        static_cast<unsigned>(globalThreadIdx[2]),
-        static_cast<unsigned>(linearizedGlobalThreadIdx[0]));
+        static_cast<unsigned>(global_thread_idx[0]),
+        static_cast<unsigned>(global_thread_idx[1]),
+        static_cast<unsigned>(global_thread_idx[2]),
+        static_cast<unsigned>(linearized_global_thread_idx[0]));
 
-    for(size_t i = 0; i < nExclamationMarks; ++i)
+    for(size_t i = 0; i < n_exclamation_marks; ++i)
     {
         printf("!");
     }
@@ -88,24 +88,24 @@ auto main() -> int
     using Queue = alpaka::Queue<Acc, QueueProperty>;
 
     // Select a device
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const dev_acc = alpaka::getDevByIdx<Acc>(0u);
 
     // Create a queue on the device
-    Queue queue(devAcc);
+    Queue queue(dev_acc);
 
     // Define the work division
     using Vec = alpaka::Vec<Dim, Idx>;
-    Vec const elementsPerThread(Vec::all(static_cast<Idx>(1)));
-    Vec const threadsPerGrid(Vec::all(static_cast<Idx>(8)));
+    Vec const elements_per_thread(Vec::all(static_cast<Idx>(1)));
+    Vec const threads_per_grid(Vec::all(static_cast<Idx>(8)));
     using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
-    WorkDiv const workDiv = alpaka::getValidWorkDiv<Acc>(
-        devAcc,
-        threadsPerGrid,
-        elementsPerThread,
+    WorkDiv const work_div = alpaka::getValidWorkDiv<Acc>(
+        dev_acc,
+        threads_per_grid,
+        elements_per_thread,
         false,
         alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
 
-    const size_t nExclamationMarks = 10;
+    const size_t n_exclamation_marks = 10;
 
     // Run "Hello World" kernel with a lambda function
     //
@@ -124,28 +124,28 @@ auto main() -> int
     // type is set to Acc.
     alpaka::exec<Acc>(
         queue,
-        workDiv,
-        [] ALPAKA_FN_ACC(Acc const& acc, size_t const nExclamationMarksAsArg) -> void
+        work_div,
+        [] ALPAKA_FN_ACC(Acc const& acc, size_t const n_exclamation_marks_as_arg) -> void
         {
-            auto globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-            auto globalThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
-            auto linearizedGlobalThreadIdx = alpaka::mapIdx<1u>(globalThreadIdx, globalThreadExtent);
+            auto global_thread_idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+            auto global_thread_extent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+            auto linearized_global_thread_idx = alpaka::mapIdx<1u>(global_thread_idx, global_thread_extent);
 
             printf(
                 "[z:%u, y:%u, x:%u][linear:%u] Hello world from a lambda",
-                static_cast<unsigned>(globalThreadIdx[0]),
-                static_cast<unsigned>(globalThreadIdx[1]),
-                static_cast<unsigned>(globalThreadIdx[2]),
-                static_cast<unsigned>(linearizedGlobalThreadIdx[0]));
+                static_cast<unsigned>(global_thread_idx[0]),
+                static_cast<unsigned>(global_thread_idx[1]),
+                static_cast<unsigned>(global_thread_idx[2]),
+                static_cast<unsigned>(linearized_global_thread_idx[0]));
 
-            for(size_t i = 0; i < nExclamationMarksAsArg; ++i)
+            for(size_t i = 0; i < n_exclamation_marks_as_arg; ++i)
             {
                 printf("!");
             }
 
             printf("\n");
         },
-        nExclamationMarks);
+        n_exclamation_marks);
     alpaka::wait(queue);
 
     return EXIT_SUCCESS;

--- a/example/kernelSpecialization/src/kernelSpecialization.cpp
+++ b/example/kernelSpecialization/src/kernelSpecialization.cpp
@@ -43,8 +43,8 @@ struct Kernel
     ALPAKA_FN_ACC auto operator()(TAcc const& acc) const
     {
         // For simplicity assume 1d thread indexing
-        auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0];
-        if(globalThreadIdx == 0u)
+        auto const global_thread_idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0];
+        if(global_thread_idx == 0u)
             printf("Running the general kernel implementation\n");
     }
 
@@ -95,23 +95,23 @@ auto main() -> int
     using Queue = alpaka::Queue<Acc, QueueProperty>;
 
     // Select a device
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const dev_acc = alpaka::getDevByIdx<Acc>(0u);
 
     // Create a queue on the device
-    Queue queue(devAcc);
+    Queue queue(dev_acc);
 
     // Define the work division
-    std::size_t const threadsPerGrid = 16u;
-    std::size_t const elementsPerThread = 1u;
-    auto const workDiv = alpaka::getValidWorkDiv<Acc>(
-        devAcc,
-        threadsPerGrid,
-        elementsPerThread,
+    std::size_t const threads_per_grid = 16u;
+    std::size_t const elements_per_thread = 1u;
+    auto const work_div = alpaka::getValidWorkDiv<Acc>(
+        dev_acc,
+        threads_per_grid,
+        elements_per_thread,
         false,
         alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
 
     // Run the kernel
-    alpaka::exec<Acc>(queue, workDiv, Kernel{});
+    alpaka::exec<Acc>(queue, work_div, Kernel{});
     alpaka::wait(queue);
 
     return EXIT_SUCCESS;

--- a/example/randomCells2D/src/randomCells2D.cpp
+++ b/example/randomCells2D/src/randomCells2D.cpp
@@ -15,9 +15,9 @@
 #include <iostream>
 #include <tuple>
 
-unsigned constexpr NUM_CALCULATIONS = 256;
-unsigned constexpr NUM_X = 1237;
-unsigned constexpr NUM_Y = 2131;
+unsigned constexpr num_calculations = 256;
+unsigned constexpr num_x = 1237;
+unsigned constexpr num_y = 2131;
 
 /// Selected PRNG engine for single-value operation
 template<typename TAcc>
@@ -38,13 +38,13 @@ struct InitRandomKernel
         TAcc const& acc,
         TExtent const extent,
         TRandEngine* const states,
-        std::size_t pitchRand) const -> void
+        std::size_t pitch_rand) const -> void
     {
         auto const idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-        auto const linearIdx = alpaka::mapIdx<1u>(idx, extent)[0];
-        auto const memoryLocationIdx = idx[0] * pitchRand + idx[1];
-        TRandEngine engine(42, static_cast<std::uint32_t>(linearIdx));
-        states[memoryLocationIdx] = engine;
+        auto const linear_idx = alpaka::mapIdx<1u>(idx, extent)[0];
+        auto const memory_location_idx = idx[0] * pitch_rand + idx[1];
+        TRandEngine engine(42, static_cast<std::uint32_t>(linear_idx));
+        states[memory_location_idx] = engine;
     }
 };
 
@@ -55,25 +55,25 @@ struct RunTimestepKernelSingle
         TAcc const& acc,
         TExtent const extent,
         RandomEngineSingle<TAcc>* const states,
-        float* const cells,
-        std::size_t pitchRand,
-        std::size_t pitchOut) const -> void
+        const float* const cells,
+        std::size_t pitch_rand,
+        std::size_t pitch_out) const -> void
     {
         auto const idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-        auto const memoryLocationRandIdx = idx[0] * pitchRand + idx[1];
-        auto const memoryLocationOutIdx = idx[0] * pitchOut + idx[1];
+        auto const memory_location_rand_idx = idx[0] * pitch_rand + idx[1];
+        auto const memory_location_out_idx = idx[0] * pitch_out + idx[1];
 
         // Setup generator and distribution.
-        RandomEngineSingle<TAcc> engine(states[memoryLocationRandIdx]);
+        RandomEngineSingle<TAcc> engine(states[memory_location_rand_idx]);
         alpaka::rand::UniformReal<float> dist;
 
         float sum = 0;
-        for(unsigned numCalculations = 0; numCalculations < NUM_CALCULATIONS; ++numCalculations)
+        for(unsigned num_calculations = 0; num_calculations < num_calculations; ++num_calculations)
         {
             sum += dist(engine);
         }
-        cells[memoryLocationOutIdx] = sum / NUM_CALCULATIONS;
-        states[memoryLocationRandIdx] = engine;
+        cells[memory_location_out_idx] = sum / num_calculations;
+        states[memory_location_rand_idx] = engine;
     }
 };
 
@@ -84,37 +84,37 @@ struct RunTimestepKernelVector
         TAcc const& acc,
         TExtent const extent,
         RandomEngineVector<TAcc>* const states,
-        float* const cells,
-        std::size_t pitchRand,
-        std::size_t pitchOut) const -> void
+        const float* const cells,
+        std::size_t pitch_rand,
+        std::size_t pitch_out) const -> void
     {
         auto const idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-        auto const memoryLocationRandIdx = idx[0] * pitchRand + idx[1];
-        auto const memoryLocationOutIdx = idx[0] * pitchOut + idx[1];
+        auto const memory_location_rand_idx = idx[0] * pitch_rand + idx[1];
+        auto const memory_location_out_idx = idx[0] * pitch_out + idx[1];
 
         // Setup generator and distribution.
-        RandomEngineVector<TAcc> engine(states[memoryLocationRandIdx]); // Load the state of the random engine
+        RandomEngineVector<TAcc> engine(states[memory_location_rand_idx]); // Load the state of the random engine
         using DistributionResult =
             typename RandomEngineVector<TAcc>::template ResultContainer<float>; // Container type which will store the
                                                                                 // distribution results
-        unsigned constexpr resultVectorSize = std::tuple_size<DistributionResult>::value; // Size of the result vector
+        unsigned constexpr result_vector_size = std::tuple_size<DistributionResult>::value; // Size of the result vector
         alpaka::rand::UniformReal<DistributionResult> dist; // Vector-aware distribution function
 
 
         float sum = 0;
         static_assert(
-            NUM_CALCULATIONS % resultVectorSize == 0,
+            num_calculations % result_vector_size == 0,
             "Number of calculations must be a multiple of result vector size.");
-        for(unsigned numCalculations = 0; numCalculations < NUM_CALCULATIONS / resultVectorSize; ++numCalculations)
+        for(unsigned num_calculations = 0; num_calculations < num_calculations / result_vector_size; ++num_calculations)
         {
             auto result = dist(engine);
-            for(unsigned i = 0; i < resultVectorSize; ++i)
+            for(unsigned i = 0; i < result_vector_size; ++i)
             {
                 sum += result[i];
             }
         }
-        cells[memoryLocationOutIdx] = sum / NUM_CALCULATIONS;
-        states[memoryLocationRandIdx] = engine;
+        cells[memory_location_out_idx] = sum / num_calculations;
+        states[memory_location_rand_idx] = engine;
     }
 };
 
@@ -125,11 +125,11 @@ auto main() -> int
     using Vec = alpaka::Vec<Dim, Idx>;
     using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
     using Host = alpaka::DevCpu;
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
-    auto const devHost = alpaka::getDevByIdx<Host>(0u);
+    auto const dev_acc = alpaka::getDevByIdx<Acc>(0u);
+    auto const dev_host = alpaka::getDevByIdx<Host>(0u);
     using QueueProperty = alpaka::Blocking;
     using QueueAcc = alpaka::Queue<Acc, QueueProperty>;
-    QueueAcc queue{devAcc};
+    QueueAcc queue{dev_acc};
 
     using BufHost = alpaka::Buf<Host, float, Dim, Idx>;
     using BufAcc = alpaka::Buf<Acc, float, Dim, Idx>;
@@ -139,108 +139,108 @@ auto main() -> int
     using BufAccRandVec = alpaka::Buf<Acc, RandomEngineVector<Acc>, Dim, Idx>;
     using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
 
-    constexpr Idx numX = NUM_X;
-    constexpr Idx numY = NUM_Y;
+    constexpr Idx num_x = num_x;
+    constexpr Idx num_y = num_y;
 
-    const Vec extent(numY, numX);
+    const Vec extent(num_y, num_x);
 
-    constexpr Idx perThreadX = 1;
-    constexpr Idx perThreadY = 1;
+    constexpr Idx per_thread_x = 1;
+    constexpr Idx per_thread_y = 1;
 
     WorkDiv workdiv{alpaka::getValidWorkDiv<Acc>(
-        devAcc,
+        dev_acc,
         extent,
-        Vec(perThreadY, perThreadX),
+        Vec(per_thread_y, per_thread_x),
         false,
         alpaka::GridBlockExtentSubDivRestrictions::Unrestricted)};
 
     // Setup buffer.
-    BufHost bufHostS{alpaka::allocBuf<float, Idx>(devHost, extent)};
-    float* const ptrBufHostS{alpaka::getPtrNative(bufHostS)};
-    BufAcc bufAccS{alpaka::allocBuf<float, Idx>(devAcc, extent)};
-    float* const ptrBufAccS{alpaka::getPtrNative(bufAccS)};
+    BufHost buf_host_s{alpaka::allocBuf<float, Idx>(dev_host, extent)};
+    float* const ptr_buf_host_s{alpaka::getPtrNative(buf_host_s)};
+    BufAcc buf_acc_s{alpaka::allocBuf<float, Idx>(dev_acc, extent)};
+    float* const ptr_buf_acc_s{alpaka::getPtrNative(buf_acc_s)};
 
-    BufHost bufHostV{alpaka::allocBuf<float, Idx>(devHost, extent)};
-    float* const ptrBufHostV{alpaka::getPtrNative(bufHostV)};
-    BufAcc bufAccV{alpaka::allocBuf<float, Idx>(devAcc, extent)};
-    float* const ptrBufAccV{alpaka::getPtrNative(bufAccV)};
+    BufHost buf_host_v{alpaka::allocBuf<float, Idx>(dev_host, extent)};
+    float* const ptr_buf_host_v{alpaka::getPtrNative(buf_host_v)};
+    BufAcc buf_acc_v{alpaka::allocBuf<float, Idx>(dev_acc, extent)};
+    float* const ptr_buf_acc_v{alpaka::getPtrNative(buf_acc_v)};
 
-    BufHostRand bufHostRandS{alpaka::allocBuf<RandomEngineSingle<Acc>, Idx>(devHost, extent)};
-    BufAccRand bufAccRandS{alpaka::allocBuf<RandomEngineSingle<Acc>, Idx>(devAcc, extent)};
-    RandomEngineSingle<Acc>* const ptrBufAccRandS{alpaka::getPtrNative(bufAccRandS)};
+    BufHostRand buf_host_rand_s{alpaka::allocBuf<RandomEngineSingle<Acc>, Idx>(dev_host, extent)};
+    BufAccRand buf_acc_rand_s{alpaka::allocBuf<RandomEngineSingle<Acc>, Idx>(dev_acc, extent)};
+    RandomEngineSingle<Acc>* const ptr_buf_acc_rand_s{alpaka::getPtrNative(buf_acc_rand_s)};
 
-    BufHostRandVec bufHostRandV{alpaka::allocBuf<RandomEngineVector<Acc>, Idx>(devHost, extent)};
-    BufAccRandVec bufAccRandV{alpaka::allocBuf<RandomEngineVector<Acc>, Idx>(devAcc, extent)};
-    RandomEngineVector<Acc>* const ptrBufAccRandV{alpaka::getPtrNative(bufAccRandV)};
+    BufHostRandVec buf_host_rand_v{alpaka::allocBuf<RandomEngineVector<Acc>, Idx>(dev_host, extent)};
+    BufAccRandVec buf_acc_rand_v{alpaka::allocBuf<RandomEngineVector<Acc>, Idx>(dev_acc, extent)};
+    RandomEngineVector<Acc>* const ptr_buf_acc_rand_v{alpaka::getPtrNative(buf_acc_rand_v)};
 
-    InitRandomKernel initRandomKernel;
-    auto pitchBufAccRandS = alpaka::getPitchBytes<1u>(bufAccRandS) / sizeof(RandomEngineSingle<Acc>);
-    alpaka::exec<Acc>(queue, workdiv, initRandomKernel, extent, ptrBufAccRandS, pitchBufAccRandS);
+    InitRandomKernel init_random_kernel;
+    auto pitch_buf_acc_rand_s = alpaka::getPitchBytes<1u>(buf_acc_rand_s) / sizeof(RandomEngineSingle<Acc>);
+    alpaka::exec<Acc>(queue, workdiv, init_random_kernel, extent, ptr_buf_acc_rand_s, pitch_buf_acc_rand_s);
     alpaka::wait(queue);
 
-    auto pitchBufAccRandV = alpaka::getPitchBytes<1u>(bufAccRandV) / sizeof(RandomEngineVector<Acc>);
-    alpaka::exec<Acc>(queue, workdiv, initRandomKernel, extent, ptrBufAccRandV, pitchBufAccRandV);
+    auto pitch_buf_acc_rand_v = alpaka::getPitchBytes<1u>(buf_acc_rand_v) / sizeof(RandomEngineVector<Acc>);
+    alpaka::exec<Acc>(queue, workdiv, init_random_kernel, extent, ptr_buf_acc_rand_v, pitch_buf_acc_rand_v);
     alpaka::wait(queue);
 
-    auto pitchHostS = alpaka::getPitchBytes<1u>(bufHostS) / sizeof(float); /// \todo: get the type from bufHostS
-    auto pitchHostV = alpaka::getPitchBytes<1u>(bufHostV) / sizeof(float); /// \todo: get the type from bufHostV
+    auto pitch_host_s = alpaka::getPitchBytes<1u>(buf_host_s) / sizeof(float); /// \todo: get the type from bufHostS
+    auto pitch_host_v = alpaka::getPitchBytes<1u>(buf_host_v) / sizeof(float); /// \todo: get the type from bufHostV
 
-    for(Idx y = 0; y < numY; ++y)
+    for(Idx y = 0; y < num_y; ++y)
     {
-        for(Idx x = 0; x < numX; ++x)
+        for(Idx x = 0; x < num_x; ++x)
         {
-            ptrBufHostS[y * pitchHostS + x] = 0;
-            ptrBufHostV[y * pitchHostV + x] = 0;
+            ptr_buf_host_s[y * pitch_host_s + x] = 0;
+            ptr_buf_host_v[y * pitch_host_v + x] = 0;
         }
     }
 
     /// \todo get the types from respective function parameters
-    auto pitchBufAccS = alpaka::getPitchBytes<1u>(bufAccS) / sizeof(float);
-    alpaka::memcpy(queue, bufAccS, bufHostS, extent);
-    RunTimestepKernelSingle runTimestepKernelSingle;
+    auto pitch_buf_acc_s = alpaka::getPitchBytes<1u>(buf_acc_s) / sizeof(float);
+    alpaka::memcpy(queue, buf_acc_s, buf_host_s, extent);
+    RunTimestepKernelSingle run_timestep_kernel_single;
     alpaka::exec<Acc>(
         queue,
         workdiv,
-        runTimestepKernelSingle,
+        run_timestep_kernel_single,
         extent,
-        ptrBufAccRandS,
-        ptrBufAccS,
-        pitchBufAccRandS,
-        pitchBufAccS);
-    alpaka::memcpy(queue, bufHostS, bufAccS, extent);
+        ptr_buf_acc_rand_s,
+        ptr_buf_acc_s,
+        pitch_buf_acc_rand_s,
+        pitch_buf_acc_s);
+    alpaka::memcpy(queue, buf_host_s, buf_acc_s, extent);
 
-    auto pitchBufAccV = alpaka::getPitchBytes<1u>(bufAccV) / sizeof(float);
-    alpaka::memcpy(queue, bufAccV, bufHostV, extent);
-    RunTimestepKernelVector runTimestepKernelVector;
+    auto pitch_buf_acc_v = alpaka::getPitchBytes<1u>(buf_acc_v) / sizeof(float);
+    alpaka::memcpy(queue, buf_acc_v, buf_host_v, extent);
+    RunTimestepKernelVector run_timestep_kernel_vector;
     alpaka::exec<Acc>(
         queue,
         workdiv,
-        runTimestepKernelVector,
+        run_timestep_kernel_vector,
         extent,
-        ptrBufAccRandV,
-        ptrBufAccV,
-        pitchBufAccRandV,
-        pitchBufAccV);
-    alpaka::memcpy(queue, bufHostV, bufAccV, extent);
+        ptr_buf_acc_rand_v,
+        ptr_buf_acc_v,
+        pitch_buf_acc_rand_v,
+        pitch_buf_acc_v);
+    alpaka::memcpy(queue, buf_host_v, buf_acc_v, extent);
     alpaka::wait(queue);
 
-    float avgS = 0;
-    float avgV = 0;
-    for(Idx y = 0; y < numY; ++y)
+    float avg_s = 0;
+    float avg_v = 0;
+    for(Idx y = 0; y < num_y; ++y)
     {
-        for(Idx x = 0; x < numX; ++x)
+        for(Idx x = 0; x < num_x; ++x)
         {
-            avgS += ptrBufHostS[y * pitchHostS + x];
-            avgV += ptrBufHostV[y * pitchHostV + x];
+            avg_s += ptr_buf_host_s[y * pitch_host_s + x];
+            avg_v += ptr_buf_host_v[y * pitch_host_v + x];
         }
     }
-    avgS /= numX * numY;
-    avgV /= numX * numY;
+    avg_s /= num_x * num_y;
+    avg_v /= num_x * num_y;
 
-    std::cout << "Number of cells: " << numX * numY << "\n";
-    std::cout << "Number of calculations: " << NUM_CALCULATIONS << "\n";
-    std::cout << "Mean value A: " << avgS << " (should converge to 0.5)\n";
-    std::cout << "Mean value B: " << avgV << " (should converge to 0.5)\n";
+    std::cout << "Number of cells: " << num_x * num_y << "\n";
+    std::cout << "Number of calculations: " << num_calculations << "\n";
+    std::cout << "Mean value A: " << avg_s << " (should converge to 0.5)\n";
+    std::cout << "Mean value B: " << avg_v << " (should converge to 0.5)\n";
 
     return 0;
 }

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -226,7 +226,7 @@ namespace alpaka
 #        pragma omp for nowait schedule(static, kernel.ompScheduleChunkSize)
                 for(i = 0; i < iNumBlocksInGrid; ++i)
 #    else
-#        pragma omp for nowait schedule(static, kernel.ompScheduleChunkSize)
+#        pragma omp for nowait schedule(static, kernel.omp_schedule_chunk_size)
                 for(TIdx i = 0; i < numIterations; ++i)
 #    endif
                 {
@@ -362,7 +362,7 @@ namespace alpaka
 #        pragma omp for nowait schedule(dynamic, kernel.ompScheduleChunkSize)
                 for(i = 0; i < iNumBlocksInGrid; ++i)
 #    else
-#        pragma omp for nowait schedule(dynamic, kernel.ompScheduleChunkSize)
+#        pragma omp for nowait schedule(dynamic, kernel.omp_schedule_chunk_size)
                 for(TIdx i = 0; i < numIterations; ++i)
 #    endif
                 {
@@ -498,7 +498,7 @@ namespace alpaka
 #        pragma omp for nowait schedule(guided, kernel.ompScheduleChunkSize)
                 for(i = 0; i < iNumBlocksInGrid; ++i)
 #    else
-#        pragma omp for nowait schedule(guided, kernel.ompScheduleChunkSize)
+#        pragma omp for nowait schedule(guided, kernel.omp_schedule_chunk_size)
                 for(TIdx i = 0; i < numIterations; ++i)
 #    endif
                 {
@@ -753,7 +753,7 @@ namespace alpaka
                 TSchedule const& schedule)
             {
                 // Forward to ParallelForImpl that performs dispatch by by chunk size
-                ParallelForImpl<TKernel, TSchedule, TKernel::ompScheduleKind>{}(
+                ParallelForImpl<TKernel, TSchedule, TKernel::omp_schedule_kind>{}(
                     kernel,
                     std::forward<TLoopBody>(loopBody),
                     numIterations,

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -161,7 +161,7 @@ namespace alpaka
         Vec<TDim, Idx<TAcc>> const& threadElemExtent,
         TArgs const&... args) -> std::size_t
     {
-        return traits::BlockSharedMemDynSizeBytes<TKernelFnObj, TAcc>::getBlockSharedMemDynSizeBytes(
+        return traits::BlockSharedMemDynSizeBytes<TKernelFnObj, TAcc>::get_block_shared_mem_dyn_size_bytes(
             kernelFnObj,
             blockThreadExtent,
             threadElemExtent,
@@ -190,7 +190,7 @@ namespace alpaka
         Vec<TDim, Idx<TAcc>> const& threadElemExtent,
         TArgs const&... args)
     {
-        return traits::OmpSchedule<TKernelFnObj, TAcc>::getOmpSchedule(
+        return traits::OmpSchedule<TKernelFnObj, TAcc>::get_omp_schedule(
             kernelFnObj,
             blockThreadExtent,
             threadElemExtent,

--- a/test/integ/axpy/src/axpy.cpp
+++ b/test/integ/axpy/src/axpy.cpp
@@ -38,27 +38,27 @@ public:
     template<typename TAcc, typename TElem, typename TIdx>
     ALPAKA_FN_ACC auto operator()(
         TAcc const& acc,
-        TIdx const& numElements,
+        TIdx const& num_elements,
         TElem const& alpha,
-        TElem const* const X,
-        TElem* const Y) const -> void
+        TElem const* const x,
+        TElem* const y) const -> void
     {
         static_assert(alpaka::Dim<TAcc>::value == 1, "The AxpyKernel expects 1-dimensional indices!");
 
-        auto const gridThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u];
-        auto const threadElemExtent = alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u];
-        auto const threadFirstElemIdx = gridThreadIdx * threadElemExtent;
+        auto const grid_thread_idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u];
+        auto const thread_elem_extent = alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u];
+        auto const thread_first_elem_idx = grid_thread_idx * thread_elem_extent;
 
-        if(threadFirstElemIdx < numElements)
+        if(thread_first_elem_idx < num_elements)
         {
             // Calculate the number of elements to compute in this thread.
             // The result is uniform for all but the last thread.
-            auto const threadLastElemIdx = threadFirstElemIdx + threadElemExtent;
-            auto const threadLastElemIdxClipped = (numElements > threadLastElemIdx) ? threadLastElemIdx : numElements;
+            auto const thread_last_elem_idx = thread_first_elem_idx + thread_elem_extent;
+            auto const thread_last_elem_idx_clipped = (num_elements > thread_last_elem_idx) ? thread_last_elem_idx : num_elements;
 
-            for(TIdx i(threadFirstElemIdx); i < threadLastElemIdxClipped; ++i)
+            for(TIdx i(thread_first_elem_idx); i < thread_last_elem_idx_clipped; ++i)
             {
-                Y[i] = alpha * X[i] + Y[i];
+                y[i] = alpha * x[i] + y[i];
             }
         }
     }
@@ -75,7 +75,7 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
 #ifdef ALPAKA_CI
     Idx const numElements = 1u << 9u;
 #else
-    Idx const numElements = 1u << 16u;
+    Idx const num_elements = 1u << 16u;
 #endif
 
     using Val = float;
@@ -88,35 +88,35 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
     AxpyKernel kernel;
 
     // Get the host device.
-    auto const devHost = alpaka::getDevByIdx<PltfHost>(0u);
+    auto const dev_host = alpaka::getDevByIdx<PltfHost>(0u);
 
     // Select a device to execute on.
-    auto const devAcc = alpaka::getDevByIdx<PltfAcc>(0u);
+    auto const dev_acc = alpaka::getDevByIdx<PltfAcc>(0u);
 
     // Get a queue on this device.
-    QueueAcc queue(devAcc);
+    QueueAcc queue(dev_acc);
 
-    alpaka::Vec<Dim, Idx> const extent(numElements);
+    alpaka::Vec<Dim, Idx> const extent(num_elements);
 
     // Let alpaka calculate good block and grid sizes given our full problem extent.
-    alpaka::WorkDivMembers<Dim, Idx> const workDiv(alpaka::getValidWorkDiv<Acc>(
-        devAcc,
+    alpaka::WorkDivMembers<Dim, Idx> const work_div(alpaka::getValidWorkDiv<Acc>(
+        dev_acc,
         extent,
         static_cast<Idx>(3u),
         false,
         alpaka::GridBlockExtentSubDivRestrictions::Unrestricted));
 
     std::cout << "AxpyKernel("
-              << " numElements:" << numElements << ", accelerator: " << alpaka::getAccName<Acc>()
-              << ", kernel: " << typeid(kernel).name() << ", workDiv: " << workDiv << ")" << std::endl;
+              << " numElements:" << num_elements << ", accelerator: " << alpaka::getAccName<Acc>()
+              << ", kernel: " << typeid(kernel).name() << ", workDiv: " << work_div << ")" << std::endl;
 
     // Allocate host memory buffers.
-    auto memBufHostX = alpaka::allocBuf<Val, Idx>(devHost, extent);
-    auto memBufHostOrigY = alpaka::allocBuf<Val, Idx>(devHost, extent);
-    auto memBufHostY = alpaka::allocBuf<Val, Idx>(devHost, extent);
-    Val* const pBufHostX = alpaka::getPtrNative(memBufHostX);
-    Val* const pBufHostOrigY = alpaka::getPtrNative(memBufHostOrigY);
-    Val* const pBufHostY = alpaka::getPtrNative(memBufHostY);
+    auto mem_buf_host_x = alpaka::allocBuf<Val, Idx>(dev_host, extent);
+    auto mem_buf_host_orig_y = alpaka::allocBuf<Val, Idx>(dev_host, extent);
+    auto mem_buf_host_y = alpaka::allocBuf<Val, Idx>(dev_host, extent);
+    Val* const p_buf_host_x = alpaka::getPtrNative(mem_buf_host_x);
+    Val* const p_buf_host_orig_y = alpaka::getPtrNative(mem_buf_host_orig_y);
+    Val* const p_buf_host_y = alpaka::getPtrNative(mem_buf_host_y);
 
     // random generator for uniformly distributed numbers in [0,1)
     // keep in mind, this can generate different values on different platforms
@@ -126,10 +126,10 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
     std::uniform_real_distribution<Val> dist(0.0, 1.0);
     std::cout << "using seed: " << seed << "\n";
     // Initialize the host input vectors
-    for(Idx i(0); i < numElements; ++i)
+    for(Idx i(0); i < num_elements; ++i)
     {
-        pBufHostX[i] = dist(eng);
-        pBufHostOrigY[i] = dist(eng);
+        p_buf_host_x[i] = dist(eng);
+        p_buf_host_orig_y[i] = dist(eng);
     }
     Val const alpha(dist(eng));
 
@@ -144,12 +144,12 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
 #endif
 
     // Allocate the buffer on the accelerator.
-    auto memBufAccX = alpaka::allocBuf<Val, Idx>(devAcc, extent);
-    auto memBufAccY = alpaka::allocBuf<Val, Idx>(devAcc, extent);
+    auto mem_buf_acc_x = alpaka::allocBuf<Val, Idx>(dev_acc, extent);
+    auto mem_buf_acc_y = alpaka::allocBuf<Val, Idx>(dev_acc, extent);
 
     // Copy Host -> Acc.
-    alpaka::memcpy(queue, memBufAccX, memBufHostX, extent);
-    alpaka::memcpy(queue, memBufAccY, memBufHostOrigY, extent);
+    alpaka::memcpy(queue, mem_buf_acc_x, mem_buf_host_x, extent);
+    alpaka::memcpy(queue, mem_buf_acc_y, mem_buf_host_orig_y, extent);
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
     alpaka::wait(queue);
@@ -163,36 +163,36 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
 #endif
 
     // Create the kernel execution task.
-    auto const taskKernel = alpaka::createTaskKernel<Acc>(
-        workDiv,
+    auto const task_kernel = alpaka::createTaskKernel<Acc>(
+        work_div,
         kernel,
-        numElements,
+        num_elements,
         alpha,
-        alpaka::getPtrNative(memBufAccX),
-        alpaka::getPtrNative(memBufAccY));
+        alpaka::getPtrNative(mem_buf_acc_x),
+        alpaka::getPtrNative(mem_buf_acc_y));
 
     // Profile the kernel execution.
-    std::cout << "Execution time: " << alpaka::test::integ::measureTaskRunTimeMs(queue, taskKernel) << " ms"
+    std::cout << "Execution time: " << alpaka::test::integ::measureTaskRunTimeMs(queue, task_kernel) << " ms"
               << std::endl;
 
     // Copy back the result.
-    alpaka::memcpy(queue, memBufHostY, memBufAccY, extent);
+    alpaka::memcpy(queue, mem_buf_host_y, mem_buf_acc_y, extent);
 
     // Wait for the queue to finish the memory operation.
     alpaka::wait(queue);
 
-    bool resultCorrect(true);
-    for(Idx i(0u); i < numElements; ++i)
+    bool result_correct(true);
+    for(Idx i(0u); i < num_elements; ++i)
     {
-        auto const& val(pBufHostY[i]);
-        auto const correctResult = alpha * pBufHostX[i] + pBufHostOrigY[i];
-        auto const relDiff = std::abs((val - correctResult) / std::min(val, correctResult));
-        if(relDiff > std::numeric_limits<Val>::epsilon())
+        auto const& val(p_buf_host_y[i]);
+        auto const correct_result = alpha * p_buf_host_x[i] + p_buf_host_orig_y[i];
+        auto const rel_diff = std::abs((val - correct_result) / std::min(val, correct_result));
+        if(rel_diff > std::numeric_limits<Val>::epsilon())
         {
-            std::cerr << "C[" << i << "] == " << val << " != " << correctResult << std::endl;
-            resultCorrect = false;
+            std::cerr << "C[" << i << "] == " << val << " != " << correct_result << std::endl;
+            result_correct = false;
         }
     }
 
-    REQUIRE(resultCorrect);
+    REQUIRE(result_correct);
 }

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -22,44 +22,44 @@
 //#define ALPAKA_MANDELBROT_TEST_CONTINOUS_COLOR_MAPPING  // Define this to enable the continuous color mapping.
 
 //! Complex Number.
-template<typename T>
+template<typename TT>
 class SimpleComplex
 {
 public:
     ALPAKA_NO_HOST_ACC_WARNING
-    ALPAKA_FN_HOST_ACC SimpleComplex(T const& a, T const& b) : r(a), i(b)
+    ALPAKA_FN_HOST_ACC SimpleComplex(TT const& a, TT const& b) : m_r(a), m_i(b)
     {
     }
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_INLINE
-    ALPAKA_FN_HOST_ACC auto absSq() const -> T
+    ALPAKA_FN_HOST_ACC auto abs_sq() const -> TT
     {
-        return r * r + i * i;
+        return m_r * m_r + m_i * m_i;
     }
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_HOST_ACC auto operator*(SimpleComplex const& a) -> SimpleComplex
     {
-        return SimpleComplex(r * a.r - i * a.i, i * a.r + r * a.i);
+        return SimpleComplex(m_r * a.m_r - m_i * a.m_i, m_i * a.m_r + m_r * a.m_i);
     }
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_HOST_ACC auto operator*(float const& a) -> SimpleComplex
     {
-        return SimpleComplex(r * a, i * a);
+        return SimpleComplex(m_r * a, m_i * a);
     }
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_HOST_ACC auto operator+(SimpleComplex const& a) -> SimpleComplex
     {
-        return SimpleComplex(r + a.r, i + a.i);
+        return SimpleComplex(m_r + a.m_r, m_i + a.m_i);
     }
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_HOST_ACC auto operator+(float const& a) -> SimpleComplex
     {
-        return SimpleComplex(r + a, i);
+        return SimpleComplex(m_r + a, m_i);
     }
 
-public:
-    T r;
-    T i;
+
+    TT m_r;
+    TT m_i;
 };
 
 //! A Mandelbrot kernel.
@@ -70,22 +70,22 @@ public:
     ALPAKA_FN_HOST_ACC MandelbrotKernel()
     {
         // Banding can be prevented by a continuous color functions.
-        m_colors[0u] = convertRgbSingleToBgra(66, 30, 15);
-        m_colors[1u] = convertRgbSingleToBgra(25, 7, 26);
-        m_colors[2u] = convertRgbSingleToBgra(9, 1, 47);
-        m_colors[3u] = convertRgbSingleToBgra(4, 4, 73);
-        m_colors[4u] = convertRgbSingleToBgra(0, 7, 100);
-        m_colors[5u] = convertRgbSingleToBgra(12, 44, 138);
-        m_colors[6u] = convertRgbSingleToBgra(24, 82, 177);
-        m_colors[7u] = convertRgbSingleToBgra(57, 125, 209);
-        m_colors[8u] = convertRgbSingleToBgra(134, 181, 229);
-        m_colors[9u] = convertRgbSingleToBgra(211, 236, 248);
-        m_colors[10u] = convertRgbSingleToBgra(241, 233, 191);
-        m_colors[11u] = convertRgbSingleToBgra(248, 201, 95);
-        m_colors[12u] = convertRgbSingleToBgra(255, 170, 0);
-        m_colors[13u] = convertRgbSingleToBgra(204, 128, 0);
-        m_colors[14u] = convertRgbSingleToBgra(153, 87, 0);
-        m_colors[15u] = convertRgbSingleToBgra(106, 52, 3);
+        m_colors[0u] = convert_rgb_single_to_bgra(66, 30, 15);
+        m_colors[1u] = convert_rgb_single_to_bgra(25, 7, 26);
+        m_colors[2u] = convert_rgb_single_to_bgra(9, 1, 47);
+        m_colors[3u] = convert_rgb_single_to_bgra(4, 4, 73);
+        m_colors[4u] = convert_rgb_single_to_bgra(0, 7, 100);
+        m_colors[5u] = convert_rgb_single_to_bgra(12, 44, 138);
+        m_colors[6u] = convert_rgb_single_to_bgra(24, 82, 177);
+        m_colors[7u] = convert_rgb_single_to_bgra(57, 125, 209);
+        m_colors[8u] = convert_rgb_single_to_bgra(134, 181, 229);
+        m_colors[9u] = convert_rgb_single_to_bgra(211, 236, 248);
+        m_colors[10u] = convert_rgb_single_to_bgra(241, 233, 191);
+        m_colors[11u] = convert_rgb_single_to_bgra(248, 201, 95);
+        m_colors[12u] = convert_rgb_single_to_bgra(255, 170, 0);
+        m_colors[13u] = convert_rgb_single_to_bgra(204, 128, 0);
+        m_colors[14u] = convert_rgb_single_to_bgra(153, 87, 0);
+        m_colors[15u] = convert_rgb_single_to_bgra(106, 52, 3);
     }
 #endif
 
@@ -103,58 +103,58 @@ public:
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(
         TAcc const& acc,
-        std::uint32_t* const pColors,
-        std::uint32_t const& numRows,
-        std::uint32_t const& numCols,
-        std::uint32_t const& pitchBytes,
-        float const& fMinR,
-        float const& fMaxR,
-        float const& fMinI,
-        float const& fMaxI,
-        std::uint32_t const& maxIterations) const -> void
+        const std::uint32_t* const p_colors,
+        std::uint32_t const& num_rows,
+        std::uint32_t const& num_cols,
+        std::uint32_t const& pitch_bytes,
+        float const& f_min_r,
+        float const& f_max_r,
+        float const& f_min_i,
+        float const& f_max_i,
+        std::uint32_t const& max_iterations) const -> void
     {
         static_assert(alpaka::Dim<TAcc>::value == 2, "The MandelbrotKernel expects 2-dimensional indices!");
 
-        auto const gridThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-        auto const& gridThreadIdxX = gridThreadIdx[1u];
-        auto const& gridThreadIdxY = gridThreadIdx[0u];
+        auto const grid_thread_idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+        auto const& grid_thread_idx_x = grid_thread_idx[1u];
+        auto const& grid_thread_idx_y = grid_thread_idx[0u];
 
-        if((gridThreadIdxY < numRows) && (gridThreadIdxX < numCols))
+        if((grid_thread_idx_y < num_rows) && (grid_thread_idx_x < num_cols))
         {
             SimpleComplex<float> c(
-                (fMinR + (static_cast<float>(gridThreadIdxX) / float(numCols - 1) * (fMaxR - fMinR))),
-                (fMinI + (static_cast<float>(gridThreadIdxY) / float(numRows - 1) * (fMaxI - fMinI))));
+                (f_min_r + (static_cast<float>(grid_thread_idx_x) / float(num_cols - 1) * (f_max_r - f_min_r))),
+                (f_min_i + (static_cast<float>(grid_thread_idx_y) / float(num_rows - 1) * (f_max_i - f_min_i))));
 
-            auto const iterationCount = iterateMandelbrot(c, maxIterations);
+            auto const iteration_count = iterate_mandelbrot(c, max_iterations);
 
-            auto const pColorsRow = pColors + ((gridThreadIdxY * pitchBytes) / sizeof(std::uint32_t));
-            pColorsRow[gridThreadIdxX] =
+            auto const p_colors_row = p_colors + ((grid_thread_idx_y * pitch_bytes) / sizeof(std::uint32_t));
+            p_colors_row[grid_thread_idx_x] =
 #ifdef ALPAKA_MANDELBROT_TEST_CONTINOUS_COLOR_MAPPING
                 iterationCountToContinousColor(iterationCount, maxIterations);
 #else
-                iterationCountToRepeatedColor(iterationCount);
+                iteration_count_to_repeated_color(iteration_count);
 #endif
         }
     }
     //! \return The number of iterations until the Mandelbrot iteration with the given Value reaches the absolute value
     //! of 2.
     //!     Only does maxIterations steps and returns maxIterations if the value would be higher.
-    ALPAKA_FN_ACC static auto iterateMandelbrot(SimpleComplex<float> const& c, std::uint32_t const& maxIterations)
+    ALPAKA_FN_ACC static auto iterate_mandelbrot(SimpleComplex<float> const& c, std::uint32_t const& max_iterations)
         -> std::uint32_t
     {
         SimpleComplex<float> z(0.0f, 0.0f);
-        for(std::uint32_t iterations(0); iterations < maxIterations; ++iterations)
+        for(std::uint32_t iterations(0); iterations < max_iterations; ++iterations)
         {
             z = z * z + c;
-            if(z.absSq() > 4.0f)
+            if(z.abs_sq() > 4.0f)
             {
                 return iterations;
             }
         }
-        return maxIterations;
+        return max_iterations;
     }
 
-    ALPAKA_FN_HOST_ACC static auto convertRgbSingleToBgra(
+    ALPAKA_FN_HOST_ACC static auto convert_rgb_single_to_bgra(
         std::uint32_t const& r,
         std::uint32_t const& g,
         std::uint32_t const& b) -> std::uint32_t
@@ -182,39 +182,39 @@ public:
 #else
     //! This uses a simple mapping from iteration count to colors.
     //! This leads to banding but allows a all pixels to be colored.
-    ALPAKA_FN_ACC auto iterationCountToRepeatedColor(std::uint32_t const& iterationCount) const -> std::uint32_t
+    ALPAKA_FN_ACC auto iteration_count_to_repeated_color(std::uint32_t const& iteration_count) const -> std::uint32_t
     {
-        return m_colors[iterationCount % 16];
+        return m_colors[iteration_count % 16];
     }
 
-    std::uint32_t m_colors[16];
+    std::uint32_t m_colors[16]{};
 #endif
 };
 
 //! Writes the buffer color data to a file.
 template<typename TBuf>
-auto writeTgaColorImage(std::string const& fileName, TBuf const& bufRgba) -> void
+auto write_tga_color_image(std::string const& file_name, TBuf const& buf_rgba) -> void
 {
     static_assert(alpaka::Dim<TBuf>::value == 2, "The buffer has to be 2 dimensional!");
     static_assert(std::is_integral<alpaka::Elem<TBuf>>::value, "The buffer element type has to be integral!");
 
     // The width of the input buffer is in input elements.
-    auto const bufWidthElems = alpaka::extent::getWidth(bufRgba);
-    auto const bufWidthBytes = bufWidthElems * sizeof(alpaka::Elem<TBuf>);
+    auto const buf_width_elems = alpaka::extent::getWidth(buf_rgba);
+    auto const buf_width_bytes = buf_width_elems * sizeof(alpaka::Elem<TBuf>);
     // The row width in bytes has to be dividable by 4 Bytes (RGBA).
-    ALPAKA_ASSERT(bufWidthBytes % sizeof(std::uint32_t) == 0);
+    ALPAKA_ASSERT(buf_width_bytes % sizeof(std::uint32_t) == 0);
     // The number of colors in a row.
-    auto const bufWidthColors = bufWidthBytes / sizeof(std::uint32_t);
-    ALPAKA_ASSERT(bufWidthColors >= 1);
-    auto const bufHeightColors = alpaka::extent::getHeight(bufRgba);
-    ALPAKA_ASSERT(bufHeightColors >= 1);
-    auto const bufPitchBytes = alpaka::getPitchBytes<alpaka::Dim<TBuf>::value - 1u>(bufRgba);
-    ALPAKA_ASSERT(bufPitchBytes >= bufWidthBytes);
+    auto const buf_width_colors = buf_width_bytes / sizeof(std::uint32_t);
+    ALPAKA_ASSERT(buf_width_colors >= 1);
+    auto const buf_height_colors = alpaka::extent::getHeight(buf_rgba);
+    ALPAKA_ASSERT(buf_height_colors >= 1);
+    auto const buf_pitch_bytes = alpaka::getPitchBytes<alpaka::Dim<TBuf>::value - 1u>(buf_rgba);
+    ALPAKA_ASSERT(buf_pitch_bytes >= buf_width_bytes);
 
-    std::ofstream ofs(fileName, std::ofstream::out | std::ofstream::binary);
+    std::ofstream ofs(file_name, std::ofstream::out | std::ofstream::binary);
     if(!ofs.is_open())
     {
-        throw std::invalid_argument("Unable to open file: " + fileName);
+        throw std::invalid_argument("Unable to open file: " + file_name);
     }
 
     // Write tga image header.
@@ -230,26 +230,26 @@ auto writeTgaColorImage(std::string const& fileName, TBuf const& bufRgba) -> voi
     ofs.put(0x00);
     ofs.put(0x00); // Y Origin of Image.
     ofs.put(0x00);
-    ofs.put(static_cast<char>(bufWidthColors & 0xFFu)); // Width of Image.
-    ofs.put(static_cast<char>((bufWidthColors >> 8) & 0xFFu));
-    ofs.put(static_cast<char>(bufHeightColors & 0xFFu)); // Height of Image.
-    ofs.put(static_cast<char>((bufHeightColors >> 8) & 0xFFu));
+    ofs.put(static_cast<char>(buf_width_colors & 0xFFu)); // Width of Image.
+    ofs.put(static_cast<char>((buf_width_colors >> 8) & 0xFFu));
+    ofs.put(static_cast<char>(buf_height_colors & 0xFFu)); // Height of Image.
+    ofs.put(static_cast<char>((buf_height_colors >> 8) & 0xFFu));
     ofs.put(0x20); // Image Pixel Size.
     ofs.put(0x20); // Image Descriptor Byte.
 
     // Write the data.
-    char const* pData(reinterpret_cast<char const*>(alpaka::getPtrNative(bufRgba)));
+    auto const* p_data(reinterpret_cast<char const*>(alpaka::getPtrNative(buf_rgba)));
     // If there is no padding, we can directly write the whole buffer data ...
-    if(bufPitchBytes == bufWidthBytes)
+    if(buf_pitch_bytes == buf_width_bytes)
     {
-        ofs.write(pData, static_cast<std::streamsize>(bufWidthBytes * bufHeightColors));
+        ofs.write(p_data, static_cast<std::streamsize>(buf_width_bytes * buf_height_colors));
     }
     // ... else we have to write row by row.
     else
     {
-        for(auto row = decltype(bufHeightColors)(0); row < bufHeightColors; ++row)
+        for(auto row = decltype(buf_height_colors)(0); row < buf_height_colors; ++row)
         {
-            ofs.write(pData + bufPitchBytes * row, static_cast<std::streamsize>(bufWidthBytes));
+            ofs.write(p_data + buf_pitch_bytes * row, static_cast<std::streamsize>(buf_width_bytes));
         }
     }
 }
@@ -265,15 +265,15 @@ TEMPLATE_LIST_TEST_CASE("mandelbrot", "[mandelbrot]", TestAccs)
 #ifdef ALPAKA_CI
     Idx const imageSize(1u << 5u);
 #else
-    Idx const imageSize(1u << 10u);
+    Idx const image_size(1u << 10u);
 #endif
-    Idx const numRows(imageSize);
-    Idx const numCols(imageSize);
-    float const fMinR(-2.0f);
-    float const fMaxR(+1.0f);
-    float const fMinI(-1.2f);
-    float const fMaxI(+1.2f);
-    Idx const maxIterations(300u);
+    Idx const num_rows(image_size);
+    Idx const num_cols(image_size);
+    float const f_min_r(-2.0f);
+    float const f_max_r(+1.0f);
+    float const f_min_i(-1.2f);
+    float const f_max_i(+1.2f);
+    Idx const max_iterations(300u);
 
     using Val = std::uint32_t;
     using DevAcc = alpaka::Dev<Acc>;
@@ -285,67 +285,67 @@ TEMPLATE_LIST_TEST_CASE("mandelbrot", "[mandelbrot]", TestAccs)
     MandelbrotKernel kernel;
 
     // Get the host device.
-    auto const devHost = alpaka::getDevByIdx<PltfHost>(0u);
+    auto const dev_host = alpaka::getDevByIdx<PltfHost>(0u);
 
     // Select a device to execute on.
-    auto const devAcc = alpaka::getDevByIdx<PltfAcc>(0u);
+    auto const dev_acc = alpaka::getDevByIdx<PltfAcc>(0u);
 
     // Get a queue on this device.
-    QueueAcc queue(devAcc);
+    QueueAcc queue(dev_acc);
 
-    alpaka::Vec<Dim, Idx> const extent(static_cast<Idx>(numRows), static_cast<Idx>(numCols));
+    alpaka::Vec<Dim, Idx> const extent(static_cast<Idx>(num_rows), static_cast<Idx>(num_cols));
 
     // Let alpaka calculate good block and grid sizes given our full problem extent.
-    alpaka::WorkDivMembers<Dim, Idx> const workDiv(alpaka::getValidWorkDiv<Acc>(
-        devAcc,
+    alpaka::WorkDivMembers<Dim, Idx> const work_div(alpaka::getValidWorkDiv<Acc>(
+        dev_acc,
         extent,
         alpaka::Vec<Dim, Idx>::ones(),
         false,
         alpaka::GridBlockExtentSubDivRestrictions::Unrestricted));
 
     std::cout << "MandelbrotKernel("
-              << " numRows:" << numRows << ", numCols:" << numCols << ", maxIterations:" << maxIterations
+              << " numRows:" << num_rows << ", numCols:" << num_cols << ", maxIterations:" << max_iterations
               << ", accelerator: " << alpaka::getAccName<Acc>() << ", kernel: " << typeid(kernel).name()
-              << ", workDiv: " << workDiv << ")" << std::endl;
+              << ", workDiv: " << work_div << ")" << std::endl;
 
     // allocate host memory
-    auto bufColorHost = alpaka::allocBuf<Val, Idx>(devHost, extent);
+    auto buf_color_host = alpaka::allocBuf<Val, Idx>(dev_host, extent);
 
     // Allocate the buffer on the accelerator.
-    auto bufColorAcc = alpaka::allocBuf<Val, Idx>(devAcc, extent);
+    auto buf_color_acc = alpaka::allocBuf<Val, Idx>(dev_acc, extent);
 
     // Copy Host -> Acc.
-    alpaka::memcpy(queue, bufColorAcc, bufColorHost, extent);
+    alpaka::memcpy(queue, buf_color_acc, buf_color_host, extent);
 
     // Create the kernel execution task.
-    auto const taskKernel = alpaka::createTaskKernel<Acc>(
-        workDiv,
+    auto const task_kernel = alpaka::createTaskKernel<Acc>(
+        work_div,
         kernel,
-        alpaka::getPtrNative(bufColorAcc),
-        numRows,
-        numCols,
-        alpaka::getPitchBytes<1u>(bufColorAcc),
-        fMinR,
-        fMaxR,
-        fMinI,
-        fMaxI,
-        maxIterations);
+        alpaka::getPtrNative(buf_color_acc),
+        num_rows,
+        num_cols,
+        alpaka::getPitchBytes<1u>(buf_color_acc),
+        f_min_r,
+        f_max_r,
+        f_min_i,
+        f_max_i,
+        max_iterations);
 
     // Profile the kernel execution.
-    std::cout << "Execution time: " << alpaka::test::integ::measureTaskRunTimeMs(queue, taskKernel) << " ms"
+    std::cout << "Execution time: " << alpaka::test::integ::measureTaskRunTimeMs(queue, task_kernel) << " ms"
               << std::endl;
 
     // Copy back the result.
-    alpaka::memcpy(queue, bufColorHost, bufColorAcc, extent);
+    alpaka::memcpy(queue, buf_color_host, buf_color_acc, extent);
 
     // Wait for the queue to finish the memory operation.
     alpaka::wait(queue);
 
     // Write the image to a file.
-    std::string fileName(
-        "mandelbrot" + std::to_string(numCols) + "x" + std::to_string(numRows) + "_" + alpaka::getAccName<Acc>()
+    std::string file_name(
+        "mandelbrot" + std::to_string(num_cols) + "x" + std::to_string(num_rows) + "_" + alpaka::getAccName<Acc>()
         + ".tga");
-    std::replace(fileName.begin(), fileName.end(), '<', '_');
-    std::replace(fileName.begin(), fileName.end(), '>', '_');
-    writeTgaColorImage(fileName, bufColorHost);
+    std::replace(file_name.begin(), file_name.end(), '<', '_');
+    std::replace(file_name.begin(), file_name.end(), '>', '_');
+    write_tga_color_image(file_name, buf_color_host);
 }

--- a/test/integ/separableCompilation/src/main.cpp
+++ b/test/integ/separableCompilation/src/main.cpp
@@ -35,27 +35,27 @@ public:
     template<typename TAcc, typename TElem, typename TIdx>
     ALPAKA_FN_ACC auto operator()(
         TAcc const& acc,
-        TElem const* const A,
-        TElem const* const B,
-        TElem* const C,
-        TIdx const& numElements) const -> void
+        TElem const* const a,
+        TElem const* const b,
+        TElem* const c,
+        TIdx const& num_elements) const -> void
     {
         static_assert(alpaka::Dim<TAcc>::value == 1, "The VectorAddKernel expects 1-dimensional indices!");
 
-        auto const gridThreadIdx(alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
-        auto const threadElemExtent(alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
-        auto const threadFirstElemIdx(gridThreadIdx * threadElemExtent);
+        auto const grid_thread_idx(alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0u]);
+        auto const thread_elem_extent(alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc)[0u]);
+        auto const thread_first_elem_idx(grid_thread_idx * thread_elem_extent);
 
-        if(threadFirstElemIdx < numElements)
+        if(thread_first_elem_idx < num_elements)
         {
             // Calculate the number of elements to compute in this thread.
             // The result is uniform for all but the last thread.
-            auto const threadLastElemIdx(threadFirstElemIdx + threadElemExtent);
-            auto const threadLastElemIdxClipped((numElements > threadLastElemIdx) ? threadLastElemIdx : numElements);
+            auto const thread_last_elem_idx(thread_first_elem_idx + thread_elem_extent);
+            auto const thread_last_elem_idx_clipped((num_elements > thread_last_elem_idx) ? thread_last_elem_idx : num_elements);
 
-            for(TIdx i(threadFirstElemIdx); i < threadLastElemIdxClipped; ++i)
+            for(TIdx i(thread_first_elem_idx); i < thread_last_elem_idx_clipped; ++i)
             {
-                C[i] = mysqrt(A[i]) + mysqrt(B[i]);
+                c[i] = mysqrt(a[i]) + mysqrt(b[i]);
             }
         }
     }
@@ -76,87 +76,87 @@ TEMPLATE_LIST_TEST_CASE("separableCompilation", "[separableCompilation]", TestAc
     using PltfHost = alpaka::PltfCpu;
     using DevHost = alpaka::Dev<PltfHost>;
 
-    Idx const numElements(32);
+    Idx const num_elements(32);
 
     // Create the kernel function object.
     SqrtKernel kernel;
 
     // Get the host device.
-    DevHost const devHost = alpaka::getDevByIdx<PltfHost>(0u);
+    DevHost const dev_host = alpaka::getDevByIdx<PltfHost>(0u);
 
     // Select a device to execute on.
-    DevAcc const devAcc = alpaka::getDevByIdx<PltfAcc>(0);
+    DevAcc const dev_acc = alpaka::getDevByIdx<PltfAcc>(0);
 
     // Get a queue on this device.
-    QueueAcc queueAcc(devAcc);
+    QueueAcc queue_acc(dev_acc);
 
     // The data extent.
-    alpaka::Vec<alpaka::DimInt<1u>, Idx> const extent(numElements);
+    alpaka::Vec<alpaka::DimInt<1u>, Idx> const extent(num_elements);
 
     // Let alpaka calculate good block and grid sizes given our full problem extent.
-    alpaka::WorkDivMembers<alpaka::DimInt<1u>, Idx> const workDiv(alpaka::getValidWorkDiv<Acc>(
-        devAcc,
+    alpaka::WorkDivMembers<alpaka::DimInt<1u>, Idx> const work_div(alpaka::getValidWorkDiv<Acc>(
+        dev_acc,
         extent,
         static_cast<Idx>(3u),
         false,
         alpaka::GridBlockExtentSubDivRestrictions::Unrestricted));
 
     std::cout << typeid(kernel).name() << "("
-              << "accelerator: " << alpaka::getAccName<Acc>() << ", workDiv: " << workDiv
-              << ", numElements:" << numElements << ")" << std::endl;
+              << "accelerator: " << alpaka::getAccName<Acc>() << ", workDiv: " << work_div
+              << ", numElements:" << num_elements << ")" << std::endl;
 
     // Allocate host memory buffers.
-    auto memBufHostA(alpaka::allocBuf<Val, Idx>(devHost, extent));
-    auto memBufHostB(alpaka::allocBuf<Val, Idx>(devHost, extent));
-    auto memBufHostC(alpaka::allocBuf<Val, Idx>(devHost, extent));
+    auto mem_buf_host_a(alpaka::allocBuf<Val, Idx>(dev_host, extent));
+    auto mem_buf_host_b(alpaka::allocBuf<Val, Idx>(dev_host, extent));
+    auto mem_buf_host_c(alpaka::allocBuf<Val, Idx>(dev_host, extent));
 
     // Initialize the host input vectors
-    for(Idx i(0); i < numElements; ++i)
+    for(Idx i(0); i < num_elements; ++i)
     {
-        alpaka::getPtrNative(memBufHostA)[i] = static_cast<Val>(rand()) / static_cast<Val>(RAND_MAX);
-        alpaka::getPtrNative(memBufHostB)[i] = static_cast<Val>(rand()) / static_cast<Val>(RAND_MAX);
+        alpaka::getPtrNative(mem_buf_host_a)[i] = static_cast<Val>(rand()) / static_cast<Val>(RAND_MAX);
+        alpaka::getPtrNative(mem_buf_host_b)[i] = static_cast<Val>(rand()) / static_cast<Val>(RAND_MAX);
     }
 
     // Allocate the buffers on the accelerator.
-    auto memBufAccA(alpaka::allocBuf<Val, Idx>(devAcc, extent));
-    auto memBufAccB(alpaka::allocBuf<Val, Idx>(devAcc, extent));
-    auto memBufAccC(alpaka::allocBuf<Val, Idx>(devAcc, extent));
+    auto mem_buf_acc_a(alpaka::allocBuf<Val, Idx>(dev_acc, extent));
+    auto mem_buf_acc_b(alpaka::allocBuf<Val, Idx>(dev_acc, extent));
+    auto mem_buf_acc_c(alpaka::allocBuf<Val, Idx>(dev_acc, extent));
 
     // Copy Host -> Acc.
-    alpaka::memcpy(queueAcc, memBufAccA, memBufHostA, extent);
-    alpaka::memcpy(queueAcc, memBufAccB, memBufHostB, extent);
+    alpaka::memcpy(queue_acc, mem_buf_acc_a, mem_buf_host_a, extent);
+    alpaka::memcpy(queue_acc, mem_buf_acc_b, mem_buf_host_b, extent);
 
     // Create the executor task.
-    auto const taskKernel = alpaka::createTaskKernel<Acc>(
-        workDiv,
+    auto const task_kernel = alpaka::createTaskKernel<Acc>(
+        work_div,
         kernel,
-        alpaka::getPtrNative(memBufAccA),
-        alpaka::getPtrNative(memBufAccB),
-        alpaka::getPtrNative(memBufAccC),
-        numElements);
+        alpaka::getPtrNative(mem_buf_acc_a),
+        alpaka::getPtrNative(mem_buf_acc_b),
+        alpaka::getPtrNative(mem_buf_acc_c),
+        num_elements);
 
     // Profile the kernel execution.
-    std::cout << "Execution time: " << alpaka::test::integ::measureTaskRunTimeMs(queueAcc, taskKernel) << " ms"
+    std::cout << "Execution time: " << alpaka::test::integ::measureTaskRunTimeMs(queue_acc, task_kernel) << " ms"
               << std::endl;
 
     // Copy back the result.
-    alpaka::memcpy(queueAcc, memBufHostC, memBufAccC, extent);
-    alpaka::wait(queueAcc);
+    alpaka::memcpy(queue_acc, mem_buf_host_c, mem_buf_acc_c, extent);
+    alpaka::wait(queue_acc);
 
-    bool resultCorrect(true);
-    auto const pHostData(alpaka::getPtrNative(memBufHostC));
-    for(Idx i(0u); i < numElements; ++i)
+    bool result_correct(true);
+    auto const p_host_data(alpaka::getPtrNative(mem_buf_host_c));
+    for(Idx i(0u); i < num_elements; ++i)
     {
-        auto const& val(pHostData[i]);
-        auto const correctResult(
-            std::sqrt(alpaka::getPtrNative(memBufHostA)[i]) + std::sqrt(alpaka::getPtrNative(memBufHostB)[i]));
-        auto const absDiff = (val - correctResult);
-        if(absDiff > std::numeric_limits<Val>::epsilon())
+        auto const& val(p_host_data[i]);
+        auto const correct_result(
+            std::sqrt(alpaka::getPtrNative(mem_buf_host_a)[i]) + std::sqrt(alpaka::getPtrNative(mem_buf_host_b)[i]));
+        auto const abs_diff = (val - correct_result);
+        if(abs_diff > std::numeric_limits<Val>::epsilon())
         {
-            std::cout << "C[" << i << "] == " << val << " != " << correctResult << std::endl;
-            resultCorrect = false;
+            std::cout << "C[" << i << "] == " << val << " != " << correct_result << std::endl;
+            result_correct = false;
         }
     }
 
-    REQUIRE(true == resultCorrect);
+    REQUIRE(true == result_correct);
 }

--- a/test/unit/acc/src/AccDevPropsTest.cpp
+++ b/test/unit/acc/src/AccDevPropsTest.cpp
@@ -19,14 +19,14 @@ TEMPLATE_LIST_TEST_CASE("getAccDevProps", "[acc]", alpaka::test::TestAccs)
     using Dev = alpaka::Dev<Acc>;
     using Pltf = alpaka::Pltf<Dev>;
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto const devProps = alpaka::getAccDevProps<Acc>(dev);
+    auto const dev_props = alpaka::getAccDevProps<Acc>(dev);
 
-    REQUIRE(devProps.m_gridBlockExtentMax.min() > 0);
-    REQUIRE(devProps.m_blockThreadExtentMax.min() > 0);
-    REQUIRE(devProps.m_threadElemExtentMax.min() > 0);
-    REQUIRE(devProps.m_gridBlockCountMax > 0);
-    REQUIRE(devProps.m_blockThreadCountMax > 0);
-    REQUIRE(devProps.m_threadElemCountMax > 0);
-    REQUIRE(devProps.m_multiProcessorCount > 0);
-    REQUIRE(devProps.m_sharedMemSizeBytes > 0);
+    REQUIRE(dev_props.m_gridBlockExtentMax.min() > 0);
+    REQUIRE(dev_props.m_blockThreadExtentMax.min() > 0);
+    REQUIRE(dev_props.m_threadElemExtentMax.min() > 0);
+    REQUIRE(dev_props.m_gridBlockCountMax > 0);
+    REQUIRE(dev_props.m_blockThreadCountMax > 0);
+    REQUIRE(dev_props.m_threadElemCountMax > 0);
+    REQUIRE(dev_props.m_multiProcessorCount > 0);
+    REQUIRE(dev_props.m_sharedMemSizeBytes > 0);
 }

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -18,8 +18,8 @@
 #include <climits>
 #include <type_traits>
 
-template<typename T1, typename T2>
-ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool equals(T1 a, T2 b)
+template<typename TT1, typename TT2>
+ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool equals(TT1 a, TT2 b)
 {
     return a == b;
 }
@@ -35,301 +35,301 @@ ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool equals(double a, double b)
 }
 
 ALPAKA_NO_HOST_ACC_WARNING
-template<typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicAdd(TAcc const& acc, bool* success, T operandOrig) -> void
+template<typename TAcc, typename TT>
+ALPAKA_FN_ACC auto test_atomic_add(TAcc const& acc, bool* success, TT operand_orig) -> void
 {
-    T const value = static_cast<T>(4);
-    T const reference = static_cast<T>(operandOrig + value);
-    auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
+    TT const value = static_cast<TT>(4);
+    TT const reference = static_cast<TT>(operand_orig + value);
+    auto& operand = alpaka::declareSharedVar<TT, __COUNTER__>(acc);
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicAdd(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicAdd(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
 ALPAKA_NO_HOST_ACC_WARNING
-template<typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicSub(TAcc const& acc, bool* success, T operandOrig) -> void
+template<typename TAcc, typename TT>
+ALPAKA_FN_ACC auto test_atomic_sub(TAcc const& acc, bool* success, TT operand_orig) -> void
 {
-    T const value = static_cast<T>(4);
-    T const reference = static_cast<T>(operandOrig - value);
-    auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
+    TT const value = static_cast<TT>(4);
+    TT const reference = static_cast<TT>(operand_orig - value);
+    auto& operand = alpaka::declareSharedVar<TT, __COUNTER__>(acc);
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicOp<alpaka::AtomicSub>(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicOp<alpaka::AtomicSub>(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicSub(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicSub(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
 ALPAKA_NO_HOST_ACC_WARNING
-template<typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicMin(TAcc const& acc, bool* success, T operandOrig) -> void
+template<typename TAcc, typename TT>
+ALPAKA_FN_ACC auto test_atomic_min(TAcc const& acc, bool* success, TT operand_orig) -> void
 {
-    T const value = static_cast<T>(4);
-    T const reference = (operandOrig < value) ? operandOrig : value;
-    auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
+    TT const value = static_cast<TT>(4);
+    TT const reference = (operand_orig < value) ? operand_orig : value;
+    auto& operand = alpaka::declareSharedVar<TT, __COUNTER__>(acc);
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicOp<alpaka::AtomicMin>(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicOp<alpaka::AtomicMin>(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicMin(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicMin(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
 ALPAKA_NO_HOST_ACC_WARNING
-template<typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicMax(TAcc const& acc, bool* success, T operandOrig) -> void
+template<typename TAcc, typename TT>
+ALPAKA_FN_ACC auto test_atomic_max(TAcc const& acc, bool* success, TT operand_orig) -> void
 {
-    T const value = static_cast<T>(4);
-    T const reference = (operandOrig > value) ? operandOrig : value;
-    auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
+    TT const value = static_cast<TT>(4);
+    TT const reference = (operand_orig > value) ? operand_orig : value;
+    auto& operand = alpaka::declareSharedVar<TT, __COUNTER__>(acc);
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicOp<alpaka::AtomicMax>(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicOp<alpaka::AtomicMax>(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicMax(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicMax(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
 ALPAKA_NO_HOST_ACC_WARNING
-template<typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicExch(TAcc const& acc, bool* success, T operandOrig) -> void
+template<typename TAcc, typename TT>
+ALPAKA_FN_ACC auto test_atomic_exch(TAcc const& acc, bool* success, TT operand_orig) -> void
 {
-    T const value = static_cast<T>(4);
-    T const reference = value;
-    auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
+    TT const value = static_cast<TT>(4);
+    TT const reference = value;
+    auto& operand = alpaka::declareSharedVar<TT, __COUNTER__>(acc);
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicOp<alpaka::AtomicExch>(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicOp<alpaka::AtomicExch>(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicExch(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicExch(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
 ALPAKA_NO_HOST_ACC_WARNING
-template<typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicInc(TAcc const& acc, bool* success, T operandOrig) -> void
+template<typename TAcc, typename TT>
+ALPAKA_FN_ACC auto test_atomic_inc(TAcc const& acc, bool* success, TT operand_orig) -> void
 {
     // \TODO: Check reset to 0 at 'value'.
-    T const value = static_cast<T>(42);
-    T const reference = static_cast<T>(operandOrig + 1);
-    auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
+    TT const value = static_cast<TT>(42);
+    TT const reference = static_cast<TT>(operand_orig + 1);
+    auto& operand = alpaka::declareSharedVar<TT, __COUNTER__>(acc);
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicOp<alpaka::AtomicInc>(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicOp<alpaka::AtomicInc>(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicInc(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicInc(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
 ALPAKA_NO_HOST_ACC_WARNING
-template<typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicDec(TAcc const& acc, bool* success, T operandOrig) -> void
+template<typename TAcc, typename TT>
+ALPAKA_FN_ACC auto test_atomic_dec(TAcc const& acc, bool* success, TT operand_orig) -> void
 {
     // \TODO: Check reset to 'value' at 0.
-    T const value = static_cast<T>(42);
-    T const reference = static_cast<T>(operandOrig - 1);
-    auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
+    TT const value = static_cast<TT>(42);
+    TT const reference = static_cast<TT>(operand_orig - 1);
+    auto& operand = alpaka::declareSharedVar<TT, __COUNTER__>(acc);
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicOp<alpaka::AtomicDec>(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicOp<alpaka::AtomicDec>(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicDec(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
-        ALPAKA_CHECK(*success, equals(operand, reference));
-    }
-}
-
-ALPAKA_NO_HOST_ACC_WARNING
-template<typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicAnd(TAcc const& acc, bool* success, T operandOrig) -> void
-{
-    T const value = static_cast<T>(4);
-    T const reference = operandOrig & value;
-    auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
-    {
-        operand = operandOrig;
-        T const ret = alpaka::atomicOp<alpaka::AtomicAnd>(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
-        ALPAKA_CHECK(*success, equals(operand, reference));
-    }
-    {
-        operand = operandOrig;
-        T const ret = alpaka::atomicAnd(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicDec(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
 ALPAKA_NO_HOST_ACC_WARNING
-template<typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicOr(TAcc const& acc, bool* success, T operandOrig) -> void
+template<typename TAcc, typename TT>
+ALPAKA_FN_ACC auto test_atomic_and(TAcc const& acc, bool* success, TT operand_orig) -> void
 {
-    T const value = static_cast<T>(4);
-    T const reference = operandOrig | value;
-    auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
+    TT const value = static_cast<TT>(4);
+    TT const reference = operand_orig & value;
+    auto& operand = alpaka::declareSharedVar<TT, __COUNTER__>(acc);
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicOp<alpaka::AtomicOr>(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicOp<alpaka::AtomicAnd>(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicOr(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicAnd(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
 ALPAKA_NO_HOST_ACC_WARNING
-template<typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicXor(TAcc const& acc, bool* success, T operandOrig) -> void
+template<typename TAcc, typename TT>
+ALPAKA_FN_ACC auto test_atomic_or(TAcc const& acc, bool* success, TT operand_orig) -> void
 {
-    T const value = static_cast<T>(operandOrig + static_cast<T>(4));
-    T const reference = operandOrig ^ value;
-    auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
+    TT const value = static_cast<TT>(4);
+    TT const reference = operand_orig | value;
+    auto& operand = alpaka::declareSharedVar<TT, __COUNTER__>(acc);
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicOp<alpaka::AtomicXor>(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicOp<alpaka::AtomicOr>(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
-        operand = operandOrig;
-        T const ret = alpaka::atomicXor(acc, &operand, value);
-        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        operand = operand_orig;
+        TT const ret = alpaka::atomicOr(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
 ALPAKA_NO_HOST_ACC_WARNING
-template<typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicCas(TAcc const& acc, bool* success, T operandOrig) -> void
+template<typename TAcc, typename TT>
+ALPAKA_FN_ACC auto test_atomic_xor(TAcc const& acc, bool* success, TT operand_orig) -> void
 {
-    T const value = static_cast<T>(4);
-    auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
+    TT const value = static_cast<TT>(operand_orig + static_cast<TT>(4));
+    TT const reference = operand_orig ^ value;
+    auto& operand = alpaka::declareSharedVar<TT, __COUNTER__>(acc);
+    {
+        operand = operand_orig;
+        TT const ret = alpaka::atomicOp<alpaka::AtomicXor>(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
+    }
+    {
+        operand = operand_orig;
+        TT const ret = alpaka::atomicXor(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operand_orig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
+    }
+}
+
+ALPAKA_NO_HOST_ACC_WARNING
+template<typename TAcc, typename TT>
+ALPAKA_FN_ACC auto test_atomic_cas(TAcc const& acc, bool* success, TT operand_orig) -> void
+{
+    TT const value = static_cast<TT>(4);
+    auto& operand = alpaka::declareSharedVar<TT, __COUNTER__>(acc);
 
     // with match
     {
-        T const compare = operandOrig;
-        T const reference = value;
+        TT const compare = operand_orig;
+        TT const reference = value;
         {
-            operand = operandOrig;
-            T const ret = alpaka::atomicOp<alpaka::AtomicCas>(acc, &operand, compare, value);
-            ALPAKA_CHECK(*success, equals(operandOrig, ret));
+            operand = operand_orig;
+            TT const ret = alpaka::atomicOp<alpaka::AtomicCas>(acc, &operand, compare, value);
+            ALPAKA_CHECK(*success, equals(operand_orig, ret));
             ALPAKA_CHECK(*success, equals(operand, reference));
         }
         {
-            operand = operandOrig;
-            T const ret = alpaka::atomicCas(acc, &operand, compare, value);
-            ALPAKA_CHECK(*success, equals(operandOrig, ret));
+            operand = operand_orig;
+            TT const ret = alpaka::atomicCas(acc, &operand, compare, value);
+            ALPAKA_CHECK(*success, equals(operand_orig, ret));
             ALPAKA_CHECK(*success, equals(operand, reference));
         }
     }
 
     // without match
     {
-        T const compare = static_cast<T>(operandOrig + static_cast<T>(1));
-        T const reference = operandOrig;
+        TT const compare = static_cast<TT>(operand_orig + static_cast<TT>(1));
+        TT const reference = operand_orig;
         {
-            operand = operandOrig;
-            T const ret = alpaka::atomicOp<alpaka::AtomicCas>(acc, &operand, compare, value);
-            ALPAKA_CHECK(*success, equals(operandOrig, ret));
+            operand = operand_orig;
+            TT const ret = alpaka::atomicOp<alpaka::AtomicCas>(acc, &operand, compare, value);
+            ALPAKA_CHECK(*success, equals(operand_orig, ret));
             ALPAKA_CHECK(*success, equals(operand, reference));
         }
         {
-            operand = operandOrig;
-            T const ret = alpaka::atomicCas(acc, &operand, compare, value);
-            ALPAKA_CHECK(*success, equals(operandOrig, ret));
+            operand = operand_orig;
+            TT const ret = alpaka::atomicCas(acc, &operand, compare, value);
+            ALPAKA_CHECK(*success, equals(operand_orig, ret));
             ALPAKA_CHECK(*success, equals(operand, reference));
         }
     }
 }
 
-template<typename TAcc, typename T, typename Sfinae = void>
+template<typename TAcc, typename TT, typename TSfinae = void>
 class AtomicTestKernel
 {
 public:
     ALPAKA_NO_HOST_ACC_WARNING
-    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, T operandOrig) const -> void
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, TT operand_orig) const -> void
     {
-        testAtomicAdd(acc, success, operandOrig);
-        testAtomicSub(acc, success, operandOrig);
+        test_atomic_add(acc, success, operand_orig);
+        test_atomic_sub(acc, success, operand_orig);
 
-        testAtomicMin(acc, success, operandOrig);
-        testAtomicMax(acc, success, operandOrig);
+        test_atomic_min(acc, success, operand_orig);
+        test_atomic_max(acc, success, operand_orig);
 
-        testAtomicExch(acc, success, operandOrig);
+        test_atomic_exch(acc, success, operand_orig);
 
-        testAtomicInc(acc, success, operandOrig);
-        testAtomicDec(acc, success, operandOrig);
+        test_atomic_inc(acc, success, operand_orig);
+        test_atomic_dec(acc, success, operand_orig);
 
-        testAtomicAnd(acc, success, operandOrig);
-        testAtomicOr(acc, success, operandOrig);
-        testAtomicXor(acc, success, operandOrig);
+        test_atomic_and(acc, success, operand_orig);
+        test_atomic_or(acc, success, operand_orig);
+        test_atomic_xor(acc, success, operand_orig);
 
-        testAtomicCas(acc, success, operandOrig);
+        test_atomic_cas(acc, success, operand_orig);
     }
 };
 
-template<typename TAcc, typename T>
-class AtomicTestKernel<TAcc, T, std::enable_if_t<std::is_floating_point<T>::value>>
+template<typename TAcc, typename TT>
+class AtomicTestKernel<TAcc, TT, std::enable_if_t<std::is_floating_point<TT>::value>>
 {
 public:
     ALPAKA_NO_HOST_ACC_WARNING
-    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, T operandOrig) const -> void
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, TT operand_orig) const -> void
     {
-        testAtomicAdd(acc, success, operandOrig);
-        testAtomicSub(acc, success, operandOrig);
+        test_atomic_add(acc, success, operand_orig);
+        test_atomic_sub(acc, success, operand_orig);
 
-        testAtomicMin(acc, success, operandOrig);
-        testAtomicMax(acc, success, operandOrig);
+        test_atomic_min(acc, success, operand_orig);
+        test_atomic_max(acc, success, operand_orig);
 
-        testAtomicExch(acc, success, operandOrig);
+        test_atomic_exch(acc, success, operand_orig);
 
         // These are not supported on float/double types
         // testAtomicInc(acc, success, operandOrig);
@@ -843,19 +843,19 @@ public:
 };
 #endif
 
-template<typename TAcc, typename T>
+template<typename TAcc, typename TT>
 struct TestAtomicOperations
 {
-    static auto testAtomicOperations() -> void
+    static auto test_atomic_operations() -> void
     {
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
 
         alpaka::test::KernelExecutionFixture<TAcc> fixture(alpaka::Vec<Dim, Idx>::ones());
 
-        AtomicTestKernel<TAcc, T> kernel;
+        AtomicTestKernel<TAcc, TT> kernel;
 
-        T value = static_cast<T>(32);
+        TT value = static_cast<TT>(32);
         REQUIRE(fixture(kernel, value));
     }
 };
@@ -866,19 +866,19 @@ TEMPLATE_LIST_TEST_CASE("atomicOperationsWorking", "[atomic]", TestAccs)
 {
     using Acc = TestType;
 
-    TestAtomicOperations<Acc, unsigned char>::testAtomicOperations();
-    TestAtomicOperations<Acc, char>::testAtomicOperations();
-    TestAtomicOperations<Acc, unsigned short>::testAtomicOperations();
-    TestAtomicOperations<Acc, short>::testAtomicOperations();
+    TestAtomicOperations<Acc, unsigned char>::test_atomic_operations();
+    TestAtomicOperations<Acc, char>::test_atomic_operations();
+    TestAtomicOperations<Acc, unsigned short>::test_atomic_operations();
+    TestAtomicOperations<Acc, short>::test_atomic_operations();
 
-    TestAtomicOperations<Acc, unsigned int>::testAtomicOperations();
-    TestAtomicOperations<Acc, int>::testAtomicOperations();
+    TestAtomicOperations<Acc, unsigned int>::test_atomic_operations();
+    TestAtomicOperations<Acc, int>::test_atomic_operations();
 
-    TestAtomicOperations<Acc, unsigned long>::testAtomicOperations();
-    TestAtomicOperations<Acc, long>::testAtomicOperations();
-    TestAtomicOperations<Acc, unsigned long long>::testAtomicOperations();
-    TestAtomicOperations<Acc, long long>::testAtomicOperations();
+    TestAtomicOperations<Acc, unsigned long>::test_atomic_operations();
+    TestAtomicOperations<Acc, long>::test_atomic_operations();
+    TestAtomicOperations<Acc, unsigned long long>::test_atomic_operations();
+    TestAtomicOperations<Acc, long long>::test_atomic_operations();
 
-    TestAtomicOperations<Acc, float>::testAtomicOperations();
-    TestAtomicOperations<Acc, double>::testAtomicOperations();
+    TestAtomicOperations<Acc, float>::test_atomic_operations();
+    TestAtomicOperations<Acc, double>::test_atomic_operations();
 }

--- a/test/unit/block/shared/src/BlockSharedMemDyn.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemDyn.cpp
@@ -45,16 +45,16 @@ namespace alpaka
         {
             //! \return The size of the shared memory allocated for a block.
             template<typename TVec>
-            ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
-                BlockSharedMemDynTestKernel const& blockSharedMemDyn,
-                TVec const& blockThreadExtent,
-                TVec const& threadElemExtent,
+            ALPAKA_FN_HOST_ACC static auto get_block_shared_mem_dyn_size_bytes(
+                BlockSharedMemDynTestKernel const& block_shared_mem_dyn,
+                TVec const& block_thread_extent,
+                TVec const& thread_elem_extent,
                 bool* success) -> std::size_t
             {
-                alpaka::ignore_unused(blockSharedMemDyn);
+                alpaka::ignore_unused(block_shared_mem_dyn);
                 alpaka::ignore_unused(success);
-                auto const gridSize = blockThreadExtent.prod() * threadElemExtent.prod();
-                return static_cast<std::size_t>(gridSize) * sizeof(std::uint32_t);
+                auto const grid_size = block_thread_extent.prod() * thread_elem_extent.prod();
+                return static_cast<std::size_t>(grid_size) * sizeof(std::uint32_t);
             }
         };
     } // namespace traits

--- a/test/unit/block/shared/src/BlockSharedMemSt.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemSt.cpp
@@ -84,7 +84,7 @@ public:
     {
         // Allocations in the loop with same template signature should be equal too this allocation.
         // 21 byte is chosen to break nice alignment for all following calls of declareSharedVar.
-        auto& baseAllocation = alpaka::declareSharedVar<alpaka::test::Array<std::uint8_t, 21>, 42>(acc);
+        auto& base_allocation = alpaka::declareSharedVar<alpaka::test::Array<std::uint8_t, 21>, 42>(acc);
 
         // Multiple runs to make sure it really works.
         for(std::size_t i = 0u; i < 10; ++i)
@@ -115,11 +115,11 @@ public:
             auto& a = alpaka::declareSharedVar<alpaka::test::Array<std::uint8_t, 21>, 42>(acc);
             auto& b = alpaka::declareSharedVar<alpaka::test::Array<std::uint8_t, 21>, 42>(acc);
             ALPAKA_CHECK(*success, &a == &b);
-            ALPAKA_CHECK(*success, &a == &baseAllocation);
+            ALPAKA_CHECK(*success, &a == &base_allocation);
 
-            auto& lastAllocation = alpaka::declareSharedVar<alpaka::test::Array<std::uint8_t, 23>, 23>(acc);
+            auto& last_allocation = alpaka::declareSharedVar<alpaka::test::Array<std::uint8_t, 23>, 23>(acc);
             auto& c = alpaka::declareSharedVar<alpaka::test::Array<std::uint8_t, 23>, 23>(acc);
-            ALPAKA_CHECK(*success, &lastAllocation == &c);
+            ALPAKA_CHECK(*success, &last_allocation == &c);
         }
     }
 };

--- a/test/unit/block/sync/src/BlockSync.cpp
+++ b/test/unit/block/sync/src/BlockSync.cpp
@@ -16,7 +16,7 @@
 class BlockSyncTestKernel
 {
 public:
-    static const std::uint8_t gridThreadExtentPerDim = 4u;
+    static const std::uint8_t grid_thread_extent_per_dim = 4u;
 
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
@@ -25,24 +25,24 @@ public:
         using Idx = alpaka::Idx<TAcc>;
 
         // Get the index of the current thread within the block and the block extent and map them to 1D.
-        auto const blockThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
-        auto const blockThreadExtent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
-        auto const blockThreadIdx1D = alpaka::mapIdx<1u>(blockThreadIdx, blockThreadExtent)[0u];
-        auto const blockThreadExtent1D = blockThreadExtent.prod();
+        auto const block_thread_idx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
+        auto const block_thread_extent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
+        auto const block_thread_idx1_d = alpaka::mapIdx<1u>(block_thread_idx, block_thread_extent)[0u];
+        auto const block_thread_extent1_d = block_thread_extent.prod();
 
         // Allocate shared memory.
-        Idx* const pBlockSharedArray = alpaka::getDynSharedMem<Idx>(acc);
+        auto* const p_block_shared_array = alpaka::getDynSharedMem<Idx>(acc);
 
         // Write the thread index into the shared memory.
-        pBlockSharedArray[blockThreadIdx1D] = blockThreadIdx1D;
+        p_block_shared_array[block_thread_idx1_d] = block_thread_idx1_d;
 
         // Synchronize the threads in the block.
         alpaka::syncBlockThreads(acc);
 
         // All other threads within the block should now have written their index into the shared memory.
-        for(auto i = static_cast<Idx>(0u); i < blockThreadExtent1D; ++i)
+        for(auto i = static_cast<Idx>(0u); i < block_thread_extent1_d; ++i)
         {
-            ALPAKA_CHECK(*success, pBlockSharedArray[i] == i);
+            ALPAKA_CHECK(*success, p_block_shared_array[i] == i);
         }
     }
 };
@@ -57,18 +57,18 @@ namespace alpaka
         {
             //! \return The size of the shared memory allocated for a block.
             template<typename TVec>
-            ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
-                BlockSyncTestKernel const& blockSharedMemDyn,
-                TVec const& blockThreadExtent,
-                TVec const& threadElemExtent,
+            ALPAKA_FN_HOST_ACC static auto get_block_shared_mem_dyn_size_bytes(
+                BlockSyncTestKernel const& block_shared_mem_dyn,
+                TVec const& block_thread_extent,
+                TVec const& thread_elem_extent,
                 bool* success) -> std::size_t
             {
                 using Idx = alpaka::Idx<TAcc>;
 
-                alpaka::ignore_unused(blockSharedMemDyn);
-                alpaka::ignore_unused(threadElemExtent);
+                alpaka::ignore_unused(block_shared_mem_dyn);
+                alpaka::ignore_unused(thread_elem_extent);
                 alpaka::ignore_unused(success);
-                return static_cast<std::size_t>(blockThreadExtent.prod()) * sizeof(Idx);
+                return static_cast<std::size_t>(block_thread_extent.prod()) * sizeof(Idx);
             }
         };
     } // namespace traits
@@ -81,7 +81,7 @@ TEMPLATE_LIST_TEST_CASE("synchronize", "[blockSync]", alpaka::test::TestAccs)
     using Idx = alpaka::Idx<Acc>;
 
     alpaka::test::KernelExecutionFixture<Acc> fixture(
-        alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(BlockSyncTestKernel::gridThreadExtentPerDim)));
+        alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(BlockSyncTestKernel::grid_thread_extent_per_dim)));
 
     BlockSyncTestKernel kernel;
 

--- a/test/unit/block/sync/src/BlockSyncPredicate.cpp
+++ b/test/unit/block/sync/src/BlockSyncPredicate.cpp
@@ -23,26 +23,26 @@ public:
         using Idx = alpaka::Idx<TAcc>;
 
         // Get the index of the current thread within the block and the block extent and map them to 1D.
-        auto const blockThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
-        auto const blockThreadExtent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
-        auto const blockThreadIdx1D = alpaka::mapIdx<1u>(blockThreadIdx, blockThreadExtent)[0u];
-        auto const blockThreadExtent1D = blockThreadExtent.prod();
+        auto const block_thread_idx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
+        auto const block_thread_extent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
+        auto const block_thread_idx1_d = alpaka::mapIdx<1u>(block_thread_idx, block_thread_extent)[0u];
+        auto const block_thread_extent1_d = block_thread_extent.prod();
 
         // syncBlockThreadsPredicate<alpaka::BlockCount>
         {
             Idx const modulus = 2u;
-            int const predicate = static_cast<int>(blockThreadIdx1D % modulus);
+            auto const predicate = static_cast<int>(block_thread_idx1_d % modulus);
             auto const result = alpaka::syncBlockThreadsPredicate<alpaka::BlockCount>(acc, predicate);
-            auto const expectedResult = static_cast<int>(blockThreadExtent1D / modulus);
-            ALPAKA_CHECK(*success, expectedResult == result);
+            auto const expected_result = static_cast<int>(block_thread_extent1_d / modulus);
+            ALPAKA_CHECK(*success, expected_result == result);
         }
         {
             Idx const modulus = 3u;
-            int const predicate = static_cast<int>(blockThreadIdx1D % modulus);
+            auto const predicate = static_cast<int>(block_thread_idx1_d % modulus);
             auto const result = alpaka::syncBlockThreadsPredicate<alpaka::BlockCount>(acc, predicate);
-            auto const expectedResult = static_cast<int>(
-                blockThreadExtent1D - ((blockThreadExtent1D + modulus - static_cast<Idx>(1u)) / modulus));
-            ALPAKA_CHECK(*success, expectedResult == result);
+            auto const expected_result = static_cast<int>(
+                block_thread_extent1_d - ((block_thread_extent1_d + modulus - static_cast<Idx>(1u)) / modulus));
+            ALPAKA_CHECK(*success, expected_result == result);
         }
 
         // syncBlockThreadsPredicate<alpaka::BlockAnd>
@@ -57,7 +57,7 @@ public:
             ALPAKA_CHECK(*success, result == 0);
         }
         {
-            int const predicate = blockThreadIdx1D != 0;
+            int const predicate = block_thread_idx1_d != 0;
             auto const result = alpaka::syncBlockThreadsPredicate<alpaka::BlockAnd>(acc, predicate);
             ALPAKA_CHECK(*success, result == 0);
         }
@@ -74,7 +74,7 @@ public:
             ALPAKA_CHECK(*success, result == 0);
         }
         {
-            int const predicate = static_cast<int>(blockThreadIdx1D != 1);
+            auto const predicate = static_cast<int>(block_thread_idx1_d != 1);
             auto const result = alpaka::syncBlockThreadsPredicate<alpaka::BlockOr>(acc, predicate);
             ALPAKA_CHECK(*success, result == 1);
         }

--- a/test/unit/core/src/OmpScheduleTest.cpp
+++ b/test/unit/core/src/OmpScheduleTest.cpp
@@ -20,11 +20,11 @@ TEST_CASE("ompScheduleDefaultConstructor", "[core]")
 
 TEST_CASE("ompScheduleConstructor", "[core]")
 {
-    auto const staticSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Static, 5};
-    alpaka::ignore_unused(staticSchedule);
+    auto const static_schedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Static, 5};
+    alpaka::ignore_unused(static_schedule);
 
-    auto const guidedSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Guided};
-    alpaka::ignore_unused(guidedSchedule);
+    auto const guided_schedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Guided};
+    alpaka::ignore_unused(guided_schedule);
 }
 
 TEST_CASE("ompScheduleConstexprConstructor", "[core]")
@@ -41,26 +41,26 @@ TEST_CASE("ompGetSchedule", "[core]")
 
 TEST_CASE("ompSetSchedule", "[core]")
 {
-    auto const expectedSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Dynamic, 3};
-    alpaka::omp::setSchedule(expectedSchedule);
+    auto const expected_schedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Dynamic, 3};
+    alpaka::omp::setSchedule(expected_schedule);
     // The check makes sense only when this feature is supported
 #if defined _OPENMP && _OPENMP >= 200805 && defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
-    auto const actualSchedule = alpaka::omp::getSchedule();
-    REQUIRE(expectedSchedule.kind == actualSchedule.kind);
-    REQUIRE(expectedSchedule.chunkSize == actualSchedule.chunkSize);
+    auto const actual_schedule = alpaka::omp::getSchedule();
+    REQUIRE(expected_schedule.kind == actual_schedule.kind);
+    REQUIRE(expected_schedule.chunkSize == actual_schedule.chunkSize);
 #endif
 }
 
 TEST_CASE("ompSetNoSchedule", "[core]")
 {
-    auto const expectedSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Guided, 2};
-    alpaka::omp::setSchedule(expectedSchedule);
-    auto const noSchedule = alpaka::omp::Schedule{alpaka::omp::Schedule::NoSchedule};
-    alpaka::omp::setSchedule(noSchedule);
+    auto const expected_schedule = alpaka::omp::Schedule{alpaka::omp::Schedule::Guided, 2};
+    alpaka::omp::setSchedule(expected_schedule);
+    auto const no_schedule = alpaka::omp::Schedule{alpaka::omp::Schedule::NoSchedule};
+    alpaka::omp::setSchedule(no_schedule);
     // The check makes sense only when this feature is supported
 #if defined _OPENMP && _OPENMP >= 200805 && defined ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
-    auto const actualSchedule = alpaka::omp::getSchedule();
-    REQUIRE(expectedSchedule.kind == actualSchedule.kind);
-    REQUIRE(expectedSchedule.chunkSize == actualSchedule.chunkSize);
+    auto const actual_schedule = alpaka::omp::getSchedule();
+    REQUIRE(expected_schedule.kind == actual_schedule.kind);
+    REQUIRE(expected_schedule.chunkSize == actual_schedule.chunkSize);
 #endif
 }

--- a/test/unit/dev/src/DevWarpSizeTest.cpp
+++ b/test/unit/dev/src/DevWarpSizeTest.cpp
@@ -17,6 +17,6 @@ TEMPLATE_LIST_TEST_CASE("getWarpSize", "[dev]", alpaka::test::TestAccs)
     using Dev = alpaka::Dev<TestType>;
     using Pltf = alpaka::Pltf<Dev>;
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::getWarpSize(dev);
-    REQUIRE(warpExtent > 0);
+    auto const warp_extent = alpaka::getWarpSize(dev);
+    REQUIRE(warp_extent > 0);
 }

--- a/test/unit/idx/src/MapIdx.cpp
+++ b/test/unit/idx/src/MapIdx.cpp
@@ -21,13 +21,13 @@ TEMPLATE_LIST_TEST_CASE("mapIdx", "[idx]", alpaka::test::TestDims)
     using Idx = std::size_t;
     using Vec = alpaka::Vec<Dim, Idx>;
 
-    auto const extentNd
+    auto const extent_nd
         = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-    auto const idxNd = extentNd - Vec::all(4u);
+    auto const idx_nd = extent_nd - Vec::all(4u);
 
-    auto const idx1d = alpaka::mapIdx<1u>(idxNd, extentNd);
+    auto const idx1d = alpaka::mapIdx<1u>(idx_nd, extent_nd);
 
-    auto const idxNdResult = alpaka::mapIdx<Dim::value>(idx1d, extentNd);
+    auto const idx_nd_result = alpaka::mapIdx<Dim::value>(idx1d, extent_nd);
 
-    REQUIRE(idxNd == idxNdResult);
+    REQUIRE(idx_nd == idx_nd_result);
 }

--- a/test/unit/idx/src/MapIdxPitchBytes.cpp
+++ b/test/unit/idx/src/MapIdxPitchBytes.cpp
@@ -24,28 +24,28 @@ TEMPLATE_LIST_TEST_CASE("mapIdxPitchBytes", "[idx]", alpaka::test::TestDims)
     using Idx = std::size_t;
     using Vec = alpaka::Vec<Dim, Idx>;
 
-    auto const extentNd
+    auto const extent_nd
         = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
 
     using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
     using Elem = std::uint8_t;
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
-    auto parentView = alpaka::createView(devAcc, static_cast<Elem*>(nullptr), extentNd);
+    auto const dev_acc = alpaka::getDevByIdx<Acc>(0u);
+    auto parent_view = alpaka::createView(dev_acc, static_cast<Elem*>(nullptr), extent_nd);
 
     auto const offset = Vec::all(4u);
     auto const extent = Vec::all(4u);
-    auto const idxNd = Vec::all(2u);
-    auto view = alpaka::createSubView(parentView, extent, offset);
+    auto const idx_nd = Vec::all(2u);
+    auto view = alpaka::createSubView(parent_view, extent, offset);
     auto pitch = alpaka::getPitchBytesVec(view);
 
-    auto const idx1d = alpaka::mapIdxPitchBytes<1u>(idxNd, pitch);
-    auto const idx1dDelta = alpaka::mapIdx<1u>(idxNd + offset, extentNd) - alpaka::mapIdx<1u>(offset, extentNd);
+    auto const idx1d = alpaka::mapIdxPitchBytes<1u>(idx_nd, pitch);
+    auto const idx1d_delta = alpaka::mapIdx<1u>(idx_nd + offset, extent_nd) - alpaka::mapIdx<1u>(offset, extent_nd);
 
-    auto const idxNdResult = alpaka::mapIdxPitchBytes<Dim::value>(idx1d, pitch);
+    auto const idx_nd_result = alpaka::mapIdxPitchBytes<Dim::value>(idx1d, pitch);
 
     // linear index in pitched offset box should be the difference between
     // linear index in parent box and linear index of offset
-    REQUIRE(idx1d == idx1dDelta);
+    REQUIRE(idx1d == idx1d_delta);
     // roundtrip
-    REQUIRE(idxNd == idxNdResult);
+    REQUIRE(idx_nd == idx_nd_result);
 }

--- a/test/unit/intrinsic/src/Ffs.cpp
+++ b/test/unit/intrinsic/src/Ffs.cpp
@@ -40,14 +40,14 @@ public:
                std::numeric_limits<TInput>::min()};
         for(auto const input : inputs)
         {
-            std::int32_t const expected = ffsNaive(input);
+            std::int32_t const expected = ffs_naive(input);
             std::int32_t const actual = alpaka::ffs(acc, input);
             ALPAKA_CHECK(*success, actual == expected);
         }
     }
 
 private:
-    ALPAKA_FN_ACC static auto ffsNaive(TInput value) -> std::int32_t
+    ALPAKA_FN_ACC static auto ffs_naive(TInput value) -> std::int32_t
     {
         if(value == 0)
             return 0;

--- a/test/unit/intrinsic/src/Popcount.cpp
+++ b/test/unit/intrinsic/src/Popcount.cpp
@@ -36,14 +36,14 @@ public:
                static_cast<TInput>(-1)};
         for(auto const input : inputs)
         {
-            int const expected = popcountNaive(input);
+            int const expected = popcount_naive(input);
             int const actual = alpaka::popcount(acc, input);
             ALPAKA_CHECK(*success, actual == expected);
         }
     }
 
 private:
-    ALPAKA_FN_ACC static auto popcountNaive(TInput value) -> int
+    ALPAKA_FN_ACC static auto popcount_naive(TInput value) -> int
     {
         int result = 0;
         while(value)

--- a/test/unit/kernel/src/KernelStdFunction.cpp
+++ b/test/unit/kernel/src/KernelStdFunction.cpp
@@ -24,8 +24,8 @@ TEST_UNIT_KERNEL_KERNEL_STD_FUNCTION
 #    include <nvfunctional>
 #endif
 
-template<typename Acc>
-void ALPAKA_FN_ACC kernelFn(Acc const& acc, bool* success, std::int32_t val)
+template<typename TAcc>
+void ALPAKA_FN_ACC kernel_fn(TAcc const& acc, bool* success, std::int32_t val)
 {
     alpaka::ignore_unused(acc);
 
@@ -42,7 +42,7 @@ TEMPLATE_LIST_TEST_CASE("stdFunctionKernelIsWorking", "[kernel]", alpaka::test::
 
     alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::ones());
 
-    const auto kernel = std::function<void(Acc const&, bool*, std::int32_t)>(kernelFn<Acc>);
+    const auto kernel = std::function<void(Acc const&, bool*, std::int32_t)>(kernel_fn<Acc>);
     REQUIRE(fixture(kernel, 42));
 }
 
@@ -54,7 +54,7 @@ TEMPLATE_LIST_TEST_CASE("stdBindKernelIsWorking", "[kernel]", alpaka::test::Test
 
     alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::ones());
 
-    const auto kernel = std::bind(kernelFn<Acc>, std::placeholders::_1, std::placeholders::_2, 42);
+    const auto kernel = std::bind(kernel_fn<Acc>, std::placeholders::_1, std::placeholders::_2, 42);
     REQUIRE(fixture(kernel));
 }
 #endif

--- a/test/unit/kernel/src/KernelWithConstructorAndMember.cpp
+++ b/test/unit/kernel/src/KernelWithConstructorAndMember.cpp
@@ -17,7 +17,7 @@
 class KernelWithConstructorAndMember
 {
 public:
-    ALPAKA_FN_HOST KernelWithConstructorAndMember(std::int32_t const val = 42) : m_val(val)
+    ALPAKA_FN_HOST explicit KernelWithConstructorAndMember(std::int32_t const val = 42) : m_val(val)
     {
     }
 

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -50,25 +50,25 @@ struct KernelWithMemberOmpScheduleKind : KernelWithOmpScheduleBase
 template<alpaka::omp::Schedule::Kind TKind>
 struct KernelWithConstexprStaticMemberOmpScheduleChunkSize : KernelWithConstexprMemberOmpScheduleKind<TKind>
 {
-    static constexpr int ompScheduleChunkSize = 5;
+    static constexpr int omp_schedule_chunk_size = 5;
 };
 
 // Kernel that sets the schedule chunk size via non-constexpr ompScheduleChunkSize in addition to schedule kind.
 template<alpaka::omp::Schedule::Kind TKind>
 struct KernelWithStaticMemberOmpScheduleChunkSize : KernelWithMemberOmpScheduleKind<TKind>
 {
-    static const int ompScheduleChunkSize;
+    static const int omp_schedule_chunk_size;
 };
 // In this case, the member has to be defined externally
 template<alpaka::omp::Schedule::Kind TKind>
-const int KernelWithStaticMemberOmpScheduleChunkSize<TKind>::ompScheduleChunkSize = 2;
+const int KernelWithStaticMemberOmpScheduleChunkSize<TKind>::omp_schedule_chunk_size = 2;
 
 // Kernel that sets the schedule chunk size via non-constexpr non-static ompScheduleChunkSize in addition to schedule
 // kind.
 template<alpaka::omp::Schedule::Kind TKind>
 struct KernelWithMemberOmpScheduleChunkSize : KernelWithConstexprMemberOmpScheduleKind<TKind>
 {
-    int ompScheduleChunkSize = 4;
+    int m_omp_schedule_chunk_size = 4;
 };
 
 // Kernel that copies the given base kernel and adds an OmpSchedule trait on top
@@ -86,15 +86,15 @@ namespace alpaka
         struct OmpSchedule<KernelWithTrait<TBase>, TAcc>
         {
             template<typename TDim, typename... TArgs>
-            ALPAKA_FN_HOST static auto getOmpSchedule(
-                KernelWithTrait<TBase> const& kernelFnObj,
-                Vec<TDim, Idx<TAcc>> const& blockThreadExtent,
-                Vec<TDim, Idx<TAcc>> const& threadElemExtent,
+            ALPAKA_FN_HOST static auto get_omp_schedule(
+                KernelWithTrait<TBase> const& kernel_fn_obj,
+                Vec<TDim, Idx<TAcc>> const& block_thread_extent,
+                Vec<TDim, Idx<TAcc>> const& thread_elem_extent,
                 TArgs const&... args) -> alpaka::omp::Schedule
             {
-                alpaka::ignore_unused(kernelFnObj);
-                alpaka::ignore_unused(blockThreadExtent);
-                alpaka::ignore_unused(threadElemExtent);
+                alpaka::ignore_unused(kernel_fn_obj);
+                alpaka::ignore_unused(block_thread_extent);
+                alpaka::ignore_unused(thread_elem_extent);
                 alpaka::ignore_unused(args...);
 
                 return alpaka::omp::Schedule{alpaka::omp::Schedule::Static, 4};
@@ -105,7 +105,7 @@ namespace alpaka
 
 // Generic testing routine for the given kernel type
 template<typename TAcc, typename TKernel>
-void testKernel()
+void test_kernel()
 {
     using Acc = TAcc;
     using Dim = alpaka::Dim<Acc>;
@@ -118,8 +118,8 @@ void testKernel()
     REQUIRE(fixture(kernel));
 
     // Same members, but with OmpSchedule trait
-    KernelWithTrait<TKernel> kernelWithTrait;
-    REQUIRE(fixture(kernelWithTrait));
+    KernelWithTrait<TKernel> kernel_with_trait;
+    REQUIRE(fixture(kernel_with_trait));
 }
 
 // Note: it turned out not possible to test all possible combinations as it causes several compilers to crash in CI.
@@ -127,33 +127,33 @@ void testKernel()
 
 TEMPLATE_LIST_TEST_CASE("kernelWithOmpScheduleBase", "[kernel]", alpaka::test::TestAccs)
 {
-    testKernel<TestType, KernelWithOmpScheduleBase>();
+    test_kernel<TestType, KernelWithOmpScheduleBase>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithConstexprMemberOmpScheduleKind", "[kernel]", alpaka::test::TestAccs)
 {
-    testKernel<TestType, KernelWithConstexprMemberOmpScheduleKind<alpaka::omp::Schedule::NoSchedule>>();
+    test_kernel<TestType, KernelWithConstexprMemberOmpScheduleKind<alpaka::omp::Schedule::NoSchedule>>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithMemberOmpScheduleKind", "[kernel]", alpaka::test::TestAccs)
 {
-    testKernel<TestType, KernelWithMemberOmpScheduleKind<alpaka::omp::Schedule::Static>>();
+    test_kernel<TestType, KernelWithMemberOmpScheduleKind<alpaka::omp::Schedule::Static>>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithConstexprStaticMemberOmpScheduleChunkSize", "[kernel]", alpaka::test::TestAccs)
 {
-    testKernel<TestType, KernelWithConstexprStaticMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Dynamic>>();
+    test_kernel<TestType, KernelWithConstexprStaticMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Dynamic>>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithStaticMemberOmpScheduleChunkSize", "[kernel]", alpaka::test::TestAccs)
 {
-    testKernel<TestType, KernelWithStaticMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Guided>>();
+    test_kernel<TestType, KernelWithStaticMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Guided>>();
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelWithMemberOmpScheduleChunkSize", "[kernel]", alpaka::test::TestAccs)
 {
 #if defined _OPENMP && _OPENMP >= 200805
-    testKernel<TestType, KernelWithMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Auto>>();
+    test_kernel<TestType, KernelWithMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Auto>>();
 #endif
-    testKernel<TestType, KernelWithMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Runtime>>();
+    test_kernel<TestType, KernelWithMemberOmpScheduleChunkSize<alpaka::omp::Schedule::Runtime>>();
 }

--- a/test/unit/kernel/src/KernelWithTemplate.cpp
+++ b/test/unit/kernel/src/KernelWithTemplate.cpp
@@ -16,7 +16,7 @@
 
 #include <type_traits>
 
-template<typename T>
+template<typename TT>
 class KernelFuntionObjectTemplate
 {
 public:
@@ -28,7 +28,7 @@ public:
             *success,
             static_cast<alpaka::Idx<TAcc>>(1) == (alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)).prod());
 
-        static_assert(std::is_same<std::int32_t, T>::value, "Incorrect additional kernel template parameter type!");
+        static_assert(std::is_same<std::int32_t, TT>::value, "Incorrect additional kernel template parameter type!");
     }
 };
 
@@ -49,14 +49,14 @@ class KernelInvocationWithAdditionalTemplate
 {
 public:
     ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TAcc, typename T>
-    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, T const&) const -> void
+    template<typename TAcc, typename TT>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, TT const&) const -> void
     {
         ALPAKA_CHECK(
             *success,
             static_cast<alpaka::Idx<TAcc>>(1) == (alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)).prod());
 
-        static_assert(std::is_same<std::int32_t, T>::value, "Incorrect additional kernel template parameter type!");
+        static_assert(std::is_same<std::int32_t, TT>::value, "Incorrect additional kernel template parameter type!");
     }
 };
 

--- a/test/unit/kernel/src/KernelWithTemplateArgumentDeduction.cpp
+++ b/test/unit/kernel/src/KernelWithTemplateArgumentDeduction.cpp
@@ -21,9 +21,9 @@ class KernelInvocationTemplateDeductionValueSemantics
 {
 public:
     ALPAKA_NO_HOST_ACC_WARNING
-    template<typename Acc, typename TByValue, typename TByConstValue, typename TByConstReference>
+    template<typename TAcc, typename TByValue, typename TByConstValue, typename TByConstReference>
     ALPAKA_FN_ACC auto operator()(
-        Acc const& acc,
+        TAcc const& acc,
         bool* success,
         TByValue,
         TByConstValue const,
@@ -31,7 +31,7 @@ public:
     {
         ALPAKA_CHECK(
             *success,
-            static_cast<alpaka::Idx<Acc>>(1) == (alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)).prod());
+            static_cast<alpaka::Idx<TAcc>>(1) == (alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)).prod());
 
         static_assert(
             std::is_same<TByValue, TExpected>::value,
@@ -71,8 +71,8 @@ TEMPLATE_LIST_TEST_CASE("kernelFuntionObjectTemplateDeductionFromConstValue", "[
     using Value = std::int32_t;
     KernelInvocationTemplateDeductionValueSemantics<Value> kernel;
 
-    Value const constValue{};
-    REQUIRE(fixture(kernel, constValue, constValue, constValue));
+    Value const const_value{};
+    REQUIRE(fixture(kernel, const_value, const_value, const_value));
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelFuntionObjectTemplateDeductionFromConstReference", "[kernel]", alpaka::test::TestAccs)
@@ -87,8 +87,8 @@ TEMPLATE_LIST_TEST_CASE("kernelFuntionObjectTemplateDeductionFromConstReference"
     KernelInvocationTemplateDeductionValueSemantics<Value> kernel;
 
     Value value{};
-    Value const& constReference = value;
-    REQUIRE(fixture(kernel, constReference, constReference, constReference));
+    Value const& const_reference = value;
+    REQUIRE(fixture(kernel, const_reference, const_reference, const_reference));
 }
 
 template<typename TExpectedFirst, typename TExpectedSecond = TExpectedFirst>
@@ -96,12 +96,12 @@ class KernelInvocationTemplateDeductionPointerSemantics
 {
 public:
     ALPAKA_NO_HOST_ACC_WARNING
-    template<typename Acc, typename TByPointer, typename TByPointerToConst>
-    ALPAKA_FN_ACC auto operator()(Acc const& acc, bool* success, TByPointer*, TByPointerToConst const*) const -> void
+    template<typename TAcc, typename TByPointer, typename TByPointerToConst>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, TByPointer*, TByPointerToConst const*) const -> void
     {
         ALPAKA_CHECK(
             *success,
-            static_cast<alpaka::Idx<Acc>>(1) == (alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)).prod());
+            static_cast<alpaka::Idx<TAcc>>(1) == (alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)).prod());
 
         static_assert(
             std::is_same<TByPointer, TExpectedFirst>::value,
@@ -139,9 +139,9 @@ TEMPLATE_LIST_TEST_CASE("kernelFuntionObjectTemplateDeductionFromPointerToConst"
     using Value = std::int32_t;
     KernelInvocationTemplateDeductionPointerSemantics<Value const, Value> kernel;
 
-    Value const constValue{};
-    Value const* pointerToConst = &constValue;
-    REQUIRE(fixture(kernel, pointerToConst, pointerToConst));
+    Value const const_value{};
+    Value const* pointer_to_const = &const_value;
+    REQUIRE(fixture(kernel, pointer_to_const, pointer_to_const));
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelFuntionObjectTemplateDeductionFromStaticArray", "[kernel]", alpaka::test::TestAccs)
@@ -155,8 +155,8 @@ TEMPLATE_LIST_TEST_CASE("kernelFuntionObjectTemplateDeductionFromStaticArray", "
     using Value = std::int32_t;
     KernelInvocationTemplateDeductionPointerSemantics<Value> kernel;
 
-    Value staticArray[4] = {};
-    REQUIRE(fixture(kernel, staticArray, staticArray));
+    Value static_array[4] = {};
+    REQUIRE(fixture(kernel, static_array, static_array));
 }
 
 TEMPLATE_LIST_TEST_CASE("kernelFuntionObjectTemplateDeductionFromConstStaticArray", "[kernel]", alpaka::test::TestAccs)
@@ -170,6 +170,6 @@ TEMPLATE_LIST_TEST_CASE("kernelFuntionObjectTemplateDeductionFromConstStaticArra
     using Value = std::int32_t;
     KernelInvocationTemplateDeductionPointerSemantics<Value const, Value> kernel;
 
-    Value const constStaticArray[4] = {};
-    REQUIRE(fixture(kernel, constStaticArray, constStaticArray));
+    Value const const_static_array[4] = {};
+    REQUIRE(fixture(kernel, const_static_array, const_static_array));
 }

--- a/test/unit/math/src/FloatEqualExactTest.cpp
+++ b/test/unit/math/src/FloatEqualExactTest.cpp
@@ -25,15 +25,15 @@ public:
 
         // Store the comparison result in a separate variable so that the function call is outside ALPAKA_CHECK.
         // In case ALPAKA_CHECK were ever somehow modified to silence the warning by itself.
-        bool testValue = false;
+        bool test_value = false;
 
-        float floatValue = -1.0f;
-        testValue = alpaka::math::floatEqualExactNoWarning(floatValue, -1.0f);
-        ALPAKA_CHECK(*success, testValue);
+        float float_value = -1.0f;
+        test_value = alpaka::math::floatEqualExactNoWarning(float_value, -1.0f);
+        ALPAKA_CHECK(*success, test_value);
 
-        double doubleValue = -1.0;
-        testValue = alpaka::math::floatEqualExactNoWarning(doubleValue, -1.0);
-        ALPAKA_CHECK(*success, testValue);
+        double double_value = -1.0;
+        test_value = alpaka::math::floatEqualExactNoWarning(double_value, -1.0);
+        ALPAKA_CHECK(*success, test_value);
     }
 };
 
@@ -43,15 +43,15 @@ TEMPLATE_LIST_TEST_CASE("floatEqualExactTest", "[math]", alpaka::test::TestAccs)
 
     // Store the comparison result in a separate variable so that the function call is outside REQUIRE.
     // In case REQUIRE were ever somehow modified to silence the warning by itself.
-    bool testValue = false;
+    bool test_value = false;
 
-    float floatValue = -1.0;
-    testValue = alpaka::math::floatEqualExactNoWarning(floatValue, -1.0f);
-    REQUIRE(testValue);
+    float float_value = -1.0;
+    test_value = alpaka::math::floatEqualExactNoWarning(float_value, -1.0f);
+    REQUIRE(test_value);
 
-    double doubleValue = -1.0;
-    testValue = alpaka::math::floatEqualExactNoWarning(doubleValue, -1.0);
-    REQUIRE(testValue);
+    double double_value = -1.0;
+    test_value = alpaka::math::floatEqualExactNoWarning(double_value, -1.0);
+    REQUIRE(test_value);
 
     // Device tests
 
@@ -61,6 +61,6 @@ TEMPLATE_LIST_TEST_CASE("floatEqualExactTest", "[math]", alpaka::test::TestAccs)
 
     alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::ones());
 
-    FloatEqualExactTestKernel kernelFloat;
-    REQUIRE(fixture(kernelFloat));
+    FloatEqualExactTestKernel kernel_float;
+    REQUIRE(fixture(kernel_float));
 }

--- a/test/unit/math/src/math.cpp
+++ b/test/unit/math/src/math.cpp
@@ -77,23 +77,23 @@ struct TestTemplate
         using Results = alpaka::test::unit::math::Buffer<TAcc, TData, capacity>;
 
         // Every functor is executed individual on one kernel.
-        static constexpr size_t elementsPerThread = 1u;
-        static constexpr size_t sizeExtent = 1u;
+        static constexpr size_t elements_per_thread = 1u;
+        static constexpr size_t size_extent = 1u;
 
-        DevAcc const devAcc = alpaka::getDevByIdx<PltfAcc>(0u);
-        DevHost const devHost = alpaka::getDevByIdx<PltfHost>(0u);
+        DevAcc const dev_acc = alpaka::getDevByIdx<PltfAcc>(0u);
+        DevHost const dev_host = alpaka::getDevByIdx<PltfHost>(0u);
 
-        QueueAcc queue{devAcc};
+        QueueAcc queue{dev_acc};
 
         TestKernel<capacity> kernel;
         TFunctor functor;
-        Args args{devAcc};
-        Results results{devAcc};
+        Args args{dev_acc};
+        Results results{dev_acc};
 
-        WorkDiv const workDiv = alpaka::getValidWorkDiv<TAcc>(
-            devAcc,
-            sizeExtent,
-            elementsPerThread,
+        WorkDiv const work_div = alpaka::getValidWorkDiv<TAcc>(
+            dev_acc,
+            size_extent,
+            elements_per_thread,
             false,
             alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
         // SETUP COMPLETED.
@@ -107,10 +107,10 @@ struct TestTemplate
         args.copyToDevice(queue);
         results.copyToDevice(queue);
 
-        auto const taskKernel
-            = alpaka::createTaskKernel<TAcc>(workDiv, kernel, results.pDevBuffer, functor, args.pDevBuffer);
+        auto const task_kernel
+            = alpaka::createTaskKernel<TAcc>(work_div, kernel, results.pDevBuffer, functor, args.pDevBuffer);
         // Enqueue the kernel execution task.
-        alpaka::enqueue(queue, taskKernel);
+        alpaka::enqueue(queue, task_kernel);
         // Copy back the results (encapsulated in the buffer class).
         results.copyFromDevice(queue);
         alpaka::wait(queue);
@@ -189,36 +189,36 @@ namespace custom
 {
     enum Custom
     {
-        Abs,
-        Acos,
-        Asin,
-        Atan,
-        Atan2,
-        Cbrt,
-        Ceil,
-        Cos,
-        Erf,
-        Exp,
-        Floor,
-        Fmod,
-        Log,
-        Max,
-        Min,
-        Pow,
-        Remainder,
-        Round,
-        Lround,
-        Llround,
-        Rsqrt,
-        Sin,
-        Sincos,
-        Sqrt,
-        Tan,
-        Trunc,
+        abs,
+        acos,
+        asin,
+        atan,
+        atan2,
+        cbrt,
+        ceil,
+        cos,
+        erf,
+        exp,
+        floor,
+        fmod,
+        log,
+        max,
+        min,
+        pow,
+        remainder,
+        round,
+        lround,
+        llround,
+        rsqrt,
+        sin,
+        sincos,
+        sqrt,
+        tan,
+        trunc,
 
-        Arg1 = 1024,
-        Arg2 = 2048,
-        Arg3 = 4096,
+        arg1 = 1024,
+        arg2 = 2048,
+        arg3 = 4096,
     };
 
     // struct Custom
@@ -228,212 +228,213 @@ namespace custom
     ALPAKA_FN_HOST_ACC auto abs(Custom c);
     ALPAKA_FN_HOST_ACC auto abs(Custom c)
     {
-        return Custom::Abs | c;
+        return Custom::abs | c;
     }
 
     ALPAKA_FN_HOST_ACC auto acos(Custom c);
     ALPAKA_FN_HOST_ACC auto acos(Custom c)
     {
-        return Custom::Acos | c;
+        return Custom::acos | c;
     }
 
     ALPAKA_FN_HOST_ACC auto asin(Custom c);
     ALPAKA_FN_HOST_ACC auto asin(Custom c)
     {
-        return Custom::Asin | c;
+        return Custom::asin | c;
     }
 
     ALPAKA_FN_HOST_ACC auto atan(Custom c);
     ALPAKA_FN_HOST_ACC auto atan(Custom c)
     {
-        return Custom::Atan | c;
+        return Custom::atan | c;
     }
 
     ALPAKA_FN_HOST_ACC auto atan2(Custom a, Custom b);
     ALPAKA_FN_HOST_ACC auto atan2(Custom a, Custom b)
     {
-        return Custom::Atan2 | a | b;
+        return Custom::atan2 | a | b;
     }
 
     ALPAKA_FN_HOST_ACC auto cbrt(Custom c);
     ALPAKA_FN_HOST_ACC auto cbrt(Custom c)
     {
-        return Custom::Cbrt | c;
+        return Custom::cbrt | c;
     }
 
     ALPAKA_FN_HOST_ACC auto ceil(Custom c);
     ALPAKA_FN_HOST_ACC auto ceil(Custom c)
     {
-        return Custom::Ceil | c;
+        return Custom::ceil | c;
     }
 
     ALPAKA_FN_HOST_ACC auto cos(Custom c);
     ALPAKA_FN_HOST_ACC auto cos(Custom c)
     {
-        return Custom::Cos | c;
+        return Custom::cos | c;
     }
 
     ALPAKA_FN_HOST_ACC auto erf(Custom c);
     ALPAKA_FN_HOST_ACC auto erf(Custom c)
     {
-        return Custom::Erf | c;
+        return Custom::erf | c;
     }
 
     ALPAKA_FN_HOST_ACC auto exp(Custom c);
     ALPAKA_FN_HOST_ACC auto exp(Custom c)
     {
-        return Custom::Exp | c;
+        return Custom::exp | c;
     }
 
     ALPAKA_FN_HOST_ACC auto floor(Custom c);
     ALPAKA_FN_HOST_ACC auto floor(Custom c)
     {
-        return Custom::Floor | c;
+        return Custom::floor | c;
     }
 
     ALPAKA_FN_HOST_ACC auto fmod(Custom a, Custom b);
     ALPAKA_FN_HOST_ACC auto fmod(Custom a, Custom b)
     {
-        return Custom::Fmod | a | b;
+        return Custom::fmod | a | b;
     }
 
     ALPAKA_FN_HOST_ACC auto log(Custom c);
     ALPAKA_FN_HOST_ACC auto log(Custom c)
     {
-        return Custom::Log | c;
+        return Custom::log | c;
     }
 
     ALPAKA_FN_HOST_ACC auto max(Custom a, Custom b);
     ALPAKA_FN_HOST_ACC auto max(Custom a, Custom b)
     {
-        return Custom::Max | a | b;
+        return Custom::max | a | b;
     }
 
     ALPAKA_FN_HOST_ACC auto min(Custom a, Custom b);
     ALPAKA_FN_HOST_ACC auto min(Custom a, Custom b)
     {
-        return Custom::Min | a | b;
+        return Custom::min | a | b;
     }
 
     ALPAKA_FN_HOST_ACC auto pow(Custom a, Custom b);
     ALPAKA_FN_HOST_ACC auto pow(Custom a, Custom b)
     {
-        return Custom::Pow | a | b;
+        return Custom::pow | a | b;
     }
 
     ALPAKA_FN_HOST_ACC auto remainder(Custom a, Custom b);
     ALPAKA_FN_HOST_ACC auto remainder(Custom a, Custom b)
     {
-        return Custom::Remainder | a | b;
+        return Custom::remainder | a | b;
     }
 
     ALPAKA_FN_HOST_ACC auto round(Custom c);
     ALPAKA_FN_HOST_ACC auto round(Custom c)
     {
-        return Custom::Round | c;
+        return Custom::round | c;
     }
 
     ALPAKA_FN_HOST_ACC auto lround(Custom c);
     ALPAKA_FN_HOST_ACC auto lround(Custom c)
     {
-        return Custom::Lround | c;
+        return Custom::lround | c;
     }
 
     ALPAKA_FN_HOST_ACC auto llround(Custom c);
     ALPAKA_FN_HOST_ACC auto llround(Custom c)
     {
-        return Custom::Llround | c;
+        return Custom::llround | c;
     }
 
     ALPAKA_FN_HOST_ACC auto rsqrt(Custom c);
     ALPAKA_FN_HOST_ACC auto rsqrt(Custom c)
     {
-        return Custom::Rsqrt | c;
+        return Custom::rsqrt | c;
     }
 
     ALPAKA_FN_HOST_ACC auto sin(Custom c);
     ALPAKA_FN_HOST_ACC auto sin(Custom c)
     {
-        return Custom::Sin | c;
+        return Custom::sin | c;
     }
 
     ALPAKA_FN_HOST_ACC void sincos(Custom c, Custom& a, Custom& b);
     ALPAKA_FN_HOST_ACC void sincos(Custom c, Custom& a, Custom& b)
     {
-        a = static_cast<Custom>(Custom::Sincos | c | Custom::Arg2);
-        b = static_cast<Custom>(Custom::Sincos | c | Custom::Arg3);
+        a = static_cast<Custom>(Custom::sincos | c | Custom::arg2);
+        b = static_cast<Custom>(Custom::sincos | c | Custom::arg3);
     }
 
     ALPAKA_FN_HOST_ACC auto sqrt(Custom c);
     ALPAKA_FN_HOST_ACC auto sqrt(Custom c)
     {
-        return Custom::Sqrt | c;
+        return Custom::sqrt | c;
     }
 
     ALPAKA_FN_HOST_ACC auto tan(Custom c);
     ALPAKA_FN_HOST_ACC auto tan(Custom c)
     {
-        return Custom::Tan | c;
+        return Custom::tan | c;
     }
 
     ALPAKA_FN_HOST_ACC auto trunc(Custom c);
     ALPAKA_FN_HOST_ACC auto trunc(Custom c)
     {
-        return Custom::Trunc | c;
+        return Custom::trunc | c;
     }
 } // namespace custom
 
 struct AdlKernel
 {
-    template<typename Acc>
-    ALPAKA_FN_ACC void operator()(Acc const& acc, bool* success) const noexcept
+    template<typename TAcc>
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, bool* success) const noexcept
     {
         using custom::Custom;
 
-        ALPAKA_CHECK(*success, alpaka::math::abs(acc, Custom::Arg1) == (Custom::Abs | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::acos(acc, Custom::Arg1) == (Custom::Acos | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::asin(acc, Custom::Arg1) == (Custom::Asin | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::atan(acc, Custom::Arg1) == (Custom::Atan | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::cbrt(acc, Custom::Arg1) == (Custom::Cbrt | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::ceil(acc, Custom::Arg1) == (Custom::Ceil | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::cos(acc, Custom::Arg1) == (Custom::Cos | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::erf(acc, Custom::Arg1) == (Custom::Erf | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::exp(acc, Custom::Arg1) == (Custom::Exp | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::floor(acc, Custom::Arg1) == (Custom::Floor | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::log(acc, Custom::Arg1) == (Custom::Log | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::round(acc, Custom::Arg1) == (Custom::Round | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::lround(acc, Custom::Arg1) == (Custom::Lround | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::llround(acc, Custom::Arg1) == (Custom::Llround | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::rsqrt(acc, Custom::Arg1) == (Custom::Rsqrt | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::sin(acc, Custom::Arg1) == (Custom::Sin | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::sqrt(acc, Custom::Arg1) == (Custom::Sqrt | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::tan(acc, Custom::Arg1) == (Custom::Tan | Custom::Arg1));
-        ALPAKA_CHECK(*success, alpaka::math::trunc(acc, Custom::Arg1) == (Custom::Trunc | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::abs(acc, Custom::arg1) == (Custom::abs | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::acos(acc, Custom::arg1) == (Custom::acos | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::asin(acc, Custom::arg1) == (Custom::asin | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::atan(acc, Custom::arg1) == (Custom::atan | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::cbrt(acc, Custom::arg1) == (Custom::cbrt | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::ceil(acc, Custom::arg1) == (Custom::ceil | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::cos(acc, Custom::arg1) == (Custom::cos | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::erf(acc, Custom::arg1) == (Custom::erf | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::exp(acc, Custom::arg1) == (Custom::exp | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::floor(acc, Custom::arg1) == (Custom::floor | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::log(acc, Custom::arg1) == (Custom::log | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::round(acc, Custom::arg1) == (Custom::round | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::lround(acc, Custom::arg1) == (Custom::lround | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::llround(acc, Custom::arg1) == (Custom::llround | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::rsqrt(acc, Custom::arg1) == (Custom::rsqrt | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::sin(acc, Custom::arg1) == (Custom::sin | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::sqrt(acc, Custom::arg1) == (Custom::sqrt | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::tan(acc, Custom::arg1) == (Custom::tan | Custom::arg1));
+        ALPAKA_CHECK(*success, alpaka::math::trunc(acc, Custom::arg1) == (Custom::trunc | Custom::arg1));
 
         ALPAKA_CHECK(
             *success,
-            alpaka::math::atan2(acc, Custom::Arg1, Custom::Arg2) == (Custom::Atan2 | Custom::Arg1 | Custom::Arg2));
+            alpaka::math::atan2(acc, Custom::arg1, Custom::arg2) == (Custom::atan2 | Custom::arg1 | Custom::arg2));
         ALPAKA_CHECK(
             *success,
-            alpaka::math::fmod(acc, Custom::Arg1, Custom::Arg2) == (Custom::Fmod | Custom::Arg1 | Custom::Arg2));
+            alpaka::math::fmod(acc, Custom::arg1, Custom::arg2) == (Custom::fmod | Custom::arg1 | Custom::arg2));
         ALPAKA_CHECK(
             *success,
-            alpaka::math::max(acc, Custom::Arg1, Custom::Arg2) == (Custom::Max | Custom::Arg1 | Custom::Arg2));
+            alpaka::math::max(acc, Custom::arg1, Custom::arg2) == (Custom::max | Custom::arg1 | Custom::arg2));
         ALPAKA_CHECK(
             *success,
-            alpaka::math::min(acc, Custom::Arg1, Custom::Arg2) == (Custom::Min | Custom::Arg1 | Custom::Arg2));
+            alpaka::math::min(acc, Custom::arg1, Custom::arg2) == (Custom::min | Custom::arg1 | Custom::arg2));
         ALPAKA_CHECK(
             *success,
-            alpaka::math::pow(acc, Custom::Arg1, Custom::Arg2) == (Custom::Pow | Custom::Arg1 | Custom::Arg2));
+            alpaka::math::pow(acc, Custom::arg1, Custom::arg2) == (Custom::pow | Custom::arg1 | Custom::arg2));
         ALPAKA_CHECK(
             *success,
-            alpaka::math::remainder(acc, Custom::Arg1, Custom::Arg2)
-                == (Custom::Remainder | Custom::Arg1 | Custom::Arg2));
+            alpaka::math::remainder(acc, Custom::arg1, Custom::arg2)
+                == (Custom::remainder | Custom::arg1 | Custom::arg2));
 
-        Custom a, b;
-        alpaka::math::sincos(acc, Custom::Arg1, a, b);
-        ALPAKA_CHECK(*success, a == (Custom::Sincos | Custom::Arg1 | Custom::Arg2));
-        ALPAKA_CHECK(*success, b == (Custom::Sincos | Custom::Arg1 | Custom::Arg3));
+        Custom a;
+        Custom b;
+        alpaka::math::sincos(acc, Custom::arg1, a, b);
+        ALPAKA_CHECK(*success, a == (Custom::sincos | Custom::arg1 | Custom::arg2));
+        ALPAKA_CHECK(*success, b == (Custom::sincos | Custom::arg1 | Custom::arg3));
     }
 };
 

--- a/test/unit/math/src/sincos.cpp
+++ b/test/unit/math/src/sincos.cpp
@@ -17,34 +17,34 @@
 #include <type_traits>
 
 // https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
-template<typename TAcc, typename FP>
-ALPAKA_FN_ACC std::enable_if_t<!std::numeric_limits<FP>::is_integer, bool> almost_equal(
+template<typename TAcc, typename TFp>
+ALPAKA_FN_ACC std::enable_if_t<!std::numeric_limits<TFp>::is_integer, bool> almost_equal(
     TAcc const& acc,
-    FP x,
-    FP y,
+    TFp x,
+    TFp y,
     int ulp)
 {
     // the machine epsilon has to be scaled to the magnitude of the values used
     // and multiplied by the desired precision in ULPs (units in the last place)
     return alpaka::math::abs(acc, x - y)
-        <= std::numeric_limits<FP>::epsilon() * alpaka::math::abs(acc, x + y) * static_cast<FP>(ulp)
+        <= std::numeric_limits<TFp>::epsilon() * alpaka::math::abs(acc, x + y) * static_cast<TFp>(ulp)
         // unless the result is subnormal
-        || alpaka::math::abs(acc, x - y) < std::numeric_limits<FP>::min();
+        || alpaka::math::abs(acc, x - y) < std::numeric_limits<TFp>::min();
 }
 
 class SinCosTestKernel
 {
 public:
     ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TAcc, typename FP>
-    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, FP const arg) const -> void
+    template<typename TAcc, typename TFp>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, TFp const arg) const -> void
     {
         // if arg is hardcoded then compiler can optimize it out
         // (PTX kernel (float) was just empty)
-        FP check_sin = alpaka::math::sin(acc, arg);
-        FP check_cos = alpaka::math::cos(acc, arg);
-        FP result_sin = 0.;
-        FP result_cos = 0.;
+        TFp check_sin = alpaka::math::sin(acc, arg);
+        TFp check_cos = alpaka::math::cos(acc, arg);
+        TFp result_sin = 0.;
+        TFp result_cos = 0.;
         alpaka::math::sincos(acc, arg, result_sin, result_cos);
         ALPAKA_CHECK(
             *success,

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 
 template<typename TAcc>
-static auto testBufferMutable(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
+static auto test_buffer_mutable(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
 {
     using Dev = alpaka::Dev<TAcc>;
     using Pltf = alpaka::Pltf<Dev>;
@@ -50,7 +50,7 @@ TEMPLATE_LIST_TEST_CASE("memBufBasicTest", "[memBuf]", alpaka::test::TestAccs)
     auto const extent
         = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
 
-    testBufferMutable<Acc>(extent);
+    test_buffer_mutable<Acc>(extent);
 }
 
 TEMPLATE_LIST_TEST_CASE("memBufZeroSizeTest", "[memBuf]", alpaka::test::TestAccs)
@@ -61,12 +61,12 @@ TEMPLATE_LIST_TEST_CASE("memBufZeroSizeTest", "[memBuf]", alpaka::test::TestAccs
 
     auto const extent = alpaka::Vec<Dim, Idx>::zeros();
 
-    testBufferMutable<Acc>(extent);
+    test_buffer_mutable<Acc>(extent);
 }
 
 
 template<typename TAcc>
-static auto testBufferImmutable(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
+static auto test_buffer_immutable(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
 {
     using Dev = alpaka::Dev<TAcc>;
     using Pltf = alpaka::Pltf<Dev>;
@@ -93,5 +93,5 @@ TEMPLATE_LIST_TEST_CASE("memBufConstTest", "[memBuf]", alpaka::test::TestAccs)
     auto const extent
         = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
 
-    testBufferImmutable<Acc>(extent);
+    test_buffer_immutable<Acc>(extent);
 }

--- a/test/unit/mem/fence/src/FenceTest.cpp
+++ b/test/unit/mem/fence/src/FenceTest.cpp
@@ -46,7 +46,7 @@ public:
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
     {
         auto const idx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u];
-        auto shared = const_cast<ALPAKA_DEVICE_VOLATILE int*>(alpaka::getDynSharedMem<int>(acc));
+        auto *shared = const_cast<ALPAKA_DEVICE_VOLATILE int*>(alpaka::getDynSharedMem<int>(acc));
 
         // Initialize
         if(idx == 0)
@@ -83,7 +83,7 @@ namespace alpaka
         {
             //! \return The size of the shared memory allocated for a block.
             template<typename TVec, typename... TArgs>
-            ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
+            ALPAKA_FN_HOST_ACC static auto get_block_shared_mem_dyn_size_bytes(
                 BlockFenceTestKernel const&,
                 TVec const&,
                 TVec const&,
@@ -113,21 +113,21 @@ TEMPLATE_LIST_TEST_CASE("FenceTest", "[fence]", TestAccs)
     auto const dev = alpaka::getDevByIdx<Pltf>(0u);
     auto queue = Queue{dev};
 
-    auto const numElements = Idx{2ul};
-    auto const extent = alpaka::Vec<Dim, Idx>{numElements};
+    auto const num_elements = Idx{2ul};
+    auto const extent = alpaka::Vec<Dim, Idx>{num_elements};
     auto vars_host = alpaka::allocBuf<int, Idx>(host, extent);
     auto vars_dev = alpaka::allocBuf<int, Idx>(dev, extent);
 
-    auto const pVarsHost = alpaka::getPtrNative(vars_host);
-    pVarsHost[0] = 1;
-    pVarsHost[1] = 2;
+    auto const p_vars_host = alpaka::getPtrNative(vars_host);
+    p_vars_host[0] = 1;
+    p_vars_host[1] = 2;
 
     alpaka::memcpy(queue, vars_dev, vars_host, extent);
     alpaka::wait(queue);
 
-    DeviceFenceTestKernel deviceKernel;
-    REQUIRE(fixture(deviceKernel, alpaka::getPtrNative(vars_dev)));
+    DeviceFenceTestKernel device_kernel;
+    REQUIRE(fixture(device_kernel, alpaka::getPtrNative(vars_dev)));
 
-    BlockFenceTestKernel blockKernel;
-    REQUIRE(fixture(blockKernel));
+    BlockFenceTestKernel block_kernel;
+    REQUIRE(fixture(block_kernel));
 }

--- a/test/unit/mem/p2p/src/P2P.cpp
+++ b/test/unit/mem/p2p/src/P2P.cpp
@@ -20,7 +20,7 @@
 #include <type_traits>
 
 template<typename TAcc>
-static auto testP2P(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
+static auto test_p2_p(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
 {
     using Dev = alpaka::Dev<TAcc>;
     using Pltf = alpaka::Pltf<Dev>;
@@ -45,7 +45,7 @@ static auto testP2P(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& ext
     auto buf1 = alpaka::allocBuf<Elem, Idx>(dev1, extent);
 
     // fill each byte with value 42
-    std::uint8_t const byte(static_cast<uint8_t>(42u));
+    auto const byte(static_cast<uint8_t>(42u));
     alpaka::memset(queue1, buf1, byte, extent);
     alpaka::wait(queue1);
 
@@ -70,6 +70,6 @@ TEMPLATE_LIST_TEST_CASE("memP2PTest", "[memP2P]", alpaka::test::TestAccs)
     auto const extent
         = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
 
-    testP2P<Acc>(extent);
+    test_p2_p<Acc>(extent);
 #endif
 }

--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -31,23 +31,23 @@ namespace alpaka
     namespace test
     {
         template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx>
-        auto testViewPlainPtrImmutable(
+        auto test_view_plain_ptr_immutable(
             alpaka::ViewPlainPtr<TDev, TElem, TDim, TIdx> const& view,
             TDev const& dev,
-            alpaka::Vec<TDim, TIdx> const& extentView,
-            alpaka::Vec<TDim, TIdx> const& offsetView) -> void
+            alpaka::Vec<TDim, TIdx> const& extent_view,
+            alpaka::Vec<TDim, TIdx> const& offset_view) -> void
         {
-            alpaka::test::testViewImmutable<TElem>(view, dev, extentView, offsetView);
+            alpaka::test::testViewImmutable<TElem>(view, dev, extent_view, offset_view);
         }
 
         template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx>
-        auto testViewPlainPtrMutable(
+        auto test_view_plain_ptr_mutable(
             alpaka::ViewPlainPtr<TDev, TElem, TDim, TIdx>& view,
             TDev const& dev,
-            alpaka::Vec<TDim, TIdx> const& extentView,
-            alpaka::Vec<TDim, TIdx> const& offsetView) -> void
+            alpaka::Vec<TDim, TIdx> const& extent_view,
+            alpaka::Vec<TDim, TIdx> const& offset_view) -> void
         {
-            testViewPlainPtrImmutable<TAcc>(view, dev, extentView, offsetView);
+            test_view_plain_ptr_immutable<TAcc>(view, dev, extent_view, offset_view);
 
             using Queue = alpaka::test::DefaultQueue<TDev>;
             Queue queue(dev);
@@ -55,7 +55,7 @@ namespace alpaka
         }
 
         template<typename TAcc, typename TElem>
-        auto testViewPlainPtr() -> void
+        auto test_view_plain_ptr() -> void
         {
             using Dev = alpaka::Dev<TAcc>;
             using Pltf = alpaka::Pltf<Dev>;
@@ -66,23 +66,23 @@ namespace alpaka
 
             Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
 
-            auto const extentBuf
+            auto const extent_buf
                 = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
+            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extent_buf);
 
-            auto const extentView = extentBuf;
-            auto const offsetView = alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0));
+            auto const extent_view = extent_buf;
+            auto const offset_view = alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0));
             View view(
                 alpaka::getPtrNative(buf),
                 alpaka::getDev(buf),
                 alpaka::extent::getExtentVec(buf),
                 alpaka::getPitchBytesVec(buf));
 
-            alpaka::test::testViewPlainPtrMutable<TAcc>(view, dev, extentView, offsetView);
+            alpaka::test::test_view_plain_ptr_mutable<TAcc>(view, dev, extent_view, offset_view);
         }
 
         template<typename TAcc, typename TElem>
-        auto testViewPlainPtrConst() -> void
+        auto test_view_plain_ptr_const() -> void
         {
             using Dev = alpaka::Dev<TAcc>;
             using Pltf = alpaka::Pltf<Dev>;
@@ -93,23 +93,23 @@ namespace alpaka
 
             Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
-            auto const extentBuf
+            auto const extent_buf
                 = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
+            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extent_buf);
 
-            auto const extentView = extentBuf;
-            auto const offsetView = alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0));
+            auto const extent_view = extent_buf;
+            auto const offset_view = alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0));
             View const view(
                 alpaka::getPtrNative(buf),
                 alpaka::getDev(buf),
                 alpaka::extent::getExtentVec(buf),
                 alpaka::getPitchBytesVec(buf));
 
-            alpaka::test::testViewPlainPtrImmutable<TAcc>(view, dev, extentView, offsetView);
+            alpaka::test::test_view_plain_ptr_immutable<TAcc>(view, dev, extent_view, offset_view);
         }
 
         template<typename TAcc, typename TElem>
-        auto testViewPlainPtrOperators() -> void
+        auto test_view_plain_ptr_operators() -> void
         {
             using Dev = alpaka::Dev<TAcc>;
             using Pltf = alpaka::Pltf<Dev>;
@@ -120,9 +120,9 @@ namespace alpaka
 
             Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
 
-            auto const extentBuf
+            auto const extent_buf
                 = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
+            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extent_buf);
 
             View view(
                 alpaka::getPtrNative(buf),
@@ -131,10 +131,10 @@ namespace alpaka
                 alpaka::getPitchBytesVec(buf));
 
             // copy-constructor
-            View viewCopy(view);
+            View view_copy(view);
 
             // move-constructor
-            View viewMove(std::move(viewCopy));
+            View view_move(std::move(view_copy));
         }
     } // namespace test
 } // namespace alpaka
@@ -144,15 +144,15 @@ namespace alpaka
 
 TEMPLATE_LIST_TEST_CASE("viewPlainPtrTest", "[memView]", alpaka::test::TestAccs)
 {
-    alpaka::test::testViewPlainPtr<TestType, float>();
+    alpaka::test::test_view_plain_ptr<TestType, float>();
 }
 
 TEMPLATE_LIST_TEST_CASE("viewPlainPtrConstTest", "[memView]", alpaka::test::TestAccs)
 {
-    alpaka::test::testViewPlainPtrConst<TestType, float>();
+    alpaka::test::test_view_plain_ptr_const<TestType, float>();
 }
 
 TEMPLATE_LIST_TEST_CASE("viewPlainPtrOperatorTest", "[memView]", alpaka::test::TestAccs)
 {
-    alpaka::test::testViewPlainPtrOperators<TestType, float>();
+    alpaka::test::test_view_plain_ptr_operators<TestType, float>();
 }

--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -24,23 +24,23 @@ using Idx = std::uint32_t;
 // from a different compilation unit and should be moved to a common header.
 // Here they are used to silence clang`s -Wmissing-variable-declarations warning
 // that forces every non-static variable to be declared with extern before the are defined.
-extern ALPAKA_STATIC_ACC_MEM_CONSTANT Elem g_constantMemory2DUninitialized[3][2];
-ALPAKA_STATIC_ACC_MEM_CONSTANT Elem g_constantMemory2DUninitialized[3][2];
+extern ALPAKA_STATIC_ACC_MEM_CONSTANT Elem g_constant_memory2_d_uninitialized[3][2];
+ALPAKA_STATIC_ACC_MEM_CONSTANT Elem g_constant_memory2_d_uninitialized[3][2];
 
 //! Uses static device memory on the accelerator defined globally for the whole compilation unit.
 struct StaticDeviceMemoryTestKernel
 {
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc, typename TElem>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc, bool* success, TElem const* const pConstantMem) const
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, bool* success, TElem const* const p_constant_mem) const
     {
-        auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
-        auto const gridThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+        auto const grid_thread_extent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+        auto const grid_thread_idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
 
-        auto const offset = gridThreadExtent[1u] * gridThreadIdx[0u] + gridThreadIdx[1u];
+        auto const offset = grid_thread_extent[1u] * grid_thread_idx[0u] + grid_thread_idx[1u];
         auto const val = offset;
 
-        ALPAKA_CHECK(*success, val == *(pConstantMem + offset));
+        ALPAKA_CHECK(*success, val == *(p_constant_mem + offset));
     }
 };
 
@@ -51,7 +51,7 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAc
     using Acc = TestType;
     using DevAcc = alpaka::Dev<Acc>;
     using PltfAcc = alpaka::Pltf<DevAcc>;
-    DevAcc devAcc = alpaka::getDevByIdx<PltfAcc>(0u);
+    DevAcc dev_acc = alpaka::getDevByIdx<PltfAcc>(0u);
 
     alpaka::Vec<Dim, Idx> const extent(3u, 2u);
 
@@ -62,21 +62,21 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAc
     // uninitialized static constant device memory
     {
         using PltfHost = alpaka::PltfCpu;
-        auto devHost(alpaka::getDevByIdx<PltfHost>(0u));
+        auto dev_host(alpaka::getDevByIdx<PltfHost>(0u));
 
         using QueueAcc = alpaka::test::DefaultQueue<DevAcc>;
-        QueueAcc queueAcc(devAcc);
+        QueueAcc queue_acc(dev_acc);
 
         std::vector<Elem> const data{0u, 1u, 2u, 3u, 4u, 5u};
-        auto bufHost = alpaka::createView(devHost, data.data(), extent);
+        auto buf_host = alpaka::createView(dev_host, data.data(), extent);
 
-        auto viewConstantMemUninitialized
-            = alpaka::createStaticDevMemView(&g_constantMemory2DUninitialized[0u][0u], devAcc, extent);
+        auto view_constant_mem_uninitialized
+            = alpaka::createStaticDevMemView(&g_constant_memory2_d_uninitialized[0u][0u], dev_acc, extent);
 
-        alpaka::memcpy(queueAcc, viewConstantMemUninitialized, bufHost, extent);
-        alpaka::wait(queueAcc);
+        alpaka::memcpy(queue_acc, view_constant_mem_uninitialized, buf_host, extent);
+        alpaka::wait(queue_acc);
 
-        REQUIRE(fixture(kernel, alpaka::getPtrNative(viewConstantMemUninitialized)));
+        REQUIRE(fixture(kernel, alpaka::getPtrNative(view_constant_mem_uninitialized)));
     }
 }
 
@@ -84,15 +84,15 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAc
 // from a different compilation unit and should be moved to a common header.
 // Here they are used to silence clang`s -Wmissing-variable-declarations warning
 // that forces every non-static variable to be declared with extern before the are defined.
-extern ALPAKA_STATIC_ACC_MEM_GLOBAL Elem g_globalMemory2DUninitialized[3][2];
-ALPAKA_STATIC_ACC_MEM_GLOBAL Elem g_globalMemory2DUninitialized[3][2];
+extern ALPAKA_STATIC_ACC_MEM_GLOBAL Elem g_global_memory2_d_uninitialized[3][2];
+ALPAKA_STATIC_ACC_MEM_GLOBAL Elem g_global_memory2_d_uninitialized[3][2];
 
 TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryConstant", "[viewStaticAccMem]", TestAccs)
 {
     using Acc = TestType;
     using DevAcc = alpaka::Dev<Acc>;
     using PltfAcc = alpaka::Pltf<DevAcc>;
-    DevAcc devAcc(alpaka::getDevByIdx<PltfAcc>(0u));
+    DevAcc dev_acc(alpaka::getDevByIdx<PltfAcc>(0u));
 
     alpaka::Vec<Dim, Idx> const extent(3u, 2u);
 
@@ -103,20 +103,20 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryConstant", "[viewStaticAccMem]", Test
     // uninitialized static global device memory
     {
         using PltfHost = alpaka::PltfCpu;
-        auto devHost(alpaka::getDevByIdx<PltfHost>(0u));
+        auto dev_host(alpaka::getDevByIdx<PltfHost>(0u));
 
         using QueueAcc = alpaka::test::DefaultQueue<DevAcc>;
-        QueueAcc queueAcc(devAcc);
+        QueueAcc queue_acc(dev_acc);
 
         std::vector<Elem> const data{0u, 1u, 2u, 3u, 4u, 5u};
-        auto bufHost = alpaka::createView(devHost, data.data(), extent);
+        auto buf_host = alpaka::createView(dev_host, data.data(), extent);
 
-        auto viewGlobalMemUninitialized
-            = alpaka::createStaticDevMemView(&g_globalMemory2DUninitialized[0u][0u], devAcc, extent);
+        auto view_global_mem_uninitialized
+            = alpaka::createStaticDevMemView(&g_global_memory2_d_uninitialized[0u][0u], dev_acc, extent);
 
-        alpaka::memcpy(queueAcc, viewGlobalMemUninitialized, bufHost, extent);
-        alpaka::wait(queueAcc);
+        alpaka::memcpy(queue_acc, view_global_mem_uninitialized, buf_host, extent);
+        alpaka::wait(queue_acc);
 
-        REQUIRE(fixture(kernel, alpaka::getPtrNative(viewGlobalMemUninitialized)));
+        REQUIRE(fixture(kernel, alpaka::getPtrNative(view_global_mem_uninitialized)));
     }
 }

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -30,51 +30,51 @@ namespace alpaka
     namespace test
     {
         template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx, typename TBuf>
-        auto testViewSubViewImmutable(
+        auto test_view_sub_view_immutable(
             alpaka::ViewSubView<TDev, TElem, TDim, TIdx> const& view,
             TBuf& buf,
             TDev const& dev,
-            alpaka::Vec<TDim, TIdx> const& extentView,
-            alpaka::Vec<TDim, TIdx> const& offsetView) -> void
+            alpaka::Vec<TDim, TIdx> const& extent_view,
+            alpaka::Vec<TDim, TIdx> const& offset_view) -> void
         {
-            alpaka::test::testViewImmutable<TElem>(view, dev, extentView, offsetView);
+            alpaka::test::testViewImmutable<TElem>(view, dev, extent_view, offset_view);
 
             // alpaka::traits::GetPitchBytes
             // The pitch of the view has to be identical to the pitch of the underlying buffer in all dimensions.
             {
-                auto const pitchBuf = alpaka::getPitchBytesVec(buf);
-                auto const pitchView = alpaka::getPitchBytesVec(view);
+                auto const pitch_buf = alpaka::getPitchBytesVec(buf);
+                auto const pitch_view = alpaka::getPitchBytesVec(view);
 
                 for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
                 {
-                    REQUIRE(pitchBuf[i - static_cast<TIdx>(1u)] == pitchView[i - static_cast<TIdx>(1u)]);
+                    REQUIRE(pitch_buf[i - static_cast<TIdx>(1u)] == pitch_view[i - static_cast<TIdx>(1u)]);
                 }
             }
 
             // alpaka::traits::GetPtrNative
             // The native pointer has to be exactly the value we calculate here.
             {
-                auto viewPtrNative = reinterpret_cast<std::uint8_t*>(alpaka::getPtrNative(buf));
-                auto const pitchBuf = alpaka::getPitchBytesVec(buf);
+                auto *view_ptr_native = reinterpret_cast<std::uint8_t*>(alpaka::getPtrNative(buf));
+                auto const pitch_buf = alpaka::getPitchBytesVec(buf);
                 for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
                 {
                     auto const pitch
-                        = (i < static_cast<TIdx>(TDim::value)) ? pitchBuf[i] : static_cast<TIdx>(sizeof(TElem));
-                    viewPtrNative += offsetView[i - static_cast<TIdx>(1u)] * pitch;
+                        = (i < static_cast<TIdx>(TDim::value)) ? pitch_buf[i] : static_cast<TIdx>(sizeof(TElem));
+                    view_ptr_native += offset_view[i - static_cast<TIdx>(1u)] * pitch;
                 }
-                REQUIRE(reinterpret_cast<TElem*>(viewPtrNative) == alpaka::getPtrNative(view));
+                REQUIRE(reinterpret_cast<TElem*>(view_ptr_native) == alpaka::getPtrNative(view));
             }
         }
 
         template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx, typename TBuf>
-        auto testViewSubViewMutable(
+        auto test_view_sub_view_mutable(
             alpaka::ViewSubView<TDev, TElem, TDim, TIdx>& view,
             TBuf& buf,
             TDev const& dev,
-            alpaka::Vec<TDim, TIdx> const& extentView,
-            alpaka::Vec<TDim, TIdx> const& offsetView) -> void
+            alpaka::Vec<TDim, TIdx> const& extent_view,
+            alpaka::Vec<TDim, TIdx> const& offset_view) -> void
         {
-            testViewSubViewImmutable<TAcc>(view, buf, dev, extentView, offsetView);
+            test_view_sub_view_immutable<TAcc>(view, buf, dev, extent_view, offset_view);
 
             using Queue = alpaka::test::DefaultQueue<TDev>;
             Queue queue(dev);
@@ -82,7 +82,7 @@ namespace alpaka
         }
 
         template<typename TAcc, typename TElem>
-        auto testViewSubViewNoOffset() -> void
+        auto test_view_sub_view_no_offset() -> void
         {
             using Dev = alpaka::Dev<TAcc>;
             using Pltf = alpaka::Pltf<Dev>;
@@ -93,19 +93,19 @@ namespace alpaka
 
             Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
 
-            auto const extentBuf
+            auto const extent_buf
                 = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
+            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extent_buf);
 
-            auto const extentView = extentBuf;
-            auto const offsetView = alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0));
+            auto const extent_view = extent_buf;
+            auto const offset_view = alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0));
             View view(buf);
 
-            alpaka::test::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
+            alpaka::test::test_view_sub_view_mutable<TAcc>(view, buf, dev, extent_view, offset_view);
         }
 
         template<typename TAcc, typename TElem>
-        auto testViewSubViewOffset() -> void
+        auto test_view_sub_view_offset() -> void
         {
             using Dev = alpaka::Dev<TAcc>;
             using Pltf = alpaka::Pltf<Dev>;
@@ -116,21 +116,21 @@ namespace alpaka
 
             Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
 
-            auto const extentBuf
+            auto const extent_buf
                 = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
+            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extent_buf);
 
-            auto const extentView = alpaka::
+            auto const extent_view = alpaka::
                 createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentSubView>();
-            auto const offsetView
+            auto const offset_view
                 = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>();
-            View view(buf, extentView, offsetView);
+            View view(buf, extent_view, offset_view);
 
-            alpaka::test::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
+            alpaka::test::test_view_sub_view_mutable<TAcc>(view, buf, dev, extent_view, offset_view);
         }
 
         template<typename TAcc, typename TElem>
-        auto testViewSubViewOffsetConst() -> void
+        auto test_view_sub_view_offset_const() -> void
         {
             using Dev = alpaka::Dev<TAcc>;
             using Pltf = alpaka::Pltf<Dev>;
@@ -141,17 +141,17 @@ namespace alpaka
 
             Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
 
-            auto const extentBuf
+            auto const extent_buf
                 = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
+            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extent_buf);
 
-            auto const extentView = alpaka::
+            auto const extent_view = alpaka::
                 createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentSubView>();
-            auto const offsetView
+            auto const offset_view
                 = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>();
-            View const view(buf, extentView, offsetView);
+            View const view(buf, extent_view, offset_view);
 
-            alpaka::test::testViewSubViewImmutable<TAcc>(view, buf, dev, extentView, offsetView);
+            alpaka::test::test_view_sub_view_immutable<TAcc>(view, buf, dev, extent_view, offset_view);
         }
     } // namespace test
 } // namespace alpaka
@@ -161,15 +161,15 @@ namespace alpaka
 
 TEMPLATE_LIST_TEST_CASE("viewSubViewNoOffsetTest", "[memView]", alpaka::test::TestAccs)
 {
-    alpaka::test::testViewSubViewNoOffset<TestType, float>();
+    alpaka::test::test_view_sub_view_no_offset<TestType, float>();
 }
 
 TEMPLATE_LIST_TEST_CASE("viewSubViewOffsetTest", "[memView]", alpaka::test::TestAccs)
 {
-    alpaka::test::testViewSubViewOffset<TestType, float>();
+    alpaka::test::test_view_sub_view_offset<TestType, float>();
 }
 
 TEMPLATE_LIST_TEST_CASE("viewSubViewOffsetConstTest", "[memView]", alpaka::test::TestAccs)
 {
-    alpaka::test::testViewSubViewOffsetConst<TestType, float>();
+    alpaka::test::test_view_sub_view_offset_const<TestType, float>();
 }

--- a/test/unit/meta/src/ApplyTest.cpp
+++ b/test/unit/meta/src/ApplyTest.cpp
@@ -14,7 +14,7 @@
 #include <tuple>
 #include <type_traits>
 
-template<typename... T>
+template<typename... TT>
 struct TypeList
 {
 };

--- a/test/unit/meta/src/ApplyTupleTest.cpp
+++ b/test/unit/meta/src/ApplyTupleTest.cpp
@@ -13,14 +13,14 @@
 
 struct Foo
 {
-    Foo(int num) : num_(num)
+    explicit Foo(int num) : m_num(num)
     {
     }
     auto add(int i) const -> int
     {
-        return num_ + i;
+        return m_num + i;
     }
-    int num_;
+    int m_num;
 };
 
 auto abs_num(int i) -> int;
@@ -52,7 +52,7 @@ TEST_CASE("invoke", "[meta]")
     REQUIRE(-314158 == alpaka::meta::invoke(&Foo::add, foo, 1));
 
     // invoke (access) a data member
-    REQUIRE(-314159 == alpaka::meta::invoke(&Foo::num_, foo));
+    REQUIRE(-314159 == alpaka::meta::invoke(&Foo::m_num, foo));
 
     // invoke a function object
     REQUIRE(18 == alpaka::meta::invoke(AbsNum(), -18));
@@ -64,8 +64,8 @@ auto add(int first, int second) -> int
     return first + second;
 }
 
-template<typename T>
-T add_generic(T first, T second)
+template<typename TT>
+TT add_generic(TT first, TT second)
 {
     return first + second;
 }

--- a/test/unit/meta/src/IsArrayOrVectorTest.cpp
+++ b/test/unit/meta/src/IsArrayOrVectorTest.cpp
@@ -20,20 +20,20 @@ TEST_CASE("isArrayOrVector", "[meta]")
     STATIC_REQUIRE(alpaka::meta::IsArrayOrVector<std::array<int, 10>>::value);
     STATIC_REQUIRE(alpaka::meta::IsArrayOrVector<std::vector<float>>::value);
 
-    float arrayFloat[4] = {1.0f, 2.0f, 3.0f, 4.0f};
-    STATIC_REQUIRE(alpaka::meta::IsArrayOrVector<decltype(arrayFloat)>::value);
+    float array_float[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+    STATIC_REQUIRE(alpaka::meta::IsArrayOrVector<decltype(array_float)>::value);
 }
 
 TEST_CASE("isActuallyNotArrayOrVector", "[meta]")
 {
-    float notAnArrayFloat = 15.0f;
-    STATIC_REQUIRE_FALSE(alpaka::meta::IsArrayOrVector<decltype(notAnArrayFloat)>::value);
+    float not_an_array_float = 15.0f;
+    STATIC_REQUIRE_FALSE(alpaka::meta::IsArrayOrVector<decltype(not_an_array_float)>::value);
 
-    float* notAnArrayFloatPointer = &notAnArrayFloat;
-    STATIC_REQUIRE_FALSE(alpaka::meta::IsArrayOrVector<decltype(notAnArrayFloatPointer)>::value);
+    float* not_an_array_float_pointer = &not_an_array_float;
+    STATIC_REQUIRE_FALSE(alpaka::meta::IsArrayOrVector<decltype(not_an_array_float_pointer)>::value);
 
-    std::string notAnArrayString{"alpaka"};
-    STATIC_REQUIRE_FALSE(alpaka::meta::IsArrayOrVector<decltype(notAnArrayString)>::value);
+    std::string not_an_array_string{"alpaka"};
+    STATIC_REQUIRE_FALSE(alpaka::meta::IsArrayOrVector<decltype(not_an_array_string)>::value);
 }
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)

--- a/test/unit/meta/src/IsStrictBaseTest.cpp
+++ b/test/unit/meta/src/IsStrictBaseTest.cpp
@@ -26,36 +26,36 @@ class C
 
 TEST_CASE("isStrictBaseTrue", "[meta]")
 {
-    constexpr bool IsStrictBaseResult = alpaka::meta::IsStrictBase<A, B>::value;
+    constexpr bool is_strict_base_result = alpaka::meta::IsStrictBase<A, B>::value;
 
-    constexpr bool IsStrictBaseReference = true;
+    constexpr bool is_strict_base_reference = true;
 
-    static_assert(IsStrictBaseReference == IsStrictBaseResult, "alpaka::meta::IsStrictBase failed!");
+    static_assert(is_strict_base_reference == is_strict_base_result, "alpaka::meta::IsStrictBase failed!");
 }
 
 TEST_CASE("isStrictBaseIdentity", "[meta]")
 {
-    constexpr bool IsStrictBaseResult = alpaka::meta::IsStrictBase<A, A>::value;
+    constexpr bool is_strict_base_result = alpaka::meta::IsStrictBase<A, A>::value;
 
-    constexpr bool IsStrictBaseReference = false;
+    constexpr bool is_strict_base_reference = false;
 
-    static_assert(IsStrictBaseReference == IsStrictBaseResult, "alpaka::meta::IsStrictBase failed!");
+    static_assert(is_strict_base_reference == is_strict_base_result, "alpaka::meta::IsStrictBase failed!");
 }
 
 TEST_CASE("isStrictBaseNoInheritance", "[meta]")
 {
-    constexpr bool IsStrictBaseResult = alpaka::meta::IsStrictBase<A, C>::value;
+    constexpr bool is_strict_base_result = alpaka::meta::IsStrictBase<A, C>::value;
 
-    constexpr bool IsStrictBaseReference = false;
+    constexpr bool is_strict_base_reference = false;
 
-    static_assert(IsStrictBaseReference == IsStrictBaseResult, "alpaka::meta::IsStrictBase failed!");
+    static_assert(is_strict_base_reference == is_strict_base_result, "alpaka::meta::IsStrictBase failed!");
 }
 
 TEST_CASE("isStrictBaseWrongOrder", "[meta]")
 {
-    constexpr bool IsStrictBaseResult = alpaka::meta::IsStrictBase<B, A>::value;
+    constexpr bool is_strict_base_result = alpaka::meta::IsStrictBase<B, A>::value;
 
-    constexpr bool IsStrictBaseReference = false;
+    constexpr bool is_strict_base_reference = false;
 
-    static_assert(IsStrictBaseReference == IsStrictBaseResult, "alpaka::meta::IsStrictBase failed!");
+    static_assert(is_strict_base_reference == is_strict_base_result, "alpaka::meta::IsStrictBase failed!");
 }

--- a/test/unit/meta/src/MetafunctionsTest.cpp
+++ b/test/unit/meta/src/MetafunctionsTest.cpp
@@ -19,7 +19,7 @@ TEST_CASE("conjunctionTrue", "[meta]")
     using ConjunctionResult
         = alpaka::meta::Conjunction<std::true_type, std::true_type, std::integral_constant<bool, true>>;
 
-    static_assert(ConjunctionResult::value == true, "alpaka::meta::Conjunction failed!");
+    static_assert(ConjunctionResult::value, "alpaka::meta::Conjunction failed!");
 }
 
 TEST_CASE("conjunctionFalse", "[meta]")
@@ -27,7 +27,7 @@ TEST_CASE("conjunctionFalse", "[meta]")
     using ConjunctionResult
         = alpaka::meta::Conjunction<std::true_type, std::false_type, std::integral_constant<bool, true>>;
 
-    static_assert(ConjunctionResult::value == false, "alpaka::meta::Conjunction failed!");
+    static_assert(!ConjunctionResult::value, "alpaka::meta::Conjunction failed!");
 }
 
 TEST_CASE("disjunctionTrue", "[meta]")
@@ -35,7 +35,7 @@ TEST_CASE("disjunctionTrue", "[meta]")
     using DisjunctionResult
         = alpaka::meta::Disjunction<std::false_type, std::true_type, std::integral_constant<bool, false>>;
 
-    static_assert(DisjunctionResult::value == true, "alpaka::meta::Disjunction failed!");
+    static_assert(DisjunctionResult::value, "alpaka::meta::Disjunction failed!");
 }
 
 TEST_CASE("disjunctionFalse", "[meta]")
@@ -43,7 +43,7 @@ TEST_CASE("disjunctionFalse", "[meta]")
     using DisjunctionResult
         = alpaka::meta::Disjunction<std::false_type, std::false_type, std::integral_constant<bool, false>>;
 
-    static_assert(DisjunctionResult::value == false, "alpaka::meta::Disjunction failed!");
+    static_assert(!DisjunctionResult::value, "alpaka::meta::Disjunction failed!");
 }
 
 TEST_CASE("negationFalse", "[meta]")

--- a/test/unit/meta/src/SetTest.cpp
+++ b/test/unit/meta/src/SetTest.cpp
@@ -18,20 +18,20 @@ TEST_CASE("isSetTrue", "[meta]")
 {
     using IsSetInput = std::tuple<int, float, long>;
 
-    constexpr bool IsSetResult = alpaka::meta::IsSet<IsSetInput>::value;
+    constexpr bool is_set_result = alpaka::meta::IsSet<IsSetInput>::value;
 
-    constexpr bool IsSetReference = true;
+    constexpr bool is_set_reference = true;
 
-    static_assert(IsSetReference == IsSetResult, "alpaka::meta::IsSet failed!");
+    static_assert(is_set_reference == is_set_result, "alpaka::meta::IsSet failed!");
 }
 
 TEST_CASE("isSetFalse", "[meta]")
 {
     using IsSetInput = std::tuple<int, float, int>;
 
-    constexpr bool IsSetResult = alpaka::meta::IsSet<IsSetInput>::value;
+    constexpr bool is_set_result = alpaka::meta::IsSet<IsSetInput>::value;
 
-    constexpr bool IsSetReference = false;
+    constexpr bool is_set_reference = false;
 
-    static_assert(IsSetReference == IsSetResult, "alpaka::meta::IsSet failed!");
+    static_assert(is_set_reference == is_set_result, "alpaka::meta::IsSet failed!");
 }

--- a/test/unit/meta/src/TransformTest.cpp
+++ b/test/unit/meta/src/TransformTest.cpp
@@ -14,8 +14,8 @@
 #include <tuple>
 #include <type_traits>
 
-template<typename T>
-using AddConst = T const;
+template<typename TT>
+using AddConst = TT const;
 
 TEST_CASE("transform", "[meta]")
 {

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -80,17 +80,17 @@ TEMPLATE_LIST_TEST_CASE("queueWaitShouldWork", "[queue]", TestQueues)
     using Fixture = alpaka::test::QueueTestFixture<DevQueue>;
     Fixture f;
 
-    std::atomic<bool> callbackFinished{false};
+    std::atomic<bool> callback_finished{false};
     alpaka::enqueue(
         f.m_queue,
-        [&callbackFinished]() noexcept
+        [&callback_finished]() noexcept
         {
             std::this_thread::sleep_for(std::chrono::milliseconds(100u));
-            callbackFinished = true;
+            callback_finished = true;
         });
 
     alpaka::wait(f.m_queue);
-    CHECK(callbackFinished.load() == true);
+    CHECK(callback_finished.load() == true);
 }
 
 TEMPLATE_LIST_TEST_CASE(
@@ -102,14 +102,14 @@ TEMPLATE_LIST_TEST_CASE(
     using Fixture = alpaka::test::QueueTestFixture<DevQueue>;
     Fixture f;
 
-    std::atomic<bool> callbackFinished{false};
+    std::atomic<bool> callback_finished{false};
     alpaka::enqueue(
         f.m_queue,
-        [&f, &callbackFinished]() noexcept
+        [&f, &callback_finished]() noexcept
         {
             LOOPED_CHECK(30, 100, !alpaka::empty(f.m_queue));
             std::this_thread::sleep_for(std::chrono::milliseconds(100u));
-            callbackFinished = true;
+            callback_finished = true;
         });
 
     // A non-blocking queue will always stay empty because the task has been executed immediately.
@@ -118,7 +118,7 @@ TEMPLATE_LIST_TEST_CASE(
         alpaka::wait(f.m_queue);
     }
 
-    CHECK(callbackFinished.load() == true);
+    CHECK(callback_finished.load() == true);
     LOOPED_CHECK(30, 100, alpaka::empty(f.m_queue));
 }
 
@@ -128,37 +128,37 @@ TEMPLATE_LIST_TEST_CASE("queueShouldNotExecuteTasksInParallel", "[queue]", TestQ
     using Fixture = alpaka::test::QueueTestFixture<DevQueue>;
     Fixture f;
 
-    std::atomic<bool> taskIsExecuting(false);
-    std::promise<void> firstTaskFinished;
-    std::future<void> firstTaskFinishedFuture = firstTaskFinished.get_future();
-    std::promise<void> secondTaskFinished;
-    std::future<void> secondTaskFinishedFuture = secondTaskFinished.get_future();
+    std::atomic<bool> task_is_executing(false);
+    std::promise<void> first_task_finished;
+    std::future<void> first_task_finished_future = first_task_finished.get_future();
+    std::promise<void> second_task_finished;
+    std::future<void> second_task_finished_future = second_task_finished.get_future();
 
     std::thread thread1(
-        [&f, &taskIsExecuting, &firstTaskFinished]()
+        [&f, &task_is_executing, &first_task_finished]()
         {
             alpaka::enqueue(
                 f.m_queue,
-                [&taskIsExecuting, &firstTaskFinished]() noexcept
+                [&task_is_executing, &first_task_finished]() noexcept
                 {
-                    CHECK(!taskIsExecuting.exchange(true));
+                    CHECK(!task_is_executing.exchange(true));
                     std::this_thread::sleep_for(std::chrono::milliseconds(100u));
-                    CHECK(taskIsExecuting.exchange(false));
-                    firstTaskFinished.set_value();
+                    CHECK(task_is_executing.exchange(false));
+                    first_task_finished.set_value();
                 });
         });
 
     std::thread thread2(
-        [&f, &taskIsExecuting, &secondTaskFinished]()
+        [&f, &task_is_executing, &second_task_finished]()
         {
             alpaka::enqueue(
                 f.m_queue,
-                [&taskIsExecuting, &secondTaskFinished]() noexcept
+                [&task_is_executing, &second_task_finished]() noexcept
                 {
-                    CHECK(!taskIsExecuting.exchange(true));
+                    CHECK(!task_is_executing.exchange(true));
                     std::this_thread::sleep_for(std::chrono::milliseconds(100u));
-                    CHECK(taskIsExecuting.exchange(false));
-                    secondTaskFinished.set_value();
+                    CHECK(task_is_executing.exchange(false));
+                    second_task_finished.set_value();
                 });
         });
 
@@ -168,6 +168,6 @@ TEMPLATE_LIST_TEST_CASE("queueShouldNotExecuteTasksInParallel", "[queue]", TestQ
 
     alpaka::wait(f.m_queue);
 
-    firstTaskFinishedFuture.get();
-    secondTaskFinishedFuture.get();
+    first_task_finished_future.get();
+    second_task_finished_future.get();
 }

--- a/test/unit/rand/src/RandTest.cpp
+++ b/test/unit/rand/src/RandTest.cpp
@@ -16,8 +16,8 @@
 class RandTestKernel
 {
     ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TAcc, typename T_Generator>
-    ALPAKA_FN_ACC void genNumbers(TAcc const& acc, bool* success, T_Generator& gen) const
+    template<typename TAcc, typename TTGenerator>
+    ALPAKA_FN_ACC void gen_numbers(TAcc const& acc, bool* success, TTGenerator& gen) const
     {
         {
             auto dist = alpaka::rand::distribution::createNormalReal<float>(acc);
@@ -65,26 +65,26 @@ public:
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
     {
         // default generator for accelerator
-        auto genDefault = alpaka::rand::engine::createDefault(acc, 12345u, 6789u);
-        genNumbers(acc, success, genDefault);
+        auto gen_default = alpaka::rand::engine::createDefault(acc, 12345u, 6789u);
+        gen_numbers(acc, success, gen_default);
 
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 #    if !defined(ALPAKA_ACC_ANY_BT_OMP5_ENABLED) && !defined(ALPAKA_ACC_ANY_BT_OACC_ENABLED)
-        // TODO: These ifdefs are wrong: They will reduce the test to the
+        // TODO(bgruber): These ifdefs are wrong: They will reduce the test to the
         // smallest common denominator from all enabled backends
         // std::random_device
-        auto genRandomDevice = alpaka::rand::engine::createDefault(alpaka::rand::RandomDevice{}, 12345u, 6789u);
-        genNumbers(acc, success, genRandomDevice);
+        auto gen_random_device = alpaka::rand::engine::createDefault(alpaka::rand::RandomDevice{}, 12345u, 6789u);
+        gen_numbers(acc, success, gen_random_device);
 
         // MersenneTwister
-        auto genMersenneTwister = alpaka::rand::engine::createDefault(alpaka::rand::MersenneTwister{}, 12345u, 6789u);
-        genNumbers(acc, success, genMersenneTwister);
+        auto gen_mersenne_twister = alpaka::rand::engine::createDefault(alpaka::rand::MersenneTwister{}, 12345u, 6789u);
+        gen_numbers(acc, success, gen_mersenne_twister);
 #    endif
 
         // TinyMersenneTwister
-        auto genTinyMersenneTwister
+        auto gen_tiny_mersenne_twister
             = alpaka::rand::engine::createDefault(alpaka::rand::TinyMersenneTwister{}, 12345u, 6789u);
-        genNumbers(acc, success, genTinyMersenneTwister);
+        gen_numbers(acc, success, gen_tiny_mersenne_twister);
 #endif
     }
 };

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -33,39 +33,39 @@ TEST_CASE("basicVecTraits", "[vec]")
     // alpaka::subVecFromIndices
     {
         using IdxSequence = std::integer_sequence<std::size_t, 0u, Dim::value - 1u, 0u>;
-        auto const vecSubIndices(alpaka::subVecFromIndices<IdxSequence>(vec));
+        auto const vec_sub_indices(alpaka::subVecFromIndices<IdxSequence>(vec));
 
-        REQUIRE(vecSubIndices[0u] == vec[0u]);
-        REQUIRE(vecSubIndices[1u] == vec[Dim::value - 1u]);
-        REQUIRE(vecSubIndices[2u] == vec[0u]);
+        REQUIRE(vec_sub_indices[0u] == vec[0u]);
+        REQUIRE(vec_sub_indices[1u] == vec[Dim::value - 1u]);
+        REQUIRE(vec_sub_indices[2u] == vec[0u]);
     }
 
     // alpaka::subVecBegin
     {
         using DimSubVecEnd = alpaka::DimInt<2u>;
-        auto const vecSubBegin(alpaka::subVecBegin<DimSubVecEnd>(vec));
+        auto const vec_sub_begin(alpaka::subVecBegin<DimSubVecEnd>(vec));
 
         for(typename Dim::value_type i(0); i < DimSubVecEnd::value; ++i)
         {
-            REQUIRE(vecSubBegin[i] == vec[i]);
+            REQUIRE(vec_sub_begin[i] == vec[i]);
         }
     }
 
     // alpaka::subVecEnd
     {
         using DimSubVecEnd = alpaka::DimInt<2u>;
-        auto const vecSubEnd(alpaka::subVecEnd<DimSubVecEnd>(vec));
+        auto const vec_sub_end(alpaka::subVecEnd<DimSubVecEnd>(vec));
 
         for(typename Dim::value_type i(0); i < DimSubVecEnd::value; ++i)
         {
-            REQUIRE(vecSubEnd[i] == vec[Dim::value - DimSubVecEnd::value + i]);
+            REQUIRE(vec_sub_end[i] == vec[Dim::value - DimSubVecEnd::value + i]);
         }
     }
 
     // alpaka::castVec
     {
         using SizeCast = std::uint16_t;
-        auto const vecCast(alpaka::castVec<SizeCast>(vec));
+        auto const vec_cast(alpaka::castVec<SizeCast>(vec));
 
         /*using VecCastConst = decltype(vecCast);
         using VecCast = std::decay_t<VecCastConst>;
@@ -78,17 +78,17 @@ TEST_CASE("basicVecTraits", "[vec]")
 
         for(typename Dim::value_type i(0); i < Dim::value; ++i)
         {
-            REQUIRE(vecCast[i] == static_cast<SizeCast>(vec[i]));
+            REQUIRE(vec_cast[i] == static_cast<SizeCast>(vec[i]));
         }
     }
 
     // alpaka::reverseVec
     {
-        auto const vecReverse(alpaka::reverseVec(vec));
+        auto const vec_reverse(alpaka::reverseVec(vec));
 
         for(typename Dim::value_type i(0); i < Dim::value; ++i)
         {
-            REQUIRE(vecReverse[i] == vec[Dim::value - 1u - i]);
+            REQUIRE(vec_reverse[i] == vec[Dim::value - 1u - i]);
         }
     }
 
@@ -97,19 +97,19 @@ TEST_CASE("basicVecTraits", "[vec]")
         using Dim2 = alpaka::DimInt<2u>;
         alpaka::Vec<Dim2, Idx> const vec2(static_cast<Idx>(47u), static_cast<Idx>(11u));
 
-        auto const vecConcat(alpaka::concatVec(vec, vec2));
+        auto const vec_concat(alpaka::concatVec(vec, vec2));
 
         static_assert(
-            std::is_same<alpaka::Dim<std::decay<decltype(vecConcat)>::type>, alpaka::DimInt<5u>>::value,
+            std::is_same<alpaka::Dim<std::decay<decltype(vec_concat)>::type>, alpaka::DimInt<5u>>::value,
             "Result dimension type of concatenation incorrect!");
 
         for(typename Dim::value_type i(0); i < Dim::value; ++i)
         {
-            REQUIRE(vecConcat[i] == vec[i]);
+            REQUIRE(vec_concat[i] == vec[i]);
         }
         for(typename Dim2::value_type i(0); i < Dim2::value; ++i)
         {
-            REQUIRE(vecConcat[Dim::value + i] == vec2[i]);
+            REQUIRE(vec_concat[Dim::value + i] == vec2[i]);
         }
     }
 
@@ -118,130 +118,130 @@ TEST_CASE("basicVecTraits", "[vec]")
 
         // alpaka::Vec operator +
         {
-            auto const vecLessEqual(vec + vec3);
+            auto const vec_less_equal(vec + vec3);
 
             static_assert(
-                std::is_same<alpaka::Dim<std::decay<decltype(vecLessEqual)>::type>, Dim>::value,
+                std::is_same<alpaka::Dim<std::decay<decltype(vec_less_equal)>::type>, Dim>::value,
                 "Result dimension type of operator <= incorrect!");
 
             static_assert(
-                std::is_same<alpaka::Idx<std::decay<decltype(vecLessEqual)>::type>, Idx>::value,
+                std::is_same<alpaka::Idx<std::decay<decltype(vec_less_equal)>::type>, Idx>::value,
                 "Result idx type of operator <= incorrect!");
 
-            alpaka::Vec<Dim, Idx> const referenceVec(
+            alpaka::Vec<Dim, Idx> const reference_vec(
                 static_cast<Idx>(47u),
                 static_cast<Idx>(16u),
                 static_cast<Idx>(18u));
 
-            REQUIRE(referenceVec == vecLessEqual);
+            REQUIRE(reference_vec == vec_less_equal);
         }
 
         // alpaka::Vec operator -
         {
-            auto const vecLessEqual(vec - vec3);
+            auto const vec_less_equal(vec - vec3);
 
             static_assert(
-                std::is_same<alpaka::Dim<std::decay<decltype(vecLessEqual)>::type>, Dim>::value,
+                std::is_same<alpaka::Dim<std::decay<decltype(vec_less_equal)>::type>, Dim>::value,
                 "Result dimension type of operator <= incorrect!");
 
             static_assert(
-                std::is_same<alpaka::Idx<std::decay<decltype(vecLessEqual)>::type>, Idx>::value,
+                std::is_same<alpaka::Idx<std::decay<decltype(vec_less_equal)>::type>, Idx>::value,
                 "Result idx type of operator <= incorrect!");
 
-            alpaka::Vec<Dim, Idx> const referenceVec(
+            alpaka::Vec<Dim, Idx> const reference_vec(
                 static_cast<Idx>(-47),
                 static_cast<Idx>(0u),
                 static_cast<Idx>(12u));
 
-            REQUIRE(referenceVec == vecLessEqual);
+            REQUIRE(reference_vec == vec_less_equal);
         }
 
         // alpaka::Vec operator *
         {
-            auto const vecLessEqual(vec * vec3);
+            auto const vec_less_equal(vec * vec3);
 
             static_assert(
-                std::is_same<alpaka::Dim<std::decay<decltype(vecLessEqual)>::type>, Dim>::value,
+                std::is_same<alpaka::Dim<std::decay<decltype(vec_less_equal)>::type>, Dim>::value,
                 "Result dimension type of operator <= incorrect!");
 
             static_assert(
-                std::is_same<alpaka::Idx<std::decay<decltype(vecLessEqual)>::type>, Idx>::value,
+                std::is_same<alpaka::Idx<std::decay<decltype(vec_less_equal)>::type>, Idx>::value,
                 "Result idx type of operator <= incorrect!");
 
-            alpaka::Vec<Dim, Idx> const referenceVec(
+            alpaka::Vec<Dim, Idx> const reference_vec(
                 static_cast<Idx>(0u),
                 static_cast<Idx>(64u),
                 static_cast<Idx>(45u));
 
-            REQUIRE(referenceVec == vecLessEqual);
+            REQUIRE(reference_vec == vec_less_equal);
         }
 
         // alpaka::Vec operator <
         {
-            auto const vecLessEqual(vec < vec3);
+            auto const vec_less_equal(vec < vec3);
 
             static_assert(
-                std::is_same<alpaka::Dim<std::decay<decltype(vecLessEqual)>::type>, Dim>::value,
+                std::is_same<alpaka::Dim<std::decay<decltype(vec_less_equal)>::type>, Dim>::value,
                 "Result dimension type of operator <= incorrect!");
 
             static_assert(
-                std::is_same<alpaka::Idx<std::decay<decltype(vecLessEqual)>::type>, bool>::value,
+                std::is_same<alpaka::Idx<std::decay<decltype(vec_less_equal)>::type>, bool>::value,
                 "Result idx type of operator <= incorrect!");
 
-            alpaka::Vec<Dim, bool> const referenceVec(true, false, false);
+            alpaka::Vec<Dim, bool> const reference_vec(true, false, false);
 
-            REQUIRE(referenceVec == vecLessEqual);
+            REQUIRE(reference_vec == vec_less_equal);
         }
 
         // alpaka::Vec operator <=
         {
-            auto const vecLessEqual(vec <= vec3);
+            auto const vec_less_equal(vec <= vec3);
 
             static_assert(
-                std::is_same<alpaka::Dim<std::decay<decltype(vecLessEqual)>::type>, Dim>::value,
+                std::is_same<alpaka::Dim<std::decay<decltype(vec_less_equal)>::type>, Dim>::value,
                 "Result dimension type of operator <= incorrect!");
 
             static_assert(
-                std::is_same<alpaka::Idx<std::decay<decltype(vecLessEqual)>::type>, bool>::value,
+                std::is_same<alpaka::Idx<std::decay<decltype(vec_less_equal)>::type>, bool>::value,
                 "Result idx type of operator <= incorrect!");
 
-            alpaka::Vec<Dim, bool> const referenceVec(true, true, false);
+            alpaka::Vec<Dim, bool> const reference_vec(true, true, false);
 
-            REQUIRE(referenceVec == vecLessEqual);
+            REQUIRE(reference_vec == vec_less_equal);
         }
 
         // alpaka::Vec operator >=
         {
-            auto const vecLessEqual(vec >= vec3);
+            auto const vec_less_equal(vec >= vec3);
 
             static_assert(
-                std::is_same<alpaka::Dim<std::decay<decltype(vecLessEqual)>::type>, Dim>::value,
+                std::is_same<alpaka::Dim<std::decay<decltype(vec_less_equal)>::type>, Dim>::value,
                 "Result dimension type of operator <= incorrect!");
 
             static_assert(
-                std::is_same<alpaka::Idx<std::decay<decltype(vecLessEqual)>::type>, bool>::value,
+                std::is_same<alpaka::Idx<std::decay<decltype(vec_less_equal)>::type>, bool>::value,
                 "Result idx type of operator <= incorrect!");
 
-            alpaka::Vec<Dim, bool> const referenceVec(false, true, true);
+            alpaka::Vec<Dim, bool> const reference_vec(false, true, true);
 
-            REQUIRE(referenceVec == vecLessEqual);
+            REQUIRE(reference_vec == vec_less_equal);
         }
 
         // alpaka::Vec operator >
         {
-            auto const vecLessEqual(vec > vec3);
+            auto const vec_less_equal(vec > vec3);
 
             static_assert(
-                std::is_same<alpaka::Dim<std::decay<decltype(vecLessEqual)>::type>, Dim>::value,
+                std::is_same<alpaka::Dim<std::decay<decltype(vec_less_equal)>::type>, Dim>::value,
                 "Result dimension type of operator <= incorrect!");
 
             static_assert(
-                std::is_same<alpaka::Idx<std::decay<decltype(vecLessEqual)>::type>, bool>::value,
+                std::is_same<alpaka::Idx<std::decay<decltype(vec_less_equal)>::type>, bool>::value,
                 "Result idx type of operator <= incorrect!");
 
-            alpaka::Vec<Dim, bool> const referenceVec(false, false, true);
+            alpaka::Vec<Dim, bool> const reference_vec(false, false, true);
 
-            REQUIRE(referenceVec == vecLessEqual);
+            REQUIRE(reference_vec == vec_less_equal);
         }
     }
 }
@@ -249,7 +249,7 @@ TEST_CASE("basicVecTraits", "[vec]")
 template<typename TDim, typename TIdx>
 struct NonAlpakaVec
 {
-    operator ::alpaka::Vec<TDim, TIdx>() const
+    explicit operator ::alpaka::Vec<TDim, TIdx>() const
     {
         using AlpakaVector = ::alpaka::Vec<TDim, TIdx>;
         AlpakaVector result = AlpakaVector::zeros();
@@ -272,12 +272,12 @@ TEMPLATE_LIST_TEST_CASE("vecNDConstructionFromNonAlpakaVec", "[vec]", alpaka::te
     using Dim = TestType;
     using Idx = std::size_t;
 
-    NonAlpakaVec<Dim, Idx> nonAlpakaVec;
-    auto const alpakaVec = static_cast<alpaka::Vec<Dim, Idx>>(nonAlpakaVec);
+    NonAlpakaVec<Dim, Idx> non_alpaka_vec;
+    auto const alpaka_vec = static_cast<alpaka::Vec<Dim, Idx>>(non_alpaka_vec);
 
     for(Idx d(0); d < Dim::value; ++d)
     {
-        REQUIRE(nonAlpakaVec[d] == alpakaVec[d]);
+        REQUIRE(non_alpaka_vec[d] == alpaka_vec[d]);
     }
 }
 

--- a/test/unit/warp/src/Activemask.cpp
+++ b/test/unit/warp/src/Activemask.cpp
@@ -24,8 +24,8 @@ public:
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
     {
-        std::int32_t const warpExtent = alpaka::warp::getSize(acc);
-        ALPAKA_CHECK(*success, warpExtent == 1);
+        std::int32_t const warp_extent = alpaka::warp::getSize(acc);
+        ALPAKA_CHECK(*success, warp_extent == 1);
 
         ALPAKA_CHECK(*success, alpaka::warp::activemask(acc) == 1u);
     }
@@ -36,26 +36,26 @@ class ActivemaskMultipleThreadWarpTestKernel
 public:
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
-    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, std::uint64_t inactiveThreadIdx) const -> void
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, std::uint64_t inactive_thread_idx) const -> void
     {
-        std::int32_t const warpExtent = alpaka::warp::getSize(acc);
-        ALPAKA_CHECK(*success, warpExtent > 1);
+        std::int32_t const warp_extent = alpaka::warp::getSize(acc);
+        ALPAKA_CHECK(*success, warp_extent > 1);
 
         // Test relies on having a single warp per thread block
-        auto const blockExtent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
-        ALPAKA_CHECK(*success, static_cast<std::int32_t>(blockExtent.prod()) == warpExtent);
-        auto const localThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
-        auto const threadIdxInWarp = static_cast<std::uint64_t>(alpaka::mapIdx<1u>(localThreadIdx, blockExtent)[0]);
+        auto const block_extent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
+        ALPAKA_CHECK(*success, static_cast<std::int32_t>(block_extent.prod()) == warp_extent);
+        auto const local_thread_idx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
+        auto const thread_idx_in_warp = static_cast<std::uint64_t>(alpaka::mapIdx<1u>(local_thread_idx, block_extent)[0]);
 
-        if(threadIdxInWarp == inactiveThreadIdx)
+        if(thread_idx_in_warp == inactive_thread_idx)
             return;
 
         auto const actual = alpaka::warp::activemask(acc);
         using Result = decltype(actual);
-        Result const allActive = static_cast<size_t>(warpExtent) == sizeof(Result) * CHAR_BIT
+        Result const all_active = static_cast<size_t>(warp_extent) == sizeof(Result) * CHAR_BIT
             ? ~Result{0u}
-            : (Result{1} << warpExtent) - 1u;
-        Result const expected = allActive & ~(Result{1} << inactiveThreadIdx);
+            : (Result{1} << warp_extent) - 1u;
+        Result const expected = all_active & ~(Result{1} << inactive_thread_idx);
         ALPAKA_CHECK(*success, actual == expected);
     }
 };
@@ -69,11 +69,11 @@ TEMPLATE_LIST_TEST_CASE("activemask", "[warp]", alpaka::test::TestAccs)
     using Idx = alpaka::Idx<Acc>;
 
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::getWarpSize(dev);
-    if(warpExtent == 1)
+    auto const warp_extent = alpaka::getWarpSize(dev);
+    if(warp_extent == 1)
     {
-        Idx const gridThreadExtentPerDim = 4;
-        alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(gridThreadExtentPerDim));
+        Idx const grid_thread_extent_per_dim = 4;
+        alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(grid_thread_extent_per_dim));
         ActivemaskSingleThreadWarpTestKernel kernel;
         REQUIRE(fixture(kernel));
     }
@@ -84,16 +84,16 @@ TEMPLATE_LIST_TEST_CASE("activemask", "[warp]", alpaka::test::TestAccs)
         return;
 #else
         using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-        auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+        auto const grid_block_extent = alpaka::Vec<Dim, Idx>::all(2);
         // Enforce one warp per thread block
-        auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-        blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-        auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-        auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-        auto fixture = ExecutionFixture{workDiv};
+        auto block_thread_extent = alpaka::Vec<Dim, Idx>::ones();
+        block_thread_extent[0] = static_cast<Idx>(warp_extent);
+        auto const thread_element_extent = alpaka::Vec<Dim, Idx>::ones();
+        auto work_div = typename ExecutionFixture::WorkDiv{grid_block_extent, block_thread_extent, thread_element_extent};
+        auto fixture = ExecutionFixture{work_div};
         ActivemaskMultipleThreadWarpTestKernel kernel;
-        for(auto inactiveThreadIdx = 0u; inactiveThreadIdx < warpExtent; inactiveThreadIdx++)
-            REQUIRE(fixture(kernel, inactiveThreadIdx));
+        for(auto inactive_thread_idx = 0u; inactive_thread_idx < warp_extent; inactive_thread_idx++)
+            REQUIRE(fixture(kernel, inactive_thread_idx));
 #endif
     }
 }

--- a/test/unit/warp/src/All.cpp
+++ b/test/unit/warp/src/All.cpp
@@ -23,8 +23,8 @@ public:
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
     {
-        std::int32_t const warpExtent = alpaka::warp::getSize(acc);
-        ALPAKA_CHECK(*success, warpExtent == 1);
+        std::int32_t const warp_extent = alpaka::warp::getSize(acc);
+        ALPAKA_CHECK(*success, warp_extent == 1);
 
         ALPAKA_CHECK(*success, alpaka::warp::all(acc, 42) != 0);
         ALPAKA_CHECK(*success, alpaka::warp::all(acc, 0) == 0);
@@ -38,28 +38,28 @@ public:
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
     {
-        std::int32_t const warpExtent = alpaka::warp::getSize(acc);
-        ALPAKA_CHECK(*success, warpExtent > 1);
+        std::int32_t const warp_extent = alpaka::warp::getSize(acc);
+        ALPAKA_CHECK(*success, warp_extent > 1);
 
         ALPAKA_CHECK(*success, alpaka::warp::all(acc, 0) == 0);
         ALPAKA_CHECK(*success, alpaka::warp::all(acc, 42) != 0);
 
         // Test relies on having a single warp per thread block
-        auto const blockExtent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
-        ALPAKA_CHECK(*success, static_cast<std::int32_t>(blockExtent.prod()) == warpExtent);
-        auto const localThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
-        auto const threadIdxInWarp = static_cast<std::int32_t>(alpaka::mapIdx<1u>(localThreadIdx, blockExtent)[0]);
+        auto const block_extent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
+        ALPAKA_CHECK(*success, static_cast<std::int32_t>(block_extent.prod()) == warp_extent);
+        auto const local_thread_idx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
+        auto const thread_idx_in_warp = static_cast<std::int32_t>(alpaka::mapIdx<1u>(local_thread_idx, block_extent)[0]);
 
         // Some threads quit the kernel to test that the warp operations
         // properly operate on the active threads only
-        if(threadIdxInWarp % 3)
+        if(thread_idx_in_warp % 3)
             return;
 
-        for(auto idx = 0; idx < warpExtent; idx++)
+        for(auto idx = 0; idx < warp_extent; idx++)
         {
-            ALPAKA_CHECK(*success, alpaka::warp::all(acc, threadIdxInWarp == idx ? 1 : 0) == 0);
+            ALPAKA_CHECK(*success, alpaka::warp::all(acc, thread_idx_in_warp == idx ? 1 : 0) == 0);
             std::int32_t const expected = idx % 3 ? 1 : 0;
-            ALPAKA_CHECK(*success, alpaka::warp::all(acc, threadIdxInWarp == idx ? 0 : 1) == expected);
+            ALPAKA_CHECK(*success, alpaka::warp::all(acc, thread_idx_in_warp == idx ? 0 : 1) == expected);
         }
     }
 };
@@ -73,11 +73,11 @@ TEMPLATE_LIST_TEST_CASE("all", "[warp]", alpaka::test::TestAccs)
     using Idx = alpaka::Idx<Acc>;
 
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::getWarpSize(dev);
-    if(warpExtent == 1)
+    auto const warp_extent = alpaka::getWarpSize(dev);
+    if(warp_extent == 1)
     {
-        Idx const gridThreadExtentPerDim = 4;
-        alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(gridThreadExtentPerDim));
+        Idx const grid_thread_extent_per_dim = 4;
+        alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(grid_thread_extent_per_dim));
         AllSingleThreadWarpTestKernel kernel;
         REQUIRE(fixture(kernel));
     }
@@ -88,13 +88,13 @@ TEMPLATE_LIST_TEST_CASE("all", "[warp]", alpaka::test::TestAccs)
         return;
 #else
         using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-        auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+        auto const grid_block_extent = alpaka::Vec<Dim, Idx>::all(2);
         // Enforce one warp per thread block
-        auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-        blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-        auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-        auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-        auto fixture = ExecutionFixture{workDiv};
+        auto block_thread_extent = alpaka::Vec<Dim, Idx>::ones();
+        block_thread_extent[0] = static_cast<Idx>(warp_extent);
+        auto const thread_element_extent = alpaka::Vec<Dim, Idx>::ones();
+        auto work_div = typename ExecutionFixture::WorkDiv{grid_block_extent, block_thread_extent, thread_element_extent};
+        auto fixture = ExecutionFixture{work_div};
         AllMultipleThreadWarpTestKernel kernel;
         REQUIRE(fixture(kernel));
 #endif

--- a/test/unit/warp/src/Ballot.cpp
+++ b/test/unit/warp/src/Ballot.cpp
@@ -24,8 +24,8 @@ public:
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
     {
-        std::int32_t const warpExtent = alpaka::warp::getSize(acc);
-        ALPAKA_CHECK(*success, warpExtent == 1);
+        std::int32_t const warp_extent = alpaka::warp::getSize(acc);
+        ALPAKA_CHECK(*success, warp_extent == 1);
 
         ALPAKA_CHECK(*success, alpaka::warp::ballot(acc, 42) == 1u);
         ALPAKA_CHECK(*success, alpaka::warp::ballot(acc, 0) == 0u);
@@ -39,35 +39,35 @@ public:
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
     {
-        std::int32_t const warpExtent = alpaka::warp::getSize(acc);
-        ALPAKA_CHECK(*success, warpExtent > 1);
+        std::int32_t const warp_extent = alpaka::warp::getSize(acc);
+        ALPAKA_CHECK(*success, warp_extent > 1);
 
         using BallotResultType = decltype(alpaka::warp::ballot(acc, 42));
-        BallotResultType const allActive = static_cast<size_t>(warpExtent) == sizeof(BallotResultType) * CHAR_BIT
+        BallotResultType const all_active = static_cast<size_t>(warp_extent) == sizeof(BallotResultType) * CHAR_BIT
             ? ~BallotResultType{0u}
-            : (BallotResultType{1} << warpExtent) - 1u;
-        ALPAKA_CHECK(*success, alpaka::warp::ballot(acc, 42) == allActive);
+            : (BallotResultType{1} << warp_extent) - 1u;
+        ALPAKA_CHECK(*success, alpaka::warp::ballot(acc, 42) == all_active);
         ALPAKA_CHECK(*success, alpaka::warp::ballot(acc, 0) == 0u);
 
         // Test relies on having a single warp per thread block
-        auto const blockExtent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
-        ALPAKA_CHECK(*success, static_cast<std::int32_t>(blockExtent.prod()) == warpExtent);
-        auto const localThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
-        auto const threadIdxInWarp = static_cast<std::int32_t>(alpaka::mapIdx<1u>(localThreadIdx, blockExtent)[0]);
+        auto const block_extent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
+        ALPAKA_CHECK(*success, static_cast<std::int32_t>(block_extent.prod()) == warp_extent);
+        auto const local_thread_idx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
+        auto const thread_idx_in_warp = static_cast<std::int32_t>(alpaka::mapIdx<1u>(local_thread_idx, block_extent)[0]);
 
         // Some threads quit the kernel to test that the warp operations
         // properly operate on the active threads only
-        if(threadIdxInWarp >= warpExtent / 2)
+        if(thread_idx_in_warp >= warp_extent / 2)
             return;
 
-        for(auto idx = 0; idx < warpExtent / 2; idx++)
+        for(auto idx = 0; idx < warp_extent / 2; idx++)
         {
             ALPAKA_CHECK(
                 *success,
-                alpaka::warp::ballot(acc, threadIdxInWarp == idx ? 1 : 0) == std::uint64_t{1} << idx);
+                alpaka::warp::ballot(acc, thread_idx_in_warp == idx ? 1 : 0) == std::uint64_t{1} << idx);
             // First warpExtent / 2 bits are 1 except bit idx
-            std::uint64_t const expected = ((std::uint64_t{1} << warpExtent / 2) - 1) & ~(std::uint64_t{1} << idx);
-            ALPAKA_CHECK(*success, alpaka::warp::ballot(acc, threadIdxInWarp == idx ? 0 : 1) == expected);
+            std::uint64_t const expected = ((std::uint64_t{1} << warp_extent / 2) - 1) & ~(std::uint64_t{1} << idx);
+            ALPAKA_CHECK(*success, alpaka::warp::ballot(acc, thread_idx_in_warp == idx ? 0 : 1) == expected);
         }
     }
 };
@@ -81,11 +81,11 @@ TEMPLATE_LIST_TEST_CASE("ballot", "[warp]", alpaka::test::TestAccs)
     using Idx = alpaka::Idx<Acc>;
 
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::getWarpSize(dev);
-    if(warpExtent == 1)
+    auto const warp_extent = alpaka::getWarpSize(dev);
+    if(warp_extent == 1)
     {
-        Idx const gridThreadExtentPerDim = 4;
-        alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(gridThreadExtentPerDim));
+        Idx const grid_thread_extent_per_dim = 4;
+        alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(grid_thread_extent_per_dim));
         BallotSingleThreadWarpTestKernel kernel;
         REQUIRE(fixture(kernel));
     }
@@ -96,13 +96,13 @@ TEMPLATE_LIST_TEST_CASE("ballot", "[warp]", alpaka::test::TestAccs)
         return;
 #else
         using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-        auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+        auto const grid_block_extent = alpaka::Vec<Dim, Idx>::all(2);
         // Enforce one warp per thread block
-        auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-        blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-        auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-        auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-        auto fixture = ExecutionFixture{workDiv};
+        auto block_thread_extent = alpaka::Vec<Dim, Idx>::ones();
+        block_thread_extent[0] = static_cast<Idx>(warp_extent);
+        auto const thread_element_extent = alpaka::Vec<Dim, Idx>::ones();
+        auto work_div = typename ExecutionFixture::WorkDiv{grid_block_extent, block_thread_extent, thread_element_extent};
+        auto fixture = ExecutionFixture{work_div};
         BallotMultipleThreadWarpTestKernel kernel;
         REQUIRE(fixture(kernel));
 #endif

--- a/test/unit/warp/src/GetSize.cpp
+++ b/test/unit/warp/src/GetSize.cpp
@@ -21,10 +21,10 @@ class GetSizeTestKernel
 public:
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
-    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, std::int32_t expectedWarpSize) const -> void
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, std::int32_t expected_warp_size) const -> void
     {
-        std::int32_t const actualWarpSize = alpaka::warp::getSize(acc);
-        ALPAKA_CHECK(*success, actualWarpSize == expectedWarpSize);
+        std::int32_t const actual_warp_size = alpaka::warp::getSize(acc);
+        ALPAKA_CHECK(*success, actual_warp_size == expected_warp_size);
     }
 };
 
@@ -37,9 +37,9 @@ TEMPLATE_LIST_TEST_CASE("getSize", "[warp]", alpaka::test::TestAccs)
     using Idx = alpaka::Idx<Acc>;
 
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto const expectedWarpSize = static_cast<int>(alpaka::getWarpSize(dev));
-    Idx const gridThreadExtentPerDim = 8;
-    alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(gridThreadExtentPerDim));
+    auto const expected_warp_size = static_cast<int>(alpaka::getWarpSize(dev));
+    Idx const grid_thread_extent_per_dim = 8;
+    alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(grid_thread_extent_per_dim));
     GetSizeTestKernel kernel;
-    REQUIRE(fixture(kernel, expectedWarpSize));
+    REQUIRE(fixture(kernel, expected_warp_size));
 }

--- a/test/unit/warp/src/Shfl.cpp
+++ b/test/unit/warp/src/Shfl.cpp
@@ -24,8 +24,8 @@ public:
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
     {
-        std::int32_t const warpExtent = alpaka::warp::getSize(acc);
-        ALPAKA_CHECK(*success, warpExtent == 1);
+        std::int32_t const warp_extent = alpaka::warp::getSize(acc);
+        ALPAKA_CHECK(*success, warp_extent == 1);
 
         ALPAKA_CHECK(*success, alpaka::warp::shfl(acc, 12, 0) == 12);
         ALPAKA_CHECK(*success, alpaka::warp::shfl(acc, 42, -1) == 42);
@@ -41,18 +41,18 @@ public:
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
     {
-        auto const localThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
-        auto const blockExtent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
-        std::int32_t const warpExtent = alpaka::warp::getSize(acc);
+        auto const local_thread_idx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
+        auto const block_extent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
+        std::int32_t const warp_extent = alpaka::warp::getSize(acc);
         // Test relies on having a single warp per thread block
-        ALPAKA_CHECK(*success, static_cast<std::int32_t>(blockExtent.prod()) == warpExtent);
-        auto const threadIdxInWarp = std::int32_t(alpaka::mapIdx<1u>(localThreadIdx, blockExtent)[0]);
+        ALPAKA_CHECK(*success, static_cast<std::int32_t>(block_extent.prod()) == warp_extent);
+        auto const thread_idx_in_warp = std::int32_t(alpaka::mapIdx<1u>(local_thread_idx, block_extent)[0]);
 
-        ALPAKA_CHECK(*success, warpExtent > 1);
+        ALPAKA_CHECK(*success, warp_extent > 1);
 
         ALPAKA_CHECK(*success, alpaka::warp::shfl(acc, 42, 0) == 42);
-        ALPAKA_CHECK(*success, alpaka::warp::shfl(acc, threadIdxInWarp, 0) == 0);
-        ALPAKA_CHECK(*success, alpaka::warp::shfl(acc, threadIdxInWarp, 1) == 1);
+        ALPAKA_CHECK(*success, alpaka::warp::shfl(acc, thread_idx_in_warp, 0) == 0);
+        ALPAKA_CHECK(*success, alpaka::warp::shfl(acc, thread_idx_in_warp, 1) == 1);
         // Note the CUDA and HIP API-s differ on lane wrapping, but both agree it should not segfault
         // https://github.com/ROCm-Developer-Tools/HIP-CPU/issues/14
         ALPAKA_CHECK(*success, alpaka::warp::shfl(acc, 5, -1) == 5);
@@ -60,13 +60,13 @@ public:
         auto const epsilon = std::numeric_limits<float>::epsilon();
 
         // Test various widths
-        for(int width = 1; width < warpExtent; width *= 2)
+        for(int width = 1; width < warp_extent; width *= 2)
         {
             for(int idx = 0; idx < width; idx++)
             {
-                int const off = width * (threadIdxInWarp / width);
-                ALPAKA_CHECK(*success, alpaka::warp::shfl(acc, threadIdxInWarp, idx, width) == idx + off);
-                float const ans = alpaka::warp::shfl(acc, 4.0f - float(threadIdxInWarp), idx, width);
+                int const off = width * (thread_idx_in_warp / width);
+                ALPAKA_CHECK(*success, alpaka::warp::shfl(acc, thread_idx_in_warp, idx, width) == idx + off);
+                float const ans = alpaka::warp::shfl(acc, 4.0f - float(thread_idx_in_warp), idx, width);
                 float const expect = 4.0f - float(idx + off);
                 ALPAKA_CHECK(*success, alpaka::math::abs(acc, ans - expect) < epsilon);
             }
@@ -74,13 +74,13 @@ public:
 
         // Some threads quit the kernel to test that the warp operations
         // properly operate on the active threads only
-        if(threadIdxInWarp >= warpExtent / 2)
+        if(thread_idx_in_warp >= warp_extent / 2)
             return;
 
-        for(int idx = 0; idx < warpExtent / 2; idx++)
+        for(int idx = 0; idx < warp_extent / 2; idx++)
         {
-            ALPAKA_CHECK(*success, alpaka::warp::shfl(acc, threadIdxInWarp, idx) == idx);
-            float const ans = alpaka::warp::shfl(acc, 4.0f - float(threadIdxInWarp), idx);
+            ALPAKA_CHECK(*success, alpaka::warp::shfl(acc, thread_idx_in_warp, idx) == idx);
+            float const ans = alpaka::warp::shfl(acc, 4.0f - float(thread_idx_in_warp), idx);
             float const expect = 4.0f - float(idx);
             ALPAKA_CHECK(*success, alpaka::math::abs(acc, ans - expect) < epsilon);
         }
@@ -96,11 +96,11 @@ TEMPLATE_LIST_TEST_CASE("shfl", "[warp]", alpaka::test::TestAccs)
     using Idx = alpaka::Idx<Acc>;
 
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::getWarpSize(dev);
-    if(warpExtent == 1)
+    auto const warp_extent = alpaka::getWarpSize(dev);
+    if(warp_extent == 1)
     {
-        Idx const gridThreadExtentPerDim = 4;
-        alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(gridThreadExtentPerDim));
+        Idx const grid_thread_extent_per_dim = 4;
+        alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(grid_thread_extent_per_dim));
         ShflSingleThreadWarpTestKernel kernel;
         REQUIRE(fixture(kernel));
     }
@@ -111,13 +111,13 @@ TEMPLATE_LIST_TEST_CASE("shfl", "[warp]", alpaka::test::TestAccs)
         return;
 #else
         using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-        auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+        auto const grid_block_extent = alpaka::Vec<Dim, Idx>::all(2);
         // Enforce one warp per thread block
-        auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-        blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-        auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-        auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-        auto fixture = ExecutionFixture{workDiv};
+        auto block_thread_extent = alpaka::Vec<Dim, Idx>::ones();
+        block_thread_extent[0] = static_cast<Idx>(warp_extent);
+        auto const thread_element_extent = alpaka::Vec<Dim, Idx>::ones();
+        auto work_div = typename ExecutionFixture::WorkDiv{grid_block_extent, block_thread_extent, thread_element_extent};
+        auto fixture = ExecutionFixture{work_div};
         ShflMultipleThreadWarpTestKernel kernel;
         REQUIRE(fixture(kernel));
 #endif

--- a/test/unit/workDiv/src/WorkDivHelpersTest.cpp
+++ b/test/unit/workDiv/src/WorkDivHelpersTest.cpp
@@ -18,7 +18,7 @@
 namespace
 {
     template<typename TAcc>
-    auto getWorkDiv()
+    auto get_work_div()
     {
         using Dev = alpaka::Dev<TAcc>;
         using Pltf = alpaka::Pltf<Dev>;
@@ -26,15 +26,15 @@ namespace
         using Idx = alpaka::Idx<TAcc>;
 
         Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-        auto const gridThreadExtent = alpaka::Vec<Dim, Idx>::all(10);
-        auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-        auto const workDiv = alpaka::getValidWorkDiv<TAcc>(
+        auto const grid_thread_extent = alpaka::Vec<Dim, Idx>::all(10);
+        auto const thread_element_extent = alpaka::Vec<Dim, Idx>::ones();
+        auto const work_div = alpaka::getValidWorkDiv<TAcc>(
             dev,
-            gridThreadExtent,
-            threadElementExtent,
+            grid_thread_extent,
+            thread_element_extent,
             false,
             alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
-        return workDiv;
+        return work_div;
     }
 } // namespace
 
@@ -42,8 +42,8 @@ TEMPLATE_LIST_TEST_CASE("getValidWorkDiv", "[workDiv]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
     // Note: getValidWorkDiv() is called inside getWorkDiv
-    auto const workDiv = getWorkDiv<Acc>();
-    alpaka::ignore_unused(workDiv);
+    auto const work_div = get_work_div<Acc>();
+    alpaka::ignore_unused(work_div);
 }
 
 TEMPLATE_LIST_TEST_CASE("isValidWorkDiv", "[workDiv]", alpaka::test::TestAccs)
@@ -53,8 +53,8 @@ TEMPLATE_LIST_TEST_CASE("isValidWorkDiv", "[workDiv]", alpaka::test::TestAccs)
     using Pltf = alpaka::Pltf<Dev>;
 
     Dev dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto const workDiv = getWorkDiv<Acc>();
+    auto const work_div = get_work_div<Acc>();
     // Test both overloads
-    REQUIRE(alpaka::isValidWorkDiv(alpaka::getAccDevProps<Acc>(dev), workDiv));
-    REQUIRE(alpaka::isValidWorkDiv<Acc>(dev, workDiv));
+    REQUIRE(alpaka::isValidWorkDiv(alpaka::getAccDevProps<Acc>(dev), work_div));
+    REQUIRE(alpaka::isValidWorkDiv<Acc>(dev, work_div));
 }


### PR DESCRIPTION
This PR tests the clang-tidy file from https://github.com/ComputationalRadiationPhysics/contributing/blob/master/formatting-tools/.clang-tidy. It just includes the result of running run-clang-tidy -fix, with no additional manual changes.