### PR TITLE
Fix bug, if alpaka_add_library() and Clang as CUDA compiler is used together

### DIFF
--- a/cmake/addLibrary.cmake
+++ b/cmake/addLibrary.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2019 Benjamin Worpitz, Maximilian Knespel
+# Copyright 2015-2021 Benjamin Worpitz, Maximilian Knespel, Simeon Ehrig
 #
 # This file is part of alpaka.
 #
@@ -94,10 +94,10 @@ MACRO(ALPAKA_ADD_LIBRARY libraryName)
             ENDFOREACH()
             ADD_LIBRARY(
                 ${libraryName}
-                ${sourceFileNames}
                 ${libraryType}
                 ${excludeFromAll}
                 ${optionArguments}
+                ${sourceFileNames}
             )
         ELSE()
             FOREACH( _file ${ARGN} )


### PR DESCRIPTION
I tested the code with the modernized cmake for cupla: https://github.com/alpaka-group/cupla/pull/203
It uses alpaka_add_library, if the examples are build.

It's related to the issue #1359