### PR TITLE
Remove obsolete workarounds for pre-C++17

### DIFF
--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -212,11 +212,7 @@ namespace alpaka
             template<typename TKernelFnObj, typename... TArgs>
             void operator()(TKernelFnObj const&, TArgs const&...)
             {
-#if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703
                 using Result = std::invoke_result_t<TKernelFnObj, TAcc const&, TArgs const&...>;
-#else
-                using Result = std::result_of_t<TKernelFnObj(TAcc const&, TArgs const&...)>;
-#endif
                 static_assert(std::is_same<Result, void>::value, "The TKernelFnObj is required to return void!");
             }
         };

--- a/include/alpaka/meta/CudaVectorArrayWrapper.hpp
+++ b/include/alpaka/meta/CudaVectorArrayWrapper.hpp
@@ -19,14 +19,6 @@
 #    include <numeric>
 #    include <type_traits>
 
-#    if(__cplusplus > 201402L)
-#        define CXX17_CONSTEXPR constexpr
-#    else
-// This is mostly needed because of nvcc 9 and should be removed upon moving to C++17.
-// Maybe some others need it too. GNU STL library uses the same trick.
-#        define CXX17_CONSTEXPR
-#    endif
-
 namespace alpaka
 {
     namespace meta
@@ -150,7 +142,7 @@ namespace alpaka
                 this->z = *it++;
                 this->w = *it++;
             }
-            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CXX17_CONSTEXPR value_type& operator[](int const k) noexcept
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr value_type& operator[](int const k) noexcept
             {
                 assert(k >= 0 && k < 4);
                 return k == 0 ? this->x : (k == 1 ? this->y : (k == 2 ? this->z : this->w));
@@ -175,7 +167,7 @@ namespace alpaka
                 this->y = *it++;
                 this->z = *it++;
             }
-            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CXX17_CONSTEXPR value_type& operator[](int const k) noexcept
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr value_type& operator[](int const k) noexcept
             {
                 assert(k >= 0 && k < 3);
                 return k == 0 ? this->x : (k == 1 ? this->y : this->z);
@@ -199,7 +191,7 @@ namespace alpaka
                 this->x = *it++;
                 this->y = *it++;
             }
-            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CXX17_CONSTEXPR value_type& operator[](int const k) noexcept
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr value_type& operator[](int const k) noexcept
             {
                 assert(k >= 0 && k < 2);
                 return k == 0 ? this->x : this->y;
@@ -222,7 +214,7 @@ namespace alpaka
                 auto it = std::begin(init);
                 this->x = *it;
             }
-            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CXX17_CONSTEXPR value_type& operator[](int const k) noexcept
+            ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr value_type& operator[](int const k) noexcept
             {
                 assert(k == 0);
                 alpaka::ignore_unused(k);

--- a/script/gitlabci/job_cuda.yml
+++ b/script/gitlabci/job_cuda.yml
@@ -37,14 +37,14 @@ linux_nvcc-11.0_gcc-7_release_extended_lambda_off:
     ALPAKA_CUDA_EXPT_EXTENDED_LAMBDA: "OFF"
 
 # nvcc + clang++
-linux_nvcc-11.0_clang-7-nvcc_release:
+linux_nvcc-11.0_clang-8-nvcc_release:
   extends: .base_cuda_clang
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "11.0"
     CMAKE_CUDA_COMPILER: nvcc
     CMAKE_CUDA_ARCHITECTURES: "50;70"
-    ALPAKA_CI_CLANG_VER: 7
+    ALPAKA_CI_CLANG_VER: 8
     ALPAKA_CI_STDLIB: libstdc++
     CMAKE_BUILD_TYPE: Release
     ALPAKA_BOOST_VERSION: 1.65.1

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -281,7 +281,6 @@ TEMPLATE_LIST_TEST_CASE("vecNDConstructionFromNonAlpakaVec", "[vec]", alpaka::te
     }
 }
 
-#ifdef __cpp_structured_bindings
 TEST_CASE("structuredBindings", "[vec]")
 {
     using Dim = alpaka::DimInt<2u>;
@@ -300,4 +299,3 @@ TEST_CASE("structuredBindings", "[vec]")
     CHECK(vec[0] == 2);
     CHECK(vec[1] == 3);
 }
-#endif


### PR DESCRIPTION
* switch clang-7/nvcc to clang-8/nvcc
* Remove obsolete workarounds for pre-C++17