### PR TITLE
fix ROCm install

### DIFF
--- a/script/install_hip.sh
+++ b/script/install_hip.sh
@@ -17,7 +17,7 @@ source ./script/set.sh
 : "${ALPAKA_CI_HIP_ROOT_DIR?'ALPAKA_CI_HIP_ROOT_DIR must be specified'}"
 
 travis_retry apt-get -y --quiet update
-travis_retry apt-get -y --quiet wget gnupg2
+travis_retry apt-get -y --quiet install wget gnupg2
 # AMD container keys are outdated and must be updated
 wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
 travis_retry apt-get -y --quiet update


### PR DESCRIPTION
Bug was instroduced with #1373.

This bug exists in alpaka 0.6.1 and 0.7.0 too, luckily it is not triggering a CI error.