### PR TITLE
.gitignore for Eclipse project files & directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ cmake-build-*/
 *.kdev?
 spack-build*
 build/
+
+# Eclipse project files
+/.project
+/.cproject
+/.settings/
+


### PR DESCRIPTION
For C/C++ projects, Eclipse stores the project configuration in the top level directory in two files, `.project` and `.cproject`, and local user settings in `.settings` directory. (I realize I might be the only one using Eclipse, but still...)