### PR TITLE
Wrapper adding operator[] to Cuda vector types

### DIFF
--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -142,6 +142,7 @@
 #include <alpaka/meta/ApplyTuple.hpp>
 #include <alpaka/meta/CartesianProduct.hpp>
 #include <alpaka/meta/Concatenate.hpp>
+#include <alpaka/meta/CudaVectorArrayWrapper.hpp>
 #include <alpaka/meta/DependentFalseType.hpp>
 #include <alpaka/meta/Filter.hpp>
 #include <alpaka/meta/Fold.hpp>

--- a/include/alpaka/meta/CudaVectorArrayWrapper.hpp
+++ b/include/alpaka/meta/CudaVectorArrayWrapper.hpp
@@ -1,0 +1,251 @@
+/* Copyright 2021 Jiri Vyskocil
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#if defined(ALPAKA_ACC_GPU_HIP_ENABLED) || defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+
+#    include <alpaka/core/Common.hpp>
+#    include <alpaka/core/Unused.hpp>
+
+#    include <functional>
+#    include <initializer_list>
+#    include <numeric>
+#    include <type_traits>
+
+#    if(__cplusplus > 201402L)
+#        define CXX17_CONSTEXPR constexpr
+#    else
+// This is mostly needed because of nvcc 9 and should be removed upon moving to C++17.
+// Maybe some others need it too. GNU STL library uses the same trick.
+#        define CXX17_CONSTEXPR
+#    endif
+
+namespace alpaka
+{
+    namespace meta
+    {
+        namespace detail
+        {
+            template<typename TScalar, unsigned N>
+            struct CudaVectorArrayTypeTraits;
+
+            template<>
+            struct CudaVectorArrayTypeTraits<float, 1>
+            {
+                using type = float1;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<float, 2>
+            {
+                using type = float2;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<float, 3>
+            {
+                using type = float3;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<float, 4>
+            {
+                using type = float4;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<double, 1>
+            {
+                using type = double1;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<double, 2>
+            {
+                using type = double2;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<double, 3>
+            {
+                using type = double3;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<double, 4>
+            {
+                using type = double4;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<unsigned, 1>
+            {
+                using type = uint1;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<unsigned, 2>
+            {
+                using type = uint2;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<unsigned, 3>
+            {
+                using type = uint3;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<unsigned, 4>
+            {
+                using type = uint4;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<int, 1>
+            {
+                using type = int1;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<int, 2>
+            {
+                using type = int2;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<int, 3>
+            {
+                using type = int3;
+            };
+
+            template<>
+            struct CudaVectorArrayTypeTraits<int, 4>
+            {
+                using type = int4;
+            };
+        } // namespace detail
+
+        /// Helper struct providing [] subscript access to CUDA vector types
+        template<typename TScalar, unsigned N>
+        struct CudaVectorArrayWrapper;
+
+        template<typename TScalar>
+        struct CudaVectorArrayWrapper<TScalar, 4> : public detail::CudaVectorArrayTypeTraits<TScalar, 4>::type
+        {
+            using value_type = TScalar;
+            constexpr static unsigned size = 4;
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CudaVectorArrayWrapper(std::initializer_list<TScalar> init)
+            {
+                auto it = std::begin(init);
+                this->x = *it++;
+                this->y = *it++;
+                this->z = *it++;
+                this->w = *it++;
+            }
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CXX17_CONSTEXPR value_type& operator[](int const k) noexcept
+            {
+                assert(k >= 0 && k < 4);
+                return k == 0 ? this->x : (k == 1 ? this->y : (k == 2 ? this->z : this->w));
+            }
+
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr const value_type& operator[](int const k) const noexcept
+            {
+                assert(k >= 0 && k < 4);
+                return k == 0 ? this->x : (k == 1 ? this->y : (k == 2 ? this->z : this->w));
+            }
+        };
+
+        template<typename TScalar>
+        struct CudaVectorArrayWrapper<TScalar, 3> : public detail::CudaVectorArrayTypeTraits<TScalar, 3>::type
+        {
+            using value_type = TScalar;
+            constexpr static unsigned size = 3;
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CudaVectorArrayWrapper(std::initializer_list<TScalar> init)
+            {
+                auto it = std::begin(init);
+                this->x = *it++;
+                this->y = *it++;
+                this->z = *it++;
+            }
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CXX17_CONSTEXPR value_type& operator[](int const k) noexcept
+            {
+                assert(k >= 0 && k < 3);
+                return k == 0 ? this->x : (k == 1 ? this->y : this->z);
+            }
+
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr const value_type& operator[](int const k) const noexcept
+            {
+                assert(k >= 0 && k < 3);
+                return k == 0 ? this->x : (k == 1 ? this->y : this->z);
+            }
+        };
+
+        template<typename TScalar>
+        struct CudaVectorArrayWrapper<TScalar, 2> : public detail::CudaVectorArrayTypeTraits<TScalar, 2>::type
+        {
+            using value_type = TScalar;
+            constexpr static unsigned size = 2;
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CudaVectorArrayWrapper(std::initializer_list<TScalar> init)
+            {
+                auto it = std::begin(init);
+                this->x = *it++;
+                this->y = *it++;
+            }
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CXX17_CONSTEXPR value_type& operator[](int const k) noexcept
+            {
+                assert(k >= 0 && k < 2);
+                return k == 0 ? this->x : this->y;
+            }
+
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr const value_type& operator[](int const k) const noexcept
+            {
+                assert(k >= 0 && k < 2);
+                return k == 0 ? this->x : this->y;
+            }
+        };
+
+        template<typename TScalar>
+        struct CudaVectorArrayWrapper<TScalar, 1> : public detail::CudaVectorArrayTypeTraits<TScalar, 1>::type
+        {
+            using value_type = TScalar;
+            constexpr static unsigned size = 1;
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CudaVectorArrayWrapper(std::initializer_list<TScalar> init)
+            {
+                auto it = std::begin(init);
+                this->x = *it;
+            }
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CXX17_CONSTEXPR value_type& operator[](int const k) noexcept
+            {
+                assert(k == 0);
+                alpaka::ignore_unused(k);
+                return this->x;
+            }
+
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr const value_type& operator[](int const k) const noexcept
+            {
+                assert(k == 0);
+                alpaka::ignore_unused(k);
+                return this->x;
+            }
+        };
+    } // namespace meta
+} // namespace alpaka
+
+namespace std
+{
+    /// Specialization of std::tuple_size for \a float4_array
+    template<typename T, unsigned N>
+    struct tuple_size<alpaka::meta::CudaVectorArrayWrapper<T, N>> : integral_constant<size_t, N>
+    {
+    };
+} // namespace std
+
+#endif

--- a/test/unit/meta/src/CudaVectorArrayWrapperTest.cpp
+++ b/test/unit/meta/src/CudaVectorArrayWrapperTest.cpp
@@ -1,0 +1,194 @@
+/* Copyright 2021 Jiri Vyskocil
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+
+#    include <alpaka/core/Unused.hpp>
+#    include <alpaka/meta/CudaVectorArrayWrapper.hpp>
+#    include <alpaka/meta/IsStrictBase.hpp>
+#    include <alpaka/rand/Traits.hpp>
+#    include <alpaka/test/KernelExecutionFixture.hpp>
+#    include <alpaka/test/acc/TestAccs.hpp>
+
+#    include <catch2/catch.hpp>
+
+#    include <type_traits>
+
+
+template<typename T>
+class CudaVectorArrayWrapperTestKernel
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAcc>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
+    {
+        alpaka::ignore_unused(acc);
+
+        using T1 = alpaka::meta::CudaVectorArrayWrapper<T, 1>;
+        T1 t1{0};
+        static_assert(T1::size == 1, "CudaVectorArrayWrapper in-kernel size test failed!");
+        static_assert(std::tuple_size<T1>::value == 1, "CudaVectorArrayWrapper in-kernel tuple_size test failed!");
+        static_assert(std::is_same<decltype(t1[0]), T&>::value, "CudaVectorArrayWrapper in-kernel type test failed!");
+#    ifdef __GNUC__
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wfloat-equal"
+#    endif
+        ALPAKA_CHECK(*success, t1[0] == 0);
+#    ifdef __GNUC__
+#        pragma GCC diagnostic pop
+#    endif
+
+        using T2 = alpaka::meta::CudaVectorArrayWrapper<T, 2>;
+        T2 t2{0, 1};
+        static_assert(T2::size == 2, "CudaVectorArrayWrapper in-kernel size test failed!");
+        static_assert(std::tuple_size<T2>::value == 2, "CudaVectorArrayWrapper in-kernel tuple_size test failed!");
+        static_assert(std::is_same<decltype(t2[0]), T&>::value, "CudaVectorArrayWrapper in-kernel type test failed!");
+#    ifdef __GNUC__
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wfloat-equal"
+#    endif
+        ALPAKA_CHECK(*success, t2[0] == 0);
+        ALPAKA_CHECK(*success, t2[1] == 1);
+#    ifdef __GNUC__
+#        pragma GCC diagnostic pop
+#    endif
+
+        using T3 = alpaka::meta::CudaVectorArrayWrapper<T, 3>;
+        T3 t3{0, 0, 0};
+        t3 = {0, 1, 2};
+        static_assert(T3::size == 3, "CudaVectorArrayWrapper in-kernel size test failed!");
+        static_assert(std::tuple_size<T3>::value == 3, "CudaVectorArrayWrapper in-kernel tuple_size test failed!");
+        static_assert(std::is_same<decltype(t3[0]), T&>::value, "CudaVectorArrayWrapper in-kernel type test failed!");
+#    ifdef __GNUC__
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wfloat-equal"
+#    endif
+        ALPAKA_CHECK(*success, t3[0] == 0);
+        ALPAKA_CHECK(*success, t3[1] == 1);
+        ALPAKA_CHECK(*success, t3[2] == 2);
+#    ifdef __GNUC__
+#        pragma GCC diagnostic pop
+#    endif
+
+        using T4 = alpaka::meta::CudaVectorArrayWrapper<T, 4>;
+        T4 t4{0, 0, 0, 0};
+        t4[1] = 1;
+        t4[2] = t4[1] + 1;
+        t4[3] = t4[2] + t2[1];
+        static_assert(T4::size == 4, "CudaVectorArrayWrapper in-kernel size test failed!");
+        static_assert(std::tuple_size<T4>::value == 4, "CudaVectorArrayWrapper in-kernel tuple_size test failed!");
+        static_assert(std::is_same<decltype(t4[0]), T&>::value, "CudaVectorArrayWrapper in-kernel type test failed!");
+#    ifdef __GNUC__
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wfloat-equal"
+#    endif
+        ALPAKA_CHECK(*success, t4[0] == 0);
+        ALPAKA_CHECK(*success, t4[1] == 1);
+        ALPAKA_CHECK(*success, t4[2] == 2);
+        ALPAKA_CHECK(*success, t4[3] == 3);
+#    ifdef __GNUC__
+#        pragma GCC diagnostic pop
+#    endif
+    }
+};
+
+TEMPLATE_LIST_TEST_CASE("cudaVectorArrayWrapperDevice", "[meta]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+    using Dim = alpaka::Dim<Acc>;
+    using Idx = alpaka::Idx<Acc>;
+
+    alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::ones());
+
+    CudaVectorArrayWrapperTestKernel<int> kernelInt;
+    REQUIRE(fixture(kernelInt));
+
+    CudaVectorArrayWrapperTestKernel<unsigned> kernelUnsigned;
+    REQUIRE(fixture(kernelUnsigned));
+
+    CudaVectorArrayWrapperTestKernel<float> kernelFloat;
+    REQUIRE(fixture(kernelFloat));
+
+    CudaVectorArrayWrapperTestKernel<double> kernelDouble;
+    REQUIRE(fixture(kernelDouble));
+}
+
+
+TEST_CASE("cudaVectorArrayWrapperHost", "[meta]")
+{
+    // TODO: It would be nice to check all possible type vs. size combinations.
+
+    using Float1 = alpaka::meta::CudaVectorArrayWrapper<float, 1>;
+    Float1 floatWrapper1{-1.0f};
+    STATIC_REQUIRE(Float1::size == 1);
+    STATIC_REQUIRE(std::tuple_size<Float1>::value == 1);
+    STATIC_REQUIRE(std::is_same<decltype(floatWrapper1[0]), float&>::value);
+    STATIC_REQUIRE(alpaka::meta::IsStrictBase<float1, Float1>::value);
+#    ifdef __GNUC__
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wfloat-equal"
+#    endif
+    REQUIRE(floatWrapper1[0] == -1.0f);
+#    ifdef __GNUC__
+#        pragma GCC diagnostic pop
+#    endif
+
+    using Int1 = alpaka::meta::CudaVectorArrayWrapper<int, 1>;
+    Int1 intWrapper1 = {-42};
+    STATIC_REQUIRE(Int1::size == 1);
+    STATIC_REQUIRE(std::tuple_size<Int1>::value == 1);
+    STATIC_REQUIRE(std::is_same<decltype(intWrapper1[0]), int&>::value);
+    STATIC_REQUIRE(alpaka::meta::IsStrictBase<int1, Int1>::value);
+    REQUIRE(intWrapper1[0] == -42);
+
+    using Uint2 = alpaka::meta::CudaVectorArrayWrapper<unsigned, 2>;
+    Uint2 uintWrapper2{0u, 1u};
+    STATIC_REQUIRE(Uint2::size == 2);
+    STATIC_REQUIRE(std::tuple_size<Uint2>::value == 2);
+    STATIC_REQUIRE(std::is_same<decltype(uintWrapper2[0]), unsigned&>::value);
+    STATIC_REQUIRE(alpaka::meta::IsStrictBase<uint2, Uint2>::value);
+    REQUIRE(uintWrapper2[0] == 0u);
+    REQUIRE(uintWrapper2[1] == 1u);
+
+    using Uint4 = alpaka::meta::CudaVectorArrayWrapper<unsigned, 4>;
+    Uint4 uintWrapper4{0u, 0u, 0u, 0u};
+    STATIC_REQUIRE(Uint4::size == 4);
+    STATIC_REQUIRE(std::tuple_size<Uint4>::value == 4);
+    STATIC_REQUIRE(std::is_same<decltype(uintWrapper4[0]), unsigned&>::value);
+    STATIC_REQUIRE(alpaka::meta::IsStrictBase<uint4, Uint4>::value);
+    uintWrapper4[1] = 1u;
+    uintWrapper4[2] = uintWrapper4[1] + 1u;
+    uintWrapper4[3] = uintWrapper4[2] + uintWrapper2[1];
+    REQUIRE(uintWrapper4[0] == 0u);
+    REQUIRE(uintWrapper4[1] == 1u);
+    REQUIRE(uintWrapper4[2] == 2u);
+    REQUIRE(uintWrapper4[3] == 3u);
+
+    using Double3 = alpaka::meta::CudaVectorArrayWrapper<double, 3>;
+    Double3 doubleWrapper3{0.0, 0.0, 0.0};
+    doubleWrapper3 = {0.0, -1.0, -2.0};
+    STATIC_REQUIRE(Double3::size == 3);
+    STATIC_REQUIRE(std::tuple_size<Double3>::value == 3);
+    STATIC_REQUIRE(std::is_same<decltype(doubleWrapper3[0]), double&>::value);
+    STATIC_REQUIRE(alpaka::meta::IsStrictBase<double3, Double3>::value);
+#    ifdef __GNUC__
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wfloat-equal"
+#    endif
+    REQUIRE(doubleWrapper3[0] == 0.0);
+    REQUIRE(doubleWrapper3[1] == -1.0);
+    REQUIRE(doubleWrapper3[2] == -2.0);
+#    ifdef __GNUC__
+#        pragma GCC diagnostic pop
+#    endif
+}
+
+#endif


### PR DESCRIPTION
This wrapper add `operator[]` to CUDA vector types such as `int4`, `float3` etc. It is a user convenience for the API of the vector variants of the _Philox_ random generator. In a perfect world, these would return a `std::array`. Unfortunately many older `nvcc`s do not support `std::array`s in device code. Their vector types are a good match for the _Philox_ generator, but they're structs with members `.x`, `.y`, etc. This syntax doesn't make much sense for a result of a random number generator, thus this wrapper.

The limitation is that it does not provide all possible type-size combination. If more are needed, they have to be manually added as new `struct CudaVectorArrayTypeTraits<T, N>` specializations. I don't know how to generate these automatically without resorting to preprocessor macro black magic, and given the wrappers will hopefully soon become obsolete, I included only `int`, `unsigned`, `float` and `double` in sizes `1` to `4`.