### PR TITLE
Add third_party STLTuple, use in TaskKernel{Oacc,Omp5}

### DIFF
--- a/include/alpaka/core/STLTuple/LICENSE.txt
+++ b/include/alpaka/core/STLTuple/LICENSE.txt
@@ -1,0 +1,33 @@
+/* Copyright 2016 Codeplay Software Ltd.
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+   Copyright 2016 Codeplay Software Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use these files except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   For your convenience, a copy of the License has been included in this
+   repository.
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   The files samples/gaussian_blur/stb_image.h and stb_image_write.h are
+   in the Public Domain. Originally authored by Sean Barrett.
+   https://github.com/nothings/stb
+
+   The file samples/smart_pointer/stack_allocator.hpp is (c) Charles Salvia
+   and is available under the MIT License.
+   https://github.com/charles-salvia/charles
+

--- a/include/alpaka/core/STLTuple/STLTuple.hpp
+++ b/include/alpaka/core/STLTuple/STLTuple.hpp
@@ -1,0 +1,302 @@
+/***************************************************************************
+ *
+ *  Copyright (C) 2018 Codeplay Software Limited
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  For your convenience, a copy of the License has been included in this
+ *  repository.
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * STLTuple.h
+ *
+ * \brief:
+ *  Minimal implementation of std::tuple that is standard layout.
+ *
+  Authors:
+ *
+ *    Mehdi Goli    Codeplay Software Ltd.
+ *    Ralph Potter  Codeplay Software Ltd.
+ *    Luke Iwanski  Codeplay Software Ltd.
+ *
+ **************************************************************************/
+
+// clang-format off
+#pragma once
+
+#include <alpaka/core/BoostPredef.hpp>
+
+// suppress warnings as this is third-party code
+#if BOOST_COMP_CLANG
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wdocumentation"
+#   pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#endif
+#if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
+#    pragma warning(push)
+#    pragma warning(disable : 4003) // not enough arguments for function-like macro invocation
+#endif
+
+namespace utility {
+namespace tuple {
+/// \struct StaticIf
+/// \brief The StaticIf struct is used to statically choose the type based on
+/// the condition.
+template <bool, typename T = void>
+struct StaticIf;
+/// \brief specialisation of the \ref StaticIf when the condition is true
+template <typename T>
+struct StaticIf<true, T> {
+  typedef T type;
+};
+
+/// \struct Tuple
+/// \brief is a fixed-size collection of heterogeneous values
+/// \ztparam Ts...	-	the types of the elements that the tuple stores.
+/// Empty list is supported.
+template <class... Ts>
+struct Tuple {};
+
+/// \brief specialisation of the \ref Tuple class when the tuple has at least
+/// one element.
+/// \tparam T : the type of the first element in the tuple.
+/// \tparam Ts... the rest of the elements in the tuple. Ts... can be empty.
+template <class T, class... Ts>
+struct Tuple<T, Ts...> {
+  Tuple(T t, Ts... ts) : head(t), tail(ts...) {}
+  T head;
+  Tuple<Ts...> tail;
+};
+
+template <typename, typename>
+struct concat_tuple {};
+
+template <typename... Ts, typename... Us>
+struct concat_tuple<Tuple<Ts...>, Tuple<Us...>> {
+  using type = Tuple<Ts..., Us...>;
+};
+
+template <typename T>
+struct remove_last_type;
+
+template <typename T>
+struct remove_last_type<Tuple<T>> {
+  using type = Tuple<>;
+};
+
+template <typename T, typename... Args>
+struct remove_last_type<Tuple<T, Args...>> {
+  using type = typename concat_tuple<
+      Tuple<T>, typename remove_last_type<Tuple<Args...>>::type>::type;
+};
+
+template <typename T>
+struct remove_first_type {};
+
+template <typename T, typename... Ts>
+struct remove_first_type<Tuple<T, Ts...>> {
+  typedef Tuple<Ts...> type;
+};
+
+///\ struct ElemTypeHolder
+/// \brief ElemTypeHolder class is used to specify the types of the
+/// elements inside the tuple
+/// \tparam size_t the number of elements inside the tuple
+/// \tparam class the tuple class
+template <size_t, class>
+struct ElemTypeHolder;
+
+/// \brief specialisation of the \ref ElemTypeHolder class when the number of
+/// elements inside the tuple is 1
+template <class T, class... Ts>
+struct ElemTypeHolder<0, Tuple<T, Ts...>> {
+  typedef T type;
+};
+
+/// \brief specialisation of the \ref ElemTypeHolder class when the number of
+/// elements inside the tuple is bigger than 1. It recursively calls itself to
+/// detect the type of each element in the tuple
+/// \tparam T : the type of the first element in the tuple.
+/// \tparam Ts... the rest of the elements in the tuple. Ts... can be empty.
+/// \tparam K is the Kth element in the tuple
+template <size_t k, class T, class... Ts>
+struct ElemTypeHolder<k, Tuple<T, Ts...>> {
+  typedef typename ElemTypeHolder<k - 1, Tuple<Ts...>>::type type;
+};
+
+/// get
+/// \brief Extracts the first element from the tuple.
+/// K=0 represents the first element of the tuple. The tuple cannot be empty.
+/// \tparam Ts... are the type of the elements in the tuple.
+/// \param t is the tuple whose contents to extract
+/// \return  typename ElemTypeHolder<0, Tuple<Ts...> >::type &>::type
+
+#define TERMINATE_CONDS_TUPLE_GET(CVQual)                                      \
+  template <size_t k, class... Ts>                                             \
+  typename StaticIf<k == 0, CVQual                                             \
+                    typename ElemTypeHolder<0, Tuple<Ts...>>::type&>::type     \
+  get(CVQual Tuple<Ts...>& t) {                                                \
+    static_assert(sizeof...(Ts) != 0,                                          \
+                  "The requseted value is bigger than the size of the tuple"); \
+    return t.head;                                                             \
+  }
+
+TERMINATE_CONDS_TUPLE_GET(const)
+TERMINATE_CONDS_TUPLE_GET()
+#undef TERMINATE_CONDS_TUPLE_GET
+/// get
+/// \brief Extracts the Kth element from the tuple.
+///\tparam K is an integer value in [0,sizeof...(Types)).
+/// \tparam T is the (sizeof...(Types) -(K+1)) element in the tuple
+/// \tparam Ts... are the type of the elements  in the tuple.
+/// \param t is the tuple whose contents to extract
+/// \return  typename ElemTypeHolder<K, Tuple<Ts...> >::type &>::type
+#define RECURSIVE_TUPLE_GET(CVQual)                                           \
+  template <size_t k, class T, class... Ts>                                   \
+  typename StaticIf<k != 0, CVQual                                            \
+                    typename ElemTypeHolder<k, Tuple<T, Ts...>>::type&>::type \
+  get(CVQual Tuple<T, Ts...>& t) {                                            \
+    return utility::tuple::get<k - 1>(t.tail);                                \
+  }
+RECURSIVE_TUPLE_GET(const)
+RECURSIVE_TUPLE_GET()
+#undef RECURSIVE_TUPLE_GET
+
+/// make_tuple
+/// \brief Creates a tuple object, deducing the target type from the types of
+/// arguments.
+/// \tparam Args the type of the arguments to construct the tuple from
+/// \param args zero or more arguments to construct the tuple from
+/// \return Tuple<Args...>
+template <typename... Args>
+Tuple<Args...> make_tuple(Args... args) {
+  return Tuple<Args...>(args...);
+}
+
+/// size
+/// \brief Provides access to the number of elements in a tuple as a
+/// compile-time constant expression.
+/// \tparam Args the type of the arguments to construct the tuple from
+/// \return size_t
+template <typename... Args>
+static constexpr size_t size(Tuple<Args...>&) {
+  return sizeof...(Args);
+}
+
+/// \struct IndexList
+/// \brief Creates a list of index from the elements in the tuple
+/// \tparam Is... a list of index from [0 to sizeof...(tuple elements))
+template <size_t... Is>
+struct IndexList {};
+
+/// \struct RangeBuilder
+/// \brief Collects internal details for generating index ranges [MIN, MAX)
+/// Declare primary template for index range builder
+/// \tparam MIN is the starting index in the tuple
+/// \tparam N represents sizeof..(elemens)- sizeof...(Is)
+/// \tparam Is... are the list of generated index so far
+template <size_t MIN, size_t N, size_t... Is>
+struct RangeBuilder;
+
+/// \brief base Step: Specialisation of the \ref RangeBuilder when the
+/// MIN==MAX. In this case the Is... is [0 to sizeof...(tuple elements))
+/// \tparam MIN is the starting index of the tuple
+/// \tparam Is is [0 to sizeof...(tuple elements))
+template <size_t MIN, size_t... Is>
+struct RangeBuilder<MIN, MIN, Is...> {
+  typedef IndexList<Is...> type;
+};
+
+/// Induction step: Specialisation of the RangeBuilder class when N!=MIN
+/// in this case we are recursively subtracting N by one and adding one
+/// index to Is... list until MIN==N
+/// \tparam MIN is the starting index in the tuple
+/// \tparam N represents sizeof..(elemens)- sizeof...(Is)
+/// \tparam Is... are the list of generated index so far
+template <size_t MIN, size_t N, size_t... Is>
+struct RangeBuilder : public RangeBuilder<MIN, N - 1, N - 1, Is...> {};
+
+/// \brief IndexRange that returns a [MIN, MAX) index range
+/// \tparam MIN is the starting index in the tuple
+/// \tparam MAX is the size of the tuple
+template <size_t MIN, size_t MAX>
+struct IndexRange : RangeBuilder<MIN, MAX>::type {};
+
+/// append_base
+/// \brief unpacking the elements of the input tuple t and creating a new tuple
+/// by adding element a at the end of it.
+///\tparam Args... the type of the elements inside the tuple t
+/// \tparam T the type of the new element going to be added at the end of tuple
+/// \tparam I... is the list of index from [0 to sizeof...(t))
+/// \param t the tuple on which we want to append a.
+/// \param a the new elements going to be added to the tuple
+/// \return Tuple<Args..., T>
+template <typename... Args, typename T, size_t... I>
+Tuple<Args..., T> append_base(Tuple<Args...> t, T a, IndexList<I...>) {
+  return utility::tuple::make_tuple(get<I>(t)..., a);
+}
+
+/// append
+/// \brief the deduction function for \ref append_base that automatically
+/// generate the \ref IndexRange
+///\tparam Args... the type of the elements inside the tuple t
+/// \tparam T the type of the new element going to be added at the end of tuple
+/// \param t the tuple on which we want to append a.
+/// \param a the new elements going to be added to the tuple
+/// \return Tuple<Args..., T>
+template <typename... Args, typename T>
+Tuple<Args..., T> append(Tuple<Args...> t, T a) {
+  return utility::tuple::append_base(t, a, IndexRange<0, sizeof...(Args)>());
+}
+
+/// append_base
+/// \brief This is a specialisation of \ref append_base when we want to
+/// concatenate
+/// tuple t2 at the end of the tuple t1. Here we unpack both tuples, generate
+/// the IndexRange for each of them and create an output tuple T that contains
+/// both elements of t1 and t2.
+///\tparam Args1... the type of the elements inside the tuple t1
+///\tparam Args2... the type of the elements inside the tuple t2
+/// \tparam I1... is the list of index from [0 to sizeof...(t1))
+/// \tparam I2... is the list of index from [0 to sizeof...(t2))
+/// \param t1 is the tuple on which we want to append t2.
+/// \param t2 is the tuple that is going to be added on t1.
+/// \return Tuple<Args1..., Args2...>
+template <typename... Args1, typename... Args2, size_t... I1, size_t... I2>
+Tuple<Args1..., Args2...> append_base(Tuple<Args1...> t1, Tuple<Args2...> t2,
+                                      IndexList<I1...>, IndexList<I2...>) {
+  return utility::tuple::make_tuple(get<I1>(t1)..., get<I2>(t2)...);
+}
+
+/// append
+/// \brief deduction function for \ref append_base when we are appending tuple
+/// t1 by tuple t2. In this case the \ref IndexRange for both tuple are
+/// automatically generated.
+///\tparam Args1... the type of the elements inside the tuple t1
+///\tparam Args2... the type of the elements inside the tuple t2
+/// \param t1 is the tuple on which we want to append t2.
+/// \param t2 is the tuple that is going to be added on t1.
+/// \return Tuple<Args1..., Args2...>
+template <typename... Args1, typename... Args2>
+Tuple<Args1..., Args2...> append(Tuple<Args1...> t1, Tuple<Args2...> t2) {
+  return utility::tuple::append_base(t1, t2, IndexRange<0, sizeof...(Args1)>(),
+                                     IndexRange<0, sizeof...(Args2)>());
+}
+
+}  // namespace tuple
+}  // namespace utility
+
+#if BOOST_COMP_CLANG
+#   pragma clang diagnostic pop
+#endif
+#if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
+#    pragma warning(pop)
+#endif

