### PR TITLE
backport: fix Philox RNG and CI configuration

### DIFF
--- a/include/alpaka/rand/Philox/PhiloxSingle.hpp
+++ b/include/alpaka/rand/Philox/PhiloxSingle.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Jiri Vyskocil
+/* Copyright 2021 Jiri Vyskocil, Rene Widera
  *
  * This file is part of alpaka.
  *
@@ -84,20 +84,43 @@ namespace alpaka
                  */
                 ALPAKA_FN_HOST_ACC auto nextNumber()
                 {
+                    // Element zero will always contain the next valid random number.
+                    auto result = state.result[0];
                     state.position++;
                     if(state.position == TParams::counterSize)
                     {
                         advanceState();
                     }
-                    return state.result[state.position];
+                    else
+                    {
+                        // Shift state results to allow hard coded access to element zero.
+                        // This will avoid high register usage on NVIDIA devices.
+                        // \todo Check if this shifting of the result vector is decreasing CPU performance.
+                        //       If so this optimization for GPUs (mostly NVIDIA) should be moved into
+                        //       PhiloxBaseCudaArray.
+                        state.result[0] = state.result[1];
+                        state.result[1] = state.result[2];
+                        state.result[2] = state.result[3];
+                    }
+
+                    return result;
                 }
 
                 /// Skips the next \a offset numbers
                 ALPAKA_FN_HOST_ACC void skip(uint64_t offset)
                 {
-                    state.position += offset & 3;
+                    static_assert(TParams::counterSize == 4, "Only counterSize is supported.");
+                    state.position = static_cast<decltype(state.position)>(state.position + (offset & 3));
                     offset += state.position < 4 ? 0 : 4;
                     state.position -= state.position < 4 ? 0 : 4u;
+                    for(auto numShifts = state.position; numShifts > 0; --numShifts)
+                    {
+                        // Shift state results to allow hard coded access to element zero.
+                        // This will avoid high register usage on NVIDIA devices.
+                        state.result[0] = state.result[1];
+                        state.result[1] = state.result[2];
+                        state.result[2] = state.result[3];
+                    }
                     this->skip4(offset / 4);
                 }
 

--- a/script/gitlabci/job_base.yml
+++ b/script/gitlabci/job_base.yml
@@ -89,8 +89,7 @@
     ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE: "OFF"
     ALPAKA_ACC_GPU_HIP_ENABLE: "ON"
     ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: "OFF"
-    # use VEGA64 GPU
-    HIP_VISIBLE_DEVICES: "2"
+    # compile for VEGA64 GPU
     GPU_TARGETS: gfx900
   extends: .base
   tags:

--- a/script/install_hip.sh
+++ b/script/install_hip.sh
@@ -47,6 +47,10 @@ which clang++
 clang++ --version
 which hipconfig
 hipconfig --platform
+echo
 hipconfig -v
+echo
+hipconfig
+rocm-smi
 # print newline as previous command does not do this
 echo


### PR DESCRIPTION
Backport to 0.8.0-rc1

- fix Philox RNG #1527
- HIP CI node changes #1530

The philox RNG bug was introduced during the development of 0.8.0 therefore there is no need to mention this fix in the changelog.