### PR TITLE
fix cheat-sheet RNG section

### DIFF
--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -307,5 +307,5 @@ Generate random numbers
   .. code-block:: c++
 
      auto distribution = rand::distribution::createNormalReal<double>(acc);
-     auto generator = rand::generator::createDefault(acc, seed, subsequence);
+     auto generator = rand::engine::createDefault(acc, seed, subsequence);
      auto number = distribution(generator);


### PR DESCRIPTION
namespace `generator` was renamed into `engine`