### PR TITLE
Ignore VS and more build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ build/
 
 # Visual Studio Code project files
 .cache/
+
+# Visual Studio project files
+.vs/
+out

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /docs/doxygen/*
 
-**/build
+**/build*
 
 # tmp files
 *~
@@ -27,7 +27,6 @@ cmake-build-*/
 .kdev?/
 *.kdev?
 spack-build*
-build/
 
 # Eclipse project files
 /.project


### PR DESCRIPTION
This adds gitignores for Visual Studio files and more kinds of `build*` directories.