### PR TITLE
create view factory methods for views

### DIFF
--- a/docs/cheatsheet/README.md
+++ b/docs/cheatsheet/README.md
@@ -13,5 +13,5 @@ pip install rst2pdf
 # Build
 
 ``` bash
-rst2pdf -s cheatsheet.style ../source/usage/cheatsheet.rst -o cheatsheet.pdf
+rst2pdf -s cheatsheet.style ../source/basics/cheatsheet.rst -o cheatsheet.pdf
 ```

--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -128,19 +128,19 @@ Create a view to host memory represented by a pointer
      using Dim = alpaka::DimInt<1u>;
      Vec<Dim, Idx> extent = value;
      DataType* date = new DataType[extent[0]];
-     auto hostView = createView(data, devHost, extent);
+     auto hostView = createView(devHost, data, extent);
 
 Create a view to host std::vector
    .. code-block:: c++
 
      auto vec = std::vector<DataType>(42u);
-     auto hostView = createView(vec, devHost);
+     auto hostView = createView(devHost, vec);
 
 Create a view to host std::array
    .. code-block:: c++
 
      std::vector<DataType, 2> array = {42u, 23};
-     auto hostView = createView(array, devHost);
+     auto hostView = createView(devHost, array);
 
 Get a raw pointer to a buffer or view initialization, etc.
   .. code-block:: c++

--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -122,10 +122,31 @@ Allocate a buffer in host memory
 
      prepareForAsyncCopy(bufHost);
 
-Get a raw pointer to a buffer initialization, etc.
+Create a view to host memory represented by a pointer
   .. code-block:: c++
 
-     DataType * raw = view::getPtrNative(bufHost);
+     using Dim = alpaka::DimInt<1u>;
+     Vec<Dim, Idx> extent = value;
+     DataType* date = new DataType[extent[0]];
+     auto hostView = createView(data, devHost, extent);
+
+Create a view to host std::vector
+   .. code-block:: c++
+
+     auto vec = std::vector<DataType>(42u);
+     auto hostView = createView(vec, devHost);
+
+Create a view to host std::array
+   .. code-block:: c++
+
+     std::vector<DataType, 2> array = {42u, 23};
+     auto hostView = createView(array, devHost);
+
+Get a raw pointer to a buffer or view initialization, etc.
+  .. code-block:: c++
+
+     DataType* raw = view::getPtrNative(bufHost);
+     DataType* rawViewPtr = view::getPtrNative(hostView);
 
 Allocate a buffer in device memory
   .. code-block:: c++

--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -197,8 +197,7 @@ auto main() -> int
     // The view does not own the underlying memory. So you have to make sure that
     // the view does not outlive its underlying memory.
     std::array<Data, nElementsPerDim * nElementsPerDim * nElementsPerDim> plainBuffer;
-    using ViewHost = alpaka::ViewPlainPtr<Host, Data, Dim, Idx>;
-    ViewHost hostViewPlainPtr(plainBuffer.data(), devHost, extents);
+    auto hostViewPlainPtr = alpaka::createView(plainBuffer.data(), devHost, extents);
 
     // Allocate accelerator memory buffers
     //

--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -197,7 +197,7 @@ auto main() -> int
     // The view does not own the underlying memory. So you have to make sure that
     // the view does not outlive its underlying memory.
     std::array<Data, nElementsPerDim * nElementsPerDim * nElementsPerDim> plainBuffer;
-    auto hostViewPlainPtr = alpaka::createView(plainBuffer.data(), devHost, extents);
+    auto hostViewPlainPtr = alpaka::createView(devHost, plainBuffer.data(), extents);
 
     // Allocate accelerator memory buffers
     //

