### PR TITLE
CI: use ubuntu container and not nvidia container for CUDA

### DIFF
--- a/script/before_install.sh
+++ b/script/before_install.sh
@@ -41,7 +41,7 @@ echo ALPAKA_CI_BOOST_BRANCH_MINOR: "${ALPAKA_CI_BOOST_BRANCH_MINOR}"
 #-------------------------------------------------------------------------------
 # CUDA
 export ALPAKA_CI_INSTALL_CUDA="OFF"
-if [[ "${ALPAKA_ACC_GPU_CUDA_ENABLE}" == "ON" && -z "${GITLAB_CI+x}" ]]
+if [[ "${ALPAKA_ACC_GPU_CUDA_ENABLE}" == "ON" ]]
 then
     export ALPAKA_CI_INSTALL_CUDA="ON"
 fi

--- a/script/gitlabci/job_base.yml
+++ b/script/gitlabci/job_base.yml
@@ -11,7 +11,7 @@
   interruptible: true
 
 .base_cuda_gcc:
-  image: nvidia/cuda:${ALPAKA_CI_CUDA_VERSION}-devel-ubuntu${ALPAKA_CI_UBUNTU_VER}
+  image: ubuntu:${ALPAKA_CI_UBUNTU_VER}
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     CC: gcc
@@ -30,7 +30,7 @@
     - intel
 
 .base_cuda_clang:
-  image: nvidia/cuda:${ALPAKA_CI_CUDA_VERSION}-devel-ubuntu${ALPAKA_CI_UBUNTU_VER}
+  image: ubuntu:${ALPAKA_CI_UBUNTU_VER}
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     CC: clang

--- a/script/install_cuda.sh
+++ b/script/install_cuda.sh
@@ -104,6 +104,16 @@ then
       sudo apt-get -y --quiet --allow-unauthenticated --no-install-recommends install cuda-core-"${ALPAKA_CI_CUDA_VERSION}" cuda-cudart-"${ALPAKA_CI_CUDA_VERSION}" cuda-cudart-dev-"${ALPAKA_CI_CUDA_VERSION}" cuda-curand-"${ALPAKA_CI_CUDA_VERSION}" cuda-curand-dev-"${ALPAKA_CI_CUDA_VERSION}"
     fi
     sudo ln -s /usr/local/cuda-"${ALPAKA_CI_CUDA_VERSION}" /usr/local/cuda
+    export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+    export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:$LD_LIBRARY_PATH
+
+    # Install driver for runtime execution.
+    if [ -n "${GITLAB_CI+x}" ]
+    then
+        latestDriverPackage=$(sudo apt search nvidia-compute-utils 2>/dev/null| grep ^nvidia | sort | tail -n 1 | cut -d"/" -f1)
+        sudo apt-get -y --quiet --allow-unauthenticated --no-install-recommends install $latestDriverPackage
+        export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+    fi
 
     if [ "${CMAKE_CUDA_COMPILER}" == "clang++" ]
     then


### PR DESCRIPTION
This is solving the issue in alpaka-group #1491 where we can not use CUDA 11.5 because NVIDIA is not providing the container.