### PR TITLE
Implement `createStaticDevMemView` for `DevOmp5` and `DevOacc`

### DIFF
--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -51,6 +51,7 @@ namespace alpaka
                     , m_iDevice(iDevice)
                     , m_gridsLock(reinterpret_cast<std::uint32_t*>(acc_malloc(2 * sizeof(std::uint32_t))))
                 {
+                    makeCurrent();
                     const auto gridsLock = m_gridsLock;
 #    pragma acc parallel loop vector default(present) deviceptr(gridsLock)
                     for(std::size_t a = 0; a < 2; ++a)
@@ -105,6 +106,14 @@ namespace alpaka
                     return m_deviceType;
                 }
 
+                void makeCurrent() const
+                {
+#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                    std::cout << "acc_set_device_num( " << iDevice() << ", [type] )" << std::endl;
+#    endif
+                    acc_set_device_num(iDevice(), deviceType());
+                }
+
                 std::uint32_t* gridsLock() const
                 {
                     return m_gridsLock;
@@ -155,10 +164,7 @@ namespace alpaka
         }
         void makeCurrent() const
         {
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-            std::cout << "acc_set_device_num( " << m_spDevOaccImpl->iDevice() << ", [type] )" << std::endl;
-#    endif
-            acc_set_device_num(m_spDevOaccImpl->iDevice(), m_spDevOaccImpl->deviceType());
+            m_spDevOaccImpl->makeCurrent();
         }
 
         std::uint32_t* gridsLock() const

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -26,6 +26,10 @@
 #    include <alpaka/queue/cpu/IGenericThreadsQueue.hpp>
 #    include <alpaka/wait/Traits.hpp>
 
+#    include <map>
+#    include <sstream>
+#    include <stdexcept>
+
 namespace alpaka
 {
     class DevOmp5;
@@ -51,7 +55,11 @@ namespace alpaka
                 DevOmp5Impl(DevOmp5Impl&&) = delete;
                 auto operator=(DevOmp5Impl const&) -> DevOmp5Impl& = delete;
                 auto operator=(DevOmp5Impl&&) -> DevOmp5Impl& = delete;
-                ~DevOmp5Impl() = default;
+                ~DevOmp5Impl()
+                {
+                    for(auto& a : m_staticMemMap)
+                        omp_target_free(a.second.first, iDevice());
+                }
 
                 ALPAKA_FN_HOST auto getAllExistingQueues() const
                     -> std::vector<std::shared_ptr<IGenericThreadsQueue<DevOmp5>>>
@@ -92,10 +100,42 @@ namespace alpaka
                     return m_iDevice;
                 }
 
+                //! Create and/or return staticlly mapped device pointer of host address.
+                template<typename TElem, typename TExtent>
+                ALPAKA_FN_HOST auto mapStatic(TElem* pHost, TExtent const& extent) -> TElem*
+                {
+                    const std::size_t sizeB = extent.prod() * sizeof(TElem);
+                    auto m = m_staticMemMap.find(pHost);
+                    if(m != m_staticMemMap.end())
+                    {
+                        if(sizeB != m->second.second)
+                        {
+                            std::ostringstream os;
+                            os << "Statically mapped size cannot change: Static size is " << m->second.second
+                               << " requested size is " << sizeB << '.';
+                            throw std::runtime_error(os.str());
+                        }
+                        return reinterpret_cast<TElem*>(m->second.first);
+                    }
+
+                    void* pDev = omp_target_alloc(sizeB, iDevice());
+                    if(!pDev)
+                        return nullptr;
+
+                    /*! Associating pointers for good measure. Not actually
+                     * required as long a not `target enter data` is done */
+                    omp_target_associate_ptr(pHost, pDev, sizeB, 0u, iDevice());
+
+                    m_staticMemMap[pHost] = std::make_pair(pDev, sizeB);
+                    return reinterpret_cast<TElem*>(pDev);
+                }
+
             private:
                 std::mutex mutable m_Mutex;
                 std::vector<std::weak_ptr<IGenericThreadsQueue<DevOmp5>>> mutable m_queues;
                 const int m_iDevice;
