### PR TITLE
Support non-cached cmake variable ALPAKA_CXX_STANDARD in external projects

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -125,7 +125,13 @@ endif()
 set(ALPAKA_DEBUG "0" CACHE STRING "Debug level")
 set_property(CACHE ALPAKA_DEBUG PROPERTY STRINGS "0;1;2")
 
-set(ALPAKA_CXX_STANDARD "14" CACHE STRING "C++ standard version")
+set(ALPAKA_CXX_STANDARD_DEFAULT "14")
+# Check whether ALPAKA_CXX_STANDARD has already been defined as a non-cached variable.
+if(DEFINED ALPAKA_CXX_STANDARD)
+    set(ALPAKA_CXX_STANDARD_DEFAULT ${ALPAKA_CXX_STANDARD})
+endif()
+
+set(ALPAKA_CXX_STANDARD ${ALPAKA_CXX_STANDARD_DEFAULT} CACHE STRING "C++ standard version")
 set_property(CACHE ALPAKA_CXX_STANDARD PROPERTY STRINGS "14;17;20")
 
 if(NOT TARGET alpaka)


### PR DESCRIPTION
Allow to use `set(ALPAKA_CXX_STANDARD 17)` in `CMakeLists.txt` of projects, which uses alpaka. The default behavior of cached variable is to overwrite non cached variables, except the variable was defined with `option()`.

Addresses issue #1415 