### PR TITLE
Revert "Avoid setting the CUDA/HIP device when not necessary"

### DIFF
--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -79,6 +79,10 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
+                    // Set the current device. \TODO: Is setting the current device before cuda/hip-EventDestroy
+                    // required?
+
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.m_iDevice));
                     // In case event has been recorded but has not yet been completed when cuda/hip-EventDestroy() is
                     // called, the function will return immediately and the resources associated with event will be
                     // released automatically once the device has completed event.

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -219,8 +219,10 @@ namespace alpaka
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     ALPAKA_API_PREFIX(Malloc)(&memPtr, static_cast<std::size_t>(widthBytes)));
                 // Prepare a deleter for this device
-                auto deleter = [](TElem* ptr)
+                auto deleter = [dev](TElem* ptr)
                 {
+                    // Set the current device.
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
                     // Free the buffer.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Free)(reinterpret_cast<void*>(ptr)));
                 };
@@ -267,8 +269,10 @@ namespace alpaka
                     ALPAKA_ASSERT(pitchBytes >= static_cast<std::size_t>(widthBytes) || (width * height) == 0);
                 }
                 // Prepare a deleter for this device
-                auto deleter = [](TElem* ptr)
+                auto deleter = [dev](TElem* ptr)
                 {
+                    // Set the current device.
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
                     // Free the buffer.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Free)(reinterpret_cast<void*>(ptr)));
                 };
@@ -314,8 +318,10 @@ namespace alpaka
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Malloc3D)(&pitchedPtrVal, extentVal));
                 }
                 // Prepare a deleter for this device
-                auto deleter = [](TElem* ptr)
+                auto deleter = [dev](TElem* ptr)
                 {
+                    // Set the current device.
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
                     // Free the buffer.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Free)(reinterpret_cast<void*>(ptr)));
                 };
@@ -371,6 +377,8 @@ namespace alpaka
                 // Prepare a deleter for this device
                 auto deleter = [queue = std::move(queue)](TElem* ptr)
                 {
+                    // Set the current device.
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(getDev(queue).m_iDevice));
                     // Free the buffer.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
                         FreeAsync)(reinterpret_cast<void*>(ptr), queue.m_spQueueImpl->m_UniformCudaHipQueue));

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -109,8 +109,6 @@ namespace alpaka
 
                 auto const& uniformCudaHipMemCpyKind(m_uniformMemCpyKind);
 
-                // cudaMemcpy variants on cudaMallocAsync'ed memory need to be called with the correct device,
-                // see https://github.com/fwyzard/nvidia_bug_3446335 .
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_iDstDevice));
                 // Initiate the memory copy.
@@ -218,8 +216,6 @@ namespace alpaka
                     return;
                 }
 
-                // cudaMemcpy variants on cudaMallocAsync'ed memory need to be called with the correct device,
-                // see https://github.com/fwyzard/nvidia_bug_3446335 .
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_iDstDevice));
                 // Initiate the memory copy.
@@ -350,9 +346,6 @@ namespace alpaka
                 // Create the struct describing the copy.
                 ALPAKA_API_PREFIX(Memcpy3DParms)
                 const uniformCudaHipMemCpy3DParms(buildUniformCudaHipMemcpy3DParms());
-
-                // cudaMemcpy variants on cudaMallocAsync'ed memory need to be called with the correct device,
-                // see https://github.com/fwyzard/nvidia_bug_3446335 .
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_iDstDevice));
 

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -108,6 +108,8 @@ namespace alpaka
                 auto const dstNativePtr = reinterpret_cast<void*>(getPtrNative(view));
                 ALPAKA_ASSERT(extentWidth <= dstWidth);
 
+                // Set the current device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(this->m_iDevice));
                 // Initiate the memory set.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(MemsetAsync)(
                     dstNativePtr,
@@ -160,6 +162,8 @@ namespace alpaka
                 ALPAKA_ASSERT(extentWidth <= dstWidth);
                 ALPAKA_ASSERT(extentHeight <= dstHeight);
 
+                // Set the current device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(this->m_iDevice));
                 // Initiate the memory set.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Memset2DAsync)(
                     dstNativePtr,
@@ -232,6 +236,8 @@ namespace alpaka
                     static_cast<size_t>(extentHeight),
                     static_cast<size_t>(extentDepth));
 
+                // Set the current device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(this->m_iDevice));
                 // Initiate the memory set.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Memset3DAsync)(
                     pitchedPtrVal,

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -72,6 +72,15 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
+                    // Set the current device. \TODO: Is setting the current device before [cuda/hip]StreamDestroy
+                    // required?
+
+                    // In case the device is still doing work in the queue when [cuda/hip]StreamDestroy() is called,
+                    // the function will return immediately and the resources associated with queue will be released
+                    // automatically once the device has completed all work in queue.
+                    // -> No need to synchronize here.
+
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.m_iDevice));
                     // In case the device is still doing work in the queue when cuda/hip-StreamDestroy() is called, the
                     // function will return immediately and the resources associated with queue will be released
                     // automatically once the device has completed all work in queue.

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -321,6 +321,8 @@ namespace alpaka
                     {
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
+                        // Set the current device.
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.m_iDevice));
                         // Free the buffer.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaFree(m_devMem));
                     }
@@ -535,6 +537,7 @@ namespace alpaka
                     {
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.m_iDevice));
                         // Free the buffer.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipFree(m_devMem));
                     }


### PR DESCRIPTION
Reverts alpaka-group/alpaka#1515

Opening this draft PR because of some weird CI issues we have been experiencing with CUDA and HIP lately. This draft is checking whether #1515 is  causing these.