### PR TITLE
Simplify math trait specializations using standard library

### DIFF
--- a/include/alpaka/math/abs/AbsStdLib.hpp
+++ b/include/alpaka/math/abs/AbsStdLib.hpp
@@ -9,37 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/abs/Traits.hpp>
-
-#include <cmath>
-#include <cstdlib>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library abs.
+        //! The standard library abs, implementation covered by the general template.
         class AbsStdLib : public concepts::Implements<ConceptMathAbs, AbsStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library abs trait specialization.
-            template<typename TArg>
-            struct Abs<
-                AbsStdLib,
-                TArg,
-                std::enable_if_t<std::is_arithmetic<TArg>::value && std::is_signed<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(AbsStdLib const& abs_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(abs_ctx);
-                    return std::abs(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/abs/Traits.hpp
+++ b/include/alpaka/math/abs/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -35,6 +35,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find abs(TArg) in the namespace of your type.
+                    using std::abs;
                     return abs(arg);
                 }
             };

--- a/include/alpaka/math/acos/AcosStdLib.hpp
+++ b/include/alpaka/math/acos/AcosStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/acos/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library acos.
+        //! The standard library acos, implementation covered by the general template.
         class AcosStdLib : public concepts::Implements<ConceptMathAcos, AcosStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library acos trait specialization.
-            template<typename TArg>
-            struct Acos<AcosStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(AcosStdLib const& acos_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(acos_ctx);
-                    return std::acos(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/acos/Traits.hpp
+++ b/include/alpaka/math/acos/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find acos(TArg) in the namespace of your type.
+                    using std::acos;
                     return acos(arg);
                 }
             };

--- a/include/alpaka/math/asin/AsinStdLib.hpp
+++ b/include/alpaka/math/asin/AsinStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/asin/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library asin.
+        //! The standard library asin, implementation covered by the general template.
         class AsinStdLib : public concepts::Implements<ConceptMathAsin, AsinStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library asin trait specialization.
-            template<typename TArg>
-            struct Asin<AsinStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(AsinStdLib const& asin_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(asin_ctx);
-                    return std::asin(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/asin/Traits.hpp
+++ b/include/alpaka/math/asin/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find asin(TArg) in the namespace of your type.
+                    using std::asin;
                     return asin(arg);
                 }
             };

--- a/include/alpaka/math/atan/AtanStdLib.hpp
+++ b/include/alpaka/math/atan/AtanStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/atan/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library atan.
+        //! The standard library atan, implementation covered by the general template.
         class AtanStdLib : public concepts::Implements<ConceptMathAtan, AtanStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library atan trait specialization.
-            template<typename TArg>
-            struct Atan<AtanStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(AtanStdLib const& atan_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(atan_ctx);
-                    return std::atan(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/atan/Traits.hpp
+++ b/include/alpaka/math/atan/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find atan(TArg) in the namespace of your type.
+                    using std::atan;
                     return atan(arg);
                 }
             };

--- a/include/alpaka/math/atan2/Atan2StdLib.hpp
+++ b/include/alpaka/math/atan2/Atan2StdLib.hpp
@@ -9,37 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/atan2/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library atan2.
+        //! The standard library atan2, implementation covered by the general template.
         class Atan2StdLib : public concepts::Implements<ConceptMathAtan2, Atan2StdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library atan2 trait specialization.
-            template<typename Ty, typename Tx>
-            struct Atan2<
-                Atan2StdLib,
-                Ty,
-                Tx,
-                std::enable_if_t<std::is_arithmetic<Ty>::value && std::is_arithmetic<Tx>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(Atan2StdLib const& abs, Ty const& y, Tx const& x)
-                {
-                    alpaka::ignore_unused(abs);
-                    return std::atan2(y, x);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/atan2/Traits.hpp
+++ b/include/alpaka/math/atan2/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find atan2(Tx, Ty) in the namespace of your type.
+                    using std::atan2;
                     return atan2(y, x);
                 }
             };

--- a/include/alpaka/math/cbrt/CbrtStdLib.hpp
+++ b/include/alpaka/math/cbrt/CbrtStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/cbrt/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library cbrt.
+        //! The standard library cbrt, implementation covered by the general template.
         class CbrtStdLib : public concepts::Implements<ConceptMathCbrt, CbrtStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library cbrt trait specialization.
