### PR TITLE
CI: HIP fix outdated apt keys 

### DIFF
--- a/script/gitlabci/job_base.yml
+++ b/script/gitlabci/job_base.yml
@@ -92,6 +92,11 @@
     # use VEGA64 GPU
     HIP_VISIBLE_DEVICES: "2"
     GPU_TARGETS: gfx900
+  before_script:
+    - apt-get -y --quiet update || echo "ignore any errors"
+    - apt-get -y --quiet install wget gnupg2
+    # AMD container keys are outdated and must be updated
+    - wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
   extends: .base
   tags:
     - amd


### PR DESCRIPTION
The apt package repository keys must be updated before we install additional packages.
We increased the retry count for travis_retry to 666, therefore HIP tests looped over 6 minutes because of the outdated apt reposetory key.

- [x] remove last commit (disabled git workflow tests)
