### PR TITLE
fix `alpaka_compiler_option`

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -15,12 +15,12 @@ include(CMakePrintHelpers) # for easier printing of variables and properties
 # Options.
 
 # Compiler options
-function(alpaka_compiler_option name description default)
+macro(alpaka_compiler_option name description default)
     if(NOT DEFINED ALPAKA_${name})
         set(ALPAKA_${name} ${default} CACHE STRING "${description}")
         set_property(CACHE ALPAKA_${name} PROPERTY STRINGS "DEFAULT;ON;OFF")
     endif()
-endfunction()
+endmacro()
 
 # Add append compiler flags to a variable or target
 #


### PR DESCRIPTION
Change cmake function `alpaka_compiler_option` to a macro else the variable will not be visible in the parameter scope.

Bug was introduced with #1289

- [x] rebase against #1404 