### PR TITLE
fix `ALPAKA_STATIC_ACC_MEM_CONSTANT` memory

### DIFF
--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -76,6 +76,20 @@
 //! In contrast to ordinary variables, you can not define such variables
 //! as static compilation unit local variables with internal linkage
 //! because this is forbidden by CUDA.
+//!
+//! \attention It is not allowed to initialize the variable together with the declaration.
+//!            To initialize the variable alpaka::createStaticDevMemView and alpaka::memcpy must be used.
+//! \code{.cpp}
+//! ALPAKA_STATIC_ACC_MEM_GLOBAL int foo;
+//!
+//! void initFoo() {
+//!     auto extent = alpaka::Vec<alpaka::DimInt<1u>, size_t>{1};
+//!     auto viewFoo = alpaka::createStaticDevMemView(&foo, device, extent);
+//!     int initialValue = 42;
+//!     alpaka::ViewPlainPtr<DevHost, int, alpaka::DimInt<1u>, size_t> bufHost(&initialValue, devHost, extent);
+//!     alpaka::memcpy(queue, viewGlobalMemUninitialized, bufHost, extent);
+//! }
+//! \endcode
 #if((BOOST_LANG_CUDA && BOOST_COMP_CLANG) || (BOOST_LANG_CUDA && BOOST_COMP_NVCC && BOOST_ARCH_PTX) || BOOST_LANG_HIP)
 #    define ALPAKA_STATIC_ACC_MEM_GLOBAL __device__
 #else
@@ -97,6 +111,20 @@
 //! In contrast to ordinary variables, you can not define such variables
 //! as static compilation unit local variables with internal linkage
 //! because this is forbidden by CUDA.
+//!
+//! \attention It is not allowed to initialize the variable together with the declaration.
+//!            To initialize the variable alpaka::createStaticDevMemView and alpaka::memcpy must be used.
+//! \code{.cpp}
+//! ALPAKA_STATIC_ACC_MEM_CONSTANT int foo;
+//!
+//! void initFoo() {
+//!     auto extent = alpaka::Vec<alpaka::DimInt<1u>, size_t>{1};
+//!     auto viewFoo = alpaka::createStaticDevMemView(&foo, device, extent);
+//!     int initialValue = 42;
+//!     alpaka::ViewPlainPtr<DevHost, int, alpaka::DimInt<1u>, size_t> bufHost(&initialValue, devHost, extent);
+//!     alpaka::memcpy(queue, viewGlobalMemUninitialized, bufHost, extent);
+//! }
+//! \endcode
 #if((BOOST_LANG_CUDA && BOOST_COMP_CLANG) || (BOOST_LANG_CUDA && BOOST_COMP_NVCC && BOOST_ARCH_PTX) || BOOST_LANG_HIP)
 #    define ALPAKA_STATIC_ACC_MEM_CONSTANT __constant__
 #else

--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -76,7 +76,7 @@
 //! In contrast to ordinary variables, you can not define such variables
 //! as static compilation unit local variables with internal linkage
 //! because this is forbidden by CUDA.
-#if(BOOST_LANG_CUDA && BOOST_ARCH_PTX) || (BOOST_LANG_HIP && (BOOST_ARCH_HSA || BOOST_ARCH_PTX))
+#if((BOOST_LANG_CUDA && BOOST_COMP_CLANG) || (BOOST_LANG_CUDA && BOOST_COMP_NVCC && BOOST_ARCH_PTX) || BOOST_LANG_HIP)
 #    define ALPAKA_STATIC_ACC_MEM_GLOBAL __device__
 #else
 #    define ALPAKA_STATIC_ACC_MEM_GLOBAL
@@ -97,7 +97,7 @@
 //! In contrast to ordinary variables, you can not define such variables
 //! as static compilation unit local variables with internal linkage
 //! because this is forbidden by CUDA.
