### PR TITLE
Small example and test fixes

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 Benjamin Worpitz, Jan Stephan
+# Copyright 2021 Benjamin Worpitz, Jan Stephan
 #
 # This file exemplifies usage of alpaka.
 #
@@ -22,7 +22,7 @@
 
 cmake_minimum_required(VERSION 3.18)
 
-project("alpakaExamples")
+project("alpakaExamples" LANGUAGES CXX)
 
 ################################################################################
 # Add subdirectories.

--- a/example/bufferCopy/CMakeLists.txt
+++ b/example/bufferCopy/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2020 Erik Zenker, Benjamin Worpitz, Jan Stephan
+# Copyright 2021 Erik Zenker, Benjamin Worpitz, Jan Stephan
 #
 # This file exemplifies usage of alpaka.
 #
@@ -28,7 +28,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(_TARGET_NAME bufferCopy)
 
-project(${_TARGET_NAME})
+project(${_TARGET_NAME} LANGUAGES CXX)
 
 #-------------------------------------------------------------------------------
 # Find alpaka.

--- a/example/heatEquation/CMakeLists.txt
+++ b/example/heatEquation/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2020 Benjamin Worpitz, Jan Stephan
+# Copyright 2021 Benjamin Worpitz, Jan Stephan
 #
 # This file exemplifies usage of alpaka.
 #
@@ -28,7 +28,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(_TARGET_NAME heatEquation)
 
-project(${_TARGET_NAME})
+project(${_TARGET_NAME} LANGUAGES CXX)
 
 
 #-------------------------------------------------------------------------------

--- a/example/helloWorld/CMakeLists.txt
+++ b/example/helloWorld/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2020 Erik Zenker, Benjamin Worpitz, Jan Stephan
+# Copyright 2021 Erik Zenker, Benjamin Worpitz, Jan Stephan
 #
 # This file exemplifies usage of alpaka.
 #
@@ -28,7 +28,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(_TARGET_NAME helloWorld)
 
-project(${_TARGET_NAME})
+project(${_TARGET_NAME} LANGUAGES CXX)
 
 #-------------------------------------------------------------------------------
 # Find alpaka.

--- a/example/helloWorldLambda/CMakeLists.txt
+++ b/example/helloWorldLambda/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2020 Erik Zenker, Benjamin Worpitz, Jan Stephan
+# Copyright 2021 Erik Zenker, Benjamin Worpitz, Jan Stephan
 #
 # This file exemplifies usage of alpaka.
 #
@@ -28,7 +28,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(_TARGET_NAME helloWorldLambda)
 
-project(${_TARGET_NAME})
+project(${_TARGET_NAME} LANGUAGES CXX)
 
 #-------------------------------------------------------------------------------
 # Find alpaka.

--- a/example/kernelSpecialization/CMakeLists.txt
+++ b/example/kernelSpecialization/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2021 Erik Zenker, Benjamin Worpitz, Jan Stephan, Sergei Bastrakov
+# Copyright 2021 Erik Zenker, Benjamin Worpitz, Jan Stephan, Sergei Bastrakov
 #
 # This file exemplifies usage of alpaka.
 #
@@ -19,7 +19,7 @@
 ################################################################################
 # Required CMake version.
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.18)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
@@ -28,7 +28,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(_TARGET_NAME kernelSpecialization)
 
-project(${_TARGET_NAME})
+project(${_TARGET_NAME} LANGUAGES CXX)
 
 #-------------------------------------------------------------------------------
 # Find alpaka.

--- a/example/monteCarloIntegration/CMakeLists.txt
+++ b/example/monteCarloIntegration/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2020 Benjamin Worpitz, Jan Stephan
+# Copyright 2021 Benjamin Worpitz, Jan Stephan
 #
 # This file exemplifies usage of alpaka.
 #
@@ -28,7 +28,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(_TARGET_NAME monteCarloIntegration)
 
-project(${_TARGET_NAME})
+project(${_TARGET_NAME} LANGUAGES CXX)
 
 
 #-------------------------------------------------------------------------------

--- a/example/openMPSchedule/CMakeLists.txt
+++ b/example/openMPSchedule/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2020 Erik Zenker, Benjamin Worpitz, Jan Stephan, Sergei Bastrakov
+# Copyright 2021 Erik Zenker, Benjamin Worpitz, Jan Stephan, Sergei Bastrakov
 #
 # This file exemplifies usage of alpaka.
 #
@@ -19,7 +19,7 @@
 ################################################################################
 # Required CMake version.
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.18)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
@@ -28,7 +28,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(_TARGET_NAME openMPSchedule)
 
