### PR TITLE
Add cmake option ALPAKA_CHECK_HEADERS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,9 @@ option(BUILD_TESTING "Build the testing tree." OFF)
 option(alpaka_INSTALL_TEST_HEADER "Install headers of the namespace alpaka::test. Attention, headers are not designed for production code, see documentation." OFF)
 include(CTest)
 
+include(CMakeDependentOption)
+cmake_dependent_option(ALPAKA_CHECK_HEADERS "Check all alpaka headers as part of the tests whether they can be compiled standalone." OFF BUILD_TESTING OFF)
+
 ################################################################################
 # Internal variables.
 

--- a/script/run_generate.sh
+++ b/script/run_generate.sh
@@ -77,6 +77,8 @@ then
     ALPAKA_CI_CMAKE_GENERATOR_PLATFORM="-A x64"
 fi
 
+ALPAKA_CHECK_HEADERS=$ALPAKA_CI_ANALYSIS
+
 mkdir -p build/
 cd build/
 
@@ -93,7 +95,7 @@ cd build/
     "$(env2cmake ALPAKA_ACC_GPU_CUDA_ENABLE)" "$(env2cmake ALPAKA_ACC_GPU_CUDA_ONLY_MODE)" "$(env2cmake CMAKE_CUDA_ARCHITECTURES)" "$(env2cmake CMAKE_CUDA_COMPILER)" "$(env2cmake CMAKE_CUDA_FLAGS)" \
     "$(env2cmake ALPAKA_CUDA_FAST_MATH)" "$(env2cmake ALPAKA_CUDA_FTZ)" "$(env2cmake ALPAKA_CUDA_SHOW_REGISTER)" "$(env2cmake ALPAKA_CUDA_KEEP_FILES)" "$(env2cmake ALPAKA_CUDA_EXPT_EXTENDED_LAMBDA)" "$(env2cmake CMAKE_CUDA_SEPARABLE_COMPILATION)" \
     "$(env2cmake GPU_TARGETS)" "$(env2cmake ALPAKA_ACC_GPU_HIP_ENABLE)" "$(env2cmake ALPAKA_ACC_GPU_HIP_ONLY_MODE)" \
-    "$(env2cmake ALPAKA_DEBUG)" "$(env2cmake ALPAKA_CI)" "$(env2cmake ALPAKA_CI_ANALYSIS)" "$(env2cmake ALPAKA_CXX_STANDARD)" \
+    "$(env2cmake ALPAKA_DEBUG)" "$(env2cmake ALPAKA_CI)" "$(env2cmake ALPAKA_CHECK_HEADERS)" "$(env2cmake ALPAKA_CXX_STANDARD)" \
     ".."
 
 cd ..

--- a/test/analysis/headerCheck/CMakeLists.txt
+++ b/test/analysis/headerCheck/CMakeLists.txt
@@ -8,7 +8,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-if(NOT ALPAKA_CI OR (ALPAKA_CI AND ALPAKA_CI_ANALYSIS))
+if(ALPAKA_CHECK_HEADERS)
 
     set(_TARGET_NAME "headerCheckTest")
 


### PR DESCRIPTION
OFF by default. Enabled by CI when ALPAKA_CI_ANALYSIS is ON.