### PR TITLE
Renamed tests

### DIFF
--- a/test/analysis/headerCheck/CMakeLists.txt
+++ b/test/analysis/headerCheck/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 if(NOT ALPAKA_CI OR (ALPAKA_CI AND ALPAKA_CI_ANALYSIS))
 
-    set(_TARGET_NAME "headerCheck")
+    set(_TARGET_NAME "headerCheckTest")
 
     #---------------------------------------------------------------------------
     # Create source files.

--- a/test/analysis/headerCheck/CMakeLists.txt
+++ b/test/analysis/headerCheck/CMakeLists.txt
@@ -48,7 +48,7 @@ if(NOT ALPAKA_CI OR (ALPAKA_CI AND ALPAKA_CI_ANALYSIS))
         ${_TARGET_NAME}
         PRIVATE common)
 
-    set_target_properties(headerCheck PROPERTIES FOLDER "test/analysis")
+    set_target_properties(headerCheckTest PROPERTIES FOLDER "test/analysis")
 
     add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME} ${_ALPAKA_TEST_OPTIONS})
 

--- a/test/integ/axpy/CMakeLists.txt
+++ b/test/integ/axpy/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "axpy")
+set(_TARGET_NAME "axpyTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/integ/cudaOnly/CMakeLists.txt
+++ b/test/integ/cudaOnly/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "cudaOnly")
+set(_TARGET_NAME "cudaOnlyTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/integ/mandelbrot/CMakeLists.txt
+++ b/test/integ/mandelbrot/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "mandelbrot")
+set(_TARGET_NAME "mandelbrotTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/integ/matMul/CMakeLists.txt
+++ b/test/integ/matMul/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "matMul")
+set(_TARGET_NAME "matMulTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/integ/separableCompilation/CMakeLists.txt
+++ b/test/integ/separableCompilation/CMakeLists.txt
@@ -12,7 +12,7 @@ if((NOT ALPAKA_ACC_GPU_CUDA_ENABLE AND NOT ALPAKA_ACC_GPU_HIP_ENABLE
    AND NOT ALPAKA_ACC_ANY_BT_OMP5_ENABLE AND NOT ALPAKA_ACC_ANY_BT_OACC_ENABLE) OR
    (ALPAKA_ACC_GPU_CUDA_ENABLE AND CMAKE_CUDA_SEPARABLE_COMPILATION))
 
-    set(_TARGET_NAME "separableCompilation")
+    set(_TARGET_NAME "separableCompilationTest")
 
     append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
     append_recursive_files_add_to_src_group("include/" "include/" "hpp" _FILES_HEADER)

--- a/test/integ/sharedMem/CMakeLists.txt
+++ b/test/integ/sharedMem/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "sharedMem")
+set(_TARGET_NAME "sharedMemTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/acc/CMakeLists.txt
+++ b/test/unit/acc/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "acc")
+set(_TARGET_NAME "accTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/atomic/CMakeLists.txt
+++ b/test/unit/atomic/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "atomic")
+set(_TARGET_NAME "atomicTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/block/shared/CMakeLists.txt
+++ b/test/unit/block/shared/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "blockShared")
+set(_TARGET_NAME "blockSharedTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/block/sync/CMakeLists.txt
+++ b/test/unit/block/sync/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "blockSync")
+set(_TARGET_NAME "blockSyncTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/core/CMakeLists.txt
+++ b/test/unit/core/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "core")
+set(_TARGET_NAME "coreTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/dev/CMakeLists.txt
+++ b/test/unit/dev/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "dev")
+set(_TARGET_NAME "devTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/event/CMakeLists.txt
+++ b/test/unit/event/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "event")
+set(_TARGET_NAME "eventTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/idx/CMakeLists.txt
+++ b/test/unit/idx/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "idx")
+set(_TARGET_NAME "idxTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/intrinsic/CMakeLists.txt
+++ b/test/unit/intrinsic/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "intrinsic")
+set(_TARGET_NAME "intrinsicTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/kernel/CMakeLists.txt
+++ b/test/unit/kernel/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "kernel")
+set(_TARGET_NAME "kernelTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/math/CMakeLists.txt
+++ b/test/unit/math/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "math")
+set(_TARGET_NAME "mathTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 append_recursive_files_add_to_src_group("src/" "src/" "hpp" _FILES_HEADER)

--- a/test/unit/mem/buf/CMakeLists.txt
+++ b/test/unit/mem/buf/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "memBuf")
+set(_TARGET_NAME "memBufTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/mem/copy/CMakeLists.txt
+++ b/test/unit/mem/copy/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "bufSlicing")
+set(_TARGET_NAME "bufSlicingTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/mem/p2p/CMakeLists.txt
+++ b/test/unit/mem/p2p/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-SET(_TARGET_NAME "memP2P")
+SET(_TARGET_NAME "memP2PTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/mem/view/CMakeLists.txt
+++ b/test/unit/mem/view/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "memView")
+set(_TARGET_NAME "memViewTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/meta/CMakeLists.txt
+++ b/test/unit/meta/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "meta")
+set(_TARGET_NAME "metaTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/queue/CMakeLists.txt
+++ b/test/unit/queue/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "queue")
+set(_TARGET_NAME "queueTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/rand/CMakeLists.txt
+++ b/test/unit/rand/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "rand")
+set(_TARGET_NAME "randTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/time/CMakeLists.txt
+++ b/test/unit/time/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "time")
+set(_TARGET_NAME "timeTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/vec/CMakeLists.txt
+++ b/test/unit/vec/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "vec")
+set(_TARGET_NAME "vecTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/warp/CMakeLists.txt
+++ b/test/unit/warp/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "warp")
+set(_TARGET_NAME "warpTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 

--- a/test/unit/workDiv/CMakeLists.txt
+++ b/test/unit/workDiv/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-set(_TARGET_NAME "workDiv")
+set(_TARGET_NAME "workDivTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 


### PR DESCRIPTION
This PR renames all the binary files created when running tests with the logic "testnameTest". This avoid the bug of Cmake reading the binary file for (i.e.) the atomic test, as the std header <atomic> is included in the source file. The same issue might happen with other tests (i.e. if the queue test included the std header <queue> in the source file).