### PR TITLE
Run CUDA 9.2 tests on HZDR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,32 +230,6 @@ jobs:
           os: ubuntu-latest
           env: {CXX: icpc,    CC: icc,                                 ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.75.0, ALPAKA_CI_CMAKE_VER: 3.19.2, OMP_NUM_THREADS: 2, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:20.04",                                                                                                                                         ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF}
 
-        ## CUDA 9.2
-        # nvcc + g++
-        - name: linux_nvcc-9.2_gcc-7_release
-          os: ubuntu-18.04
-          env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 7,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.68.0, ALPAKA_CI_CMAKE_VER: 3.20.0,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "9.2", CMAKE_CUDA_COMPILER: nvcc, CMAKE_CUDA_ARCHITECTURES: "30;35",            ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
-        - name: linux_nvcc-9.2_gcc-7_debug_separable_compilation
-          os: ubuntu-18.04
-          env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 7,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.74.0, ALPAKA_CI_CMAKE_VER: 3.18.6,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "9.2", CMAKE_CUDA_COMPILER: nvcc, CUDA_SEPARABLE_COMPILATION: ON,               ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
-        - name: linux_nvcc-9.2_gcc-7_release_extended_lambda_off
-          os: ubuntu-latest
-          env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 7,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.73.0, ALPAKA_CI_CMAKE_VER: 3.20.0,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:20.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "9.2", CMAKE_CUDA_COMPILER: nvcc, ALPAKA_CUDA_EXPT_EXTENDED_LAMBDA: OFF,        ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
-        # nvcc + clang++
-        - name: linux_nvcc-9.2_clang-5_release
-          os: ubuntu-latest
-          env: {CXX: clang++, CC: clang,  ALPAKA_CI_CLANG_VER: "5.0",  ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.65.1, ALPAKA_CI_CMAKE_VER: 3.19.7,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "9.2", CMAKE_CUDA_COMPILER: nvcc, CMAKE_CUDA_ARCHITECTURES: "30;70",            ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF}
-        # clang++
-        - name: linux_clang-9_cuda-9.2_release
-          os: ubuntu-latest
-          env: {CXX: clang++, CC: clang,  ALPAKA_CI_CLANG_VER: 9,      ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.69.0, ALPAKA_CI_CMAKE_VER: 3.19.7,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:18.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "9.2", CMAKE_CUDA_COMPILER: clang++, CMAKE_CUDA_ARCHITECTURES: "35;72",         ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
-        - name: linux_clang-10_cuda-9.2_release
-          os: ubuntu-latest
-          env: {CXX: clang++, CC: clang,  ALPAKA_CI_CLANG_VER: 10,     ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.68.0, ALPAKA_CI_CMAKE_VER: 3.19.7,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:20.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "9.2", CMAKE_CUDA_COMPILER: clang++,                                            ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
-        - name: linux_clang-11_cuda-9.2_release
-          os: ubuntu-latest
-          env: {CXX: clang++, CC: clang,  ALPAKA_CI_CLANG_VER: 11,     ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.74.0, ALPAKA_CI_CMAKE_VER: 3.19.7,                     ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:20.04", ALPAKA_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "9.2", CMAKE_CUDA_COMPILER: clang++,                                            ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
-
         ## CUDA 10.0
         # nvcc + g++
         - name: linux_nvcc-10.0_gcc-7_release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,3 @@
-include:
-  - local: '/script/gitlabci/job_base.yml'
-
 variables:
   ALPAKA_GITLAB_CI_CONTAINER_VERSION: "1.4"
   ALPAKA_CI_OS_NAME: "Linux"
@@ -21,25 +18,14 @@ variables:
   # needs to be enabled, that test on the GPU are executed
   ALPAKA_FORCE_RUNTIME_TEST: "ON"
   ALPAKA_CI_SANITIZERS: ""
-  ALPAKA_CI_CMAKE_DIR: "/opt/cmake/"
   ALPAKA_CI_INSTALL_CUDA: "OFF"
   ALPAKA_CI_INSTALL_HIP: "OFF"
+  ALPAKA_CI_CMAKE_DIR: "$HOME/cmake"
+  BOOST_ROOT: "$HOME/boost"
+  ALPAKA_CI_BOOST_LIB_DIR: "$HOME/boost_libs"
+  ALPAKA_CI_CUDA_DIR: "$HOME/cuda"
+  ALPAKA_CI_HIP_ROOT_DIR: "$HOME/hip"
 
-linux_gcc-9_release:
-  variables:
-    ALPAKA_CI_GCC_VER: 9
-    CMAKE_BUILD_TYPE: Release
-    ALPAKA_CI_STDLIB: libc++
-    ALPAKA_BOOST_VERSION: 1.74.0
-    ALPAKA_CI_CMAKE_VER: 3.20.0
-  extends: .base_gcc
-
-linux_nvcc-11.3_gcc-7_release:
-  variables:
-    ALPAKA_CONTAINER_SUFFIX: cuda113
-    ALPAKA_CI_GCC_VER: 7
-    ALPAKA_CI_STDLIB: libc++
-    CMAKE_BUILD_TYPE: Release
-    ALPAKA_BOOST_VERSION: 1.74.0
-    ALPAKA_CI_CMAKE_VER: 3.20.0
-  extends: .base_cuda
+include:
+  - local: '/script/gitlabci/job_base.yml'
+  - local: '/script/gitlabci/job_cuda9.2.yml'

--- a/script/before_install.sh
+++ b/script/before_install.sh
@@ -32,6 +32,7 @@ fi
 
 #-------------------------------------------------------------------------------
 # Boost.
+echo $ALPAKA_CI_BOOST_BRANCH
 ALPAKA_CI_BOOST_BRANCH_MAJOR=${ALPAKA_CI_BOOST_BRANCH:6:1}
 echo ALPAKA_CI_BOOST_BRANCH_MAJOR: "${ALPAKA_CI_BOOST_BRANCH_MAJOR}"
 ALPAKA_CI_BOOST_BRANCH_MINOR=${ALPAKA_CI_BOOST_BRANCH:8:2}
@@ -40,7 +41,7 @@ echo ALPAKA_CI_BOOST_BRANCH_MINOR: "${ALPAKA_CI_BOOST_BRANCH_MINOR}"
 #-------------------------------------------------------------------------------
 # CUDA
 export ALPAKA_CI_INSTALL_CUDA="OFF"
-if [ "${ALPAKA_ACC_GPU_CUDA_ENABLE}" == "ON" ]
+if [[ "${ALPAKA_ACC_GPU_CUDA_ENABLE}" == "ON" && -z "${GITLAB_CI+x}" ]]
 then
     export ALPAKA_CI_INSTALL_CUDA="ON"
 fi
@@ -85,9 +86,9 @@ fi
 # GCC-5.5 has broken avx512vlintrin.h in Release mode with NVCC 9.X
 #   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=76731
 #   https://github.com/tensorflow/tensorflow/issues/10220
-if [ "${ALPAKA_CI_INSTALL_CUDA}" == "ON" ]
+if [ "${ALPAKA_CI_INSTALL_CUDA}" == "ON"  ]
 then
-    if [ "${CXX}" == "g++" ]
+    if [[ "${CXX}" == "g++"* ]]
     then
         if (( "${ALPAKA_CI_GCC_VER_MAJOR}" == 5 ))
         then
@@ -107,7 +108,7 @@ if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
 then
     if [ "${ALPAKA_CI_STDLIB}" == "libc++" ]
     then
-        if [ "${CXX}" == "g++" ]
+        if [[ "${CXX}" == "g++"* ]]
         then
             echo "using libc++ with g++ not yet supported."
             exit 1

--- a/script/gitlabci/job_base.yml
+++ b/script/gitlabci/job_base.yml
@@ -1,40 +1,48 @@
 .base:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-${ALPAKA_CONTAINER_SUFFIX}:${ALPAKA_GITLAB_CI_CONTAINER_VERSION}
   variables:
     ALPAKA_DEBUG: 0
-    BOOST_ROOT: /opt/boost/${ALPAKA_BOOST_VERSION}
-    BOOST_LIBRARYDIR: /opt/boost/${ALPAKA_BOOST_VERSION}/lib
-    ALPAKA_CI_BOOST_LIB_DIR: /opt/boost/${ALPAKA_BOOST_VERSION}
+    ALPAKA_CI_BOOST_BRANCH: "boost-${ALPAKA_BOOST_VERSION}"
+    BOOST_LIBRARYDIR: "/opt/boost/${ALPAKA_BOOST_VERSION}/lib"
+    ALPAKA_CI_OS_NAME: "Linux"
   script:
-    # create fake sudo
-    - cp ./script/gitlabci/fake_sudo.sh /bin/sudo
-    - chmod +x /bin/sudo
-    - mkdir -p ${ALPAKA_CI_CMAKE_DIR}
-    - source ./script/install_cmake.sh
+    - source ./script/before_install.sh
+    - source ./script/install.sh
     - source ./script/run.sh
+  interruptible: true
 
-.base_gcc:
+.base_cuda_gcc:
+  image: nvidia/cuda:${ALPAKA_CI_CUDA_VERSION}-devel-ubuntu${ALPAKA_CI_UBUNTU_VER}
   variables:
-    ALPAKA_CONTAINER_SUFFIX: gcc
-    CC: gcc-${ALPAKA_CI_GCC_VER}
-    CXX: g++-${ALPAKA_CI_GCC_VER}
-    OMP_NUM_THREADS: 8
-    ALPAKA_CI_BUILD_JOBS: 8
-  extends: .base
-  tags:
-    - x86_64
-
-.base_cuda:
-  image: registry.gitlab.com/hzdr/crp/alpaka-group-container/alpaka-ci-${ALPAKA_CONTAINER_SUFFIX}:${ALPAKA_GITLAB_CI_CONTAINER_VERSION}
-  variables:
-    CC: gcc-${ALPAKA_CI_GCC_VER}
-    CXX: g++-${ALPAKA_CI_GCC_VER}
+    ALPAKA_CI_UBUNTU_VER: "20.04"
+    CC: gcc
+    CXX: g++
     OMP_NUM_THREADS: 2
     ALPAKA_CI_BUILD_JOBS: 2
-    ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE: "OFF"
-    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
+    ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE: "ON"
+    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "ON"
     ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: "OFF"
     ALPAKA_ACC_GPU_CUDA_ENABLE: "ON"
+    ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: "OFF"
+    CMAKE_CUDA_COMPILER: nvcc
+  extends: .base
+  tags:
+    - cuda
+    - intel
+
+.base_cuda_clang:
+  image: nvidia/cuda:${ALPAKA_CI_CUDA_VERSION}-devel-ubuntu${ALPAKA_CI_UBUNTU_VER}
+  variables:
+    ALPAKA_CI_UBUNTU_VER: "20.04"
+    CC: clang
+    CXX: clang++
+    OMP_NUM_THREADS: 2
+    ALPAKA_CI_BUILD_JOBS: 2
+    ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE: "ON"
+    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "ON"
+    ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: "OFF"
+    ALPAKA_ACC_GPU_CUDA_ENABLE: "ON"
+    ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: "OFF"
+    CMAKE_CUDA_COMPILER: clang++
   extends: .base
   tags:
     - cuda

--- a/script/gitlabci/job_cuda9.2.yml
+++ b/script/gitlabci/job_cuda9.2.yml
@@ -1,0 +1,91 @@
+# nvcc + g++
+linux_nvcc-9.2_gcc-7_release:
+  extends: .base_cuda_gcc
+  variables:
+    ALPAKA_CI_UBUNTU_VER: "18.04"
+    ALPAKA_CI_CUDA_VERSION: "9.2"
+    ALPAKA_CI_GCC_VER: 7
+    ALPAKA_CI_STDLIB: libstdc++
+    CMAKE_BUILD_TYPE: Release
+    ALPAKA_BOOST_VERSION: 1.68.0
+    ALPAKA_CI_CMAKE_VER: 3.20.0
+    CMAKE_CUDA_ARCHITECTURES: "30;35"
+
+linux_nvcc-9.2_gcc-7_debug_separable_compilation:
+  extends: .base_cuda_gcc
+  variables:
+    ALPAKA_CI_UBUNTU_VER: "18.04"
+    ALPAKA_CI_CUDA_VERSION: "9.2"
+    ALPAKA_CI_GCC_VER: 7
+    ALPAKA_CI_STDLIB: libstdc++
+    CMAKE_BUILD_TYPE: Debug
+    ALPAKA_BOOST_VERSION: 1.74.0
+    ALPAKA_CI_CMAKE_VER: 3.18.6
+    CUDA_SEPARABLE_COMPILATION: "ON"
+
+linux_nvcc-9.2_gcc-7_release_extended_lambda_off:
+  extends: .base_cuda_gcc
+  variables:
+    ALPAKA_CI_UBUNTU_VER: "18.04"
+    ALPAKA_CI_CUDA_VERSION: "9.2"
+    ALPAKA_CI_GCC_VER: 7
+    ALPAKA_CI_STDLIB: libstdc++
+    CMAKE_BUILD_TYPE: Release
+    ALPAKA_BOOST_VERSION: 1.73.0
+    ALPAKA_CI_CMAKE_VER: 3.20.0
+    ALPAKA_ACC_GPU_CUDA_ENABLE: "ON"
+    ALPAKA_CUDA_EXPT_EXTENDED_LAMBDA: "OFF"
+
+# nvcc + clang++
+linux_nvcc-9.2_clang-5-nvcc_release:
+  extends: .base_cuda_clang
+  variables:
+    ALPAKA_CI_UBUNTU_VER: "18.04"
+    ALPAKA_CI_CUDA_VERSION: "9.2"
+    CMAKE_CUDA_COMPILER: nvcc
+    CMAKE_CUDA_ARCHITECTURES: "30;70"
+    ALPAKA_CI_CLANG_VER: "5.0"
+    ALPAKA_CI_STDLIB: libstdc++
+    CMAKE_BUILD_TYPE: Release
+    ALPAKA_BOOST_VERSION: 1.65.1
+    ALPAKA_CI_CMAKE_VER: 3.19.7
+
+# clang++
+linux_clang-9_cuda-9.2_release:
+  extends: .base_cuda_clang
+  variables:
+    ALPAKA_CI_UBUNTU_VER: "18.04"
+    ALPAKA_CI_CUDA_VERSION: "9.2"
+    CMAKE_CUDA_ARCHITECTURES: "35;72"
+    ALPAKA_CI_CLANG_VER: 9
+    ALPAKA_CI_STDLIB: libstdc++
+    CMAKE_BUILD_TYPE: Release
+    ALPAKA_BOOST_VERSION: 1.69.0
+    ALPAKA_CI_CMAKE_VER: 3.19.7
+    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
+
+linux_clang-10_cuda-9.2_release:
+  extends: .base_cuda_clang
+  variables:
+    ALPAKA_CI_UBUNTU_VER: "18.04"
+    ALPAKA_CI_CUDA_VERSION: "9.2"
+    ALPAKA_CI_CLANG_VER: 10
+    ALPAKA_CI_STDLIB: libstdc++
+    CMAKE_BUILD_TYPE: Release
+    ALPAKA_BOOST_VERSION: 1.68.0
+    ALPAKA_CI_CMAKE_VER: 3.19.7
+    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
+
+linux_clang-11_cuda-9.2_release:
+  extends: .base_cuda_clang
+  variables:
+    ALPAKA_CI_UBUNTU_VER: "18.04"
+    ALPAKA_CI_CUDA_VERSION: "9.2"
+    ALPAKA_CI_CLANG_VER: 11
+    ALPAKA_CI_STDLIB: libstdc++
+    CMAKE_BUILD_TYPE: Release
+    ALPAKA_BOOST_VERSION: 1.74.0
+    ALPAKA_CI_CMAKE_VER: 3.19.7
+    ALPAKA_ACC_GPU_CUDA_ENABLE: "ON"
+    CMAKE_CUDA_COMPILER: clang++
+    ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"

--- a/script/install.sh
+++ b/script/install.sh
@@ -33,25 +33,25 @@ then
     # software-properties-common: 'add-apt-repository' and certificates for wget https download
     # binutils: ld
     # xz-utils: xzcat
-    travis_retry sudo apt-get -y --quiet --allow-unauthenticated --no-install-recommends install software-properties-common wget git make binutils xz-utils
+    travis_retry sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --allow-unauthenticated --no-install-recommends install software-properties-common wget git make binutils xz-utils gnupg2
 fi
 
 if [ "$ALPAKA_CI_OS_NAME" = "Linux" ] || [ "$ALPAKA_CI_OS_NAME" = "Windows" ]
 then
-    ./script/install_cmake.sh
+    source ./script/install_cmake.sh
 fi
 
-if [ "${ALPAKA_CI_ANALYSIS}" == "ON" ] ;then ./script/install_analysis.sh ;fi
+if [ "${ALPAKA_CI_ANALYSIS}" == "ON" ] ;then source ./script/install_analysis.sh ;fi
 
 # Install CUDA before installing gcc as it installs gcc-4.8 and overwrites our selected compiler
-if [ "${ALPAKA_CI_INSTALL_CUDA}" == "ON" ] ;then ./script/install_cuda.sh ;fi
+if [ "${ALPAKA_CI_INSTALL_CUDA}" == "ON" ] ;then source ./script/install_cuda.sh ;fi
 
 if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
 then
-    if [ "${CXX}" == "g++" ] ;then ./script/install_gcc.sh ;fi
+    if [[ "${CXX}" == "g++"* ]] ;then source ./script/install_gcc.sh ;fi
     # do not install clang if we use HIP, HIP/ROCm is shipping an own clang version
-    if [ "${CXX}" == "clang++" ] && [ "${ALPAKA_CI_INSTALL_HIP}" != "ON" ] ;then source ./script/install_clang.sh ;fi
-    if [ "${CXX}" == "icpc" ] ;then source ./script/install_icpc.sh ;fi
+    if [[ "${CXX}" == "clang++" ]] && [ "${ALPAKA_CI_INSTALL_HIP}" != "ON" ] ;then source ./script/install_clang.sh ;fi
+    if [[ "${CXX}" == "icpc"* ]] ;then source ./script/install_icpc.sh ;fi
 elif [ "$ALPAKA_CI_OS_NAME" = "macOS" ]
 then
     echo "### list all applications ###"
@@ -62,7 +62,7 @@ fi
 
 if [ "${ALPAKA_CI_INSTALL_TBB}" = "ON" ]
 then
-    ./script/install_tbb.sh
+    source ./script/install_tbb.sh
 fi
 
 # HIP
@@ -71,5 +71,5 @@ then
     source ./script/install_hip.sh
 fi
 
-./script/install_boost.sh
+source ./script/install_boost.sh
 

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -104,7 +104,7 @@ then
 
     # Clang is not supported by the FindBoost script.
     # boost (especially old versions) produces too much warnings when using clang (newer versions) so that the 4 MiB log is too short.
-    if [ "${CXX}" == "clang++" ]
+    if [[ "${CXX}" == "clang++"* ]]
     then
         ALPAKA_BOOST_B2_CXXFLAGS+=" -Wunused-private-field -Wno-unused-local-typedef -Wno-c99-extensions -Wno-variadic-macros"
     fi

--- a/script/install_clang.sh
+++ b/script/install_clang.sh
@@ -18,6 +18,17 @@ source ./script/set.sh
 : "${ALPAKA_CI_STDLIB?'ALPAKA_CI_STDLIB must be specified'}"
 : "${CXX?'CXX must be specified'}"
 
+# add clang-11 reposetory for ubuntu 18.04
+if [[ "$(cat /etc/os-release)" == *"18.04"* && "${ALPAKA_CI_CLANG_VER}" -eq 11 ]]
+then
+    travis_retry sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --allow-unauthenticated --no-install-recommends install tzdata
+    travis_retry apt-get -y --quiet install wget gnupg2
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+    echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main" | sudo tee /etc/apt/sources.list.d/clang11.list
+    echo "deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main" | sudo tee -a  /etc/apt/sources.list.d/clang11.list
+    travis_retry apt-get -y --quiet update
+fi
+
 travis_retry sudo apt-get -y --quiet --allow-unauthenticated --no-install-recommends install clang-${ALPAKA_CI_CLANG_VER}
 
 if [ "${ALPAKA_CI_STDLIB}" == "libc++" ]

--- a/script/install_cuda.sh
+++ b/script/install_cuda.sh
@@ -32,7 +32,7 @@ then
         travis_retry sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F60F4B3D7FA2AF80
     elif [[ "$(cat /etc/os-release)" == *"20.04"* ]]
     then
-        travis_retry sudo apt-get -y --quiet --allow-unauthenticated --no-install-recommends install dirmngr gpg-agent
+        travis_retry sudo apt-get -y --quiet --allow-unauthenticated --no-install-recommends install dirmngr gpg-agent gnupg2
         travis_retry sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F60F4B3D7FA2AF80
     fi
 

--- a/script/prepare_sanitizers.sh
+++ b/script/prepare_sanitizers.sh
@@ -42,7 +42,7 @@ then
     CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fno-optimize-sibling-calls"
 
     # g++ needs to use a different linker
-    if [[ "${CXX}" == "g++" ]]
+    if [[ "${CXX}" == "g++"* ]]
     then
         CMAKE_EXE_LINKER_FLAGS="${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold"
     fi
@@ -52,7 +52,7 @@ then
     then
         CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fsanitize=undefined"
 
-        if [[ "${CXX}" == "clang++" ]]
+        if [[ "${CXX}" == "clang++"* ]]
         then
             CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fsanitize-blacklist=$(pwd)/test/sanitizer_ubsan_blacklist.txt"
 
@@ -82,7 +82,7 @@ then
 
         CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fsanitize=address"
 
-        if [[ "${CXX}" != "clang++" ]]
+        if [[ "${CXX}" != "clang++"* ]]
         then
             CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fsanitize-address-use-after-scope"
         fi
@@ -104,7 +104,7 @@ then
         fi
 
         CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fsanitize=thread"
-        if [ "${CXX}" == "g++" ]
+        if [[ "${CXX}" == "g++"* ]]
         then
             CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -pie -fPIE"
             CMAKE_EXE_LINKER_FLAGS="${CMAKE_EXE_LINKER_FLAGS} -ltsan"

--- a/script/run.sh
+++ b/script/run.sh
@@ -33,7 +33,7 @@ then
     then
         LD_LIBRARY_PATH=
     fi
-    if [ "${CXX}" = "clang++" ]
+    if [[ "${CXX}" = "clang++"* ]]
     then
         if [ "${ALPAKA_CI_CLANG_VER}" -ge "10" ]
         then
@@ -96,7 +96,7 @@ then
             export CMAKE_CXX_FLAGS=
         fi
 
-        if [ "${CXX}" == "clang++" ]
+        if [[ "${CXX}" == "clang++"* ]]
         then
             CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -stdlib=libc++"
         fi


### PR DESCRIPTION
Copy github actions CUDA 9.2 jobs over to HZDR gitlab CI.
Reuse install script we already use for the Github actions CI.

HZDR CI:
  - CUDA: use nvidia cuda container (do not install CUDA)
  - use Ubuntu 18.04 for CUDA 9.2 (Ubuntu 20.04 container does not exists)
  - do not test `ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE` together with CUDA
(reduce compile time)
    - OpenMP + CUDA is still tested with `ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE`

Sometimes it is required to make a step back to go forward.
Therefore I used nvidia container sinstead of the alpaka containers provided by @SimeonEhrig.
The alpaka containers provide `avx512` compile time errors we workaround only for GCC 5: https://github.com/alpaka-group/alpaka/blob/9ac94b8faf85a9bceb3c260ddb3a32599644d99f/script/before_install.sh#L85-L103
It looks like the alpaka clang-cuda versions are built against GCC5 headers.
Switching back to the alpaka headers should be implemented in a follow-up PR. The advantage of first using the current existing script and then switching to the specialized containers is that we can reuse all our scripts and need only small changes to avoid installing already shipped software or compilers.