--- a/include/alpaka/core/Tuple.hpp
+++ b/include/alpaka/core/Tuple.hpp
@@ -1,0 +1,41 @@
+/* Copyright 2021 Jeffrey Kelling, Jan Stephan
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/STLTuple/STLTuple.hpp>
+
+#include <cstddef>
+#include <utility>
+
+namespace alpaka
+{
+    namespace core
+    {
+        using namespace ::utility::tuple;
+
+        namespace detail
+        {
+            template<typename TFunc, typename... TArgs, std::size_t... Is>
+            constexpr auto apply_impl(TFunc&& f, Tuple<TArgs...>&& t, std::index_sequence<Is...>)
+            {
+                return f(get<Is>(std::forward<Tuple<TArgs...>&&>(t))...);
+            }
+        } // namespace detail
+
+        template<typename TFunc, typename... TArgs>
+        constexpr auto apply(TFunc&& f, Tuple<TArgs...> t)
+        {
+            return detail::apply_impl(
+                std::forward<TFunc>(f),
+                std::forward<Tuple<TArgs...>&&>(t),
+                std::make_index_sequence<sizeof...(TArgs)>{});
+        }
+    } // namespace core
+} // namespace alpaka

--- a/include/alpaka/kernel/TaskKernelOacc.hpp
+++ b/include/alpaka/kernel/TaskKernelOacc.hpp
@@ -25,6 +25,7 @@
 // Implementation details.
 #    include <alpaka/acc/AccOacc.hpp>
 #    include <alpaka/core/Decay.hpp>
+#    include <alpaka/core/Tuple.hpp>
 #    include <alpaka/ctx/block/CtxBlockOacc.hpp>
 #    include <alpaka/dev/DevOacc.hpp>
 #    include <alpaka/idx/MapIdx.hpp>
@@ -35,7 +36,6 @@
 #    include <algorithm>
 #    include <functional>
 #    include <stdexcept>
-#    include <tuple>
 #    include <type_traits>
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
 #        include <iostream>
@@ -83,7 +83,7 @@ namespace alpaka
 #    endif
 
             // Get the size of the block shared dynamic memory.
-            auto const blockSharedMemDynSizeBytes = meta::apply(
+            auto const blockSharedMemDynSizeBytes = core::apply(
                 [&](ALPAKA_DECAY_T(TArgs) const&... args) {
                     return getBlockSharedMemDynSizeBytes<AccOacc<TDim, TIdx>>(
                         m_kernelFnObj,
@@ -154,7 +154,7 @@ namespace alpaka
                         {
                             AccOacc<TDim, TIdx> acc(w, blockShared);
 
-                            meta::apply(
+                            core::apply(
                                 [kernelFnObj, &acc](typename std::decay<TArgs>::type const&... args) {
                                     kernelFnObj(acc, args...);
                                 },
@@ -168,7 +168,7 @@ namespace alpaka
 
     private:
         TKernelFnObj m_kernelFnObj;
-        std::tuple<std::decay_t<TArgs>...> m_args;
+        core::Tuple<std::decay_t<TArgs>...> m_args;
     };
 
     namespace traits

--- a/include/alpaka/kernel/TaskKernelOmp5.hpp
+++ b/include/alpaka/kernel/TaskKernelOmp5.hpp
@@ -25,10 +25,10 @@
 // Implementation details.
 #    include <alpaka/acc/AccOmp5.hpp>
 #    include <alpaka/core/Decay.hpp>
+#    include <alpaka/core/Tuple.hpp>
 #    include <alpaka/dev/DevOmp5.hpp>
 #    include <alpaka/idx/MapIdx.hpp>
 #    include <alpaka/kernel/Traits.hpp>
-#    include <alpaka/meta/ApplyTuple.hpp>
 #    include <alpaka/workdiv/WorkDivMembers.hpp>
 
 #    include <omp.h>
@@ -36,8 +36,8 @@
 #    include <algorithm>
 #    include <functional>
 #    include <stdexcept>
-#    include <tuple>
 #    include <type_traits>
+
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
 #        include <iostream>
 #    endif
@@ -84,7 +84,7 @@ namespace alpaka
 #    endif
 
             // Get the size of the block shared dynamic memory.
-            auto const blockSharedMemDynSizeBytes = meta::apply(
+            auto const blockSharedMemDynSizeBytes = core::apply(
                 [&](ALPAKA_DECAY_T(TArgs) const&... args) {
                     return getBlockSharedMemDynSizeBytes<AccOmp5<TDim, TIdx>>(
                         m_kernelFnObj,
@@ -184,7 +184,7 @@ namespace alpaka
                             }
                         }
 #    endif
-                        meta::apply(
+                        core::apply(
                             [kernelFnObj, &acc](typename std::decay<TArgs>::type const&... args) {
                                 kernelFnObj(acc, args...);
                             },
@@ -203,7 +203,7 @@ namespace alpaka
 
     private:
         TKernelFnObj m_kernelFnObj;
-        std::tuple<std::decay_t<TArgs>...> m_args;
+        core::Tuple<std::decay_t<TArgs>...> m_args;
     };
     namespace traits
     {


### PR DESCRIPTION
This PR uses a `tuple` [implementation](https://github.com/codeplaysoftware/computecpp-sdk/blob/master/include/stl-tuple/STLTuple.hpp) which `is_trivially_copyable` if all component types are [suggested](https://github.com/alpaka-group/alpaka/issues/1381#issuecomment-895853621) by @j-stephan , thereby removing the clang warning about `std::tuple<of, anything>` not being trivially copyable and thus potentially not save to map to target.

1. The included library is included in `third_party`, so that the include directory can be added as `SYSTEM` to portably silence warning immanating fro this file. The file is currently not installed, so currently an installed alpaka would not work. I need directions on how this should be handled:
   * installing a third-party library outside of `include/alpaka` would be problematic, because this could break other installations of that third-party lib in the same prefix.
   * installing the file in `alpaka/include` would change its path between build and install, breaking includes (except if cmake `configure(FILE...)` is used)
   * placing it directly inside `include/alpaka` in this source tree would make it impossible to use `target_include_directories( ... SYSTEM ... )` on it to silence warnings with all compilers, which would make it necessary to change the file.
2. [include/alpaka/core/Tuple.hpp](https://github.com/jkelling/alpaka/blob/14cf2d69e39a06da63959c8d5fee95a59fd24d8f/include/alpaka/core/Tuple.hpp) is added to provide an `apply` implementation working for this `Tuple` type (taken from #789). While it is located inside `include/alpaka` (and uses alpaka style) it currently adds to the namespaces from `STLTuple`, because it logcally extents it. To resolve this inconsistency some policy decisions must be taken first:
   1. Point 1. above.
   2. It is located in `core/` because `Tuple` is provided through it. It would belong int `meta/` instead of `core/` as it only adding `apply()` if `STLTuple` were to be moved into the `include/alpaka` tree.
   3. In `meta/` it would somewhat collide with the existing `ApplyTuple.hpp`.
   4. It could make `ApplyTuple.hpp` if `STLTuple` were to be used exclusively internally instead of `std::tuple`. Is this possible and desirable?

This is note marked as draft, because it is done as far as I know how to do it at the moment and needs discussion.

closes #1381