### PR TITLE
Backport to 0.7.0

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -774,8 +774,8 @@ if(TARGET alpaka)
     endif()
 endif()
 
-# NVCC does not incorporate the COMPILE_OPTIONS of a target but only the CMAKE_CXX_FLAGS
-if(ALPAKA_ACC_GPU_HIP_ENABLE AND ALPAKA_CUDA_COMPILER MATCHES "nvcc")
+# For hipcc we need to propagate the CMAKE_CXX_FLAGS to HIP_HIPCC_FLAGS.
+if(ALPAKA_ACC_GPU_HIP_ENABLE)
     get_property(_ALPAKA_COMPILE_OPTIONS_PUBLIC
                  TARGET alpaka
                  PROPERTY INTERFACE_COMPILE_OPTIONS)
@@ -783,9 +783,13 @@ if(ALPAKA_ACC_GPU_HIP_ENABLE AND ALPAKA_CUDA_COMPILER MATCHES "nvcc")
     alpaka_set_compiler_options(HOST var CMAKE_CXX_FLAGS "${_ALPAKA_COMPILE_OPTIONS_STRING}")
 
     # Append CMAKE_CXX_FLAGS_[Release|Debug|RelWithDebInfo] to CMAKE_CXX_FLAGS
-    # because FindCUDA only propagates the latter to nvcc.
+    # because cmake HIP modules do not use the former variables
     string(TOUPPER "${CMAKE_BUILD_TYPE}" build_config)
     alpaka_set_compiler_options(HOST var CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_${build_config}}")
+
+    # additionally CMAKE_CXX_FLAGS must be propagated to HIP_HIPCC_FLAGS
+    string(REPLACE " " ";" CMAKE_CXX_FLAGS_AS_LIST "${CMAKE_CXX_FLAGS}")
+    alpaka_set_compiler_options(DEVICE list HIP_HIPCC_FLAGS "${CMAKE_CXX_FLAGS_AS_LIST}")
 endif()
 
 if(ALPAKA_COMPILER_OPTIONS_DEVICE OR ALPAKA_COMPILER_OPTIONS_DEVICE)

--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -29,7 +29,7 @@
 //!
 //! Prints distribution of alpaka thread indices between OpenMP threads.
 //! Its operator() is reused in other kernels of this example.