-            template<typename TArg>
-            struct Cbrt<CbrtStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(CbrtStdLib const& cbrt_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(cbrt_ctx);
-                    return std::cbrt(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/cbrt/Traits.hpp
+++ b/include/alpaka/math/cbrt/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find cbrt(TArg) in the namespace of your type.
+                    using std::cbrt;
                     return cbrt(arg);
                 }
             };

--- a/include/alpaka/math/ceil/CeilStdLib.hpp
+++ b/include/alpaka/math/ceil/CeilStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/ceil/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library ceil.
+        //! The standard library ceil, implementation covered by the general template.
         class CeilStdLib : public concepts::Implements<ConceptMathCeil, CeilStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library ceil trait specialization.
-            template<typename TArg>
-            struct Ceil<CeilStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(CeilStdLib const& ceil_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(ceil_ctx);
-                    return std::ceil(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/ceil/Traits.hpp
+++ b/include/alpaka/math/ceil/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find ceil(TArg) in the namespace of your type.
+                    using std::ceil;
                     return ceil(arg);
                 }
             };

--- a/include/alpaka/math/cos/CosStdLib.hpp
+++ b/include/alpaka/math/cos/CosStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/cos/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library cos.
+        //! The standard library cos, implementation covered by the general template.
         class CosStdLib : public concepts::Implements<ConceptMathCos, CosStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library cos trait specialization.
-            template<typename TArg>
-            struct Cos<CosStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(CosStdLib const& cos_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(cos_ctx);
-                    return std::cos(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/cos/Traits.hpp
+++ b/include/alpaka/math/cos/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find cos(TArg) in the namespace of your type.
+                    using std::cos;
                     return cos(arg);
                 }
             };

--- a/include/alpaka/math/erf/ErfStdLib.hpp
+++ b/include/alpaka/math/erf/ErfStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/erf/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library erf.
+        //! The standard library erf, implementation covered by the general template.
         class ErfStdLib : public concepts::Implements<ConceptMathErf, ErfStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library erf trait specialization.
-            template<typename TArg>
-            struct Erf<ErfStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(ErfStdLib const& erf_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(erf_ctx);
-                    return std::erf(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/erf/Traits.hpp
+++ b/include/alpaka/math/erf/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find erf(TArg) in the namespace of your type.
+                    using std::erf;
                     return erf(arg);
                 }
             };

--- a/include/alpaka/math/exp/ExpStdLib.hpp
+++ b/include/alpaka/math/exp/ExpStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/exp/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library exp.
+        //! The standard library exp, implementation covered by the general template.
         class ExpStdLib : public concepts::Implements<ConceptMathExp, ExpStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library exp trait specialization.
-            template<typename TArg>
-            struct Exp<ExpStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(ExpStdLib const& exp_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(exp_ctx);
-                    return std::exp(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/exp/Traits.hpp
+++ b/include/alpaka/math/exp/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find exp(TArg) in the namespace of your type.
+                    using std::exp;
                     return exp(arg);
                 }
             };

--- a/include/alpaka/math/floor/FloorStdLib.hpp
+++ b/include/alpaka/math/floor/FloorStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/floor/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library floor.
+        //! The standard library floor, implementation covered by the general template.
         class FloorStdLib : public concepts::Implements<ConceptMathFloor, FloorStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library floor trait specialization.
-            template<typename TArg>
-            struct Floor<FloorStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(FloorStdLib const& floor_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(floor_ctx);
-                    return std::floor(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/floor/Traits.hpp
+++ b/include/alpaka/math/floor/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find floor(TArg) in the namespace of your type.
+                    using std::floor;
                     return floor(arg);
                 }
             };

--- a/include/alpaka/math/fmod/FmodStdLib.hpp
+++ b/include/alpaka/math/fmod/FmodStdLib.hpp
@@ -9,37 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/fmod/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library fmod.
+        //! The standard library fmod, implementation covered by the general template.
         class FmodStdLib : public concepts::Implements<ConceptMathFmod, FmodStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library fmod trait specialization.
-            template<typename Tx, typename Ty>
-            struct Fmod<
-                FmodStdLib,
-                Tx,
-                Ty,
-                std::enable_if_t<std::is_arithmetic<Tx>::value && std::is_arithmetic<Ty>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(FmodStdLib const& fmod_ctx, Tx const& x, Ty const& y)
-                {
-                    alpaka::ignore_unused(fmod_ctx);
-                    return std::fmod(x, y);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/fmod/Traits.hpp
+++ b/include/alpaka/math/fmod/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find fmod(Tx, Ty) in the namespace of your type.
+                    using std::fmod;
                     return fmod(x, y);
                 }
             };

