### PR TITLE
Fix Boost version docs and remove redundant check in Boost installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,11 @@ Other compilers or combinations marked with :x: in the table above may work but 
 Dependencies
 ------------
 
-[Boost](https://boost.org/) 1.65.1+ is the only mandatory external dependency.
+[Boost](https://boost.org/) 1.74.0+ is the only mandatory external dependency.
 The **alpaka** library itself just requires header-only libraries.
 However some of the accelerator back-end implementations require different boost libraries to be built.
 
 When an accelerator back-end using *Boost.Fiber* is enabled, `boost-fiber` and all of its dependencies are required to be built in C++17 mode `./b2 cxxflags="-std=c++17"`.
-When *Boost.Fiber* is enabled and alpaka is built with clang and libstc++, Boost >= 1.67.0 is required.
 
 When an accelerator back-end using *CUDA* is enabled, version *11.0* (with nvcc as CUDA compiler) or version *9.2* (with clang as CUDA compiler) of the *CUDA SDK* is the minimum requirement.
 *NOTE*: When using nvcc as *CUDA* compiler, the *CUDA accelerator back-end* can not be enabled together with the *Boost.Fiber accelerator back-end* due to bugs in the nvcc compiler.

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -99,7 +99,6 @@ then
         ALPAKA_BOOST_B2+=" --layout=tagged --toolset=${CC}"
     fi
 
-    # TODO: Win32: adress-model=32
     ALPAKA_BOOST_B2+=" architecture=x86 address-model=64 link=static threading=multi runtime-link=shared"
 
     if [ "$ALPAKA_CI_OS_NAME" = "Windows" ]
@@ -120,16 +119,12 @@ then
     then
         ALPAKA_BOOST_B2_CXXFLAGS+=" -Wunused-private-field -Wno-unused-local-typedef -Wno-c99-extensions -Wno-variadic-macros"
     fi
-    # Select the libraries required.
-    # If the variable is not set, the backend will most probably be used by default so we install it.
-    if [ "${ALPAKA_CI_INSTALL_FIBERS}" == "ON" ]
+    if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
     then
-        if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
-        then
-            ALPAKA_BOOST_B2_CXXFLAGS+=" -std=c++17"
-        fi
-        ALPAKA_BOOST_B2+=" --with-fiber --with-context --with-thread --with-atomic --with-system --with-chrono --with-date_time"
+        ALPAKA_BOOST_B2_CXXFLAGS+=" -std=c++17"
     fi
+    ALPAKA_BOOST_B2+=" --with-fiber --with-context --with-thread --with-atomic --with-system --with-chrono --with-date_time"
+
     if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
     then
         if [ "${ALPAKA_CI_STDLIB}" == "libc++" ]


### PR DESCRIPTION
I just saw that we forgot to update the minimum required Boost verison in the README.md and looked for checks we no longer need to do. This lead to a drive-by fix in the Boost installation script.