### PR TITLE
Silence warnings on non-x86 CPUs

### DIFF
--- a/include/alpaka/dev/cpu/SysInfo.hpp
+++ b/include/alpaka/dev/cpu/SysInfo.hpp
@@ -52,26 +52,26 @@ namespace alpaka
 #    if BOOST_COMP_GNUC || BOOST_COMP_CLANG || (!BOOST_COMP_MSVC_EMULATED && defined(__INTEL_COMPILER))               \
         || BOOST_COMP_PGI
 #        include <cpuid.h>
-            inline auto cpuid(std::uint32_t const level, std::uint32_t const subfunction, std::uint32_t ex[4]) -> void
+            inline auto cpuid(std::uint32_t level, std::uint32_t subfunction, std::uint32_t ex[4]) -> void
             {
                 __cpuid_count(level, subfunction, ex[0], ex[1], ex[2], ex[3]);
             }
 
 #    elif BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED) || defined(__INTEL_COMPILER)
 #        include <intrin.h>
-            inline auto cpuid(std::uint32_t const level, std::uint32_t const subfunction, std::uint32_t ex[4]) -> void
+            inline auto cpuid(std::uint32_t level, std::uint32_t subfunction, std::uint32_t ex[4]) -> void
             {
                 __cpuidex(reinterpret_cast<int*>(ex), level, subfunction);
             }
 #    else
-            inline auto cpuid(std::uint32_t const level, std::uint32_t const subfunction, std::uint32_t ex[4]) -> void
+            inline auto cpuid(std::uint32_t, std::uint32_t, std::uint32_t ex[4]) -> void
             {
                 ex[0] = ex[2] = ex[3] = NO_CPUID;
                 ex[1] = UNKNOWN_COMPILER;
             }
 #    endif
 #else
-            inline auto cpuid(std::uint32_t const level, std::uint32_t const subfunction, std::uint32_t ex[4]) -> void
+            inline auto cpuid(std::uint32_t, std::uint32_t, std::uint32_t ex[4]) -> void
             {
                 ex[0] = ex[2] = ex[3] = NO_CPUID;
                 ex[1] = UNKNOWN_CPU;


### PR DESCRIPTION
Fixes #1412. Also removes unnecessary `const` from value parameters.