-//! Sets no schedule explicitly, so the default is used, controlled by the OMP_SCHEDULE environment variable.
+//! Sets no schedule explicitly, so no schedule() clause is used.
 struct OpenMPScheduleDefaultKernel
 {
     template<typename TAcc>
@@ -76,9 +76,7 @@ namespace alpaka
     {
         //! Schedule trait specialization for OpenMPScheduleTraitKernel.
         //! This is the most general way to define a schedule.
-        //! In case neither the trait nor the member are provided, alpaka does not set any runtime schedule and the
-        //! schedule used is defined by omp_set_schedule() called on the user side, or otherwise by the OMP_SCHEDULE
-        //! environment variable.
+        //! In case neither the trait nor the member are provided, there will be no schedule() clause.
         template<typename TAcc>
         struct OmpSchedule<OpenMPScheduleTraitKernel, TAcc>
         {
@@ -137,7 +135,6 @@ auto main() -> int
         alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
 
     // Run the kernel setting no schedule explicitly.
-    // In this case the schedule is controlled by the OMP_SCHEDULE environment variable.
     std::cout << "OpenMPScheduleDefaultKernel setting no schedule explicitly:\n";
     alpaka::exec<Acc>(queue, workDiv, OpenMPScheduleDefaultKernel{});
     alpaka::wait(queue);

--- a/include/alpaka/block/shared/st/detail/BlockSharedMemStMemberImpl.hpp
+++ b/include/alpaka/block/shared/st/detail/BlockSharedMemStMemberImpl.hpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <type_traits>
 
 namespace alpaka
@@ -31,24 +32,24 @@ namespace alpaka
             struct MetaData
             {
                 //! Unique id if the next data chunk.
-                uint32_t id = std::numeric_limits<uint32_t>::max();
+                std::uint32_t id = std::numeric_limits<std::uint32_t>::max();
                 //! Offset to the next meta data header, relative to m_mem.
                 //! To access the meta data header the offset must by aligned first.
-                uint32_t offset = 0;
+                std::uint32_t offset = 0;
             };
 
-            static constexpr uint32_t metaDataSize = sizeof(MetaData);
+            static constexpr std::uint32_t metaDataSize = sizeof(MetaData);
 
         public:
 #ifndef NDEBUG
-            BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t capacity)
+            BlockSharedMemStMemberImpl(std::uint8_t* mem, std::size_t capacity)
                 : m_mem(mem)
                 , m_capacity(static_cast<std::uint32_t>(capacity))
             {
                 ALPAKA_ASSERT_OFFLOAD((m_mem == nullptr) == (m_capacity == 0u));
             }
 #else
-            BlockSharedMemStMemberImpl(uint8_t* mem, std::size_t) : m_mem(mem)
+            BlockSharedMemStMemberImpl(std::uint8_t* mem, std::size_t) : m_mem(mem)
             {
             }
 #endif
@@ -59,7 +60,7 @@ namespace alpaka
             /*virtual*/ ~BlockSharedMemStMemberImpl() = default;
 
             template<typename T>
-            void alloc(uint32_t id) const
+            void alloc(std::uint32_t id) const
             {
                 // Add meta data chunk in front of the user data
                 m_allocdBytes = varChunkEnd<MetaData>(m_allocdBytes);
@@ -87,19 +88,19 @@ namespace alpaka
             //! @param id unique id of the variable
             //! @return nullptr if variable with id not exists
             template<typename T>
-            T* getVarPtr(uint32_t id) const
+            T* getVarPtr(std::uint32_t id) const
             {
                 // Offset in bytes to the next unaligned meta data header behind the variable.
-                uint32_t off = 0;
+                std::uint32_t off = 0;
 
                 // Iterate over allocated data only
                 while(off < m_allocdBytes)
                 {
                     // Adjust offset to be aligned
-                    uint32_t const alignedMetaDataOffset
-                        = varChunkEnd<MetaData>(off) - static_cast<uint32_t>(sizeof(MetaData));
+                    std::uint32_t const alignedMetaDataOffset
+                        = varChunkEnd<MetaData>(off) - static_cast<std::uint32_t>(sizeof(MetaData));
                     ALPAKA_ASSERT_OFFLOAD(
-                        (alignedMetaDataOffset + static_cast<uint32_t>(sizeof(MetaData))) <= m_allocdBytes);
+                        (alignedMetaDataOffset + static_cast<std::uint32_t>(sizeof(MetaData))) <= m_allocdBytes);
                     MetaData* metaDataPtr = reinterpret_cast<MetaData*>(m_mem + alignedMetaDataOffset);
                     off = metaDataPtr->offset;
 
@@ -133,12 +134,12 @@ namespace alpaka
             //! \param byteOffset Current byte offset.
             //! \result Byte offset to the end of the data chunk, relative to m_mem..
             template<typename T>
-            std::uint32_t varChunkEnd(uint32_t byteOffset) const
+            std::uint32_t varChunkEnd(std::uint32_t byteOffset) const
             {
-                size_t const ptr = reinterpret_cast<size_t>(m_mem + byteOffset);
+                std::size_t const ptr = reinterpret_cast<std::size_t>(m_mem + byteOffset);
                 constexpr size_t align = std::max(TMinDataAlignBytes, alignof(T));
-                size_t const newPtrAdress = ((ptr + align - 1u) / align) * align + sizeof(T);
-                return static_cast<uint32_t>(newPtrAdress - reinterpret_cast<size_t>(m_mem));
+                std::size_t const newPtrAdress = ((ptr + align - 1u) / align) * align + sizeof(T);
+                return static_cast<uint32_t>(newPtrAdress - reinterpret_cast<std::size_t>(m_mem));
             }
 
             //! Offset in bytes relative to m_mem to next free data area.
@@ -148,7 +149,7 @@ namespace alpaka
             //! Memory layout
             //! |Header|Padding|Variable|Padding|Header|....uninitialized Data ....
             //! Size of padding can be zero if data after padding is already aligned.
-            uint8_t* const m_mem;
+            std::uint8_t* const m_mem;
 #ifndef NDEBUG
             const std::uint32_t m_capacity;
 #endif

--- a/include/alpaka/kernel/TaskKernelOacc.hpp
+++ b/include/alpaka/kernel/TaskKernelOacc.hpp
@@ -114,8 +114,13 @@ namespace alpaka
             auto argsD = m_args;
             auto kernelFnObj = m_kernelFnObj;
             dev.makeCurrent();
-#    pragma acc parallel num_workers(blockThreadCount)                                                                \
-        copyin(threadElemExtent, blockThreadExtent, argsD, gridBlockExtent) default(present)
+#    pragma acc parallel num_workers(blockThreadCount) copyin(                                                        \
+        threadElemExtent,                                                                                             \
+        blockThreadExtent,                                                                                            \
+        gridBlockExtent,                                                                                              \
+        argsD,                                                                                                        \
+        blockSharedMemDynSizeBytes,                                                                                   \
+        kernelFnObj) default(present)
             {
                 {
 #    pragma acc loop gang

--- a/test/unit/warp/src/Activemask.cpp
+++ b/test/unit/warp/src/Activemask.cpp
@@ -14,6 +14,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <climits>
 #include <cstdint>
 
 class ActivemaskSingleThreadWarpTestKernel
@@ -51,7 +52,9 @@ public:
 
         auto const actual = alpaka::warp::activemask(acc);
         using Result = decltype(actual);
-        Result const allActive = (Result{1} << static_cast<Result>(warpExtent)) - 1;
+        Result const allActive = static_cast<size_t>(warpExtent) == sizeof(Result) * CHAR_BIT
+            ? ~Result{0u}
+            : (Result{1} << warpExtent) - 1u;
         Result const expected = allActive & ~(Result{1} << inactiveThreadIdx);
         ALPAKA_CHECK(*success, actual == expected);
     }

--- a/test/unit/warp/src/Ballot.cpp
+++ b/test/unit/warp/src/Ballot.cpp
@@ -14,6 +14,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <climits>
 #include <cstdint>
 
 class BallotSingleThreadWarpTestKernel
@@ -41,7 +42,11 @@ public:
         std::int32_t const warpExtent = alpaka::warp::getSize(acc);
         ALPAKA_CHECK(*success, warpExtent > 1);
 
-        ALPAKA_CHECK(*success, alpaka::warp::ballot(acc, 42) == (std::uint64_t{1} << warpExtent) - 1);
+        using BallotResultType = decltype(alpaka::warp::ballot(acc, 42));
+        BallotResultType const allActive = static_cast<size_t>(warpExtent) == sizeof(BallotResultType) * CHAR_BIT
+            ? ~BallotResultType{0u}
+            : (BallotResultType{1} << warpExtent) - 1u;
+        ALPAKA_CHECK(*success, alpaka::warp::ballot(acc, 42) == allActive);
         ALPAKA_CHECK(*success, alpaka::warp::ballot(acc, 0) == 0u);
 
         // Test relies on having a single warp per thread block


### PR DESCRIPTION
This backports some commits from `develop` to 0.7.0 that are already present in 0.6.1. Please notify me if you think commits are missing and need to be added to this list.

- fix HIP compiler options not recognized #1324 
- Add missing <limits> header and fix integer namespace #1327
- CI: fix warp test #1339
- Fix outdated comments in the OpenMP schedule example #1341
- TaskKernelOacc: copyin(all used local vars) #1342 