-project(${_TARGET_NAME})
+project(${_TARGET_NAME} LANGUAGES CXX)
 
 #-------------------------------------------------------------------------------
 # Find alpaka.

--- a/example/randomCells2D/CMakeLists.txt
+++ b/example/randomCells2D/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2021 Benjamin Worpitz, Jan Stephan, Jiri Vyskocil
+# Copyright 2021 Benjamin Worpitz, Jan Stephan, Jiri Vyskocil
 #
 # This file exemplifies usage of alpaka.
 #
@@ -28,7 +28,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(_TARGET_NAME randomCells2D)
 
-project(${_TARGET_NAME})
+project(${_TARGET_NAME} LANGUAGES CXX)
 
 
 #-------------------------------------------------------------------------------

--- a/example/randomStrategies/CMakeLists.txt
+++ b/example/randomStrategies/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2021 Benjamin Worpitz, Jan Stephan, Jiri Vyskocil
+# Copyright 2021 Benjamin Worpitz, Jan Stephan, Jiri Vyskocil
 #
 # This file exemplifies usage of alpaka.
 #
@@ -28,7 +28,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(_TARGET_NAME randomStrategies)
 
-project(${_TARGET_NAME})
+project(${_TARGET_NAME} LANGUAGES CXX)
 
 
 #-------------------------------------------------------------------------------

--- a/example/reduce/CMakeLists.txt
+++ b/example/reduce/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2020 Erik Zenker, Benjamin Worpitz, Jan Stephan
+# Copyright 2021 Erik Zenker, Benjamin Worpitz, Jan Stephan
 #
 # This file exemplifies usage of alpaka.
 #
@@ -28,7 +28,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(_TARGET_NAME reduce)
 
-project(${_TARGET_NAME})
+project(${_TARGET_NAME} LANGUAGES CXX)
 
 #-------------------------------------------------------------------------------
 # Find alpaka.

--- a/example/vectorAdd/CMakeLists.txt
+++ b/example/vectorAdd/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2020 Benjamin Worpitz, Jan Stephan
+# Copyright 2021 Benjamin Worpitz, Jan Stephan
 #
 # This file exemplifies usage of alpaka.
 #
@@ -28,7 +28,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(_TARGET_NAME vectorAdd)
 
-project(${_TARGET_NAME})
+project(${_TARGET_NAME} LANGUAGES CXX)
 
 
 #-------------------------------------------------------------------------------

--- a/test/analysis/CMakeLists.txt
+++ b/test/analysis/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2020 Benjamin Worpitz, Jan Stephan
+# Copyright 2021 Benjamin Worpitz, Jan Stephan
 #
 # This file is part of alpaka.
 #
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.18)
 
-project("alpakaAnalysisTest")
+project("alpakaAnalysisTest" LANGUAGES CXX)
 
 ################################################################################
 # Add subdirectories.

--- a/test/catch_main/CMakeLists.txt
+++ b/test/catch_main/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2020 Benjamin Worpitz, Axel Huebl
+# Copyright 2021 Benjamin Worpitz, Axel Huebl
 #
 # This file is part of alpaka.
 #
@@ -11,7 +11,7 @@
 option(ALPAKA_USE_INTERNAL_CATCH2 "Use internally shipped Catch2" ON)
 
 if(ALPAKA_USE_INTERNAL_CATCH2)
-    message(STATUS "Catch2: Using INTERNAL version 2.13.3")
+    message(STATUS "Catch2: Using INTERNAL version 2.13.7")
 else()
     find_package(Catch2 2.13.3 CONFIG REQUIRED)
     set_target_properties(Catch2::Catch2 PROPERTIES IMPORTED_GLOBAL TRUE)

--- a/test/integ/CMakeLists.txt
+++ b/test/integ/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2020 Benjamin Worpitz, Jan Stephan
+# Copyright 2021 Benjamin Worpitz, Jan Stephan
 #
 # This file is part of alpaka.
 #
@@ -14,7 +14,7 @@
 
 cmake_minimum_required(VERSION 3.18)
 
-project("alpakaIntegTest")
+project("alpakaIntegTest" LANGUAGES CXX)
 
 ################################################################################
 # Add subdirectories.


### PR DESCRIPTION
This PR fixes some minor issues I noticed while upgrading the SYCL branch:

* The Catch2 version printed out now matches the version shipped internally.
* The CMake `project()` commands for the examples and test cases now only enable `CXX` as language. The previous approach would implicitly enable `C`, too, which breaks the Intel DPC++ toolchain which comes without a C compiler.
* All subprojects now require the same CMake version as alpaka itself.

Needs to be backported to 0.8.