### PR TITLE
OpenMP Target fixes: assert, printf

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -78,7 +78,7 @@ struct TestBufferKernel
 
         for(size_t i(linearizedGlobalThreadIdx[0]); i < extents.prod(); i += globalThreadExtent.prod())
         {
-            ALPAKA_ASSERT(data[linIdxToPitchedIdx<2>(i, pitch)] == i);
+            ALPAKA_ASSERT_OFFLOAD(data[linIdxToPitchedIdx<2>(i, pitch)] == i);
         }
     }
 };

--- a/include/alpaka/acc/AccOmp5.hpp
+++ b/include/alpaka/acc/AccOmp5.hpp
@@ -15,6 +15,12 @@
 #        error If ALPAKA_ACC_ANY_BT_OMP5_ENABLED is set, the compiler has to support OpenMP 4.0 or higher!
 #    endif
 
+// Kill printf in AMD GPU code because of missing compiler support
+#    ifdef __AMDGCN__
+#        include <cstdio> // the define breaks <cstdio> if it is included afterwards
+#        define printf(...)
+#    endif
+
 // Base classes.
 #    include <alpaka/atomic/AtomicHierarchy.hpp>
 #    include <alpaka/atomic/AtomicOmpBuiltIn.hpp>

--- a/include/alpaka/core/Assert.hpp
+++ b/include/alpaka/core/Assert.hpp
@@ -20,6 +20,13 @@
 
 #ifdef ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST
 #    define ALPAKA_ASSERT_OFFLOAD(EXPRESSION) ALPAKA_ASSERT(EXPRESSION)
+#elif defined __AMDGCN__ && (!defined NDEBUG)
+#    define ALPAKA_ASSERT_OFFLOAD(EXPRESSION)                                                                         \
+        do                                                                                                            \
+        {                                                                                                             \
+            if(!(EXPRESSION))                                                                                         \
+                __builtin_trap();                                                                                     \
+        } while(false)
 #else
 #    define ALPAKA_ASSERT_OFFLOAD(EXPRESSION)
 #endif
@@ -38,11 +45,8 @@ namespace alpaka
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto assertValueUnsigned(TArg const& arg) -> void
                 {
-#ifdef NDEBUG
                     alpaka::ignore_unused(arg);
-#else
-                    ALPAKA_ASSERT(arg >= 0);
-#endif
+                    ALPAKA_ASSERT_OFFLOAD(arg >= 0);
                 }
             };
             template<typename TArg>
@@ -78,11 +82,8 @@ namespace alpaka
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto assertGreaterThan(TRhs const& lhs) -> void
                 {
-#ifdef NDEBUG
                     alpaka::ignore_unused(lhs);
-#else
-                    ALPAKA_ASSERT(TLhs::value > lhs);
-#endif
+                    ALPAKA_ASSERT_OFFLOAD(TLhs::value > lhs);
                 }
             };
             template<typename TLhs, typename TRhs>

--- a/include/alpaka/idx/bt/IdxBtOmp.hpp
+++ b/include/alpaka/idx/bt/IdxBtOmp.hpp
@@ -59,7 +59,7 @@ namespace alpaka
             {
                 alpaka::ignore_unused(idx);
                 // We assume that the thread id is positive.
-                ALPAKA_ASSERT(::omp_get_thread_num() >= 0);
+                ALPAKA_ASSERT_OFFLOAD(::omp_get_thread_num() >= 0);
                 // \TODO: Would it be faster to precompute the index and cache it inside an array?
                 return mapIdx<TDim::value>(
                     Vec<DimInt<1u>, TIdx>(static_cast<TIdx>(::omp_get_thread_num())),


### PR DESCRIPTION
This PR
* fixes some places in which `ALPAKA_ASSERT_OFFLOAD` should be used instead of `ALPAKA_ASSERT` because they occur in device code,
* adds a non-empty definition of `ALPAKA_ASSERT_OFFLOAD` for `__AMDGCN__`,
* defines `ALPAKA_ASSERT_OFFLOAD` as `alpaka::ignore_unused(EXPRESSION)`  when empty to avoid triggering unused argument warnings, and
* defines `printf(...)` as empty macro for `__AMDGCN__` because it is not yet supported in Clang or AOMP offloading compilers and it will still take some time until it is.