### PR TITLE
math: Add isnan, isinf, isfinite

### DIFF
--- a/include/alpaka/math/MathStdLib.hpp
+++ b/include/alpaka/math/MathStdLib.hpp
@@ -21,6 +21,9 @@
 #include <alpaka/math/exp/ExpStdLib.hpp>
 #include <alpaka/math/floor/FloorStdLib.hpp>
 #include <alpaka/math/fmod/FmodStdLib.hpp>
+#include <alpaka/math/isfinite/IsfiniteStdLib.hpp>
+#include <alpaka/math/isinf/IsinfStdLib.hpp>
+#include <alpaka/math/isnan/IsnanStdLib.hpp>
 #include <alpaka/math/log/LogStdLib.hpp>
 #include <alpaka/math/max/MaxStdLib.hpp>
 #include <alpaka/math/min/MinStdLib.hpp>
@@ -65,6 +68,9 @@ namespace alpaka
             , public SqrtStdLib
             , public TanStdLib
             , public TruncStdLib
+            , public IsnanStdLib
+            , public IsinfStdLib
+            , public IsfiniteStdLib
         {
         };
     } // namespace math

--- a/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
@@ -23,6 +23,9 @@
 #    include <alpaka/math/exp/ExpUniformCudaHipBuiltIn.hpp>
 #    include <alpaka/math/floor/FloorUniformCudaHipBuiltIn.hpp>
 #    include <alpaka/math/fmod/FmodUniformCudaHipBuiltIn.hpp>
+#    include <alpaka/math/isfinite/IsfiniteUniformCudaHipBuiltIn.hpp>
+#    include <alpaka/math/isinf/IsinfUniformCudaHipBuiltIn.hpp>
+#    include <alpaka/math/isnan/IsnanUniformCudaHipBuiltIn.hpp>
 #    include <alpaka/math/log/LogUniformCudaHipBuiltIn.hpp>
 #    include <alpaka/math/max/MaxUniformCudaHipBuiltIn.hpp>
 #    include <alpaka/math/min/MinUniformCudaHipBuiltIn.hpp>
@@ -67,6 +70,9 @@ namespace alpaka
             , public SqrtUniformCudaHipBuiltIn
             , public TanUniformCudaHipBuiltIn
             , public TruncUniformCudaHipBuiltIn
+            , public IsnanUniformCudaHipBuiltIn
+            , public IsinfUniformCudaHipBuiltIn
+            , public IsfiniteUniformCudaHipBuiltIn
         {
         };
     } // namespace math

