### PR TITLE
Avoid setting the CUDA/HIP device when not necessary

### DIFF
--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -79,10 +79,6 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                    // Set the current device. \TODO: Is setting the current device before cuda/hip-EventDestroy
-                    // required?
-
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.m_iDevice));
                     // In case event has been recorded but has not yet been completed when cuda/hip-EventDestroy() is
                     // called, the function will return immediately and the resources associated with event will be
                     // released automatically once the device has completed event.

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -219,10 +219,8 @@ namespace alpaka
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     ALPAKA_API_PREFIX(Malloc)(&memPtr, static_cast<std::size_t>(widthBytes)));
                 // Prepare a deleter for this device
-                auto deleter = [dev](TElem* ptr)
+                auto deleter = [](TElem* ptr)
                 {
-                    // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
                     // Free the buffer.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Free)(reinterpret_cast<void*>(ptr)));
                 };
@@ -269,10 +267,8 @@ namespace alpaka
                     ALPAKA_ASSERT(pitchBytes >= static_cast<std::size_t>(widthBytes) || (width * height) == 0);
                 }
                 // Prepare a deleter for this device
-                auto deleter = [dev](TElem* ptr)
+                auto deleter = [](TElem* ptr)
                 {
-                    // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
                     // Free the buffer.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Free)(reinterpret_cast<void*>(ptr)));
                 };
@@ -318,10 +314,8 @@ namespace alpaka
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Malloc3D)(&pitchedPtrVal, extentVal));
                 }
                 // Prepare a deleter for this device
-                auto deleter = [dev](TElem* ptr)
+                auto deleter = [](TElem* ptr)
                 {
-                    // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
                     // Free the buffer.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Free)(reinterpret_cast<void*>(ptr)));
                 };
@@ -377,8 +371,6 @@ namespace alpaka
                 // Prepare a deleter for this device
                 auto deleter = [queue = std::move(queue)](TElem* ptr)
                 {
-                    // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(getDev(queue).m_iDevice));
                     // Free the buffer.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
                         FreeAsync)(reinterpret_cast<void*>(ptr), queue.m_spQueueImpl->m_UniformCudaHipQueue));

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -109,6 +109,8 @@ namespace alpaka
 
                 auto const& uniformCudaHipMemCpyKind(m_uniformMemCpyKind);
 
+                // cudaMemcpy variants on cudaMallocAsync'ed memory need to be called with the correct device,
+                // see https://github.com/fwyzard/nvidia_bug_3446335 .
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_iDstDevice));
                 // Initiate the memory copy.
@@ -216,6 +218,8 @@ namespace alpaka
                     return;
                 }
 
+                // cudaMemcpy variants on cudaMallocAsync'ed memory need to be called with the correct device,
+                // see https://github.com/fwyzard/nvidia_bug_3446335 .
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_iDstDevice));
                 // Initiate the memory copy.
@@ -346,6 +350,9 @@ namespace alpaka
                 // Create the struct describing the copy.
                 ALPAKA_API_PREFIX(Memcpy3DParms)
                 const uniformCudaHipMemCpy3DParms(buildUniformCudaHipMemcpy3DParms());
+
+                // cudaMemcpy variants on cudaMallocAsync'ed memory need to be called with the correct device,
+                // see https://github.com/fwyzard/nvidia_bug_3446335 .
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_iDstDevice));
 

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -108,8 +108,6 @@ namespace alpaka
                 auto const dstNativePtr = reinterpret_cast<void*>(getPtrNative(view));
                 ALPAKA_ASSERT(extentWidth <= dstWidth);
 
-                // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(this->m_iDevice));
                 // Initiate the memory set.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(MemsetAsync)(
                     dstNativePtr,
@@ -162,8 +160,6 @@ namespace alpaka
                 ALPAKA_ASSERT(extentWidth <= dstWidth);
                 ALPAKA_ASSERT(extentHeight <= dstHeight);
 
-                // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(this->m_iDevice));
                 // Initiate the memory set.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Memset2DAsync)(
                     dstNativePtr,
@@ -236,8 +232,6 @@ namespace alpaka
                     static_cast<size_t>(extentHeight),
                     static_cast<size_t>(extentDepth));
 
-                // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(this->m_iDevice));
                 // Initiate the memory set.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Memset3DAsync)(
                     pitchedPtrVal,

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -72,15 +72,6 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                    // Set the current device. \TODO: Is setting the current device before [cuda/hip]StreamDestroy
-                    // required?
-
-                    // In case the device is still doing work in the queue when [cuda/hip]StreamDestroy() is called,
-                    // the function will return immediately and the resources associated with queue will be released
-                    // automatically once the device has completed all work in queue.
-                    // -> No need to synchronize here.
-
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.m_iDevice));
                     // In case the device is still doing work in the queue when cuda/hip-StreamDestroy() is called, the
                     // function will return immediately and the resources associated with queue will be released
                     // automatically once the device has completed all work in queue.

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -321,8 +321,6 @@ namespace alpaka
                     {
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                        // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.m_iDevice));
                         // Free the buffer.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaFree(m_devMem));
                     }
@@ -537,7 +535,6 @@ namespace alpaka
                     {
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.m_iDevice));
                         // Free the buffer.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipFree(m_devMem));
                     }


### PR DESCRIPTION
Do not set the current CUDA/HIP device when it's not necessary:
  - `cudaMemsetAsync` variants can be called with a different device
  - `cudaFree` and `cudaFreeAsync` can be called with a different device
  - `cudaStreamSynchronize` and `cudaStreamDestroy` can be called with a different device
  - `cudaEventQuery` and `cudaEventDestroy` can be called with a different device

`cudaMemset` requires setting the current device, but is not used in Alpaka.

`cudaMemcpy` and `cudaMemcpy` variants working on `cudaMalloc`'ed memory can be called with a different device.
Unfortunately, the correct device must be set when working on memory allocated by `cudaMallocAsync` (see https://github.com/fwyzard/nvidia_bug_3446335).