--- a/include/alpaka/math/isfinite/IsfiniteStdLib.hpp
+++ b/include/alpaka/math/isfinite/IsfiniteStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/isfinite/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library isfinite.
+        //! The standard library isfinite, implementation covered by the general template.
         class IsfiniteStdLib : public concepts::Implements<ConceptMathIsfinite, IsfiniteStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library isfinite trait specialization.
-            template<typename TArg>
-            struct Isfinite<IsfiniteStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(IsfiniteStdLib const& ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(ctx);
-                    return std::isfinite(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/isfinite/Traits.hpp
+++ b/include/alpaka/math/isfinite/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find isfinite(TArg) in the namespace of your type.
+                    using std::isfinite;
                     return isfinite(arg);
                 }
             };

--- a/include/alpaka/math/isinf/IsinfStdLib.hpp
+++ b/include/alpaka/math/isinf/IsinfStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/isinf/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library isinf.
+        //! The standard library isinf, implementation covered by the general template.
         class IsinfStdLib : public concepts::Implements<ConceptMathIsinf, IsinfStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library isinf trait specialization.
-            template<typename TArg>
-            struct Isinf<IsinfStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(IsinfStdLib const& ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(ctx);
-                    return std::isinf(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/isinf/Traits.hpp
+++ b/include/alpaka/math/isinf/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find isinf(TArg) in the namespace of your type.
+                    using std::isinf;
                     return isinf(arg);
                 }
             };

--- a/include/alpaka/math/isnan/IsnanStdLib.hpp
+++ b/include/alpaka/math/isnan/IsnanStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/isnan/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library isnan.
+        //! The standard library isnan, implementation covered by the general template.
         class IsnanStdLib : public concepts::Implements<ConceptMathIsnan, IsnanStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library isnan trait specialization.
-            template<typename TArg>
-            struct Isnan<IsnanStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(IsnanStdLib const& ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(ctx);
-                    return std::isnan(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/isnan/Traits.hpp
+++ b/include/alpaka/math/isnan/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find isnan(TArg) in the namespace of your type.
+                    using std::isnan;
                     return isnan(arg);
                 }
             };

--- a/include/alpaka/math/log/LogStdLib.hpp
+++ b/include/alpaka/math/log/LogStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/log/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library log.
+        //! The standard library log, implementation covered by the general template.
         class LogStdLib : public concepts::Implements<ConceptMathLog, LogStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library log trait specialization.
-            template<typename TArg>
-            struct Log<LogStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(LogStdLib const& log_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(log_ctx);
-                    return std::log(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/log/Traits.hpp
+++ b/include/alpaka/math/log/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find log(TArg) in the namespace of your type.
+                    using std::log;
                     return log(arg);
                 }
             };

--- a/include/alpaka/math/max/MaxStdLib.hpp
+++ b/include/alpaka/math/max/MaxStdLib.hpp
@@ -34,7 +34,8 @@ namespace alpaka
                 ALPAKA_FN_HOST auto operator()(MaxStdLib const& max_ctx, Tx const& x, Ty const& y)
                 {
                     alpaka::ignore_unused(max_ctx);
-                    return std::max(x, y);
+                    using std::max;
+                    return max(x, y);
                 }
             };
             //! The standard library mixed integral floating point max trait specialization.
@@ -50,7 +51,8 @@ namespace alpaka
                 ALPAKA_FN_HOST auto operator()(MaxStdLib const& max_ctx, Tx const& x, Ty const& y)
                 {
                     alpaka::ignore_unused(max_ctx);
-                    return std::fmax(x, y);
+                    using std::fmax;
+                    return fmax(x, y);
                 }
             };
         } // namespace traits

--- a/include/alpaka/math/max/Traits.hpp
+++ b/include/alpaka/math/max/Traits.hpp
@@ -13,7 +13,8 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <algorithm>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +35,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find max(Tx, Ty) in the namespace of your type.
+                    using std::max;
                     return max(x, y);
                 }
             };

