### PR TITLE
fix Clang-CUDA math tests

### DIFF
--- a/test/unit/math/src/math.cpp
+++ b/test/unit/math/src/math.cpp
@@ -125,7 +125,7 @@ struct TestTemplate
         {
             INFO("Idx i: " << i)
             TData std_result = functor(args(i));
-            REQUIRE(results(i) == Approx(std_result));
+            REQUIRE(results(i) == Approx(std_result).margin(std::numeric_limits<TData>::epsilon()));
         }
     }
 };


### PR DESCRIPTION
fix: #1020

The math tests sometimes failed because we using random input data for tests and `exp` results are not exact compared to `std::exp`.

Implement https://github.com/alpaka-group/alpaka/issues/1020#issuecomment-898558123 and allow result differences of one epsilon.