### PR TITLE
CI: update ROCm apt package keys

### DIFF
--- a/script/install_hip.sh
+++ b/script/install_hip.sh
@@ -16,6 +16,12 @@ source ./script/set.sh
 
 : "${ALPAKA_CI_HIP_ROOT_DIR?'ALPAKA_CI_HIP_ROOT_DIR must be specified'}"
 
+travis_retry apt-get -y --quiet update
+travis_retry apt-get -y --quiet wget gnupg2
+# AMD container keys are outdated and must be updated
+wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+travis_retry apt-get -y --quiet update
+
 # AMD container are not shipped with rocrand/hiprand
 travis_retry sudo apt-get -y --quiet install rocrand
 


### PR DESCRIPTION
The keys for ROCm apt repositories are outdated and must be updated to be able to install additional ROCm dependencies.


This PR is equal to #1372 but against the dev branch!