--- a/include/alpaka/math/min/MinStdLib.hpp
+++ b/include/alpaka/math/min/MinStdLib.hpp
@@ -34,7 +34,8 @@ namespace alpaka
                 ALPAKA_FN_HOST auto operator()(MinStdLib const& min_ctx, Tx const& x, Ty const& y)
                 {
                     alpaka::ignore_unused(min_ctx);
-                    return std::min(x, y);
+                    using std::min;
+                    return min(x, y);
                 }
             };
             //! The standard library mixed integral floating point min trait specialization.
@@ -50,7 +51,8 @@ namespace alpaka
                 ALPAKA_FN_HOST auto operator()(MinStdLib const& min_ctx, Tx const& x, Ty const& y)
                 {
                     alpaka::ignore_unused(min_ctx);
-                    return std::fmin(x, y);
+                    using std::fmin;
+                    return fmin(x, y);
                 }
             };
         } // namespace traits

--- a/include/alpaka/math/min/Traits.hpp
+++ b/include/alpaka/math/min/Traits.hpp
@@ -13,7 +13,8 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <algorithm>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +35,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find min(Tx, Ty) in the namespace of your type.
+                    using std::min;
                     return min(x, y);
                 }
             };

--- a/include/alpaka/math/pow/PowStdLib.hpp
+++ b/include/alpaka/math/pow/PowStdLib.hpp
@@ -9,37 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/pow/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library pow.
+        //! The standard library pow, implementation covered by the general template.
         class PowStdLib : public concepts::Implements<ConceptMathPow, PowStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library pow trait specialization.
-            template<typename TBase, typename TExp>
-            struct Pow<
-                PowStdLib,
-                TBase,
-                TExp,
-                std::enable_if_t<std::is_arithmetic<TBase>::value && std::is_arithmetic<TExp>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(PowStdLib const& pow_ctx, TBase const& base, TExp const& exp)
-                {
-                    alpaka::ignore_unused(pow_ctx);
-                    return std::pow(base, exp);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/pow/Traits.hpp
+++ b/include/alpaka/math/pow/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find pow(base, exp) in the namespace of your type.
+                    using std::pow;
                     return pow(base, exp);
                 }
             };

--- a/include/alpaka/math/remainder/RemainderStdLib.hpp
+++ b/include/alpaka/math/remainder/RemainderStdLib.hpp
@@ -9,37 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/remainder/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library remainder.
+        //! The standard library remainder, implementation covered by the general template.
         class RemainderStdLib : public concepts::Implements<ConceptMathRemainder, RemainderStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library remainder trait specialization.
-            template<typename Tx, typename Ty>
-            struct Remainder<
-                RemainderStdLib,
-                Tx,
-                Ty,
-                std::enable_if_t<std::is_floating_point<Tx>::value && std::is_floating_point<Ty>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(RemainderStdLib const& remainder_ctx, Tx const& x, Ty const& y)
-                {
-                    alpaka::ignore_unused(remainder_ctx);
-                    return std::remainder(x, y);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/remainder/Traits.hpp
+++ b/include/alpaka/math/remainder/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find remainder(Tx, Ty) in the namespace of your type.
+                    using std::remainder;
                     return remainder(x, y);
                 }
             };

--- a/include/alpaka/math/round/RoundStdLib.hpp
+++ b/include/alpaka/math/round/RoundStdLib.hpp
@@ -9,53 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/round/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library round.
+        //! The standard library round, implementation covered by the general template.
         class RoundStdLib : public concepts::Implements<ConceptMathRound, RoundStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library round trait specialization.
-            template<typename TArg>
-            struct Round<RoundStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(RoundStdLib const& round_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(round_ctx);
-                    return std::round(arg);
-                }
-            };
-            //! The standard library round trait specialization.
-            template<typename TArg>
-            struct Lround<RoundStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(RoundStdLib const& lround_ctx, TArg const& arg) -> long int
-                {
-                    alpaka::ignore_unused(lround_ctx);
-                    return std::lround(arg);
-                }
-            };
-            //! The standard library round trait specialization.
-            template<typename TArg>
-            struct Llround<RoundStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(RoundStdLib const& llround_ctx, TArg const& arg) -> long int
-                {
-                    alpaka::ignore_unused(llround_ctx);
-                    return std::llround(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/round/Traits.hpp
+++ b/include/alpaka/math/round/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find round(TArg) in the namespace of your type.
+                    using std::round;
                     return round(arg);
                 }
             };