-#if(BOOST_LANG_CUDA && BOOST_ARCH_PTX) || (BOOST_LANG_HIP && (BOOST_ARCH_HSA || BOOST_ARCH_PTX))
+#if((BOOST_LANG_CUDA && BOOST_COMP_CLANG) || (BOOST_LANG_CUDA && BOOST_COMP_NVCC && BOOST_ARCH_PTX) || BOOST_LANG_HIP)
 #    define ALPAKA_STATIC_ACC_MEM_CONSTANT __constant__
 #else
 #    define ALPAKA_STATIC_ACC_MEM_CONSTANT

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -189,19 +189,9 @@ namespace alpaka
             static auto createStaticDevMemView(TElem* pMem, DevUniformCudaHipRt const& dev, TExtent const& extent)
             {
                 TElem* pMemAcc(nullptr);
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaGetSymbolAddress(reinterpret_cast<void**>(&pMemAcc), *pMem));
-#    else
-#        ifdef __HIP_PLATFORM_NVCC__
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    hipCUDAErrorTohipError(cudaGetSymbolAddress(reinterpret_cast<void**>(&pMemAcc), *pMem)));
-#        else
-                // FIXME: still does not work in HIP(clang) (results in hipErrorNotFound)
-                // HIP_SYMBOL(X) not useful because it only does #X on HIP(clang), while &X on HIP(NVCC)
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipGetSymbolAddress(reinterpret_cast<void**>(&pMemAcc), pMem));
-#        endif
-#    endif
+                    ALPAKA_API_PREFIX(GetSymbolAddress)(reinterpret_cast<void**>(&pMemAcc), *pMem));
+
                 return alpaka::ViewPlainPtr<DevUniformCudaHipRt, TElem, alpaka::Dim<TExtent>, alpaka::Idx<TExtent>>(
                     pMemAcc,
                     dev,

--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -24,11 +24,7 @@ using Idx = std::uint32_t;
 // from a different compilation unit and should be moved to a common header.
 // Here they are used to silence clang`s -Wmissing-variable-declarations warning
 // that forces every non-static variable to be declared with extern before the are defined.
-extern ALPAKA_STATIC_ACC_MEM_CONSTANT Elem g_constantMemory2DInitialized[3][2];
 extern ALPAKA_STATIC_ACC_MEM_CONSTANT Elem g_constantMemory2DUninitialized[3][2];
-
-ALPAKA_STATIC_ACC_MEM_CONSTANT Elem g_constantMemory2DInitialized[3][2] = {{0u, 1u}, {2u, 3u}, {4u, 5u}};
-
 ALPAKA_STATIC_ACC_MEM_CONSTANT Elem g_constantMemory2DUninitialized[3][2];
 
 //! Uses static device memory on the accelerator defined globally for the whole compilation unit.
@@ -52,8 +48,6 @@ using TestAccs = alpaka::test::EnabledAccs<Dim, Idx>;
 
 TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAccs)
 {
-// FIXME: static device memory in HIP is still not working
-#if !BOOST_COMP_HIP
     using Acc = TestType;
     using DevAcc = alpaka::Dev<Acc>;
     using PltfAcc = alpaka::Pltf<DevAcc>;
@@ -65,13 +59,6 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAc
 
     StaticDeviceMemoryTestKernel kernel;
 
-    // initialized static constant device memory
-    {
-        auto const viewConstantMemInitialized
-            = alpaka::createStaticDevMemView(&g_constantMemory2DInitialized[0u][0u], devAcc, extent);
-
-        REQUIRE(fixture(kernel, alpaka::getPtrNative(viewConstantMemInitialized)));
-    }
     // uninitialized static constant device memory
     {
         using PltfHost = alpaka::PltfCpu;
@@ -91,24 +78,17 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAc
 
         REQUIRE(fixture(kernel, alpaka::getPtrNative(viewConstantMemUninitialized)));
     }
-#endif
 }
 
 // These forward declarations are only necessary when you want to access those variables
 // from a different compilation unit and should be moved to a common header.
 // Here they are used to silence clang`s -Wmissing-variable-declarations warning
 // that forces every non-static variable to be declared with extern before the are defined.
-extern ALPAKA_STATIC_ACC_MEM_GLOBAL Elem g_globalMemory2DInitialized[3][2];
 extern ALPAKA_STATIC_ACC_MEM_GLOBAL Elem g_globalMemory2DUninitialized[3][2];
-
-ALPAKA_STATIC_ACC_MEM_GLOBAL Elem g_globalMemory2DInitialized[3][2] = {{0u, 1u}, {2u, 3u}, {4u, 5u}};
-
 ALPAKA_STATIC_ACC_MEM_GLOBAL Elem g_globalMemory2DUninitialized[3][2];
 
 TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryConstant", "[viewStaticAccMem]", TestAccs)
 {
-// FIXME: static device memory in HIP is still not working
-#if !BOOST_COMP_HIP
     using Acc = TestType;
     using DevAcc = alpaka::Dev<Acc>;
     using PltfAcc = alpaka::Pltf<DevAcc>;
@@ -119,14 +99,6 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryConstant", "[viewStaticAccMem]", Test
     alpaka::test::KernelExecutionFixture<Acc> fixture(extent);
 
     StaticDeviceMemoryTestKernel kernel;
-
-    // initialized static global device memory
-    {
-        auto const viewGlobalMemInitialized
-            = alpaka::createStaticDevMemView(&g_globalMemory2DInitialized[0u][0u], devAcc, extent);
-
-        REQUIRE(fixture(kernel, alpaka::getPtrNative(viewGlobalMemInitialized)));
-    }
 
     // uninitialized static global device memory
     {
@@ -147,5 +119,4 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryConstant", "[viewStaticAccMem]", Test
 
         REQUIRE(fixture(kernel, alpaka::getPtrNative(viewGlobalMemUninitialized)));
     }
-#endif
 }


### PR DESCRIPTION
- Usage of `ALPAKA_STATIC_ACC_MEM_CONSTANT` and `ALPAKA_STATIC_ACC_MEM_GLOBAL`  was broken for clang CUDA and HIP
- HIP: fix `hipGetSymbolAddress` interface was wrongly used
- remove tests for direct initialization
- update documentation

# Usage of both memory types changed!!
Remove the possibility to initialize both types of memory during the definition. (more information)[https://github.com/alpaka-group/alpaka/pull/1386#issuecomment-896962596)

Co-authored-by: Simeon Ehrig <s.ehrig@hzdr.de>
