### PR TITLE
Add support for Xcode 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
         - name: macos_xcode-12.5.1_release
           os: macos-11
           env: {CXX: clang++, CC: clang,  ALPAKA_CI_XCODE_VER: 12.5.1,                              CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.66.0,                                                  ALPAKA_CXX_STANDARD: 17,                                                                                                                                                                  ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
+        - name: macos_xcode-13.0.0_debug
+          os: macos-11
+          env: {CXX: clang++, CC: clang,  ALPAKA_CI_XCODE_VER: 13.0.0,                              CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_BOOST_BRANCH: boost-1.68.0,                                                  ALPAKA_CXX_STANDARD: 17,                                                                                                                                                                  ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
 
         ### Windows
         - name: windows_cl-2019_release

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Supported Compilers
 
 This library uses C++14 (or newer when available).
 
-|Accelerator Back-end|gcc 7.5 <br/> (Linux)|gcc 8.5 <br/> (Linux)|gcc 9.4 <br/> (Linux)|gcc 10.3 <br/> (Linux)|gcc 11.1 <br/> (Linux)|clang 5/6/7/8 <br/> (Linux)|clang 9 <br/> (Linux)|clang 10 <br/> (Linux)|clang 11 <br/> (Linux)|clang 12 <br/> (Linux)|Apple LLVM 11.3.1/12.4.0/12.5.1 <br /> (macOS)|MSVC 2019 <br/> (Windows)|
+|Accelerator Back-end|gcc 7.5 <br/> (Linux)|gcc 8.5 <br/> (Linux)|gcc 9.4 <br/> (Linux)|gcc 10.3 <br/> (Linux)|gcc 11.1 <br/> (Linux)|clang 5/6/7/8 <br/> (Linux)|clang 9 <br/> (Linux)|clang 10 <br/> (Linux)|clang 11 <br/> (Linux)|clang 12 <br/> (Linux)|Apple LLVM 11.3.1/12.4.0/12.5.1/13.0.0 <br /> (macOS)|MSVC 2019 <br/> (Windows)|
 |---|---|---|---|---|---|---|---|---|---|---|---|---|
 |Serial|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |OpenMP 2.0+ blocks|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|


### PR DESCRIPTION
This PR adds support for Xcode 13 by adding the corresponding CI check. Hopefully, this will work out of the box.