### PR TITLE
Fixed travis_retry.sh license header

### DIFF
--- a/script/travis_retry.sh
+++ b/script/travis_retry.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
 #
-# Copyright 2019 Benjamin Worpitz, Rene Widera
+# MIT LICENSE
 #
-# This file is part of alpaka.
+# Copyright (c) 2018 Travis CI GmbH <contact+travis-build@travis-ci.org>
 #
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
 #
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ANSI_RED="\033[31m"
 ANSI_RESET="\033[0m"


### PR DESCRIPTION
Looks like the licence header has been changed by mistake

Original file: https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/travis_retry.bash