### PR TITLE
Simplify ALPAKA_UNROLL

### DIFF
--- a/include/alpaka/core/Unroll.hpp
+++ b/include/alpaka/core/Unroll.hpp
@@ -18,19 +18,13 @@
 //!  for(...){...}`
 // \TODO: Implement for other compilers.
 #if BOOST_ARCH_PTX
-#    if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
-#        define ALPAKA_UNROLL(...) __pragma(unroll __VA_ARGS__)
-#    else
-#        define ALPAKA_UNROLL_STRINGIFY(x) #        x
-#        define ALPAKA_UNROLL(...) _Pragma(ALPAKA_UNROLL_STRINGIFY(unroll __VA_ARGS__))
-#    endif
+#    define ALPAKA_UNROLL_STRINGIFY(x) #    x
+#    define ALPAKA_UNROLL(...) _Pragma(ALPAKA_UNROLL_STRINGIFY(unroll __VA_ARGS__))
+#elif BOOST_COMP_INTEL || BOOST_COMP_IBM || BOOST_COMP_SUNPRO || BOOST_COMP_HPACC
+#    define ALPAKA_UNROLL_STRINGIFY(x) #    x
+#    define ALPAKA_UNROLL(...) _Pragma(ALPAKA_UNROLL_STRINGIFY(unroll(__VA_ARGS__)))
+#elif BOOST_COMP_PGI
+#    define ALPAKA_UNROLL(...) _Pragma("unroll")
 #else
-#    if BOOST_COMP_INTEL || BOOST_COMP_IBM || BOOST_COMP_SUNPRO || BOOST_COMP_HPACC
-#        define ALPAKA_UNROLL_STRINGIFY(x) #        x
-#        define ALPAKA_UNROLL(...) _Pragma(ALPAKA_UNROLL_STRINGIFY(unroll(__VA_ARGS__)))
-#    elif BOOST_COMP_PGI
-#        define ALPAKA_UNROLL(...) _Pragma("unroll")
-#    else
-#        define ALPAKA_UNROLL(...)
-#    endif
+#    define ALPAKA_UNROLL(...)
 #endif


### PR DESCRIPTION
MSVC supports `_Pragma` for a while now in addition to `__pragma`, so we can streamline the implementation of `ALPAKA_UNROLL`.