### PR TITLE
fix CUDA 11.3+ compile

### DIFF
--- a/example/reduce/src/iterator.hpp
+++ b/example/reduce/src/iterator.hpp
@@ -149,7 +149,7 @@ public:
     //! Returns the iterator for the last item.
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto end() const -> IteratorCpu
     {
-        IteratorCpu ret(*this);
+        auto ret = *this;
         ret.mIndex = this->mMaximum;
         return ret;
     }
@@ -170,7 +170,7 @@ public:
     //! Returns a reference to the current index.
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto operator++(int) -> IteratorCpu
     {
-        auto ret(*this);
+        auto ret = *this;
         ++(this->mIndex);
         return ret;
     }
@@ -191,7 +191,7 @@ public:
     //! Returns a reference to the current index.
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto operator--(int) -> IteratorCpu
     {
-        auto ret(*this);
+        auto ret = *this;
         --(this->mIndex);
         return ret;
     }
@@ -201,7 +201,7 @@ public:
     //! \param n The offset.
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto operator+(uint64_t n) const -> IteratorCpu
     {
-        IteratorCpu ret(*this);
+        auto ret = *this;
         ret.mIndex += n;
         return ret;
     }
@@ -211,7 +211,7 @@ public:
     //! \param n The offset.
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto operator-(uint64_t n) const -> IteratorCpu
     {
-        IteratorCpu ret(*this);
+        auto ret = *this;
         ret.mIndex -= n;
         return ret;
     }
@@ -267,7 +267,7 @@ public:
     //! Returns the iterator for the last item.
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto end() const -> IteratorGpu
     {
-        IteratorGpu ret(*this);
+        auto ret = *this;
         ret.mIndex = this->mMaximum;
         return ret;
     }
@@ -288,7 +288,7 @@ public:
     //! Returns a reference to the current index.
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto operator++(int) -> IteratorGpu
     {
-        auto ret(*this);
+        auto ret = *this;
         this->mIndex += this->mGridSize;
         return ret;
     }
@@ -309,7 +309,7 @@ public:
     //! Returns a reference to the current index.
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto operator--(int) -> IteratorGpu
     {
-        auto ret(*this);
+        auto ret = *this;
         this->mIndex -= this->mGridSize;
         return ret;
     }
@@ -319,7 +319,7 @@ public:
     //! \param n The offset.
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto operator+(uint64_t n) const -> IteratorGpu
     {
-        auto ret(*this);
+        auto ret = *this;
         ret.mIndex += n * mGridSize;
         return ret;
     }
@@ -329,7 +329,7 @@ public:
     //! \param n The offset.
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto operator-(uint64_t n) const -> IteratorGpu
     {
-        auto ret(*this);
+        auto ret = *this;
         ret.mIndex -= n * mGridSize;
         return ret;
     }

--- a/example/reduce/src/reduce.cpp
+++ b/example/reduce/src/reduce.cpp
@@ -90,22 +90,22 @@ T reduce(
     WorkDiv workDiv2{static_cast<Extent>(1), static_cast<Extent>(blockSize), static_cast<Extent>(1)};
 
     // create main reduction kernel execution task
-    auto const taskKernelReduceMain(alpaka::createTaskKernel<Acc>(
+    auto const taskKernelReduceMain = alpaka::createTaskKernel<Acc>(
         workDiv1,
         kernel1,
         alpaka::getPtrNative(sourceDeviceMemory),
         alpaka::getPtrNative(destinationDeviceMemory),
         n,
-        func));
+        func);
 
     // create last block reduction kernel execution task
-    auto const taskKernelReduceLastBlock(alpaka::createTaskKernel<Acc>(
+    auto const taskKernelReduceLastBlock = alpaka::createTaskKernel<Acc>(
         workDiv2,
         kernel2,
         alpaka::getPtrNative(destinationDeviceMemory),
         alpaka::getPtrNative(destinationDeviceMemory),
         blockCount,
-        func));
+        func);
 
     // enqueue both kernel execution tasks
     alpaka::enqueue(queue, taskKernelReduceMain);

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -163,13 +163,13 @@ auto main() -> int
     VectorAddKernel kernel;
 
     // Create the kernel execution task.
-    auto const taskKernel(alpaka::createTaskKernel<Acc>(
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(
         workDiv,
         kernel,
         alpaka::getPtrNative(bufAccA),
         alpaka::getPtrNative(bufAccB),
         alpaka::getPtrNative(bufAccC),
-        numElements));
+        numElements);
 
     // Enqueue the kernel execution task
     {

--- a/test/integ/separableCompilation/src/main.cpp
+++ b/test/integ/separableCompilation/src/main.cpp
@@ -127,13 +127,13 @@ TEMPLATE_LIST_TEST_CASE("separableCompilation", "[separableCompilation]", TestAc
     alpaka::memcpy(queueAcc, memBufAccB, memBufHostB, extent);
 
     // Create the executor task.
-    auto const taskKernel(alpaka::createTaskKernel<Acc>(
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(
         workDiv,
         kernel,
         alpaka::getPtrNative(memBufAccA),
         alpaka::getPtrNative(memBufAccB),
         alpaka::getPtrNative(memBufAccC),
-        numElements));
+        numElements);
 
     // Profile the kernel execution.
     std::cout << "Execution time: " << alpaka::test::integ::measureTaskRunTimeMs(queueAcc, taskKernel) << " ms"


### PR DESCRIPTION
Fix error shown with CUDA 11.3+

```
/builds/hzdr/crp/alpaka/example/reduce/src/reduce.cpp:93:38: error: '__T14' was not declared in this scope
     auto const taskKernelReduceMain(alpaka::createTaskKernel<Acc>(
                                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Some kind of error was already fixed with #1293, it is not clear why this piece of code was not producing errors before.
@SimeonEhrig said maybe the bug is coming because of the fix in  #1392, before #1392 maybe some compile options were not set correctly.