--- a/example/reduce/src/reduce.cpp
+++ b/example/reduce/src/reduce.cpp
@@ -113,7 +113,7 @@ T reduce(
 
     //  download result from GPU
     T resultGpuHost;
-    auto resultGpuDevice = alpaka::createView(&resultGpuHost, devHost, static_cast<Extent>(blockSize));
+    auto resultGpuDevice = alpaka::createView(devHost, &resultGpuHost, static_cast<Extent>(blockSize));
 
     alpaka::memcpy(queue, resultGpuDevice, destinationDeviceMemory, 1);
 

--- a/example/reduce/src/reduce.cpp
+++ b/example/reduce/src/reduce.cpp
@@ -113,8 +113,7 @@ T reduce(
 
     //  download result from GPU
     T resultGpuHost;
-    auto resultGpuDevice
-        = alpaka::ViewPlainPtr<DevHost, T, Dim, Idx>(&resultGpuHost, devHost, static_cast<Extent>(blockSize));
+    auto resultGpuDevice = alpaka::createView(&resultGpuHost, devHost, static_cast<Extent>(blockSize));
 
     alpaka::memcpy(queue, resultGpuDevice, destinationDeviceMemory, 1);
 

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -343,7 +343,7 @@ namespace alpaka
 
         //! Calculate the pitches purely from the extents.
         template<typename TElem, typename TDim, typename TIdx>
-        ALPAKA_FN_HOST static auto calculatePitchesFromExtents(Vec<TDim, TIdx> const& extent)
+        ALPAKA_FN_HOST inline auto calculatePitchesFromExtents(Vec<TDim, TIdx> const& extent)
         {
             Vec<TDim, TIdx> pitchBytes(Vec<TDim, TIdx>::all(0));
             pitchBytes[TDim::value - 1u] = extent[TDim::value - 1u] * static_cast<TIdx>(sizeof(TElem));
@@ -377,90 +377,91 @@ namespace alpaka
         return traits::CreateStaticDevMemView<TDev>::createStaticDevMemView(pMem, dev, extent);
     }
 
-    //! Creates a view to a pointer device
+    //! Creates a view to a device pointer
     //!
-    //! \param pMem Pointer to memory.
     //! \param dev Device from where pMem can be accessed.
+    //! \param pMem Pointer to memory. The pointer must be accessible from the given device.
     //! \param extent Number of elements represented by the pMem.
     //!               Using a multi dimensional extent will result in a multi dimension view to the memory represented
     //!               by pMem.
     //! \return A view to device memory.
-    template<typename TElem, typename TDev, typename TExtent>
-    auto createView(TElem* pMem, TDev const& dev, TExtent const& extent)
+    template<typename TDev, typename TElem, typename TExtent>
+    auto createView(TDev const& dev, TElem* pMem, TExtent const& extent)
     {
         using Dim = alpaka::Dim<TExtent>;
         using Idx = alpaka::Idx<TExtent>;
         auto const extentVec = Vec<Dim, Idx>(extent);
         return traits::CreateViewPlainPtr<TDev>::createViewPlainPtr(
-            pMem,
             dev,
+            pMem,
             extentVec,
             detail::calculatePitchesFromExtents<TElem>(extentVec));
     }
 
     //! Creates a view to a device pointer
     //!
-    //! \param pMem Pointer to memory.
     //! \param dev Device from where pMem can be accessed.
+    //! \param pMem Pointer to memory. The pointer must be accessible from the given device.
     //! \param extent Number of elements represented by the pMem.
     //!               Using a multi dimensional extent will result in a multi dimension view to the memory represented
     //!               by pMem.
     //! \param pitch Pitch in bytes for each dimension. Dimensionality must be equal to extent.
     //! \return A view to device memory.
-    template<typename TElem, typename TDev, typename TExtent, typename TPitch>
-    auto createView(TElem* pMem, TDev const& dev, TExtent const& extent, TPitch const& pitch)
+    template<typename TDev, typename TElem, typename TExtent, typename TPitch>
+    auto createView(TDev const& dev, TElem* pMem, TExtent const& extent, TPitch const& pitch)
     {
-        return traits::CreateViewPlainPtr<TDev>::createViewPlainPtr(pMem, dev, extent, pitch);
+        return traits::CreateViewPlainPtr<TDev>::createViewPlainPtr(dev, pMem, extent, pitch);
     }
 
     //! Creates a view to a device std::vector
     //!
-    //! \param vec Pointer to memory.
     //! \param dev Device from where vec can be accessed.
+    //! \param vec std::vector container. The data hold by the container the must be accessible from the given device.
     //! \return A view to device memory.
-    template<typename TElem, typename TAllocator, typename TDev>
-    auto createView(std::vector<TElem, TAllocator>& vec, TDev const& dev)
+    template<typename TDev, typename TElem, typename TAllocator>
+    auto createView(TDev const& dev, std::vector<TElem, TAllocator>& vec)
     {
-        return createView(vec.data(), dev, extent::getExtent(vec));
+        //! \todo With C++17 use std::data() and add support for all contiguous container
+        return createView(dev, vec.data(), extent::getExtent(vec));
     }
 
     //! Creates a view to a device std::vector
     //!
-    //! \param vec Pointer to memory.
     //! \param dev Device from where pMem can be accessed.
+    //! \param vec std::vector container. The data hold by the container the must be accessible from the given device.
     //! \param extent Number of elements represented by vec.
     //!               Using a multi dimensional extent will result in a multi dimension view to the memory represented
     //!               by vec.
     //! \return A view to device memory.
-    template<typename TElem, typename TAllocator, typename TDev, typename TExtent>
-    auto createView(std::vector<TElem, TAllocator>& vec, TDev const& dev, TExtent const& extent)
+    template<typename TDev, typename TElem, typename TAllocator, typename TExtent>
+    auto createView(TDev const& dev, std::vector<TElem, TAllocator>& vec, TExtent const& extent)
     {
-        return createView(vec.data(), dev, extent);
+        return createView(dev, vec.data(), extent);
     }
 
     //! Creates a view to a device std::array
     //!
-    //! \param array Pointer to memory.
     //! \param dev Device from where array can be accessed.
+    //! \param array std::array container. The data hold by the container the must be accessible from the given device.
     //! \return A view to device memory.
-    template<typename TElem, std::size_t Tsize, typename TDev>
-    auto createView(std::array<TElem, Tsize>& array, TDev const& dev)
+    template<typename TDev, typename TElem, std::size_t Tsize>
+    auto createView(TDev const& dev, std::array<TElem, Tsize>& array)
     {
-        return createView(array.data(), dev, extent::getExtent(array));
+        return createView(dev, array.data(), extent::getExtent(array));
     }
 
     //! Creates a view to a device std::vector
     //!
-    //! \param array Pointer to memory.
     //! \param dev Device from where array can be accessed.
+    //! \param array std::array container. The data hold by the container the must be accessible from the given device
     //! \param extent Number of elements represented by array.
     //!               Using a multi dimensional extent will result in a multi dimension view to the memory represented
     //!               by array.
     //! \return A view to device memory.
-    template<typename TElem, std::size_t Tsize, typename TDev, typename TExtent>
-    auto createView(std::array<TElem, Tsize>& array, TDev const& dev, TExtent const& extent)
+    template<typename TDev, typename TElem, std::size_t Tsize, typename TExtent>
+    auto createView(TDev const& dev, std::array<TElem, Tsize>& array, TExtent const& extent)
     {
-        return createView(array.data(), dev, extent);
+        return createView(dev, array.data(), extent);
     }
 
     //! Creates a sub view to an existing view.

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -224,7 +224,7 @@ namespace alpaka
         struct CreateViewPlainPtr<DevCpu>
         {
             template<typename TElem, typename TExtent, typename TPitch>
-            static auto createViewPlainPtr(TElem* pMem, DevCpu const& dev, TExtent const& extent, TPitch const& pitch)
+            static auto createViewPlainPtr(DevCpu const& dev, TElem* pMem, TExtent const& extent, TPitch const& pitch)
             {
                 return alpaka::ViewPlainPtr<DevCpu, TElem, alpaka::Dim<TExtent>, alpaka::Idx<TExtent>>(
                     pMem,
@@ -241,8 +241,8 @@ namespace alpaka
         {
             template<typename TElem, typename TExtent, typename TPitch>
             static auto createViewPlainPtr(
-                TElem* pMem,
                 DevUniformCudaHipRt const& dev,
+                TElem* pMem,
                 TExtent const& extent,
                 TPitch const& pitch)
             {
@@ -262,7 +262,7 @@ namespace alpaka
         struct CreateViewPlainPtr<DevOmp5>
         {
             template<typename TElem, typename TExtent, typename TPitch>
-            static auto createViewPlainPtr(TElem* pMem, DevOmp5 const& dev, TExtent const& extent, TPitch const& pitch)
+            static auto createViewPlainPtr(DevOmp5 const& dev, TElem* pMem, TExtent const& extent, TPitch const& pitch)
             {
                 return alpaka::ViewPlainPtr<DevOmp5, TElem, alpaka::Dim<TExtent>, alpaka::Idx<TExtent>>(
                     pMem,
@@ -279,7 +279,7 @@ namespace alpaka
         struct CreateViewPlainPtr<DevOacc>
         {
             template<typename TElem, typename TExtent, typename TPitch>
-            static auto createViewPlainPtr(TElem* pMem, DevOacc const& dev, TExtent const& extent, TPitch const& pitch)
+            static auto createViewPlainPtr(DevOacc const& dev, TElem* pMem, TExtent const& extent, TPitch const& pitch)
             {
                 return alpaka::ViewPlainPtr<DevOacc, TElem, alpaka::Dim<TExtent>, alpaka::Idx<TExtent>>(
                     pMem,

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -270,5 +270,22 @@ namespace alpaka
         {
             using type = TIdx;
         };
+
+        //! The CPU device CreateSubView trait default implementation
+        template<typename TDev, typename TSfinae>
+        struct CreateSubView
+        {
+            template<typename TView, typename TExtent, typename TOffsets>
+            static auto createSubView(
+                TView& view,
+                TExtent const& extentElements,
+                TOffsets const& relativeOffsetsElements)
+            {
+                using Dim = alpaka::Dim<TExtent>;
+                using Idx = alpaka::Idx<TExtent>;
+                using Elem = typename traits::ElemType<TView>::type;
+                return ViewSubView<TDev, Elem, Dim, Idx>(view, extentElements, relativeOffsetsElements);
+            }
+        };
     } // namespace traits
 } // namespace alpaka

--- a/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/include/alpaka/test/mem/view/ViewTest.hpp
@@ -218,15 +218,10 @@ namespace alpaka
         template<typename TView, typename TQueue>
         ALPAKA_FN_HOST auto iotaFillView(TQueue& queue, TView& view) -> void
         {
-            using Dim = alpaka::Dim<TView>;
-            using Idx = alpaka::Idx<TView>;
-
             using DevHost = alpaka::DevCpu;
             using PltfHost = alpaka::Pltf<DevHost>;
 
             using Elem = alpaka::Elem<TView>;
-
-            using ViewPlainPtr = alpaka::ViewPlainPtr<DevHost, Elem, Dim, Idx>;
 
             DevHost const devHost = alpaka::getDevByIdx<PltfHost>(0);
 
@@ -235,7 +230,7 @@ namespace alpaka
             // Init buf with increasing values
             std::vector<Elem> v(static_cast<std::size_t>(extent.prod()), static_cast<Elem>(0));
             std::iota(v.begin(), v.end(), static_cast<Elem>(0));
-            ViewPlainPtr plainBuf(v.data(), devHost, extent);
+            auto plainBuf = alpaka::createView(v, devHost, extent);
 
             // Copy the generated content into the given view.
             alpaka::memcpy(queue, view, plainBuf, extent);

--- a/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/include/alpaka/test/mem/view/ViewTest.hpp
@@ -230,7 +230,7 @@ namespace alpaka
             // Init buf with increasing values
             std::vector<Elem> v(static_cast<std::size_t>(extent.prod()), static_cast<Elem>(0));
             std::iota(v.begin(), v.end(), static_cast<Elem>(0));
-            auto plainBuf = alpaka::createView(v, devHost, extent);
+            auto plainBuf = alpaka::createView(devHost, v, extent);
 
             // Copy the generated content into the given view.
             alpaka::memcpy(queue, view, plainBuf, extent);

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -242,10 +242,9 @@ TEMPLATE_LIST_TEST_CASE("matMul", "[matMul]", TestAccs)
     // Wrap the std::vectors into a memory buffer object.
     // For 1D data this would not be required because alpaka::copy is specialized for std::vector and std::array.
     // For multi dimensional data you could directly create them using alpaka::malloc<Type>(devHost, extent), which is
-    // not used here. Instead we use ViewPlainPtr to wrap the data.
-    using BufWrapper = alpaka::ViewPlainPtr<DevHost, Val, Dim, Idx>;
-    BufWrapper bufAHost(bufAHost1d.data(), devHost, extentA);
-    BufWrapper bufBHost(bufBHost1d.data(), devHost, extentB);
+    // not used here. Instead we create a View to wrap the data.
+    auto bufAHost = alpaka::createView(bufAHost1d.data(), devHost, extentA);
+    auto bufBHost = alpaka::createView(bufBHost1d.data(), devHost, extentB);
 
     // Allocate C and set it to zero.
     auto bufCHost = alpaka::allocBuf<Val, Idx>(devHost, extentC);

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -243,8 +243,8 @@ TEMPLATE_LIST_TEST_CASE("matMul", "[matMul]", TestAccs)
     // For 1D data this would not be required because alpaka::copy is specialized for std::vector and std::array.
     // For multi dimensional data you could directly create them using alpaka::malloc<Type>(devHost, extent), which is
     // not used here. Instead we create a View to wrap the data.
-    auto bufAHost = alpaka::createView(bufAHost1d.data(), devHost, extentA);
-    auto bufBHost = alpaka::createView(bufBHost1d.data(), devHost, extentB);
+    auto bufAHost = alpaka::createView(devHost, bufAHost1d.data(), extentA);
+    auto bufBHost = alpaka::createView(devHost, bufBHost1d.data(), extentB);
 
     // Allocate C and set it to zero.
     auto bufCHost = alpaka::allocBuf<Val, Idx>(devHost, extentC);

--- a/test/unit/idx/src/MapIdxPitchBytes.cpp
+++ b/test/unit/idx/src/MapIdxPitchBytes.cpp
@@ -28,15 +28,14 @@ TEMPLATE_LIST_TEST_CASE("mapIdxPitchBytes", "[idx]", alpaka::test::TestDims)
         = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
 
     using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
-    using Dev = alpaka::Dev<Acc>;
     using Elem = std::uint8_t;
     auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
-    alpaka::ViewPlainPtr<Dev, Elem, Dim, Idx> parentView(nullptr, devAcc, extentNd);
+    auto parentView = alpaka::createView(static_cast<Elem*>(nullptr), devAcc, extentNd);
 
     auto const offset = Vec::all(4u);
     auto const extent = Vec::all(4u);
     auto const idxNd = Vec::all(2u);
-    alpaka::ViewSubView<Dev, Elem, Dim, Idx> view(parentView, extent, offset);
+    auto view = createSubView(parentView, extent, offset);
     auto pitch = alpaka::getPitchBytesVec(view);
 
     auto const idx1d = alpaka::mapIdxPitchBytes<1u>(idxNd, pitch);

--- a/test/unit/idx/src/MapIdxPitchBytes.cpp
+++ b/test/unit/idx/src/MapIdxPitchBytes.cpp
@@ -30,12 +30,12 @@ TEMPLATE_LIST_TEST_CASE("mapIdxPitchBytes", "[idx]", alpaka::test::TestDims)
     using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
     using Elem = std::uint8_t;
     auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
-    auto parentView = alpaka::createView(static_cast<Elem*>(nullptr), devAcc, extentNd);
+    auto parentView = alpaka::createView(devAcc, static_cast<Elem*>(nullptr), extentNd);
 
     auto const offset = Vec::all(4u);
     auto const extent = Vec::all(4u);
     auto const idxNd = Vec::all(2u);
-    auto view = createSubView(parentView, extent, offset);
+    auto view = alpaka::createSubView(parentView, extent, offset);
     auto pitch = alpaka::getPitchBytesVec(view);
 
     auto const idx1d = alpaka::mapIdxPitchBytes<1u>(idxNd, pitch);

--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -68,7 +68,7 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAc
         QueueAcc queueAcc(devAcc);
 
         std::vector<Elem> const data{0u, 1u, 2u, 3u, 4u, 5u};
-        auto bufHost = alpaka::createView(data.data(), devHost, extent);
+        auto bufHost = alpaka::createView(devHost, data.data(), extent);
 
         auto viewConstantMemUninitialized
             = alpaka::createStaticDevMemView(&g_constantMemory2DUninitialized[0u][0u], devAcc, extent);
@@ -109,7 +109,7 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryConstant", "[viewStaticAccMem]", Test
         QueueAcc queueAcc(devAcc);
 
         std::vector<Elem> const data{0u, 1u, 2u, 3u, 4u, 5u};
-        auto bufHost = alpaka::createView(data.data(), devHost, extent);
+        auto bufHost = alpaka::createView(devHost, data.data(), extent);
 
         auto viewGlobalMemUninitialized
             = alpaka::createStaticDevMemView(&g_globalMemory2DUninitialized[0u][0u], devAcc, extent);

--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -68,7 +68,7 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAc
         QueueAcc queueAcc(devAcc);
 
         std::vector<Elem> const data{0u, 1u, 2u, 3u, 4u, 5u};
-        alpaka::ViewPlainPtr<decltype(devHost), const Elem, Dim, Idx> bufHost(data.data(), devHost, extent);
+        auto bufHost = alpaka::createView(data.data(), devHost, extent);
 
         auto viewConstantMemUninitialized
             = alpaka::createStaticDevMemView(&g_constantMemory2DUninitialized[0u][0u], devAcc, extent);
@@ -109,7 +109,7 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryConstant", "[viewStaticAccMem]", Test
         QueueAcc queueAcc(devAcc);
 
         std::vector<Elem> const data{0u, 1u, 2u, 3u, 4u, 5u};
-        alpaka::ViewPlainPtr<decltype(devHost), const Elem, Dim, Idx> bufHost(data.data(), devHost, extent);
+        auto bufHost = alpaka::createView(data.data(), devHost, extent);
 
         auto viewGlobalMemUninitialized
             = alpaka::createStaticDevMemView(&g_globalMemory2DUninitialized[0u][0u], devAcc, extent);

--- a/test/unit/queue/src/CollectiveQueue.cpp
+++ b/test/unit/queue/src/CollectiveQueue.cpp
@@ -106,11 +106,8 @@ TEST_CASE("TestCollectiveMemcpy", "[queue]")
     {
         int threadId = omp_get_thread_num();
 
-        using View = alpaka::ViewPlainPtr<Dev, int, Dim, Idx>;
-
-        View dst(results.data() + threadId, dev, Vec(static_cast<Idx>(1u)), Vec(sizeof(int)));
-
-        View src(&threadId, dev, Vec(static_cast<Idx>(1u)), Vec(sizeof(int)));
+        auto dst = alpaka::createView(results.data() + threadId, dev, Vec(static_cast<Idx>(1u)), Vec(sizeof(int)));
+        auto src = alpaka::createView(&threadId, dev, Vec(static_cast<Idx>(1u)), Vec(sizeof(int)));
 
         // avoid that the first thread is executing the copy (can not be guaranteed)
         size_t sleep_ms = (results.size() - static_cast<uint32_t>(threadId)) * 100u;

--- a/test/unit/queue/src/CollectiveQueue.cpp
+++ b/test/unit/queue/src/CollectiveQueue.cpp
@@ -106,8 +106,8 @@ TEST_CASE("TestCollectiveMemcpy", "[queue]")
     {
         int threadId = omp_get_thread_num();
 
-        auto dst = alpaka::createView(results.data() + threadId, dev, Vec(static_cast<Idx>(1u)), Vec(sizeof(int)));
-        auto src = alpaka::createView(&threadId, dev, Vec(static_cast<Idx>(1u)), Vec(sizeof(int)));
+        auto dst = alpaka::createView(dev, results.data() + threadId, Vec(static_cast<Idx>(1u)), Vec(sizeof(int)));
+        auto src = alpaka::createView(dev, &threadId, Vec(static_cast<Idx>(1u)), Vec(sizeof(int)));
 
         // avoid that the first thread is executing the copy (can not be guaranteed)
         size_t sleep_ms = (results.size() - static_cast<uint32_t>(threadId)) * 100u;


### PR DESCRIPTION
alpaka is providing a helper factory method to create a view to static constant and global memory via `createStaticDevMemView()`.
Such a simple method is missing to create views from a pointer, `std::vector`,  or `std::array`.

This PR provides new factory methods to create Views or SubView without the required knowledge of the device type by using the device instants and derive dimensionality from the extend, equally to `createStaticDevMemView()`.
The cheatsheet is extended with the new methods.

```C++
int* ptr = nullptr;
using View = alpaka::ViewPlainPtr<Dev, int, Dim, Idx>;
View dst(ptr, dev, Vec(static_cast<Idx>(1u)), Vec(sizeof(int)));
```

is becoming

```C++
int* ptr = nullptr;
auto src = alpaka::createView(ptr, dev, Vec(1u));
```

- [x] rebase against #1404 