### PR TITLE
fix `alpaka_add_(executable|library)`

### DIFF
--- a/cmake/addExecutable.cmake
+++ b/cmake/addExecutable.cmake
@@ -16,6 +16,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.18)
 # https://github.com/ROCm-Developer-Tools/HIP/issues/631
 MACRO(ALPAKA_ADD_EXECUTABLE In_Name)
     IF(ALPAKA_ACC_GPU_CUDA_ENABLE)
+        ENABLE_LANGUAGE(CUDA)
         FOREACH(_file ${ARGN})
             IF((${_file} MATCHES "\\.cpp$") OR (${_file} MATCHES "\\.cxx$") OR (${_file} MATCHES "\\.cu$"))
                 SET_SOURCE_FILES_PROPERTIES(${_file} PROPERTIES LANGUAGE CUDA)

--- a/cmake/addLibrary.cmake
+++ b/cmake/addLibrary.cmake
@@ -83,12 +83,13 @@ MACRO(ALPAKA_ADD_LIBRARY libraryName)
 
     # call add_library or cuda_add_library now
     IF( ALPAKA_ACC_GPU_CUDA_ENABLE )
+        ENABLE_LANGUAGE(CUDA)
         FOREACH( _file ${ARGN} )
             IF( ( ${_file} MATCHES "\\.cpp$" ) OR
                 ( ${_file} MATCHES "\\.cxx$" ) OR
                 ( ${_file} MATCHES "\\.cu$" )
             )
-                SET_SOURCE_FILES_PROPERTIES(${_file} LANGUAGE CUDA)
+                SET_SOURCE_FILES_PROPERTIES(${_file} PROPERTIES LANGUAGE CUDA)
             ENDIF()
         ENDFOREACH()
 


### PR DESCRIPTION
- activate language `CUDA` if CUDA back-end is enabled
- fix missing argument in `SET_SOURCE_FILES_PROPERTIES`


This PR fix https://github.com/alpaka-group/cupla/pull/203#issuecomment-889940738 due to the missing argument `PROPERTIES` files were not handled as CUDA files.
Additionally `alpaka_add_executable` and `alpaka_add_library` are macros and will be executed in users application scope, therefore the cmake language CUDA must be loaded else the compiler can not give the files to the correct compiler.

I will open a PR for the dev branch as soon as this is merged. There is no need to add this bug to the changelog because it is a bug introduced in 0.7.0 and not exists in 0.6.X.