### PR TITLE
Atomic tests enabled and fix for float/double

### DIFF
--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -9,6 +9,7 @@
 
 #include <alpaka/atomic/Traits.hpp>
 #include <alpaka/core/Unused.hpp>
+#include <alpaka/math/FloatEqualExact.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 #include <alpaka/test/acc/TestAccs.hpp>
 
@@ -16,6 +17,24 @@
 
 #include <climits>
 #include <type_traits>
+
+template<typename T1, typename T2>
+ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool equals(T1 a, T2 b)
+{
+    return a == b;
+}
+
+template<>
+ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool equals<float, float>(float a, float b)
+{
+    return alpaka::math::floatEqualExactNoWarning(a, b);
+}
+
+template<>
+ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool equals<double, double>(double a, double b)
+{
+    return alpaka::math::floatEqualExactNoWarning(a, b);
+}
 
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename TAcc, typename T>
@@ -27,14 +46,14 @@ ALPAKA_FN_ACC auto testAtomicAdd(TAcc const& acc, bool* success, T operandOrig) 
     {
         operand = operandOrig;
         T const ret = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
         operand = operandOrig;
         T const ret = alpaka::atomicAdd(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
@@ -48,14 +67,14 @@ ALPAKA_FN_ACC auto testAtomicSub(TAcc const& acc, bool* success, T operandOrig) 
     {
         operand = operandOrig;
         T const ret = alpaka::atomicOp<alpaka::AtomicSub>(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
         operand = operandOrig;
         T const ret = alpaka::atomicSub(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
@@ -69,14 +88,14 @@ ALPAKA_FN_ACC auto testAtomicMin(TAcc const& acc, bool* success, T operandOrig) 
     {
         operand = operandOrig;
         T const ret = alpaka::atomicOp<alpaka::AtomicMin>(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
         operand = operandOrig;
         T const ret = alpaka::atomicMin(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
@@ -90,14 +109,14 @@ ALPAKA_FN_ACC auto testAtomicMax(TAcc const& acc, bool* success, T operandOrig) 
     {
         operand = operandOrig;
         T const ret = alpaka::atomicOp<alpaka::AtomicMax>(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
         operand = operandOrig;
         T const ret = alpaka::atomicMax(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
@@ -111,14 +130,14 @@ ALPAKA_FN_ACC auto testAtomicExch(TAcc const& acc, bool* success, T operandOrig)
     {
         operand = operandOrig;
         T const ret = alpaka::atomicOp<alpaka::AtomicExch>(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
         operand = operandOrig;
         T const ret = alpaka::atomicExch(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
@@ -133,14 +152,14 @@ ALPAKA_FN_ACC auto testAtomicInc(TAcc const& acc, bool* success, T operandOrig) 
     {
         operand = operandOrig;
         T const ret = alpaka::atomicOp<alpaka::AtomicInc>(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
         operand = operandOrig;
         T const ret = alpaka::atomicInc(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
@@ -155,14 +174,14 @@ ALPAKA_FN_ACC auto testAtomicDec(TAcc const& acc, bool* success, T operandOrig) 
     {
         operand = operandOrig;
         T const ret = alpaka::atomicOp<alpaka::AtomicDec>(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
         operand = operandOrig;
         T const ret = alpaka::atomicDec(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
@@ -176,14 +195,14 @@ ALPAKA_FN_ACC auto testAtomicAnd(TAcc const& acc, bool* success, T operandOrig) 
     {
         operand = operandOrig;
         T const ret = alpaka::atomicOp<alpaka::AtomicAnd>(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
         operand = operandOrig;
         T const ret = alpaka::atomicAnd(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
@@ -197,14 +216,14 @@ ALPAKA_FN_ACC auto testAtomicOr(TAcc const& acc, bool* success, T operandOrig) -
     {
         operand = operandOrig;
         T const ret = alpaka::atomicOp<alpaka::AtomicOr>(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
         operand = operandOrig;
         T const ret = alpaka::atomicOr(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
@@ -218,14 +237,14 @@ ALPAKA_FN_ACC auto testAtomicXor(TAcc const& acc, bool* success, T operandOrig) 
     {
         operand = operandOrig;
         T const ret = alpaka::atomicOp<alpaka::AtomicXor>(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
     {
         operand = operandOrig;
         T const ret = alpaka::atomicXor(acc, &operand, value);
-        ALPAKA_CHECK(*success, operandOrig == ret);
-        ALPAKA_CHECK(*success, operand == reference);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
     }
 }
 
@@ -243,14 +262,14 @@ ALPAKA_FN_ACC auto testAtomicCas(TAcc const& acc, bool* success, T operandOrig) 
         {
             operand = operandOrig;
             T const ret = alpaka::atomicOp<alpaka::AtomicCas>(acc, &operand, compare, value);
-            ALPAKA_CHECK(*success, operandOrig == ret);
-            ALPAKA_CHECK(*success, operand == reference);
+            ALPAKA_CHECK(*success, equals(operandOrig, ret));
+            ALPAKA_CHECK(*success, equals(operand, reference));
         }
         {
             operand = operandOrig;
             T const ret = alpaka::atomicCas(acc, &operand, compare, value);
-            ALPAKA_CHECK(*success, operandOrig == ret);
-            ALPAKA_CHECK(*success, operand == reference);
+            ALPAKA_CHECK(*success, equals(operandOrig, ret));
+            ALPAKA_CHECK(*success, equals(operand, reference));
         }
     }
 
@@ -261,14 +280,14 @@ ALPAKA_FN_ACC auto testAtomicCas(TAcc const& acc, bool* success, T operandOrig) 
         {
             operand = operandOrig;
             T const ret = alpaka::atomicOp<alpaka::AtomicCas>(acc, &operand, compare, value);
-            ALPAKA_CHECK(*success, operandOrig == ret);
-            ALPAKA_CHECK(*success, operand == reference);
+            ALPAKA_CHECK(*success, equals(operandOrig, ret));
+            ALPAKA_CHECK(*success, equals(operand, reference));
         }
         {
             operand = operandOrig;
             T const ret = alpaka::atomicCas(acc, &operand, compare, value);
-            ALPAKA_CHECK(*success, operandOrig == ret);
-            ALPAKA_CHECK(*success, operand == reference);
+            ALPAKA_CHECK(*success, equals(operandOrig, ret));
+            ALPAKA_CHECK(*success, equals(operand, reference));
         }
     }
 }
@@ -299,11 +318,58 @@ public:
     }
 };
 
+template<typename TAcc, typename T>
+class AtomicTestKernel<TAcc, T, std::enable_if_t<std::is_floating_point<T>::value>>
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, T operandOrig) const -> void
+    {
+        testAtomicAdd(acc, success, operandOrig);
+        testAtomicSub(acc, success, operandOrig);
+
+        testAtomicMin(acc, success, operandOrig);
+        testAtomicMax(acc, success, operandOrig);
+
+        testAtomicExch(acc, success, operandOrig);
+
+        // These are not supported on float/double types
+        // testAtomicInc(acc, success, operandOrig);
+        // testAtomicDec(acc, success, operandOrig);
+        // testAtomicAnd(acc, success, operandOrig);
+        // testAtomicOr(acc, success, operandOrig);
+        // testAtomicXor(acc, success, operandOrig);
+        // testAtomicCas(acc, success, operandOrig);
+    }
+};
+
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 // Skip all atomic tests for the unified CUDA/HIP backend.
 // CUDA and HIP atomics will be tested separate.
 template<typename T, typename TDim, typename TIdx>
-class AtomicTestKernel<alpaka::AccGpuUniformCudaHipRt<TDim, TIdx>, T>
+class AtomicTestKernel<
+    alpaka::AccGpuUniformCudaHipRt<TDim, TIdx>,
+    T,
+    std::enable_if_t<!std::is_floating_point<T>::value>>
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    ALPAKA_FN_ACC auto operator()(alpaka::AccGpuUniformCudaHipRt<TDim, TIdx> const& acc, bool* success, T operandOrig)
+        const -> void
+    {
+        alpaka::ignore_unused(acc);
+        alpaka::ignore_unused(success);
+        alpaka::ignore_unused(operandOrig);
+    }
+};
+
+// We need this partial specialization because of partial ordering of the
+// template specializations
+template<typename T, typename TDim, typename TIdx>
+class AtomicTestKernel<
+    alpaka::AccGpuUniformCudaHipRt<TDim, TIdx>,
+    T,
+    std::enable_if_t<std::is_floating_point<T>::value>>
 {
 public:
     ALPAKA_NO_HOST_ACC_WARNING
@@ -783,13 +849,10 @@ TEMPLATE_LIST_TEST_CASE("atomicOperationsWorking", "[atomic]", TestAccs)
 {
     using Acc = TestType;
 
-    // Types smaller than 32-bit are not supoported on accelerators for most atomics
-    // these should be reenabled for supporting backends (all CPU backends)
-    // when atomic testing is made more consistent
-    // TestAtomicOperations<Acc, unsigned char>::testAtomicOperations();
-    // TestAtomicOperations<Acc, char>::testAtomicOperations();
-    // TestAtomicOperations<Acc, unsigned short>::testAtomicOperations();
-    // TestAtomicOperations<Acc, short>::testAtomicOperations();
+    TestAtomicOperations<Acc, unsigned char>::testAtomicOperations();
+    TestAtomicOperations<Acc, char>::testAtomicOperations();
+    TestAtomicOperations<Acc, unsigned short>::testAtomicOperations();
+    TestAtomicOperations<Acc, short>::testAtomicOperations();
 
     TestAtomicOperations<Acc, unsigned int>::testAtomicOperations();
     TestAtomicOperations<Acc, int>::testAtomicOperations();
@@ -799,7 +862,6 @@ TEMPLATE_LIST_TEST_CASE("atomicOperationsWorking", "[atomic]", TestAccs)
     TestAtomicOperations<Acc, unsigned long long>::testAtomicOperations();
     TestAtomicOperations<Acc, long long>::testAtomicOperations();
 
-    // Not all atomic operations are possible with floating point values.
-    // TestAtomicOperations<Acc, float>::testAtomicOperations();
-    // TestAtomicOperations<Acc, double>::testAtomicOperations();
+    TestAtomicOperations<Acc, float>::testAtomicOperations();
+    TestAtomicOperations<Acc, double>::testAtomicOperations();
 }

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -24,14 +24,12 @@ ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool equals(T1 a, T2 b)
     return a == b;
 }
 
-template<>
-ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool equals<float, float>(float a, float b)
+ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool equals(float a, float b)
 {
     return alpaka::math::floatEqualExactNoWarning(a, b);
 }
 
-template<>
-ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool equals<double, double>(double a, double b)
+ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool equals(double a, double b)
 {
     return alpaka::math::floatEqualExactNoWarning(a, b);
 }

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -823,6 +823,25 @@ public:
 };
 #endif
 
+#ifdef ALPAKA_ACC_ANY_BT_OACC_ENABLED
+template<typename TDim, typename TIdx, typename T>
+class AtomicTestKernel<
+    alpaka::AccOacc<TDim, TIdx>,
+    T,
+    std::enable_if_t<sizeof(T) <= 2>> // disable 8-bit and 16-bit tests
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    ALPAKA_FN_ACC auto operator()(alpaka::AccOacc<TDim, TIdx> const& acc, bool* success, T operandOrig) const -> void
+    {
+        alpaka::ignore_unused(acc);
+        alpaka::ignore_unused(operandOrig);
+
+        // All other types are not supported by Oacc atomic operations.
+        ALPAKA_CHECK(*success, true);
+    }
+};
+#endif
 
 template<typename TAcc, typename T>
 struct TestAtomicOperations


### PR DESCRIPTION
This Pull request enables back all the atomic tests. The 8- and 16-bit tests are skipped for the CUDA/HIP backend; the float and double tests for atomics are re-enabled but not run for bitwise operations (and, or, xor).