### PR TITLE
Implement queue-ordered memory buffers

### DIFF
--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Alexander Matthes, Benjamin Worpitz
+/* Copyright 2021 Alexander Matthes, Benjamin Worpitz, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -24,6 +24,10 @@ namespace alpaka
         //! The memory allocator trait.
         template<typename TElem, typename TDim, typename TIdx, typename TDev, typename TSfinae = void>
         struct BufAlloc;
+
+        //! The stream-ordered memory allocator trait.
+        template<typename TElem, typename TDim, typename TIdx, typename TDev, typename TSfinae = void>
+        struct AsyncBufAlloc;
 
         //! The memory mapping trait.
         template<typename TBuf, typename TDev, typename TSfinae = void>
@@ -67,6 +71,21 @@ namespace alpaka
     ALPAKA_FN_HOST auto allocBuf(TDev const& dev, TExtent const& extent = TExtent())
     {
         return traits::BufAlloc<TElem, Dim<TExtent>, TIdx, TDev>::allocBuf(dev, extent);
+    }
+
+    //! Allocates stream-ordered memory on the given device.
+    //!
+    //! \tparam TElem The element type of the returned buffer.
+    //! \tparam TIdx The linear index type of the buffer.
+    //! \tparam TExtent The extent type of the buffer.
+    //! \tparam TQueue The type of queue used to order the buffer allocation.
+    //! \param queue The queue used to order the buffer allocation.
+    //! \param extent The extent of the buffer.
+    //! \return The newly allocated buffer.
+    template<typename TElem, typename TIdx, typename TExtent, typename TQueue>
+    ALPAKA_FN_HOST auto allocAsyncBuf(TQueue queue, TExtent const& extent = TExtent())
+    {
+        return traits::AsyncBufAlloc<TElem, Dim<TExtent>, TIdx, alpaka::Dev<TQueue>>::allocAsyncBuf(queue, extent);
     }
 
     //! Maps the buffer into the memory of the given device.


### PR DESCRIPTION
Move the implementation of the allocation and deallocation strategy from the `BufCpuImpl` and `BufUniformCudaHipRt` classes to the `AllocBuf<DevCpu>` and `AllocBuf<DevUniformCudaHipRt>` factory functors. This allows the implementation of different strategies in the `allocBuf` or other functions, without affecting the buffer classes.

Add the `allocAsyncBuf` function to allocate buffers using non-blocking, queue-ordered memory allocations and deallocations.

These functions take as argument a queue instead of a device; the memory associated with the buffer is guaranteed to be "alive" according to the lifetime of the buffer as seen by the queue: from the moment the queue reaches the buffer's constructor to the moment it reaches the destructor.

So far only the `DevCpu` and `DevCudaRt` devices are supported.
Attempting to use this with HIP raises an error, since HIP does not support the underlying stream-ordered memory allocation functions.

The `DevCpu` implementation
  - allocates memory immediately;
  - frees memory when the queue associated to the buffer reaches the point where the destructor of the buffer is called.

The `DevCudaRt` implementation
  - allocates memory with `cudaMallocAsync`, so only 1D buffers are supported;
  - frees memory with `cudaFreeAsync`.