### PR TITLE
Add Accessor for views and buffers (only feature)

### DIFF
--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -148,6 +148,11 @@ Get a raw pointer to a buffer or view initialization, etc.
      DataType* raw = view::getPtrNative(bufHost);
      DataType* rawViewPtr = view::getPtrNative(hostView);
 
+Get an accessor to a buffer and the accessor's type (experimental)
+  .. code-block:: c++
+
+     experimental::BufferAccessor<Acc, Elem, N, AccessTag> a = experimental::access(buffer);
+
 Allocate a buffer in device memory
   .. code-block:: c++
 

--- a/docs/source/basic/library.rst
+++ b/docs/source/basic/library.rst
@@ -212,6 +212,38 @@ It does not return raw pointers but reference counted memory buffer objects that
 Additionally the memory buffer objects know their extents, their pitches as well as the device they reside on.
 This allows buffers that possibly reside on different devices with different pitches to be copied only by providing the buffer objects as well as the extents of the region to copy (``alpaka::memcpy(bufDevA, bufDevB, copyExtents``).
 
+Accessors
+`````````
+
+An accessor is an interface to access the data stored by a buffer or, more generally, a view.
+Accessors take care of the multidimensionality of their underlying buffers when indexed, including pitched allocations.
+It is created via one of the following calls:
+
+.. code-block:: cpp
+
+   auto accessor = alpaka::experimental::access(buffer);      // read/write
+   auto accessor = alpaka::experimental::readAccess(buffer);  // read
+   auto accessor = alpaka::experimental::writeAccess(buffer); // write
+
+Accessors have many template parameter and users are adviced to use the ``BufferAccessor`` convenience alias to get the type of an accessor for a buffer of a given accelerator.
+Example kernel with 3D accessor:
+
+.. code-block:: c++
+
+   struct Kernel {
+      template<typename Acc>
+      ALPAKA_FN_ACC void operator()(Acc const & acc, alpaka::experimental::BufferAccessor<Acc, float, 3, alpaka::experimental::WriteAccess> data) const {
+         ...
+         for(Idx z = 0; z < data.extents[0];  ++z)
+             for(Idx y = 0; y < data.extents[1]; ++y)
+                 for(Idx x = 0; x < data.extents[2];  ++x)
+                     data(z, y, x) = 42.0f;
+      }
+   };
+   ...
+   alpaka::exec<Acc>(queue, workDiv, kernel, alpaka::experimental::writeAccess(buffer));
+
+
 Kernel Execution
 ````````````````
 

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Axel Huebl, Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera
+/* Copyright 2019-2021 Axel Huebl, Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -131,7 +131,9 @@
 #include <alpaka/mem/fence/MemFenceOmp5.hpp>
 #include <alpaka/mem/fence/MemFenceUniformCudaHipBuiltIn.hpp>
 #include <alpaka/mem/fence/Traits.hpp>
+#include <alpaka/mem/view/Accessor.hpp>
 #include <alpaka/mem/view/Traits.hpp>
+#include <alpaka/mem/view/ViewAccessor.hpp>
 #include <alpaka/mem/view/ViewCompileTimeArray.hpp>
 #include <alpaka/mem/view/ViewPlainPtr.hpp>
 #include <alpaka/mem/view/ViewStdArray.hpp>

--- a/include/alpaka/mem/view/Accessor.hpp
+++ b/include/alpaka/mem/view/Accessor.hpp
@@ -1,0 +1,192 @@
+/* Copyright 2021 Bernhard Manfred Gruber
+
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS” AND ISC DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+ * IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <alpaka/core/Utility.hpp>
+#include <alpaka/mem/buf/Traits.hpp>
+#include <alpaka/mem/view/Traits.hpp>
+#include <alpaka/meta/DependentFalseType.hpp>
+#include <alpaka/meta/TypeListOps.hpp>
+
+#include <tuple>
+
+namespace alpaka
+{
+    namespace experimental
+    {
+        //! Access tag type indicating read-only access.
+        struct ReadAccess
+        {
+        };
+
+        //! Access tag type indicating write-only access.
+        struct WriteAccess
+        {
+        };
+
+        //! Access tag type indicating read-write access.
+        struct ReadWriteAccess
+        {
+        };
+
+        //! An accessor is an abstraction for accessing memory objects such as views and buffers.
+        //! @tparam TMemoryHandle A handle to a memory object.
+        //! @tparam TElem The type of the element stored by the memory object. Values and references to this type are
+        //! returned on access.
+        //! @tparam TBufferIdx The integral type used for indexing and index computations.
+        //! @tparam TDim The dimensionality of the accessed data.
+        //! @tparam TAccessModes Either a single access tag type or a `std::tuple` containing multiple access tag
+        //! types.
+        template<typename TMemoryHandle, typename TElem, typename TBufferIdx, std::size_t TDim, typename TAccessModes>
+        struct Accessor;
+
+        namespace traits
+        {
+            //! The customization point for how to build an accessor for a given memory object.
+            template<typename TMemoryObject, typename SFINAE = void>
+            struct BuildAccessor
+            {
+                template<typename... TAccessModes, typename TMemoryObjectForwardRef>
+                ALPAKA_FN_HOST_ACC static auto buildAccessor(TMemoryObjectForwardRef&&)
+                {
+                    static_assert(
+                        meta::DependentFalseType<TMemoryObject>::value,
+                        "BuildAccessor<TMemoryObject> is not specialized for your TMemoryObject.");
+                }
+            };
+        } // namespace traits
+
+        namespace internal
+        {
+            template<typename AccessorOrBuffer>
+            struct MemoryHandle
+            {
+            };
+
+            template<
+                typename TMemoryHandle,
+                typename TElem,
+                typename TBufferIdx,
+                std::size_t TDim,
+                typename TAccessModes>
+            struct MemoryHandle<Accessor<TMemoryHandle, TElem, TBufferIdx, TDim, TAccessModes>>
+            {
+                using type = TMemoryHandle;
+            };
+        } // namespace internal
+
+        /// Get the memory handle type of the given accessor or buffer type.
+        template<typename Accessor>
+        using MemoryHandle = typename internal::MemoryHandle<Accessor>::type;
+
+        namespace internal
+        {
+            template<typename T>
+            struct IsAccessor : std::false_type
+            {
+            };
+
+            template<
+                typename TMemoryHandle,
+                typename TElem,
+                typename TBufferIdx,
+                std::size_t Dim,
+                typename TAccessModes>
+            struct IsAccessor<Accessor<TMemoryHandle, TElem, TBufferIdx, Dim, TAccessModes>> : std::true_type
+            {
+            };
+        } // namespace internal
+
+        //! Creates an accessor for the given memory object using the specified access modes. Memory objects are e.g.
+        //! alpaka views and buffers.
+        template<
+            typename... TAccessModes,
+            typename TMemoryObject,
+            typename = std::enable_if_t<!internal::IsAccessor<std::decay_t<TMemoryObject>>::value>>
+        ALPAKA_FN_HOST_ACC auto accessWith(TMemoryObject&& memoryObject)
+        {
+            return traits::BuildAccessor<std::decay_t<TMemoryObject>>::template buildAccessor<TAccessModes...>(
+                memoryObject);
+        }
+
+        //! Constrains an existing accessor with multiple access modes to the specified access modes.
+        // TODO: currently only allows constraining down to 1 access mode
+        template<
+            typename TNewAccessMode,
+            typename TMemoryHandle,
+            typename TElem,
+            typename TBufferIdx,
+            std::size_t TDim,
+            typename... TPrevAccessModes>
+        ALPAKA_FN_HOST_ACC auto accessWith(
+            const Accessor<TMemoryHandle, TElem, TBufferIdx, TDim, std::tuple<TPrevAccessModes...>>& acc)
+        {
+            static_assert(
+                meta::Contains<std::tuple<TPrevAccessModes...>, TNewAccessMode>::value,
+                "The accessed accessor must already contain the requested access mode");
+            return Accessor<TMemoryHandle, TElem, TBufferIdx, TDim, TNewAccessMode>{acc};
+        }
+
+        //! Constrains an existing accessor to the specified access modes.
+        // constraining accessor to the same access mode again just passes through
+        template<
+            typename TNewAccessMode,
+            typename TMemoryHandle,
+            typename TElem,
+            typename TBufferIdx,
+            std::size_t TDim>
+        ALPAKA_FN_HOST_ACC auto accessWith(const Accessor<TMemoryHandle, TElem, TBufferIdx, TDim, TNewAccessMode>& acc)
+        {
+            return acc;
+        }
+
+        //! Creates a read-write accessor for the given memory object (view, buffer, ...) or accessor.
+        template<typename TMemoryObjectOrAccessor>
+        ALPAKA_FN_HOST_ACC auto access(TMemoryObjectOrAccessor&& viewOrAccessor)
+        {
+            return accessWith<ReadWriteAccess>(std::forward<TMemoryObjectOrAccessor>(viewOrAccessor));
+        }
+
+        //! Creates a read-only accessor for the given memory object (view, buffer, ...) or accessor.
+        template<typename TMemoryObjectOrAccessor>
+        ALPAKA_FN_HOST_ACC auto readAccess(TMemoryObjectOrAccessor&& viewOrAccessor)
+        {
+            return accessWith<ReadAccess>(std::forward<TMemoryObjectOrAccessor>(viewOrAccessor));
+        }
+
+        //! Creates a write-only accessor for the given memory object (view, buffer, ...) or accessor.
+        template<typename TMemoryObjectOrAccessor>
+        ALPAKA_FN_HOST_ACC auto writeAccess(TMemoryObjectOrAccessor&& viewOrAccessor)
+        {
+            return accessWith<WriteAccess>(std::forward<TMemoryObjectOrAccessor>(viewOrAccessor));
+        }
+
+        //! An alias for an accessor accessing a buffer on the given accelerator.
+        template<
+            typename TAcc,
+            typename TElem,
+            std::size_t TDim,
+            typename TAccessModes = ReadWriteAccess,
+            typename TIdx = Idx<TAcc>>
+        using BufferAccessor = Accessor<
+            MemoryHandle<decltype(accessWith<TAccessModes>(
+                alpaka::core::declval<Buf<TAcc, TElem, DimInt<TDim>, TIdx>>()))>,
+            TElem,
+            TIdx,
+            TDim,
+            TAccessModes>;
+    } // namespace experimental
+} // namespace alpaka

--- a/include/alpaka/mem/view/ViewAccessor.hpp
+++ b/include/alpaka/mem/view/ViewAccessor.hpp
@@ -1,0 +1,273 @@
+/* Copyright 2021 Bernhard Manfred Gruber
+
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS” AND ISC DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+ * IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <alpaka/dim/Traits.hpp>
+#include <alpaka/mem/view/Accessor.hpp>
+#include <alpaka/meta/Void.hpp>
+
+namespace alpaka
+{
+    namespace experimental
+    {
+        namespace internal
+        {
+            template<typename T>
+            ALPAKA_FN_HOST_ACC auto asBytePtr(T* p)
+            {
+                return reinterpret_cast<char*>(p);
+            }
+
+            template<typename T>
+            struct WriteOnlyProxy
+            {
+                ALPAKA_FN_HOST_ACC WriteOnlyProxy(T& location) : loc(location)
+                {
+                }
+
+                template<typename U>
+                ALPAKA_FN_HOST_ACC auto& operator=(U&& value)
+                {
+                    loc = std::forward<U>(value);
+                    return *this;
+                }
+
+            private:
+                T& loc;
+            };
+
+            template<typename TElem, typename TAccessModes>
+            struct AccessReturnTypeImpl;
+
+            template<typename TElem>
+            struct AccessReturnTypeImpl<TElem, ReadAccess>
+            {
+                using type = TElem;
+            };
+
+            template<typename TElem>
+            struct AccessReturnTypeImpl<TElem, WriteAccess>
+            {
+                using type = WriteOnlyProxy<TElem>;
+            };
+
+            template<typename TElem>
+            struct AccessReturnTypeImpl<TElem, ReadWriteAccess>
+            {
+                using type = TElem&;
+            };
+
+            template<typename TElem, typename THeadAccessMode, typename... TTailAccessModes>
+            struct AccessReturnTypeImpl<TElem, std::tuple<THeadAccessMode, TTailAccessModes...>>
+                : AccessReturnTypeImpl<TElem, THeadAccessMode>
+            {
+            };
+
+            template<typename TElem, typename TAccessModes>
+            using AccessReturnType = typename internal::AccessReturnTypeImpl<TElem, TAccessModes>::type;
+        } // namespace internal
+
+        //! 1D accessor to memory objects represented by a pointer.
+        // We keep this specialization to not store the zero-dim pitch vector and provide one more operator[].
+        template<typename TElem, typename TBufferIdx, typename TAccessModes>
+        struct Accessor<TElem*, TElem, TBufferIdx, 1, TAccessModes>
+        {
+            using ReturnType = internal::AccessReturnType<TElem, TAccessModes>;
+
+            ALPAKA_FN_HOST_ACC Accessor(
+                TElem* p_,
+                Vec<DimInt<0>, TBufferIdx> pitchesInBytes_,
+                Vec<DimInt<1>, TBufferIdx> extents_)
+                : p(p_)
+                , extents(extents_)
+            {
+                (void) pitchesInBytes_;
+            }
+
+            template<typename TOtherAccessModes>
+            ALPAKA_FN_HOST_ACC Accessor(const Accessor<TElem*, TElem, TBufferIdx, 1, TOtherAccessModes>& other)
+                : p(other.p)
+                , extents(other.extents)
+            {
+            }
+
+            ALPAKA_FN_HOST_ACC auto operator[](Vec<DimInt<1>, TBufferIdx> i) const -> ReturnType
+            {
+                return (*this)(i[0]);
+            }
+
+            ALPAKA_FN_HOST_ACC auto operator[](TBufferIdx i) const -> ReturnType
+            {
+                return (*this)(i);
+            }
+
+            ALPAKA_FN_HOST_ACC auto operator()(TBufferIdx i) const -> ReturnType
+            {
+                return p[i];
+            }
+
+            TElem* p;
+            Vec<DimInt<1>, TBufferIdx> extents;
+        };
+
+        //! Higher than 1D accessor to memory objects represented by a pointer.
+        template<typename TElem, typename TBufferIdx, std::size_t TDim, typename TAccessModes>
+        struct Accessor<TElem*, TElem, TBufferIdx, TDim, TAccessModes>
+        {
+            using ReturnType = internal::AccessReturnType<TElem, TAccessModes>;
+
+            ALPAKA_FN_HOST_ACC Accessor(
+                TElem* p_,
+                Vec<DimInt<TDim - 1>, TBufferIdx> pitchesInBytes_,
+                Vec<DimInt<TDim>, TBufferIdx> extents_)
+                : p(p_)
+                , pitchesInBytes(pitchesInBytes_)
+                , extents(extents_)
+            {
+            }
+
+            template<typename TOtherAccessModes>
+            ALPAKA_FN_HOST_ACC Accessor(const Accessor<TElem*, TElem, TBufferIdx, TDim, TOtherAccessModes>& other)
+                : p(other.p)
+                , pitchesInBytes(other.pitchesInBytes)
+                , extents(other.extents)
+            {
+            }
+
+        private:
+            template<std::size_t... TIs>
+            ALPAKA_FN_HOST_ACC auto subscript(Vec<DimInt<TDim>, TBufferIdx> index) const -> ReturnType
+            {
+#if BOOST_COMP_GNUC
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wcast-align"
+#endif
+                auto bp = internal::asBytePtr(p);
+                for(std::size_t i = 0u; i < TDim; i++)
+                {
+                    const auto pitch = i < TDim - 1 ? pitchesInBytes[i] : static_cast<TBufferIdx>(sizeof(TElem));
+                    bp += index[i] * pitch;
+                }
+                return *reinterpret_cast<TElem*>(bp);
+#if BOOST_COMP_GNUC
+#    pragma GCC diagnostic pop
+#endif
+            }
+
+        public:
+            ALPAKA_FN_HOST_ACC auto operator[](Vec<DimInt<TDim>, TBufferIdx> i) const -> ReturnType
+            {
+                return subscript(i);
+            }
+
+            template<typename... Ts>
+            ALPAKA_FN_HOST_ACC auto operator()(Ts... i) const -> ReturnType
+            {
+                static_assert(sizeof...(Ts) == TDim, "You need to specify TDim indices.");
+                return subscript(Vec<DimInt<TDim>, TBufferIdx>{static_cast<TBufferIdx>(i)...});
+            }
+
+            TElem* p;
+            Vec<DimInt<TDim - 1>, TBufferIdx> pitchesInBytes;
+            Vec<DimInt<TDim>, TBufferIdx> extents;
+        };
+
+        namespace traits
+        {
+            namespace internal
+            {
+                template<typename T, typename SFINAE = void>
+                struct IsView : std::false_type
+                {
+                };
+
+                // TODO: replace this by a concept in C++20
+                template<typename TView>
+                struct IsView<
+                    TView,
+                    meta::Void<
+                        Idx<TView>,
+                        Dim<TView>,
+                        decltype(getPtrNative(std::declval<TView>())),
+                        decltype(getPitchBytes<0>(std::declval<TView>())),
+                        decltype(extent::getExtent<0>(std::declval<TView>()))>> : std::true_type
+                {
+                };
+
+                template<typename... TAccessModes>
+                struct BuildAccessModeList;
+
+                template<typename TAccessMode>
+                struct BuildAccessModeList<TAccessMode>
+                {
+                    using type = TAccessMode;
+                };
+
+                template<typename TAccessMode1, typename TAccessMode2, typename... TAccessModes>
+                struct BuildAccessModeList<TAccessMode1, TAccessMode2, TAccessModes...>
+                {
+                    using type = std::tuple<TAccessMode1, TAccessMode2, TAccessModes...>;
+                };
+
+                ALPAKA_NO_HOST_ACC_WARNING
+                template<
+                    typename... TAccessModes,
+                    typename TViewForwardRef,
+                    std::size_t... TPitchIs,
+                    std::size_t... TExtentIs>
+                ALPAKA_FN_HOST_ACC auto buildViewAccessor(
+                    TViewForwardRef&& view,
+                    std::index_sequence<TPitchIs...>,
+                    std::index_sequence<TExtentIs...>)
+                {
+                    using TView = std::decay_t<TViewForwardRef>;
+                    static_assert(IsView<TView>::value, "");
+                    using TBufferIdx = Idx<TView>;
+                    constexpr auto dim = Dim<TView>::value;
+                    using Elem = Elem<TView>;
+                    auto p = getPtrNative(view);
+                    static_assert(
+                        std::is_same<decltype(p), const Elem*>::value || std::is_same<decltype(p), Elem*>::value,
+                        "We assume that getPtrNative() returns a raw pointer to the view's elements");
+                    static_assert(
+                        !std::is_same<decltype(p), const Elem*>::value
+                            || std::is_same<std::tuple<TAccessModes...>, std::tuple<ReadAccess>>::value,
+                        "When getPtrNative() returns a const raw pointer, the access mode must be ReadAccess");
+                    using AccessModeList = typename BuildAccessModeList<TAccessModes...>::type;
+                    return Accessor<Elem*, Elem, TBufferIdx, dim, AccessModeList>{
+                        const_cast<Elem*>(p), // strip constness, this is handled the the access modes
+                        {getPitchBytes<TPitchIs + 1>(view)...},
+                        {extent::getExtent<TExtentIs>(view)...}};
+                }
+            } // namespace internal
+
+            //! Builds an accessor from view like memory objects.
+            template<typename TView>
+            struct BuildAccessor<TView, std::enable_if_t<internal::IsView<TView>::value>>
+            {
+                template<typename... TAccessModes, typename TViewForwardRef>
+                ALPAKA_FN_HOST_ACC static auto buildAccessor(TViewForwardRef&& view)
+                {
+                    using Dim = Dim<std::decay_t<TView>>;
+                    return internal::buildViewAccessor<TAccessModes...>(
+                        std::forward<TViewForwardRef>(view),
+                        std::make_index_sequence<Dim::value - 1>{},
+                        std::make_index_sequence<Dim::value>{});
+                }
+            };
+        } // namespace traits
+    } // namespace experimental
+} // namespace alpaka

--- a/test/unit/mem/view/src/Accessor.cpp
+++ b/test/unit/mem/view/src/Accessor.cpp
@@ -1,0 +1,376 @@
+/* Copyright 2021 Bernhard Manfred Gruber
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <alpaka/example/ExampleDefaultAcc.hpp>
+#include <alpaka/mem/view/Accessor.hpp>
+#include <alpaka/mem/view/ViewPlainPtr.hpp>
+#include <alpaka/mem/view/ViewStdArray.hpp>
+#include <alpaka/mem/view/ViewStdVector.hpp>
+#include <alpaka/mem/view/ViewSubView.hpp>
+
+#include <catch2/catch.hpp>
+
+namespace alpakaex = alpaka::experimental;
+
+TEST_CASE("IsView", "[accessor]")
+{
+    using alpakaex::traits::internal::IsView;
+
+    using Dim = alpaka::DimInt<1>;
+    using Size = std::size_t;
+    using Acc = alpaka::ExampleDefaultAcc<Dim, Size>;
+    using Dev = alpaka::Dev<Acc>;
+
+    // buffer
+    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto buffer = alpaka::allocBuf<int, Size>(devAcc, Size{1});
+    STATIC_REQUIRE(IsView<decltype(buffer)>::value);
+
+    // views
+    STATIC_REQUIRE(IsView<alpaka::ViewPlainPtr<Dev, int, Dim, Size>>::value);
+    STATIC_REQUIRE(IsView<std::array<int, 42>>::value);
+    STATIC_REQUIRE(IsView<std::vector<int>>::value);
+    STATIC_REQUIRE(IsView<alpaka::ViewSubView<Dev, int, Dim, Size>>::value);
+
+    // accessor
+    auto accessor = alpakaex::access(buffer);
+    STATIC_REQUIRE(!IsView<decltype(accessor)>::value);
+}
+
+namespace
+{
+    constexpr auto N = 1024;
+
+    struct WriteKernelTemplate
+    {
+        template<typename TAcc, typename TAccessor>
+        ALPAKA_FN_ACC void operator()(TAcc const&, TAccessor data) const
+        {
+            data[1] = 1.0f;
+            data(2) = 2.0f;
+            data[alpaka::Vec<alpaka::DimInt<1>, alpaka::Idx<TAcc>>{alpaka::Idx<TAcc>{3}}] = 3.0f;
+        }
+    };
+
+    struct WriteKernelExplicit
+    {
+        template<typename TAcc, typename TMemoryHandle, typename TIdx>
+        ALPAKA_FN_ACC void operator()(
+            TAcc const&,
+            alpakaex::Accessor<TMemoryHandle, float, TIdx, 1, alpakaex::WriteAccess> const data) const
+        {
+            data[1] = 1.0f;
+            data(2) = 2.0f;
+            data[alpaka::Vec<alpaka::DimInt<1>, TIdx>{TIdx{3}}] = 3.0f;
+        }
+    };
+
+    struct ReadKernelTemplate
+    {
+        template<typename TAcc, typename TAccessor>
+        ALPAKA_FN_ACC void operator()(TAcc const&, TAccessor data) const
+        {
+            float const v1 = data[1];
+            float const v2 = data(2);
+            float const v3 = data[alpaka::Vec<alpaka::DimInt<1>, alpaka::Idx<TAcc>>{alpaka::Idx<TAcc>{3}}];
+            (void) v1;
+            (void) v2;
+            (void) v3;
+        }
+    };
+
+    struct ReadKernelExplicit
+    {
+        template<typename TAcc, typename TMemoryHandle, typename TIdx>
+        ALPAKA_FN_ACC void operator()(
+            TAcc const&,
+            alpakaex::Accessor<TMemoryHandle, float, TIdx, 1, alpakaex::ReadAccess> const data) const
+        {
+            float const v1 = data[1];
+            float const v2 = data(2);
+            float const v3 = data[alpaka::Vec<alpaka::DimInt<1>, TIdx>{TIdx{3}}];
+            (void) v1;
+            (void) v2;
+            (void) v3;
+        }
+    };
+
+    struct ReadWriteKernelExplicit
+    {
+        template<typename TAcc, typename TMemoryHandle, typename TIdx>
+        ALPAKA_FN_ACC void operator()(
+            TAcc const&,
+            alpakaex::Accessor<TMemoryHandle, float, TIdx, 1, alpakaex::ReadWriteAccess> const data) const
+        {
+            float const v1 = data[1];
+            float const v2 = data(2);
+            float const v3 = data[alpaka::Vec<alpaka::DimInt<1>, TIdx>{TIdx{3}}];
+            (void) v1;
+            (void) v2;
+            (void) v3;
+
+            data[1] = 1.0f;
+            data(2) = 2.0f;
+            data[alpaka::Vec<alpaka::DimInt<1>, TIdx>{TIdx{3}}] = 3.0f;
+        }
+    };
+} // namespace
+
+TEST_CASE("readWrite", "[accessor]")
+{
+    using Dim = alpaka::DimInt<1>;
+    using Size = std::size_t;
+    using Acc = alpaka::ExampleDefaultAcc<Dim, Size>;
+    using DevAcc = alpaka::Dev<Acc>;
+    using Queue = alpaka::Queue<DevAcc, alpaka::Blocking>;
+
+    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto queue = Queue{devAcc};
+    auto buffer = alpaka::allocBuf<float, Size>(devAcc, Size{N});
+    auto const workdiv = alpaka::WorkDivMembers<Dim, Size>{
+        alpaka::Vec<Dim, Size>{Size{1}},
+        alpaka::Vec<Dim, Size>{Size{1}},
+        alpaka::Vec<Dim, Size>{Size{1}}};
+
+    alpaka::exec<Acc>(queue, workdiv, WriteKernelTemplate{}, alpakaex::writeAccess(buffer));
+    alpaka::exec<Acc>(queue, workdiv, WriteKernelExplicit{}, alpakaex::writeAccess(buffer));
+    alpaka::exec<Acc>(queue, workdiv, ReadKernelTemplate{}, alpakaex::readAccess(buffer));
+    alpaka::exec<Acc>(queue, workdiv, ReadKernelExplicit{}, alpakaex::readAccess(buffer));
+    alpaka::exec<Acc>(queue, workdiv, ReadWriteKernelExplicit{}, alpakaex::access(buffer));
+}
+
+namespace
+{
+    template<typename TProjection, typename TMemoryHandle, typename TElem, typename TBufferIdx, std::size_t TDim>
+    struct AccessorWithProjection;
+
+    template<typename TProjection, typename TMemoryHandle, typename TElem, typename TBufferIdx>
+    struct AccessorWithProjection<TProjection, TMemoryHandle, TElem, TBufferIdx, 1>
+    {
+        ALPAKA_FN_ACC auto operator[](alpaka::Vec<alpaka::DimInt<1>, TBufferIdx> i) const -> TElem
+        {
+            return TProjection{}(accessor[i]);
+        }
+
+        ALPAKA_FN_ACC auto operator[](TBufferIdx i) const -> TElem
+        {
+            return TProjection{}(accessor[i]);
+        }
+
+        ALPAKA_FN_ACC auto operator()(TBufferIdx i) const -> TElem
+        {
+            return TProjection{}(accessor(i));
+        }
+
+        alpakaex::Accessor<TMemoryHandle, TElem, TBufferIdx, 1, alpakaex::ReadAccess> accessor;
+    };
+
+    template<typename TProjection, typename TMemoryHandle, typename TElem, typename TBufferIdx>
+    struct AccessorWithProjection<TProjection, TMemoryHandle, TElem, TBufferIdx, 2>
+    {
+        ALPAKA_FN_ACC auto operator[](alpaka::Vec<alpaka::DimInt<2>, TBufferIdx> i) const -> TElem
+        {
+            return TProjection{}(accessor[i]);
+        }
+
+        ALPAKA_FN_ACC auto operator()(TBufferIdx y, TBufferIdx x) const -> TElem
+        {
+            return TProjection{}(accessor(y, x));
+        }
+
+        alpakaex::Accessor<TMemoryHandle, TElem, TBufferIdx, 2, alpakaex::ReadAccess> accessor;
+    };
+
+    template<typename TProjection, typename TMemoryHandle, typename TElem, typename TBufferIdx>
+    struct AccessorWithProjection<TProjection, TMemoryHandle, TElem, TBufferIdx, 3>
+    {
+        ALPAKA_FN_ACC auto operator[](alpaka::Vec<alpaka::DimInt<3>, TBufferIdx> i) const -> TElem
+        {
+            return TProjection{}(accessor[i]);
+        }
+
+        ALPAKA_FN_ACC auto operator()(TBufferIdx z, TBufferIdx y, TBufferIdx x) const -> TElem
+        {
+            return TProjection{}(accessor(z, y, x));
+        }
+
+        alpakaex::Accessor<TMemoryHandle, TElem, TBufferIdx, 3, alpakaex::ReadAccess> accessor;
+    };
+
+    struct DoubleValue
+    {
+        ALPAKA_FN_ACC auto operator()(int i) const
+        {
+            return i * 2;
+        }
+    };
+
+    struct CopyKernel
+    {
+        template<typename TAcc, typename TMemoryHandle, typename TIdx>
+        ALPAKA_FN_ACC void operator()(
+            TAcc const&,
+            alpakaex::Accessor<TMemoryHandle, int, TIdx, 1, alpakaex::ReadAccess> const src,
+            alpakaex::Accessor<TMemoryHandle, int, TIdx, 1, alpakaex::WriteAccess> const dst) const
+        {
+            auto const projSrc = AccessorWithProjection<DoubleValue, TMemoryHandle, int, TIdx, 1>{src};
+            dst[0] = projSrc[0];
+        }
+    };
+} // namespace
+
+TEST_CASE("projection", "[accessor]")
+{
+    using Dim = alpaka::DimInt<1>;
+    using Size = std::size_t;
+    using Acc = alpaka::ExampleDefaultAcc<Dim, Size>;
+    using DevAcc = alpaka::Dev<Acc>;
+    using Queue = alpaka::Queue<DevAcc, alpaka::Blocking>;
+
+    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto queue = Queue{devAcc};
+
+    auto srcBuffer = alpaka::allocBuf<int, Size>(devAcc, Size{1});
+    auto dstBuffer = alpaka::allocBuf<int, Size>(devAcc, Size{1});
+
+    std::array<int, 1> host{{42}};
+    alpaka::memcpy(queue, srcBuffer, host, 1);
+
+    auto const workdiv = alpaka::WorkDivMembers<Dim, Size>{
+        alpaka::Vec<Dim, Size>{Size{1}},
+        alpaka::Vec<Dim, Size>{Size{1}},
+        alpaka::Vec<Dim, Size>{Size{1}}};
+    alpaka::exec<Acc>(queue, workdiv, CopyKernel{}, alpakaex::readAccess(srcBuffer), alpakaex::writeAccess(dstBuffer));
+
+    alpaka::memcpy(queue, host, dstBuffer, 1);
+
+    REQUIRE(host[0] == 84);
+}
+
+TEST_CASE("constraining", "[accessor]")
+{
+    using Dim = alpaka::DimInt<1>;
+    using Size = std::size_t;
+    using Acc = alpaka::ExampleDefaultAcc<Dim, Size>;
+
+    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto buffer = alpaka::allocBuf<int, Size>(devAcc, Size{1});
+    using MemoryHandle = alpakaex::MemoryHandle<decltype(alpakaex::access(buffer))>;
+
+    alpakaex::Accessor<
+        MemoryHandle,
+        int,
+        Size,
+        1,
+        std::tuple<alpakaex::ReadAccess, alpakaex::WriteAccess, alpakaex::ReadWriteAccess>>
+        acc = alpakaex::accessWith<alpakaex::ReadAccess, alpakaex::WriteAccess, alpakaex::ReadWriteAccess>(buffer);
+
+    // constraining from multi-tag to single-tag
+    alpakaex::Accessor<MemoryHandle, int, Size, 1, alpakaex::ReadAccess> readAcc = alpakaex::readAccess(acc);
+    alpakaex::Accessor<MemoryHandle, int, Size, 1, alpakaex::WriteAccess> writeAcc = alpakaex::writeAccess(acc);
+    alpakaex::Accessor<MemoryHandle, int, Size, 1, alpakaex::ReadWriteAccess> readWriteAcc = alpakaex::access(acc);
+    (void) readAcc;
+    (void) writeAcc;
+    (void) readWriteAcc;
+
+    // constraining from single-tag to single-tag
+    alpakaex::Accessor<MemoryHandle, int, Size, 1, alpakaex::ReadAccess> readAcc2 = alpakaex::readAccess(readAcc);
+    alpakaex::Accessor<MemoryHandle, int, Size, 1, alpakaex::WriteAccess> writeAcc2 = alpakaex::writeAccess(writeAcc);
+    alpakaex::Accessor<MemoryHandle, int, Size, 1, alpakaex::ReadWriteAccess> readWriteAcc2
+        = alpakaex::access(readWriteAcc);
+    (void) readAcc2;
+    (void) writeAcc2;
+    (void) readWriteAcc2;
+}
+
+namespace
+{
+    struct BufferAccessorKernelRead
+    {
+        template<typename TAcc, typename TMemoryHandle, typename TIdx>
+        ALPAKA_FN_ACC void operator()(
+            TAcc const&,
+            alpakaex::Accessor<TMemoryHandle, int, TIdx, 1, alpakaex::ReadAccess> const r1,
+            alpakaex::BufferAccessor<TAcc, int, 1, alpakaex::ReadAccess> const r2,
+            alpakaex::BufferAccessor<TAcc, int, 1, alpakaex::ReadAccess, TIdx> const r3) const noexcept
+        {
+            static_assert(std::is_same<decltype(r1), decltype(r2)>::value, "");
+            static_assert(std::is_same<decltype(r2), decltype(r3)>::value, "");
+        }
+    };
+
+    struct BufferAccessorKernelWrite
+    {
+        template<typename TAcc, typename TMemoryHandle, typename TIdx>
+        ALPAKA_FN_ACC void operator()(
+            TAcc const&,
+            alpakaex::Accessor<TMemoryHandle, int, TIdx, 1, alpakaex::WriteAccess> const w1,
+            alpakaex::BufferAccessor<TAcc, int, 1, alpakaex::WriteAccess> const w2,
+            alpakaex::BufferAccessor<TAcc, int, 1, alpakaex::WriteAccess, TIdx> const w3) const noexcept
+        {
+            static_assert(std::is_same<decltype(w1), decltype(w2)>::value, "");
+            static_assert(std::is_same<decltype(w2), decltype(w3)>::value, "");
+        }
+    };
+    struct BufferAccessorKernelReadWrite
+    {
+        template<typename TAcc, typename TMemoryHandle, typename TIdx>
+        ALPAKA_FN_ACC void operator()(
+            TAcc const&,
+            alpakaex::Accessor<TMemoryHandle, int, TIdx, 1, alpakaex::ReadWriteAccess> const rw1,
+            alpakaex::BufferAccessor<TAcc, int, 1> const rw2,
+            alpakaex::BufferAccessor<TAcc, int, 1, alpakaex::ReadWriteAccess> const rw3,
+            alpakaex::BufferAccessor<TAcc, int, 1, alpakaex::ReadWriteAccess, TIdx> const rw4) const noexcept
+        {
+            static_assert(std::is_same<decltype(rw1), decltype(rw2)>::value, "");
+            static_assert(std::is_same<decltype(rw2), decltype(rw3)>::value, "");
+            static_assert(std::is_same<decltype(rw3), decltype(rw4)>::value, "");
+        }
+    };
+} // namespace
+
+TEST_CASE("BufferAccessor", "[accessor]")
+{
+    using Dim = alpaka::DimInt<1>;
+    using Size = std::size_t;
+    using Acc = alpaka::ExampleDefaultAcc<Dim, Size>;
+    using DevAcc = alpaka::Dev<Acc>;
+    using Queue = alpaka::Queue<DevAcc, alpaka::Blocking>;
+
+    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto queue = Queue{devAcc};
+    auto buffer = alpaka::allocBuf<int, Size>(devAcc, Size{1});
+
+    auto const workdiv = alpaka::WorkDivMembers<Dim, Size>{
+        alpaka::Vec<Dim, Size>{Size{1}},
+        alpaka::Vec<Dim, Size>{Size{1}},
+        alpaka::Vec<Dim, Size>{Size{1}}};
+    alpaka::exec<Acc>(
+        queue,
+        workdiv,
+        BufferAccessorKernelRead{},
+        alpakaex::readAccess(buffer),
+        alpakaex::readAccess(buffer),
+        alpakaex::readAccess(buffer));
+    alpaka::exec<Acc>(
+        queue,
+        workdiv,
+        BufferAccessorKernelWrite{},
+        alpakaex::writeAccess(buffer),
+        alpakaex::writeAccess(buffer),
+        alpakaex::writeAccess(buffer));
+    alpaka::exec<Acc>(
+        queue,
+        workdiv,
+        BufferAccessorKernelReadWrite{},
+        alpakaex::access(buffer),
+        alpakaex::access(buffer),
+        alpakaex::access(buffer),
+        alpakaex::access(buffer));
+}


### PR DESCRIPTION
* add access mode tags for read, write and read-write access
* add readAccess()/writeAccess()/access()
* only allow writing via WriteAccess accessors
* add Accessor specific tests
* add example for an accessor with a projection
* allow constraining Accessors
* add BuildAccessor customization point
* view accessors are separate from generic Accessor functionality
* add MemoryHandle trait to query memory handle of an accessor
* add BufferAccessor convenience alias
* add brief documentation

This PR is split off from #1249 and only proposes the feature without changing any of the tests and examples.