+
+                std::map<void*, std::pair<void*, std::size_t>> m_staticMemMap;
             };
         } // namespace detail
     } // namespace omp5
@@ -127,6 +167,13 @@ namespace alpaka
         int iDevice() const
         {
             return m_spDevOmp5Impl->iDevice();
+        }
+
+        //! Create and/or return staticlly mapped device pointer of host address.
+        template<typename TElem, typename TExtent>
+        ALPAKA_FN_HOST auto mapStatic(TElem* pHost, TExtent const& extent) const -> TElem*
+        {
+            return m_spDevOmp5Impl->mapStatic(pHost, extent);
         }
 
         ALPAKA_FN_HOST auto getAllQueues() const -> std::vector<std::shared_ptr<IGenericThreadsQueue<DevOmp5>>>

--- a/include/alpaka/mem/buf/oacc/Copy.hpp
+++ b/include/alpaka/mem/buf/oacc/Copy.hpp
@@ -15,7 +15,9 @@
 #        error If ALPAKA_ACC_ANY_BT_OACC_ENABLED is set, the compiler has to support OpenACC 2.0 or higher!
 #    endif
 
+#    include <alpaka/core/AlignedAlloc.hpp>
 #    include <alpaka/core/Assert.hpp>
+#    include <alpaka/core/Vectorize.hpp>
 #    include <alpaka/dev/DevCpu.hpp>
 #    include <alpaka/dev/DevOacc.hpp>
 #    include <alpaka/dim/DimIntegralConst.hpp>
@@ -29,10 +31,6 @@
 #    include <set>
 #    include <tuple>
 #    include <utility>
-
-#    if _OPENACC < 201510
-#        include <vector>
-#    endif
 
 namespace alpaka
 {
@@ -284,9 +282,10 @@ namespace alpaka
                         // acc_memcpy_device is only available since OpenACC2.5
                         // , but we want the tests to compile anyway
                         [](void* dst, void* src, std::size_t size) {
-                            std::vector<std::size_t> buf(size / sizeof(std::size_t));
-                            acc_memcpy_from_device(static_cast<void*>(buf.data()), src, size);
-                            acc_memcpy_to_device(dst, static_cast<void*>(buf.data()), size);
+                            void* buf = core::alignedAlloc(core::vectorization::defaultAlignment, size);
+                            acc_memcpy_from_device(buf, src, size);
+                            acc_memcpy_to_device(dst, buf, size);
+                            core::alignedFree(buf);
                         }
 #    endif
                     );

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -202,7 +202,6 @@ namespace alpaka
 
 #ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
         //! The Omp5 device CreateStaticDevMemView trait specialization.
-        //! \todo What ist this for? Does this exist in OMP5?
         template<>
         struct CreateStaticDevMemView<DevOmp5>
         {
@@ -210,7 +209,7 @@ namespace alpaka
             static auto createStaticDevMemView(TElem* pMem, DevOmp5 const& dev, TExtent const& extent)
             {
                 return alpaka::ViewPlainPtr<DevOmp5, TElem, alpaka::Dim<TExtent>, alpaka::Idx<TExtent>>(
-                    pMem,
+                    dev.mapStatic(pMem, extent),
                     dev,
                     extent);
             }

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -225,7 +225,7 @@ namespace alpaka
             static auto createStaticDevMemView(TElem* pMem, DevOacc const& dev, TExtent const& extent)
             {
                 return alpaka::ViewPlainPtr<DevOacc, TElem, alpaka::Dim<TExtent>, alpaka::Idx<TExtent>>(
-                    pMem,
+                    dev.mapStatic(pMem, extent),
                     dev,
                     extent);
             }


### PR DESCRIPTION
This PR properly implements `createStaticDevMemView` for `DevOmp5` and `DevOacc`. 

- [x] #1386 must be merged first.

This PR also fixes two other bugs in the OpenAcc backend:
* `DevOacc::ctor`: call `makeCurrent` before allocating and running device code to make sure the correct device is active.
* OpenACC device-to-device copy: Fix pre 2.5 fallback via host buffer.