--- a/include/alpaka/math/isfinite/IsfiniteStdLib.hpp
+++ b/include/alpaka/math/isfinite/IsfiniteStdLib.hpp
@@ -1,0 +1,41 @@
+/* Copyright 2021 Axel Huebl, Benjamin Worpitz, Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/Unused.hpp>
+#include <alpaka/math/isfinite/Traits.hpp>
+
+#include <cmath>
+#include <type_traits>
+
+namespace alpaka
+{
+    namespace math
+    {
+        //! The standard library isfinite.
+        class IsfiniteStdLib : public concepts::Implements<ConceptMathIsfinite, IsfiniteStdLib>
+        {
+        };
+
+        namespace traits
+        {
+            //! The standard library isfinite trait specialization.
+            template<typename TArg>
+            struct Isfinite<IsfiniteStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
+            {
+                ALPAKA_FN_HOST auto operator()(IsfiniteStdLib const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    return std::isfinite(arg);
+                }
+            };
+        } // namespace traits
+    } // namespace math
+} // namespace alpaka

--- a/include/alpaka/math/isfinite/IsfiniteUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/isfinite/IsfiniteUniformCudaHipBuiltIn.hpp
@@ -1,0 +1,46 @@
+/* Copyright 2021 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+
+#    include <alpaka/core/CudaHipMath.hpp>
+#    include <alpaka/core/Unused.hpp>
+#    include <alpaka/math/isfinite/Traits.hpp>
+
+#    include <type_traits>
+
+namespace alpaka
+{
+    namespace math
+    {
+        //! The CUDA built in isfinite.
+        class IsfiniteUniformCudaHipBuiltIn
+            : public concepts::Implements<ConceptMathIsfinite, IsfiniteUniformCudaHipBuiltIn>
+        {
+        };
+
+        namespace traits
+        {
+            //! The CUDA isfinite trait specialization.
+            template<typename TArg>
+            struct Isfinite<IsfiniteUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
+            {
+                __device__ auto operator()(IsfiniteUniformCudaHipBuiltIn const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    return ::isfinite(arg);
+                }
+            };
+        } // namespace traits
+    } // namespace math
+} // namespace alpaka
+
+#endif

--- a/include/alpaka/math/isfinite/Traits.hpp
+++ b/include/alpaka/math/isfinite/Traits.hpp
@@ -1,0 +1,56 @@
+/* Copyright 2021 Benjamin Worpitz, Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/Common.hpp>
+#include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
+
+#include <type_traits>
+
+namespace alpaka
+{
+    namespace math
+    {
+        struct ConceptMathIsfinite
+        {
+        };
+
+        namespace traits
+        {
+            //! The exp trait.
+            template<typename T, typename TArg, typename TSfinae = void>
+            struct Isfinite
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find isfinite(TArg) in the namespace of your type.
+                    return isfinite(arg);
+                }
+            };
+        } // namespace traits
+
+        //! Checks if given value is finite.
+        //!
+        //! \tparam T The type of the object specializing Isfinite.
+        //! \tparam TArg The arg type.
+        //! \param ctx The object specializing Isfinite.
+        //! \param arg The arg.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<typename T, typename TArg>
+        ALPAKA_FN_HOST_ACC auto isfinite(T const& ctx, TArg const& arg)
+        {
+            using ImplementationBase = concepts::ImplementationBase<ConceptMathIsfinite, T>;
+            return traits::Isfinite<ImplementationBase, TArg>{}(ctx, arg);
+        }
+    } // namespace math
+} // namespace alpaka

--- a/include/alpaka/math/isinf/IsinfStdLib.hpp
+++ b/include/alpaka/math/isinf/IsinfStdLib.hpp
@@ -1,0 +1,41 @@
+/* Copyright 2021 Axel Huebl, Benjamin Worpitz, Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/Unused.hpp>
+#include <alpaka/math/isinf/Traits.hpp>
+
+#include <cmath>
+#include <type_traits>
+
+namespace alpaka
+{
+    namespace math
+    {
+        //! The standard library isinf.
+        class IsinfStdLib : public concepts::Implements<ConceptMathIsinf, IsinfStdLib>
+        {
+        };
+
+        namespace traits
+        {
+            //! The standard library isinf trait specialization.
+            template<typename TArg>
+            struct Isinf<IsinfStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
+            {
+                ALPAKA_FN_HOST auto operator()(IsinfStdLib const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    return std::isinf(arg);
+                }
+            };
+        } // namespace traits
+    } // namespace math
+} // namespace alpaka

--- a/include/alpaka/math/isinf/IsinfUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/isinf/IsinfUniformCudaHipBuiltIn.hpp
@@ -1,0 +1,45 @@
+/* Copyright 2021 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+
+#    include <alpaka/core/CudaHipMath.hpp>
+#    include <alpaka/core/Unused.hpp>
+#    include <alpaka/math/isinf/Traits.hpp>
+
+#    include <type_traits>
+
+namespace alpaka
+{
+    namespace math
+    {
+        //! The CUDA built in isinf.
+        class IsinfUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathIsinf, IsinfUniformCudaHipBuiltIn>
+        {
+        };
+
+        namespace traits
+        {
+            //! The CUDA isinf trait specialization.
+            template<typename TArg>
+            struct Isinf<IsinfUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
+            {
+                __device__ auto operator()(IsinfUniformCudaHipBuiltIn const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    return ::isinf(arg);
+                }
+            };
+        } // namespace traits
+    } // namespace math
+} // namespace alpaka
+
+#endif

--- a/include/alpaka/math/isinf/Traits.hpp
+++ b/include/alpaka/math/isinf/Traits.hpp
@@ -1,0 +1,56 @@
+/* Copyright 2021 Benjamin Worpitz, Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/Common.hpp>
+#include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
+
+#include <type_traits>
+
+namespace alpaka
+{
+    namespace math
+    {
+        struct ConceptMathIsinf
+        {
+        };
+
+        namespace traits
+        {
+            //! The exp trait.
+            template<typename T, typename TArg, typename TSfinae = void>
+            struct Isinf
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find isinf(TArg) in the namespace of your type.
+                    return isinf(arg);
+                }
+            };
+        } // namespace traits
+
+        //! Checks if given value is inf.
+        //!
+        //! \tparam T The type of the object specializing Isinf.
+        //! \tparam TArg The arg type.
+        //! \param ctx The object specializing Isinf.
+        //! \param arg The arg.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<typename T, typename TArg>
+        ALPAKA_FN_HOST_ACC auto isinf(T const& ctx, TArg const& arg)
+        {
+            using ImplementationBase = concepts::ImplementationBase<ConceptMathIsinf, T>;
+            return traits::Isinf<ImplementationBase, TArg>{}(ctx, arg);
+        }
+    } // namespace math
+} // namespace alpaka

--- a/include/alpaka/math/isnan/IsnanStdLib.hpp
+++ b/include/alpaka/math/isnan/IsnanStdLib.hpp
@@ -1,0 +1,41 @@
+/* Copyright 2021 Axel Huebl, Benjamin Worpitz, Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/Unused.hpp>
+#include <alpaka/math/isnan/Traits.hpp>
+
+#include <cmath>
+#include <type_traits>
+
+namespace alpaka
+{
+    namespace math
+    {
+        //! The standard library isnan.
+        class IsnanStdLib : public concepts::Implements<ConceptMathIsnan, IsnanStdLib>
+        {
+        };
+
+        namespace traits
+        {
+            //! The standard library isnan trait specialization.
+            template<typename TArg>
+            struct Isnan<IsnanStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
+            {
+                ALPAKA_FN_HOST auto operator()(IsnanStdLib const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    return std::isnan(arg);
+                }
+            };
+        } // namespace traits
+    } // namespace math
+} // namespace alpaka

--- a/include/alpaka/math/isnan/IsnanUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/isnan/IsnanUniformCudaHipBuiltIn.hpp
@@ -1,0 +1,45 @@
+/* Copyright 2021 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+
+#    include <alpaka/core/CudaHipMath.hpp>
+#    include <alpaka/core/Unused.hpp>
+#    include <alpaka/math/isnan/Traits.hpp>
+
+#    include <type_traits>
+
+namespace alpaka
+{
+    namespace math
+    {
+        //! The CUDA built in isnan.
+        class IsnanUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathIsnan, IsnanUniformCudaHipBuiltIn>
+        {
+        };
+
+        namespace traits
+        {
+            //! The CUDA isnan trait specialization.
+            template<typename TArg>
+            struct Isnan<IsnanUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
+            {
+                __device__ auto operator()(IsnanUniformCudaHipBuiltIn const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    return ::isnan(arg);
+                }
+            };
+        } // namespace traits
+    } // namespace math
+} // namespace alpaka
+
+#endif

--- a/include/alpaka/math/isnan/Traits.hpp
+++ b/include/alpaka/math/isnan/Traits.hpp
@@ -1,0 +1,56 @@
+/* Copyright 2021 Benjamin Worpitz, Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/Common.hpp>
+#include <alpaka/core/Concepts.hpp>
+#include <alpaka/core/Unused.hpp>
+
+#include <type_traits>
+
+namespace alpaka
+{
+    namespace math
+    {
+        struct ConceptMathIsnan
+        {
+        };
+
+        namespace traits
+        {
+            //! The exp trait.
+            template<typename T, typename TArg, typename TSfinae = void>
+            struct Isnan
+            {
+                ALPAKA_FN_HOST_ACC auto operator()(T const& ctx, TArg const& arg)
+                {
+                    alpaka::ignore_unused(ctx);
+                    // This is an ADL call. If you get a compile error here then your type is not supported by the
+                    // backend and we could not find isnan(TArg) in the namespace of your type.
+                    return isnan(arg);
+                }
+            };
+        } // namespace traits
+
+        //! Checks if given value is NaN.
+        //!
+        //! \tparam T The type of the object specializing Isnan.
+        //! \tparam TArg The arg type.
+        //! \param ctx The object specializing Isnan.
+        //! \param arg The arg.
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<typename T, typename TArg>
+        ALPAKA_FN_HOST_ACC auto isnan(T const& ctx, TArg const& arg)
+        {
+            using ImplementationBase = concepts::ImplementationBase<ConceptMathIsnan, T>;
+            return traits::Isnan<ImplementationBase, TArg>{}(ctx, arg);
+        }
+    } // namespace math
+} // namespace alpaka

--- a/test/unit/math/src/DataGen.hpp
+++ b/test/unit/math/src/DataGen.hpp
@@ -1,4 +1,4 @@
-/** Copyright 2019 Jakob Krude, Benjamin Worpitz
+/** Copyright 2019 Jakob Krude, Benjamin Worpitz, Jeffrey Kelling
  *
  * This file is part of alpaka.
  *
@@ -49,7 +49,7 @@ namespace alpaka
                     static_assert(
                         TArgs::value_type::arity == TFunctor::arity,
                         "Buffer properties must match TFunctor::arity");
-                    static_assert(TArgs::capacity > 2, "Set of args must provide > 2 entries.");
+                    static_assert(TArgs::capacity > 6, "Set of args must provide > 6 entries.");
                     constexpr auto max = std::numeric_limits<TData>::max();
                     constexpr auto low = std::numeric_limits<TData>::lowest();
                     std::default_random_engine eng{static_cast<std::default_random_engine::result_type>(seed)};
@@ -118,6 +118,28 @@ namespace alpaka
                                     args(i).arg[k] = dist(eng);
                                 else
                                     args(i).arg[k] = -dist(eng);
+                            }
+                            break;
+
+                        case Range::Anything:
+                            matchedSwitch = true;
+                            args(0).arg[k] = 0.0;
+                            args(1).arg[k] = std::numeric_limits<TData>::quiet_NaN();
+                            args(2).arg[k] = std::numeric_limits<TData>::signaling_NaN();
+                            args(3).arg[k] = std::numeric_limits<TData>::infinity();
+                            args(4).arg[k] = -std::numeric_limits<TData>::infinity();
+                            constexpr size_t nFixed = 5;
+                            size_t i = nFixed;
+                            // no need to test for denormal for now: not supported by CUDA
+                            // for(; i < nFixed + (TArgs::capacity - nFixed) / 2; ++i)
+                            // {
+                            //     const TData v = dist(eng) * std::numeric_limits<TData>::denorm_min();
+                            //     args(i).arg[k] = (i % 2 == 0) ? v : -v;
+                            // }
+                            for(; i < TArgs::capacity; ++i)
+                            {
+                                const TData v = dist(eng);
+                                args(i).arg[k] = (i % 2 == 0) ? v : -v;
                             }
                             break;
                         }

--- a/test/unit/math/src/Defines.hpp
+++ b/test/unit/math/src/Defines.hpp
@@ -29,7 +29,8 @@ namespace alpaka
                     PositiveOnly,
                     PositiveAndZero,
                     NotZero,
-                    Unrestricted
+                    Unrestricted,
+                    Anything
                 };
 
                 // New types need to be added to the operator() function in Functor.hpp

--- a/test/unit/math/src/Functor.hpp
+++ b/test/unit/math/src/Functor.hpp
@@ -154,6 +154,17 @@ namespace alpaka
                     alpaka::math::trunc,
                     Range::Unrestricted)
 
+                ALPAKA_TEST_MATH_OP_FUNCTOR(OpIsnan, Arity::Unary, std::isnan, alpaka::math::isnan, Range::Anything)
+
+                ALPAKA_TEST_MATH_OP_FUNCTOR(OpIsinf, Arity::Unary, std::isinf, alpaka::math::isinf, Range::Anything)
+
+                ALPAKA_TEST_MATH_OP_FUNCTOR(
+                    OpIsfinite,
+                    Arity::Unary,
+                    std::isfinite,
+                    alpaka::math::isfinite,
+                    Range::Anything)
+
                 // All binary operators.
                 ALPAKA_TEST_MATH_OP_FUNCTOR(
                     OpAtan2,
@@ -222,7 +233,10 @@ namespace alpaka
                     OpSin,
                     OpSqrt,
                     OpTan,
-                    OpTrunc>;
+                    OpTrunc,
+                    OpIsnan,
+                    OpIsinf,
+                    OpIsfinite>;
 
             } // namespace math
         } // namespace unit


### PR DESCRIPTION
Add `isnan`, `isinf`, `isfinite` to `alpaka::math`.

Their friends `isnormal`, `fpclassify`, `isunordered` are not supported by cuda (yet), so are not added even though they should go with them.

`isnan` is required by https://github.com/alpaka-group/alpaka/pull/1444 .