### PR TITLE
fix warning: annotated defaulted constructors

### DIFF
--- a/example/reduce/src/iterator.hpp
+++ b/example/reduce/src/iterator.hpp
@@ -47,7 +47,7 @@ public:
     //! Constructor.
     //!
     //! \param other The other iterator object.
-    ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE Iterator(const Iterator& other) = default;
+    Iterator(const Iterator& other) = default;
 
     //! Compare operator.
     //!

--- a/include/alpaka/block/sync/BlockSyncBarrierOacc.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierOacc.hpp
@@ -23,7 +23,7 @@ namespace alpaka
     class BlockSyncBarrierOacc
     {
     public:
-        ALPAKA_FN_HOST BlockSyncBarrierOacc() = default;
+        BlockSyncBarrierOacc() = default;
         ALPAKA_FN_HOST BlockSyncBarrierOacc(BlockSyncBarrierOacc const&) = delete;
         ALPAKA_FN_HOST BlockSyncBarrierOacc(BlockSyncBarrierOacc&&) = delete;
         ALPAKA_FN_HOST auto operator=(BlockSyncBarrierOacc const&) -> BlockSyncBarrierOacc& = delete;

--- a/include/alpaka/block/sync/BlockSyncNoOp.hpp
+++ b/include/alpaka/block/sync/BlockSyncNoOp.hpp
@@ -19,12 +19,12 @@ namespace alpaka
     class BlockSyncNoOp : public concepts::Implements<ConceptBlockSync, BlockSyncNoOp>
     {
     public:
-        ALPAKA_FN_ACC BlockSyncNoOp() = default;
+        BlockSyncNoOp() = default;
         ALPAKA_FN_ACC BlockSyncNoOp(BlockSyncNoOp const&) = delete;
         ALPAKA_FN_ACC BlockSyncNoOp(BlockSyncNoOp&&) = delete;
         ALPAKA_FN_ACC auto operator=(BlockSyncNoOp const&) -> BlockSyncNoOp& = delete;
         ALPAKA_FN_ACC auto operator=(BlockSyncNoOp&&) -> BlockSyncNoOp& = delete;
-        /*virtual*/ ALPAKA_FN_ACC ~BlockSyncNoOp() = default;
+        /*virtual*/ ~BlockSyncNoOp() = default;
     };
 
     namespace traits

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -47,7 +47,6 @@ namespace alpaka
         {
         }
 
-        ALPAKA_FN_HOST
         ViewPlainPtr(ViewPlainPtr const&) = default;
         ALPAKA_FN_HOST
         ViewPlainPtr(ViewPlainPtr&& other) noexcept
@@ -61,7 +60,7 @@ namespace alpaka
         auto operator=(ViewPlainPtr const&) -> ViewPlainPtr& = delete;
         ALPAKA_FN_HOST
         auto operator=(ViewPlainPtr&&) -> ViewPlainPtr& = delete;
-        ALPAKA_FN_HOST ~ViewPlainPtr() = default;
+        ~ViewPlainPtr() = default;
 
     public:
         TElem* const m_pMem;

--- a/include/alpaka/rand/RandUniformCudaHipRand.hpp
+++ b/include/alpaka/rand/RandUniformCudaHipRand.hpp
@@ -72,7 +72,7 @@ namespace alpaka
                     }
 
 #    if BOOST_COMP_HIP
-                    ALPAKA_FN_HOST_ACC ~Xor() = default;
+                    ~Xor() = default;
 #    endif
 
                     __device__ Xor(

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -605,7 +605,7 @@ namespace alpaka
             {
                 return !((*this) == rhs);
             }
-            ALPAKA_FN_HOST ~EventHostManualTriggerHip() = default;
+            ~EventHostManualTriggerHip() = default;
 
             void trigger()
             {

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -112,20 +112,11 @@ namespace alpaka
         {
         }
 
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC
         Vec(Vec const&) = default;
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC
         Vec(Vec&&) noexcept = default;
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC
         auto operator=(Vec const&) -> Vec& = default;
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC
         auto operator=(Vec&&) noexcept -> Vec& = default;
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC ~Vec() = default;
+        ~Vec() = default;
 
     private:
         //! A function object that returns the given value for each index.

--- a/include/alpaka/workdiv/WorkDivMembers.hpp
+++ b/include/alpaka/workdiv/WorkDivMembers.hpp
@@ -50,14 +50,9 @@ namespace alpaka
             , m_threadElemExtent(subVecEnd<TDim>(getWorkDiv<Thread, Elems>(other)))
         {
         }
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC
+
         WorkDivMembers(WorkDivMembers&&) = default;
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC
         auto operator=(WorkDivMembers const&) -> WorkDivMembers& = default;
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC
         auto operator=(WorkDivMembers&&) -> WorkDivMembers& = default;
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TWorkDiv>
@@ -68,8 +63,8 @@ namespace alpaka
             m_threadElemExtent = subVecEnd<TDim>(getWorkDiv<Thread, Elems>(other));
             return *this;
         }
-        ALPAKA_NO_HOST_ACC_WARNING
-        /*virtual*/ ALPAKA_FN_HOST_ACC ~WorkDivMembers() = default;
+
+        /*virtual*/ ~WorkDivMembers() = default;
 
     public:
         Vec<TDim, TIdx> m_gridBlockExtent;


### PR DESCRIPTION
```
alpaka/workdiv/WorkDivMembers.hpp(57): warning: __device__ annotation is ignored on a function("operator=") that is explicitly defaulted on its first declaration
```

Shown with CUDA 11.2 and @j-stephan's example https://github.com/infn-esc/esc21/blob/master/hands-on/alpaka_exercises/computePi/computePi.cu