### PR TITLE
Add function to bypass compiler warnings for exact float comparisons

### DIFF
--- a/include/alpaka/math/FloatEqualExact.hpp
+++ b/include/alpaka/math/FloatEqualExact.hpp
@@ -1,0 +1,57 @@
+/* Copyright 2021 Jiri Vyskocil
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/Common.hpp>
+
+#include <type_traits>
+
+namespace alpaka
+{
+    namespace math
+    {
+        /** Compare two floating point numbers for exact equivalence. Use only when necessary, and be aware of the
+         * implications. Most codes should not use this function and instead implement a correct epsilon-based
+         * comparison. If you are unfamiliar with the topic, check out
+         * https://www.geeksforgeeks.org/problem-in-comparing-floating-point-numbers-and-how-to-compare-them-correctly/
+         * or Goldberg 1991: "What every computer scientist should know about floating-point arithmetic",
+         * https://dl.acm.org/doi/10.1145/103162.103163
+         *
+         * This function calls the == operator for floating point types, but disables the warning issued by the
+         * compiler when compiling with the float equality warning checks enabled. This warning is valid an valuable in
+         * most codes and should be generally enabled, but there are specific instances where a piece of code might
+         * need to do an exact comparison (e.g. @a CudaVectorArrayWrapperTest.cpp). The verbose name for the function
+         * is intentional as it should raise a red flag if used while not absolutely needed. Users are advised to add a
+         * justification whenever they use this function.
+         *
+         * @tparam T both operands have to be the same type and conform to std::is_floating_point
+         * @param a first operand
+         * @param b second operand
+         * @return a == b
+         */
+        template<typename T>
+        ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool floatEqualExactNoWarning(T a, T b)
+        {
+            static_assert(
+                std::is_floating_point<T>::value,
+                "floatEqualExactNoWarning is for floating point values only!");
+
+            // So far only GCC and Clang check for float comparison and both accept the GCC pragmas.
+#ifdef __GNUC__
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+            return a == b;
+#ifdef __GNUC__
+#    pragma GCC diagnostic pop
+#endif
+        }
+    } // namespace math
+} // namespace alpaka

--- a/test/unit/math/src/FloatEqualExactTest.cpp
+++ b/test/unit/math/src/FloatEqualExactTest.cpp
@@ -1,0 +1,66 @@
+/* Copyright 2021 Jiri Vyskocil
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <alpaka/core/Unused.hpp>
+#include <alpaka/math/FloatEqualExact.hpp>
+#include <alpaka/test/KernelExecutionFixture.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
+
+#include <catch2/catch.hpp>
+
+class FloatEqualExactTestKernel
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAcc>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
+    {
+        alpaka::ignore_unused(acc);
+
+        // Store the comparison result in a separate variable so that the function call is outside ALPAKA_CHECK.
+        // In case ALPAKA_CHECK were ever somehow modified to silence the warning by itself.
+        bool testValue = false;
+
+        float floatValue = -1.0f;
+        testValue = alpaka::math::floatEqualExactNoWarning(floatValue, -1.0f);
+        ALPAKA_CHECK(*success, testValue);
+
+        double doubleValue = -1.0;
+        testValue = alpaka::math::floatEqualExactNoWarning(doubleValue, -1.0);
+        ALPAKA_CHECK(*success, testValue);
+    }
+};
+
+TEMPLATE_LIST_TEST_CASE("floatEqualExactTest", "[math]", alpaka::test::TestAccs)
+{
+    // Host tests
+
+    // Store the comparison result in a separate variable so that the function call is outside REQUIRE.
+    // In case REQUIRE were ever somehow modified to silence the warning by itself.
+    bool testValue = false;
+
+    float floatValue = -1.0;
+    testValue = alpaka::math::floatEqualExactNoWarning(floatValue, -1.0f);
+    REQUIRE(testValue);
+
+    double doubleValue = -1.0;
+    testValue = alpaka::math::floatEqualExactNoWarning(doubleValue, -1.0);
+    REQUIRE(testValue);
+
+    // Device tests
+
+    using Acc = TestType;
+    using Dim = alpaka::Dim<Acc>;
+    using Idx = alpaka::Idx<Acc>;
+
+    alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::ones());
+
+    FloatEqualExactTestKernel kernelFloat;
+    REQUIRE(fixture(kernelFloat));
+}


### PR DESCRIPTION
This replaces the discontinued PR #1436 with a function that can be explicitly called when exact float comparison is needed. It should be used sparingly (this is repeatedly mentioned in the comments), but in case it is needed, it can help reduce source length (e.g. in PR #1431) by moving the necessary pragmas to one place.