@@ -47,6 +48,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find lround(TArg) in the namespace of your type.
+                    using std::lround;
                     return lround(arg);
                 }
             };
@@ -60,6 +62,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find llround(TArg) in the namespace of your type.
+                    using std::llround;
                     return llround(arg);
                 }
             };

--- a/include/alpaka/math/rsqrt/RsqrtStdLib.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/rsqrt/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library rsqrt.
+        //! The standard library rsqrt, implementation covered by the general template.
         class RsqrtStdLib : public concepts::Implements<ConceptMathRsqrt, RsqrtStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library rsqrt trait specialization.
-            template<typename TArg>
-            struct Rsqrt<RsqrtStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(RsqrtStdLib const& rsqrt_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(rsqrt_ctx);
-                    return static_cast<TArg>(1) / std::sqrt(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/rsqrt/Traits.hpp
+++ b/include/alpaka/math/rsqrt/Traits.hpp
@@ -13,8 +13,6 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
-
 namespace alpaka
 {
     namespace math

--- a/include/alpaka/math/rsqrt/Traits.hpp
+++ b/include/alpaka/math/rsqrt/Traits.hpp
@@ -13,6 +13,8 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
+#include <cmath>
+
 namespace alpaka
 {
     namespace math
@@ -23,6 +25,18 @@ namespace alpaka
 
         namespace traits
         {
+            namespace detail
+            {
+                //! Fallback implementation when no better ADL match was found
+                template<typename TArg>
+                ALPAKA_FN_HOST_ACC auto rsqrt(TArg const& arg)
+                {
+                    // Still use ADL to try find sqrt(arg)
+                    using std::sqrt;
+                    return static_cast<TArg>(1) / sqrt(arg);
+                }
+            } // namespace detail
+
             //! The rsqrt trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct Rsqrt
@@ -32,6 +46,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find rsqrt(TArg) in the namespace of your type.
+                    using detail::rsqrt;
                     return rsqrt(arg);
                 }
             };

--- a/include/alpaka/math/sin/SinStdLib.hpp
+++ b/include/alpaka/math/sin/SinStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/sin/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library sin.
+        //! The standard library sin, implementation covered by the general template.
         class SinStdLib : public concepts::Implements<ConceptMathSin, SinStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library sin trait specialization.
-            template<typename TArg>
-            struct Sin<SinStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(SinStdLib const& sin_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(sin_ctx);
-                    return std::sin(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/sin/Traits.hpp
+++ b/include/alpaka/math/sin/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find sin(TArg) in the namespace of your type.
+                    using std::sin;
                     return sin(arg);
                 }
             };

--- a/include/alpaka/math/sincos/SinCosStdLib.hpp
+++ b/include/alpaka/math/sincos/SinCosStdLib.hpp
@@ -9,38 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/sincos/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library sincos.
+        //! The standard library sincos, implementation covered by the general template.
         class SinCosStdLib : public concepts::Implements<ConceptMathSinCos, SinCosStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library sincos trait specialization.
-            template<typename TArg>
-            struct SinCos<SinCosStdLib, TArg, std::enable_if_t<std::is_floating_point<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(
-                    SinCosStdLib const& sincos_ctx,
-                    TArg const& arg,
-                    TArg& result_sin,
-                    TArg& result_cos) -> void
-                {
-                    alpaka::ignore_unused(sincos_ctx);
-                    result_sin = std::sin(arg);
-                    result_cos = std::cos(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/sincos/Traits.hpp
+++ b/include/alpaka/math/sincos/Traits.hpp
@@ -13,8 +13,6 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
-
 namespace alpaka
 {
     namespace math

--- a/include/alpaka/math/sincos/Traits.hpp
+++ b/include/alpaka/math/sincos/Traits.hpp
@@ -13,6 +13,8 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
+#include <cmath>
+
 namespace alpaka
 {
     namespace math
@@ -23,6 +25,20 @@ namespace alpaka
 
         namespace traits
         {
+            namespace detail
+            {
+                //! Fallback implementation when no better ADL match was found
+                template<typename TArg>
+                ALPAKA_FN_HOST_ACC auto sincos(TArg const& arg, TArg& result_sin, TArg& result_cos)
+                {
+                    // Still use ADL to try find sin(arg) and cos(arg)
+                    using std::sin;
+                    result_sin = sin(arg);
+                    using std::cos;
+                    result_cos = cos(arg);
+                }
+            } // namespace detail
+
             //! The sincos trait.
             template<typename T, typename TArg, typename TSfinae = void>
             struct SinCos
@@ -32,6 +48,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find sincos(TArg, TArg&, TArg&) in the namespace of your type.
+                    using detail::sincos;
                     return sincos(arg, result_sin, result_cos);
                 }
             };

--- a/include/alpaka/math/sqrt/SqrtStdLib.hpp
+++ b/include/alpaka/math/sqrt/SqrtStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/sqrt/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library sqrt.
+        //! The standard library sqrt, implementation covered by the general template.
         class SqrtStdLib : public concepts::Implements<ConceptMathSqrt, SqrtStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library sqrt trait specialization.
-            template<typename TArg>
-            struct Sqrt<SqrtStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(SqrtStdLib const& sqrt_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(sqrt_ctx);
-                    return std::sqrt(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/sqrt/Traits.hpp
+++ b/include/alpaka/math/sqrt/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find sqrt(TArg) in the namespace of your type.
+                    using std::sqrt;
                     return sqrt(arg);
                 }
             };

--- a/include/alpaka/math/tan/TanStdLib.hpp
+++ b/include/alpaka/math/tan/TanStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/tan/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library tan.
+        //! The standard library tan, implementation covered by the general template.
         class TanStdLib : public concepts::Implements<ConceptMathTan, TanStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library tan trait specialization.
-            template<typename TArg>
-            struct Tan<TanStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(TanStdLib const& tan_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(tan_ctx);
-                    return std::tan(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka

--- a/include/alpaka/math/tan/Traits.hpp
+++ b/include/alpaka/math/tan/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find tan(TArg) in the namespace of your type.
+                    using std::tan;
                     return tan(arg);
                 }
             };

--- a/include/alpaka/math/trunc/Traits.hpp
+++ b/include/alpaka/math/trunc/Traits.hpp
@@ -13,7 +13,7 @@
 #include <alpaka/core/Concepts.hpp>
 #include <alpaka/core/Unused.hpp>
 
-#include <type_traits>
+#include <cmath>
 
 namespace alpaka
 {
@@ -34,6 +34,7 @@ namespace alpaka
                     alpaka::ignore_unused(ctx);
                     // This is an ADL call. If you get a compile error here then your type is not supported by the
                     // backend and we could not find trunc(TArg) in the namespace of your type.
+                    using std::trunc;
                     return trunc(arg);
                 }
             };

--- a/include/alpaka/math/trunc/TruncStdLib.hpp
+++ b/include/alpaka/math/trunc/TruncStdLib.hpp
@@ -9,33 +9,15 @@
 
 #pragma once
 
-#include <alpaka/core/Unused.hpp>
 #include <alpaka/math/trunc/Traits.hpp>
-
-#include <cmath>
-#include <type_traits>
 
 namespace alpaka
 {
     namespace math
     {
-        //! The standard library trunc.
+        //! The standard library trunc, implementation covered by the general template.
         class TruncStdLib : public concepts::Implements<ConceptMathTrunc, TruncStdLib>
         {
         };
-
-        namespace traits
-        {
-            //! The standard library trunc trait specialization.
-            template<typename TArg>
-            struct Trunc<TruncStdLib, TArg, std::enable_if_t<std::is_arithmetic<TArg>::value>>
-            {
-                ALPAKA_FN_HOST auto operator()(TruncStdLib const& trunc_ctx, TArg const& arg)
-                {
-                    alpaka::ignore_unused(trunc_ctx);
-                    return std::trunc(arg);
-                }
-            };
-        } // namespace traits
     } // namespace math
 } // namespace alpaka


### PR DESCRIPTION
Merge most of them with the general ADL trait implementations by adding `using std::[math_function];` there. Exceptions are `max`, `min`, `rsqrt` which had custom logic in specialization, it is unchanged. A custom specialization is still possible with the old way, just now mostly unnecessary. Implements [this suggestion](https://github.com/alpaka-group/alpaka/issues/1414#issuecomment-963962497).
It should help with complex number math implementations, and maybe also solve some issues with ambiguity leading to compile-time errors or unnecessary casts.

It should probably be possible to to the same for CUDA/HIP. That requires that `std::` versions are callable from device side, which should be the case for functions with `constexpr` versions. However this may require more checks and passes for CI. Also we would need to check that no unnecessary casts are done and correct precision is used. So this PR only does the CPU side.