### PR TITLE
HIP CI node changes

### DIFF
--- a/script/gitlabci/job_base.yml
+++ b/script/gitlabci/job_base.yml
@@ -89,8 +89,7 @@
     ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: "OFF"
     ALPAKA_ACC_GPU_HIP_ENABLE: "ON"
     ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: "OFF"
-    # use VEGA64 GPU
-    HIP_VISIBLE_DEVICES: "2"
+    # compile for VEGA64 GPU
     GPU_TARGETS: gfx900
   before_script:
     - apt-get -y --quiet update || echo "ignore any errors"

--- a/script/install_hip.sh
+++ b/script/install_hip.sh
@@ -47,6 +47,10 @@ which clang++
 clang++ --version
 which hipconfig
 hipconfig --platform
+echo
 hipconfig -v
+echo
+hipconfig
+rocm-smi
 # print newline as previous command does not do this
 echo


### PR DESCRIPTION
We removed a dual GPU from the CI node therefore GPU zero should be used
for testing.

Add a little bit more output to the hip install script to see if we have trouble accessing the GPU within the container.