### PR TITLE
fix `alpaka_add_(executable|library)`

### DIFF
--- a/cmake/addExecutable.cmake
+++ b/cmake/addExecutable.cmake
@@ -16,6 +16,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.18)
 # https://github.com/ROCm-Developer-Tools/HIP/issues/631
 MACRO(ALPAKA_ADD_EXECUTABLE In_Name)
     IF(ALPAKA_ACC_GPU_CUDA_ENABLE)
+        ENABLE_LANGUAGE(CUDA)
         FOREACH(_file ${ARGN})
             IF((${_file} MATCHES "\\.cpp$") OR (${_file} MATCHES "\\.cxx$") OR (${_file} MATCHES "\\.cu$"))
                 SET_SOURCE_FILES_PROPERTIES(${_file} PROPERTIES LANGUAGE CUDA)

--- a/cmake/addLibrary.cmake
+++ b/cmake/addLibrary.cmake
@@ -83,12 +83,13 @@ MACRO(ALPAKA_ADD_LIBRARY libraryName)
 
     # call add_library or cuda_add_library now
     IF( ALPAKA_ACC_GPU_CUDA_ENABLE )
+        ENABLE_LANGUAGE(CUDA)
         FOREACH( _file ${ARGN} )
             IF( ( ${_file} MATCHES "\\.cpp$" ) OR
                 ( ${_file} MATCHES "\\.cxx$" ) OR
                 ( ${_file} MATCHES "\\.cu$" )
             )
-                SET_SOURCE_FILES_PROPERTIES(${_file} LANGUAGE CUDA)
+                SET_SOURCE_FILES_PROPERTIES(${_file} PROPERTIES LANGUAGE CUDA)
             ENDIF()
         ENDFOREACH()
 


### PR DESCRIPTION
- activate language `CUDA` if CUDA back-end is enabled
- fix missing argument in `SET_SOURCE_FILES_PROPERTIES`


This PR is equivalent to #1364 we pushed already into 0.7.0.