### PR TITLE
RFC: Implement queue-ordered memory buffers

### DIFF
--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -118,6 +118,8 @@
 #include <alpaka/mem/alloc/AllocCpuAligned.hpp>
 #include <alpaka/mem/alloc/AllocCpuNew.hpp>
 #include <alpaka/mem/alloc/Traits.hpp>
+#include <alpaka/mem/buf/AsyncBufCpu.hpp>
+#include <alpaka/mem/buf/AsyncBufUniformCudaHipRt.hpp>
 #include <alpaka/mem/buf/BufCpu.hpp>
 #include <alpaka/mem/buf/BufOacc.hpp>
 #include <alpaka/mem/buf/BufOmp5.hpp>

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -196,6 +196,9 @@ namespace alpaka
     template<typename TElem, typename TDim, typename TIdx>
     class BufCpu;
 
+    template<typename TElem, typename TDim, typename TIdx>
+    class AsyncBufCpu;
+
     namespace traits
     {
         //! The CPU device memory buffer type trait specialization.
@@ -203,6 +206,12 @@ namespace alpaka
         struct BufType<DevCpu, TElem, TDim, TIdx>
         {
             using type = BufCpu<TElem, TDim, TIdx>;
+        };
+        //! The CPU device memory buffer type trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct AsyncBufType<DevCpu, TElem, TDim, TIdx>
+        {
+            using type = AsyncBufCpu<TElem, TDim, TIdx>;
         };
 
         //! The CPU device platform type trait specialization.

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -169,6 +169,9 @@ namespace alpaka
     template<typename TElem, typename TDim, typename TIdx>
     class BufUniformCudaHipRt;
 
+    template<typename TElem, typename TDim, typename TIdx>
+    class AsyncBufUniformCudaHipRt;
+
     namespace traits
     {
         //! The CUDA/HIP RT device memory buffer type trait specialization.
@@ -176,6 +179,12 @@ namespace alpaka
         struct BufType<DevUniformCudaHipRt, TElem, TDim, TIdx>
         {
             using type = BufUniformCudaHipRt<TElem, TDim, TIdx>;
+        };
+        //! The CUDA/HIP RT stream-ordered device memory buffer type trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct AsyncBufType<DevUniformCudaHipRt, TElem, TDim, TIdx>
+        {
+            using type = AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>;
         };
 
         //! The CUDA/HIP RT device platform type trait specialization.

--- a/include/alpaka/mem/buf/AsyncBufCpu.hpp
+++ b/include/alpaka/mem/buf/AsyncBufCpu.hpp
@@ -1,0 +1,293 @@
+/* Copyright 2019 Alexander Matthes, Axel Huebl, Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/Unused.hpp>
+#include <alpaka/core/Vectorize.hpp>
+#include <alpaka/dev/DevCpu.hpp>
+#include <alpaka/dev/Traits.hpp>
+#include <alpaka/mem/buf/BufCpu.hpp>
+#include <alpaka/mem/buf/Traits.hpp>
+#include <alpaka/vec/Vec.hpp>
+
+// Backend specific includes.
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#    include <alpaka/core/Cuda.hpp>
+#elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#    include <alpaka/core/Hip.hpp>
+#endif
+
+#include <alpaka/mem/alloc/AllocCpuAligned.hpp>
+#include <alpaka/meta/DependentFalseType.hpp>
+
+#include <memory>
+#include <type_traits>
+
+namespace alpaka
+{
+    //! The CPU memory buffer.
+    template<typename TElem, typename TDim, typename TIdx>
+    class AsyncBufCpu
+    {
+    public:
+        template<typename TQueue, typename TExtent>
+        ALPAKA_FN_HOST AsyncBufCpu(TQueue queue, TExtent const& extent)
+            : m_spBufCpuImpl{
+                new detail::BufCpuImpl<TElem, TDim, TIdx>(getDev(queue), extent),
+                [queue = std::move(queue)](detail::BufCpuImpl<TElem, TDim, TIdx>* ptr) mutable
+                { alpaka::enqueue(queue, [ptr]() { delete ptr; }); }}
+        {
+            static_assert(
+                std::is_same<Dev<TQueue>, DevCpu>::value,
+                "The AsyncBufCpu buffer can only be used with a queue on a DevCpu device!");
+        }
+
+    public:
+        std::shared_ptr<detail::BufCpuImpl<TElem, TDim, TIdx>> m_spBufCpuImpl;
+    };
+
+    namespace traits
+    {
+        //! The AsyncBufCpu device type trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct DevType<AsyncBufCpu<TElem, TDim, TIdx>>
+        {
+            using type = DevCpu;
+        };
+        //! The AsyncBufCpu device get trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct GetDev<AsyncBufCpu<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto getDev(AsyncBufCpu<TElem, TDim, TIdx> const& buf) -> DevCpu
+            {
+                return buf.m_spBufCpuImpl->m_dev;
+            }
+        };
+
+        //! The AsyncBufCpu dimension getter trait.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct DimType<AsyncBufCpu<TElem, TDim, TIdx>>
+        {
+            using type = TDim;
+        };
+
+        //! The AsyncBufCpu memory element type get trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct ElemType<AsyncBufCpu<TElem, TDim, TIdx>>
+        {
+            using type = TElem;
+        };
+    } // namespace traits
+    namespace extent
+    {
+        namespace traits
+        {
+            //! The AsyncBufCpu width get trait specialization.
+            template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
+            struct GetExtent<
+                TIdxIntegralConst,
+                AsyncBufCpu<TElem, TDim, TIdx>,
+                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
+            {
+                ALPAKA_FN_HOST static auto getExtent(AsyncBufCpu<TElem, TDim, TIdx> const& extent) -> TIdx
+                {
+                    return extent.m_spBufCpuImpl->m_extentElements[TIdxIntegralConst::value];
+                }
+            };
+        } // namespace traits
+    } // namespace extent
+    namespace traits
+    {
+        //! The AsyncBufCpu native pointer get trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct GetPtrNative<AsyncBufCpu<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto getPtrNative(AsyncBufCpu<TElem, TDim, TIdx> const& buf) -> TElem const*
+            {
+                return buf.m_spBufCpuImpl->m_pMem;
+            }
+            ALPAKA_FN_HOST static auto getPtrNative(AsyncBufCpu<TElem, TDim, TIdx>& buf) -> TElem*
+            {
+                return buf.m_spBufCpuImpl->m_pMem;
+            }
+        };
+        //! The AsyncBufCpu pointer on device get trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct GetPtrDev<AsyncBufCpu<TElem, TDim, TIdx>, DevCpu>
+        {
+            ALPAKA_FN_HOST static auto getPtrDev(AsyncBufCpu<TElem, TDim, TIdx> const& buf, DevCpu const& dev)
+                -> TElem const*
+            {
+                if(dev == getDev(buf))
+                {
+                    return buf.m_spBufCpuImpl->m_pMem;
+                }
+                else
+                {
+                    throw std::runtime_error("The buffer is not accessible from the given device!");
+                }
+            }
+            ALPAKA_FN_HOST static auto getPtrDev(AsyncBufCpu<TElem, TDim, TIdx>& buf, DevCpu const& dev) -> TElem*
+            {
+                if(dev == getDev(buf))
+                {
+                    return buf.m_spBufCpuImpl->m_pMem;
+                }
+                else
+                {
+                    throw std::runtime_error("The buffer is not accessible from the given device!");
+                }
+            }
+        };
+        //! The AsyncBufCpu pitch get trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct GetPitchBytes<DimInt<TDim::value - 1u>, AsyncBufCpu<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto getPitchBytes(AsyncBufCpu<TElem, TDim, TIdx> const& pitch) -> TIdx
+            {
+                return pitch.m_spBufCpuImpl->m_pitchBytes;
+            }
+        };
+
+        //! The AsyncBufCpu memory allocation trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct AsyncBufAlloc<TElem, TDim, TIdx, DevCpu>
+        {
+            template<typename TQueue, typename TExtent>
+            ALPAKA_FN_HOST static auto allocAsyncBuf(TQueue queue, TExtent const& extent)
+                -> AsyncBufCpu<TElem, TDim, TIdx>
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                return AsyncBufCpu<TElem, TDim, TIdx>(queue, extent);
+            }
+        };
+        //! The AsyncBufCpu memory mapping trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct Map<AsyncBufCpu<TElem, TDim, TIdx>, DevCpu>
+        {
+            ALPAKA_FN_HOST static auto map(AsyncBufCpu<TElem, TDim, TIdx>& buf, DevCpu const& dev) -> void
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                if(getDev(buf) != dev)
+                {
+                    throw std::runtime_error("Memory mapping of AsyncBufCpu between two devices is not implemented!");
+                }
+                // If it is the same device, nothing has to be mapped.
+            }
+        };
+        //! The AsyncBufCpu memory unmapping trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct Unmap<AsyncBufCpu<TElem, TDim, TIdx>, DevCpu>
+        {
+            ALPAKA_FN_HOST static auto unmap(AsyncBufCpu<TElem, TDim, TIdx>& buf, DevCpu const& dev) -> void
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                if(getDev(buf) != dev)
+                {
+                    throw std::runtime_error(
+                        "Memory unmapping of AsyncBufCpu between two devices is not implemented!");
+                }
+                // If it is the same device, nothing has to be mapped.
+            }
+        };
+        //! The AsyncBufCpu memory pinning trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct Pin<AsyncBufCpu<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto pin(AsyncBufCpu<TElem, TDim, TIdx>& buf) -> void
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                if(!isPinned(buf))
+                {
+#if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+                    if(buf.m_spBufCpuImpl->m_extentElements.prod() != 0)
+                    {
+                        // - cudaHostRegisterDefault:
+                        //   See http://cgi.cs.indiana.edu/~nhusted/dokuwiki/doku.php?id=programming:cudaperformance1
+                        // - cudaHostRegisterPortable:
+                        //   The memory returned by this call will be considered as pinned memory by all CUDA contexts,
+                        //   not just the one that performed the allocation.
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
+                            ALPAKA_API_PREFIX(HostRegister)(
+                                const_cast<void*>(reinterpret_cast<void const*>(getPtrNative(buf))),
+                                extent::getExtentProduct(buf) * sizeof(Elem<AsyncBufCpu<TElem, TDim, TIdx>>),
+                                ALPAKA_API_PREFIX(HostRegisterDefault)),
+                            ALPAKA_API_PREFIX(ErrorHostMemoryAlreadyRegistered));
+
+                        buf.m_spBufCpuImpl->m_bPinned = true;
+                    }
+#else
+                    static_assert(
+                        meta::DependentFalseType<TElem>::value,
+                        "Memory pinning of AsyncBufCpu is not implemented when CUDA or HIP is not enabled!");
+#endif
+                }
+            }
+        };
+        //! The AsyncBufCpu memory unpinning trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct Unpin<AsyncBufCpu<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto unpin(AsyncBufCpu<TElem, TDim, TIdx>& buf) -> void
+            {
+                alpaka::unpin(*buf.m_spBufCpuImpl.get());
+            }
+        };
+        //! The AsyncBufCpu memory pin state trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct IsPinned<AsyncBufCpu<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto isPinned(AsyncBufCpu<TElem, TDim, TIdx> const& buf) -> bool
+            {
+                return alpaka::isPinned(*buf.m_spBufCpuImpl.get());
+            }
+        };
+        //! The AsyncBufCpu memory prepareForAsyncCopy trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct PrepareForAsyncCopy<AsyncBufCpu<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto prepareForAsyncCopy(AsyncBufCpu<TElem, TDim, TIdx>& buf) -> void
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+                // to optimize the data transfer performance between a cuda/hip device the cpu buffer has to be pinned,
+                // for exclusive cpu use, no preparing is needed
+#if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+                pin(buf);
+#else
+                alpaka::ignore_unused(buf);
+#endif
+            }
+        };
+
+        //! The AsyncBufCpu offset get trait specialization.
+        template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
+        struct GetOffset<TIdxIntegralConst, AsyncBufCpu<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto getOffset(AsyncBufCpu<TElem, TDim, TIdx> const&) -> TIdx
+            {
+                return 0u;
+            }
+        };
+
+        //! The AsyncBufCpu idx type trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct IdxType<AsyncBufCpu<TElem, TDim, TIdx>>
+        {
+            using type = TIdx;
+        };
+    } // namespace traits
+} // namespace alpaka
+
+#include <alpaka/mem/buf/cpu/Copy.hpp>
+#include <alpaka/mem/buf/cpu/Set.hpp>

--- a/include/alpaka/mem/buf/AsyncBufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/AsyncBufUniformCudaHipRt.hpp
@@ -1,0 +1,307 @@
+/* Copyright 2019 Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+
+#    include <alpaka/core/BoostPredef.hpp>
+
+#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#    endif
+
+#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#    endif
+
+// Backend specific includes.
+#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#        include <alpaka/core/Cuda.hpp>
+#    else
+#        error HIP does not support stream-ordered memory allocations
+#    endif
+
+#    include <alpaka/core/Assert.hpp>
+#    include <alpaka/dev/DevUniformCudaHipRt.hpp>
+#    include <alpaka/dev/Traits.hpp>
+#    include <alpaka/dim/DimIntegralConst.hpp>
+#    include <alpaka/mem/buf/Traits.hpp>
+#    include <alpaka/vec/Vec.hpp>
+
+#    include <functional>
+#    include <memory>
+#    include <type_traits>
+
+namespace alpaka
+{
+    class DevUniformCudaHipRt;
+
+    template<typename TElem, typename TDim, typename TIdx>
+    class BufCpu;
+
+    //! The CUDA/HIP stream-ordered memory buffer.
+    template<typename TElem, typename TDim, typename TIdx>
+    class AsyncBufUniformCudaHipRt
+    {
+        static_assert(
+            !std::is_const<TElem>::value,
+            "The elem type of the buffer can not be const because the C++ Standard forbids containers of const "
+            "elements!");
+        static_assert(!std::is_const<TIdx>::value, "The idx type of the buffer can not be const!");
+
+    private:
+        using Elem = TElem;
+        using Dim = TDim;
+
+    public:
+        //! Constructor
+        template<typename TQueue, typename TExtent>
+        ALPAKA_FN_HOST AsyncBufUniformCudaHipRt(
+            TQueue queue,
+            TElem* const pMem,
+            TIdx const& pitchBytes,
+            TExtent const& extent)
+            : m_dev(getDev(queue))
+            , m_extentElements(extent::getExtentVecEnd<TDim>(extent))
+            , m_spMem(pMem, [queue](TElem* const ptr) { AsyncBufUniformCudaHipRt::freeBuffer(ptr, queue); })
+        {
+            ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+            static_assert(
+                TDim::value == alpaka::Dim<TExtent>::value,
+                "The dimensionality of TExtent and the dimensionality of the TDim template parameter have to be "
+                "identical!");
+            static_assert(
+                std::is_same<TIdx, Idx<TExtent>>::value,
+                "The idx type of TExtent and the TIdx template parameter have to be identical!");
+        }
+
+    private:
+        //! Frees the shared buffer.
+        template<typename TQueue>
+        ALPAKA_FN_HOST static auto freeBuffer(TElem* const memPtr, TQueue const& queue) -> void
+        {
+            ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+            // FIXME Do we really need to set the current device ?
+            // Set the current device.
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(getDev(queue).m_iDevice));
+            // Free the buffer.
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
+                FreeAsync)(reinterpret_cast<void*>(memPtr), queue.m_spQueueImpl->m_UniformCudaHipQueue));
+        }
+
+    public:
+        DevUniformCudaHipRt m_dev;
+        Vec<TDim, TIdx> m_extentElements;
+        std::shared_ptr<TElem> m_spMem;
+    };
+
+    namespace traits
+    {
+        //! The AsyncBufUniformCudaHipRt device type trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct DevType<AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>>
+        {
+            using type = DevUniformCudaHipRt;
+        };
+        //! The AsyncBufUniformCudaHipRt device get trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct GetDev<AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto getDev(AsyncBufUniformCudaHipRt<TElem, TDim, TIdx> const& buf)
+                -> DevUniformCudaHipRt
+            {
+                return buf.m_dev;
+            }
+        };
+
+        //! The AsyncBufUniformCudaHipRt dimension getter trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct DimType<AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>>
+        {
+            using type = TDim;
+        };
+
+        //! The AsyncBufUniformCudaHipRt memory element type get trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct ElemType<AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>>
+        {
+            using type = TElem;
+        };
+    } // namespace traits
+    namespace extent
+    {
+        namespace traits
+        {
+            //! The AsyncBufUniformCudaHipRt extent get trait specialization.
+            template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
+            struct GetExtent<
+                TIdxIntegralConst,
+                AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>,
+                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
+            {
+                ALPAKA_FN_HOST static auto getExtent(AsyncBufUniformCudaHipRt<TElem, TDim, TIdx> const& extent) -> TIdx
+                {
+                    return extent.m_extentElements[TIdxIntegralConst::value];
+                }
+            };
+        } // namespace traits
+    } // namespace extent
+    namespace traits
+    {
+        //! The AsyncBufUniformCudaHipRt native pointer get trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct GetPtrNative<AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto getPtrNative(AsyncBufUniformCudaHipRt<TElem, TDim, TIdx> const& buf)
+                -> TElem const*
+            {
+                return buf.m_spMem.get();
+            }
+            ALPAKA_FN_HOST static auto getPtrNative(AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>& buf) -> TElem*
+            {
+                return buf.m_spMem.get();
+            }
+        };
+        //! The AsyncBufUniformCudaHipRt pointer on device get trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct GetPtrDev<AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>, DevUniformCudaHipRt>
+        {
+            ALPAKA_FN_HOST static auto getPtrDev(
+                AsyncBufUniformCudaHipRt<TElem, TDim, TIdx> const& buf,
+                DevUniformCudaHipRt const& dev) -> TElem const*
+            {
+                if(dev == getDev(buf))
+                {
+                    return buf.m_spMem.get();
+                }
+                else
+                {
+                    throw std::runtime_error("The buffer is not accessible from the given device!");
+                }
+            }
+            ALPAKA_FN_HOST static auto getPtrDev(
+                AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>& buf,
+                DevUniformCudaHipRt const& dev) -> TElem*
+            {
+                if(dev == getDev(buf))
+                {
+                    return buf.m_spMem.get();
+                }
+                else
+                {
+                    throw std::runtime_error("The buffer is not accessible from the given device!");
+                }
+            }
+        };
+
+        //! The CUDA/HIP 1D memory allocation trait specialization.
+        template<typename TElem, typename TIdx>
+        struct AsyncBufAlloc<TElem, DimInt<1u>, TIdx, DevUniformCudaHipRt>
+        {
+            template<typename TQueue, typename TExtent>
+            ALPAKA_FN_HOST static auto allocAsyncBuf(TQueue queue, TExtent const& extent)
+                -> AsyncBufUniformCudaHipRt<TElem, DimInt<1u>, TIdx>
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                auto const width = extent::getWidth(extent);
+                auto const widthBytes = width * static_cast<TIdx>(sizeof(TElem));
+
+                // Set the current device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(getDev(queue).m_iDevice));
+                // Allocate the buffer on this device.
+                void* memPtr;
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(MallocAsync)(
+                    &memPtr,
+                    static_cast<std::size_t>(widthBytes),
+                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
+
+#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                std::cout << __func__ << " ew: " << width << " ewb: " << widthBytes << " ptr: " << memPtr << std::endl;
+#    endif
+                return AsyncBufUniformCudaHipRt<TElem, DimInt<1u>, TIdx>(
+                    queue,
+                    reinterpret_cast<TElem*>(memPtr),
+                    static_cast<TIdx>(widthBytes),
+                    extent);
+            }
+        };
+        //! The AsyncBufUniformCudaHipRt memory pinning trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct Pin<AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto pin(AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>&) -> void
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                // CUDA/HIP device memory is always pinned, it can not be swapped out.
+            }
+        };
+        //! The AsyncBufUniformCudaHipRt memory unpinning trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct Unpin<AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto unpin(AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>&) -> void
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                // CUDA/HIP device memory is always pinned, it can not be swapped out.
+            }
+        };
+        //! The AsyncBufUniformCudaHipRt memory pin state trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct IsPinned<AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto isPinned(AsyncBufUniformCudaHipRt<TElem, TDim, TIdx> const&) -> bool
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                // CUDA/HIP device memory is always pinned, it can not be swapped out.
+                return true;
+            }
+        };
+        //! The AsyncBufUniformCudaHipRt memory prepareForAsyncCopy trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct PrepareForAsyncCopy<AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto prepareForAsyncCopy(AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>&) -> void
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                // CUDA/HIP device memory is always ready for async copy
+            }
+        };
+
+        //! The AsyncBufUniformCudaHipRt offset get trait specialization.
+        template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
+        struct GetOffset<TIdxIntegralConst, AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>>
+        {
+            ALPAKA_FN_HOST static auto getOffset(AsyncBufUniformCudaHipRt<TElem, TDim, TIdx> const&) -> TIdx
+            {
+                return 0u;
+            }
+        };
+
+        //! The AsyncBufUniformCudaHipRt idx type trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct IdxType<AsyncBufUniformCudaHipRt<TElem, TDim, TIdx>>
+        {
+            using type = TIdx;
+        };
+
+    } // namespace traits
+} // namespace alpaka
+
+#    include <alpaka/mem/buf/uniformCudaHip/Copy.hpp>
+#    include <alpaka/mem/buf/uniformCudaHip/Set.hpp>
+
+#endif

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -25,6 +25,14 @@ namespace alpaka
         template<typename TElem, typename TDim, typename TIdx, typename TDev, typename TSfinae = void>
         struct BufAlloc;
 
+        //! The stream-ordered memory buffer type trait.
+        template<typename TDev, typename TElem, typename TDim, typename TIdx, typename TSfinae = void>
+        struct AsyncBufType;
+
+        //! The stream-ordered memory allocator trait.
+        template<typename TElem, typename TDim, typename TIdx, typename TDev, typename TSfinae = void>
+        struct AsyncBufAlloc;
+
         //! The memory mapping trait.
         template<typename TBuf, typename TDev, typename TSfinae = void>
         struct Map;
@@ -54,6 +62,10 @@ namespace alpaka
     template<typename TDev, typename TElem, typename TDim, typename TIdx>
     using Buf = typename traits::BufType<alpaka::Dev<TDev>, TElem, TDim, TIdx>::type;
 
+    //! The stream-ordered memory buffer type trait alias template to remove the ::type.
+    template<typename TDev, typename TElem, typename TDim, typename TIdx>
+    using AsyncBuf = typename traits::AsyncBufType<alpaka::Dev<TDev>, TElem, TDim, TIdx>::type;
+
     //! Allocates memory on the given device.
     //!
     //! \tparam TElem The element type of the returned buffer.
@@ -67,6 +79,21 @@ namespace alpaka
     ALPAKA_FN_HOST auto allocBuf(TDev const& dev, TExtent const& extent = TExtent())
     {
         return traits::BufAlloc<TElem, Dim<TExtent>, TIdx, TDev>::allocBuf(dev, extent);
+    }
+
+    //! Allocates stream-ordered memory on the given device.
+    //!
+    //! \tparam TElem The element type of the returned buffer.
+    //! \tparam TIdx The linear index type of the buffer.
+    //! \tparam TExtent The extent type of the buffer.
+    //! \tparam TQueue The type of queue used to order the buffer allocation.
+    //! \param queue The queue used to order the buffer allocation.
+    //! \param extent The extent of the buffer.
+    //! \return The newly allocated buffer.
+    template<typename TElem, typename TIdx, typename TExtent, typename TQueue>
+    ALPAKA_FN_HOST auto allocAsyncBuf(TQueue queue, TExtent const& extent = TExtent())
+    {
+        return traits::AsyncBufAlloc<TElem, Dim<TExtent>, TIdx, alpaka::Dev<TQueue>>::allocAsyncBuf(queue, extent);
     }
 
     //! Maps the buffer into the memory of the given device.


### PR DESCRIPTION
Add a new type of buffer that uses non-blocking, queue-ordered memory allocations and deallocations.

So far only the `DevCpu` and `DevCudaRt` devices are supported.
Compilation with HIP raises an error, since it does not support the the underlying stream-ordered memory allocation functions.

The `DevCpu` implementation
  - allocates memory immediately;
  - frees memory when the queue associated to the buffer reaches the point in time where the destructor of the buffer is called.

The `DevCudaRt` implementation
  - allocates memory with `cudaMallocAsync`;
  - frees memory with `cudaFreeAsync`.