### PR TITLE
Default memory operations to the whole buffer

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -250,8 +250,8 @@ auto main() -> int
     // not currently supported.
     // In this example both host buffers are copied
     // into device buffers.
-    alpaka::memcpy(devQueue, deviceBuffer1, hostViewPlainPtr, extents);
-    alpaka::memcpy(devQueue, deviceBuffer2, hostBuffer, extents);
+    alpaka::memcpy(devQueue, deviceBuffer1, hostViewPlainPtr);
+    alpaka::memcpy(devQueue, deviceBuffer2, hostBuffer);
 
     // Depending on the accelerator, the allocation function may introduce
     // padding between rows/planes of multidimensional memory allocations.

--- a/example/heatEquation/src/heatEquation.cpp
+++ b/example/heatEquation/src/heatEquation.cpp
@@ -158,9 +158,9 @@ auto main() -> int
     HeatEquationKernel kernel;
 
     // Copy host -> device
-    alpaka::memcpy(queue, uCurrBufAcc, uCurrBufHost, extent);
+    alpaka::memcpy(queue, uCurrBufAcc, uCurrBufHost);
     // Copy to the buffer for next as well to have boundary values set
-    alpaka::memcpy(queue, uNextBufAcc, uCurrBufAcc, extent);
+    alpaka::memcpy(queue, uNextBufAcc, uCurrBufAcc);
     alpaka::wait(queue);
 
     for(uint32_t step = 0; step < numTimeSteps; step++)
@@ -175,7 +175,7 @@ auto main() -> int
     }
 
     // Copy device -> host
-    alpaka::memcpy(queue, uNextBufHost, uNextBufAcc, extent);
+    alpaka::memcpy(queue, uNextBufHost, uNextBufAcc);
     alpaka::wait(queue);
 
     // Calculate error

--- a/example/monteCarloIntegration/src/monteCarloIntegration.cpp
+++ b/example/monteCarloIntegration/src/monteCarloIntegration.cpp
@@ -123,11 +123,11 @@ auto main() -> int
 
     // Initialize the global count to 0.
     ptrBufHost[0] = 0.0f;
-    alpaka::memcpy(queue, bufAcc, bufHost, extent);
+    alpaka::memcpy(queue, bufAcc, bufHost);
 
     Kernel kernel;
     alpaka::exec<Acc>(queue, workdiv, kernel, numPoints, ptrBufAcc, Function{});
-    alpaka::memcpy(queue, bufHost, bufAcc, extent);
+    alpaka::memcpy(queue, bufHost, bufAcc);
     alpaka::wait(queue);
 
     // Check the result.

--- a/example/randomCells2D/src/randomCells2D.cpp
+++ b/example/randomCells2D/src/randomCells2D.cpp
@@ -209,7 +209,7 @@ auto main() -> int
 
     /// \todo get the types from respective function parameters
     auto pitchBufAccS = alpaka::getPitchBytes<1u>(bufAccS) / sizeof(float);
-    alpaka::memcpy(queue, bufAccS, bufHostS, extent);
+    alpaka::memcpy(queue, bufAccS, bufHostS);
     RunTimestepKernelSingle runTimestepKernelSingle;
     alpaka::exec<Acc>(
         queue,
@@ -220,10 +220,10 @@ auto main() -> int
         ptrBufAccS,
         pitchBufAccRandS,
         pitchBufAccS);
-    alpaka::memcpy(queue, bufHostS, bufAccS, extent);
+    alpaka::memcpy(queue, bufHostS, bufAccS);
 
     auto pitchBufAccV = alpaka::getPitchBytes<1u>(bufAccV) / sizeof(float);
-    alpaka::memcpy(queue, bufAccV, bufHostV, extent);
+    alpaka::memcpy(queue, bufAccV, bufHostV);
     RunTimestepKernelVector runTimestepKernelVector;
     alpaka::exec<Acc>(
         queue,
@@ -234,7 +234,7 @@ auto main() -> int
         ptrBufAccV,
         pitchBufAccRandV,
         pitchBufAccV);
-    alpaka::memcpy(queue, bufHostV, bufAccV, extent);
+    alpaka::memcpy(queue, bufHostV, bufAccV);
     alpaka::wait(queue);
 
     float avgS = 0;

--- a/example/randomStrategies/src/randomStrategies.cpp
+++ b/example/randomStrategies/src/randomStrategies.cpp
@@ -268,7 +268,7 @@ void runStrategy(Box& box)
 
     // OPTIONAL: copy the the initial states to host if you want to check them yourself
     // alpaka_rand::Philox4x32x10<Box::Acc>* const ptrBufHostRand{alpaka::getPtrNative(box.bufHostRand)};
-    // alpaka::memcpy(box.queue, box.bufHostRand, box.bufAccRand, box.extentRand);
+    // alpaka::memcpy(box.queue, box.bufHostRand, box.bufAccRand);
     // alpaka::wait(box.queue);
 
     // Set up the pointers to the results buffers
@@ -280,10 +280,10 @@ void runStrategy(Box& box)
         ptrBufHostResult[i] = 0;
 
     // Run the "computation" kernel filling the results buffer with random numbers in parallel
-    alpaka::memcpy(box.queue, box.bufAccResult, box.bufHostResult, box.extentResult);
+    alpaka::memcpy(box.queue, box.bufAccResult, box.bufHostResult);
     FillKernel fillKernel;
     alpaka::exec<Box::Acc>(box.queue, box.workdivResult, fillKernel, box.extentResult, ptrBufAccRand, ptrBufAccResult);
-    alpaka::memcpy(box.queue, box.bufHostResult, box.bufAccResult, box.extentResult);
+    alpaka::memcpy(box.queue, box.bufHostResult, box.bufAccResult);
     alpaka::wait(box.queue);
 
     // save the results to a CSV file

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -155,9 +155,9 @@ auto main() -> int
     BufAcc bufAccC(alpaka::allocBuf<Data, Idx>(devAcc, extent));
 
     // Copy Host -> Acc
-    alpaka::memcpy(queue, bufAccA, bufHostA, extent);
-    alpaka::memcpy(queue, bufAccB, bufHostB, extent);
-    alpaka::memcpy(queue, bufAccC, bufHostC, extent);
+    alpaka::memcpy(queue, bufAccA, bufHostA);
+    alpaka::memcpy(queue, bufAccB, bufHostB);
+    alpaka::memcpy(queue, bufAccC, bufHostC);
 
     // Instantiate the kernel function object
     VectorAddKernel kernel;
@@ -184,7 +184,7 @@ auto main() -> int
     // Copy back the result
     {
         auto beginT = std::chrono::high_resolution_clock::now();
-        alpaka::memcpy(queue, bufHostC, bufAccC, extent);
+        alpaka::memcpy(queue, bufHostC, bufAccC);
         alpaka::wait(queue);
         const auto endT = std::chrono::high_resolution_clock::now();
         std::cout << "Time for HtoD copy: " << std::chrono::duration<double>(endT - beginT).count() << 's'

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Axel Huebl, Benjamin Worpitz, Matthias Werner
+/* Copyright 2021 Axel Huebl, Benjamin Worpitz, Matthias Werner, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -191,6 +191,17 @@ namespace alpaka
         enqueue(queue, createTaskMemset(view, byte, extent));
     }
 
+    //! Sets the whole view to the given value.
+    //!
+    //! \param queue The queue to enqueue the view fill task into.
+    //! \param view The memory view to fill.
+    //! \param byte Value to set for each element of the specified view.
+    template<typename TView, typename TQueue>
+    ALPAKA_FN_HOST auto memset(TQueue& queue, TView& view, std::uint8_t const& byte) -> void
+    {
+        enqueue(queue, createTaskMemset(view, byte, extent::getExtentVec(view)));
+    }
+
     //! Creates a memory copy task.
     //!
     //! \param viewDst The destination memory view.
@@ -226,6 +237,17 @@ namespace alpaka
         -> void
     {
         enqueue(queue, createTaskMemcpy(viewDst, viewSrc, extent));
+    }
+
+    //! Copies the whole view possibly between different memory spaces.
+    //!
+    //! \param queue The queue to enqueue the view copy task into.
+    //! \param viewDst The destination memory view.
+    //! \param viewSrc The source memory view.
+    template<typename TViewSrc, typename TViewDst, typename TQueue>
+    ALPAKA_FN_HOST auto memcpy(TQueue& queue, TViewDst& viewDst, TViewSrc const& viewSrc) -> void
+    {
+        enqueue(queue, createTaskMemcpy(viewDst, viewSrc, extent::getExtentVec(viewSrc)));
     }
 
     namespace detail

--- a/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/include/alpaka/test/KernelExecutionFixture.hpp
@@ -56,7 +56,7 @@ namespace alpaka
             {
                 // Allocate the result value
                 auto bufAccResult = alpaka::allocBuf<bool, Idx>(m_devAcc, static_cast<Idx>(1u));
-                alpaka::memset(m_queue, bufAccResult, static_cast<std::uint8_t>(true), bufAccResult);
+                alpaka::memset(m_queue, bufAccResult, static_cast<std::uint8_t>(true));
 
                 alpaka::exec<Acc>(
                     m_queue,
@@ -67,7 +67,7 @@ namespace alpaka
 
                 // Copy the result value to the host
                 auto bufHostResult = alpaka::allocBuf<bool, Idx>(m_devHost, static_cast<Idx>(1u));
-                alpaka::memcpy(m_queue, bufHostResult, bufAccResult, bufAccResult);
+                alpaka::memcpy(m_queue, bufHostResult, bufAccResult);
                 alpaka::wait(m_queue);
 
                 auto const result = *alpaka::getPtrNative(bufHostResult);

--- a/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/include/alpaka/test/mem/view/ViewTest.hpp
@@ -233,7 +233,7 @@ namespace alpaka
             auto plainBuf = alpaka::createView(devHost, v, extent);
 
             // Copy the generated content into the given view.
-            alpaka::memcpy(queue, view, plainBuf, extent);
+            alpaka::memcpy(queue, view, plainBuf);
 
             alpaka::wait(queue);
         }
@@ -253,12 +253,10 @@ namespace alpaka
                     "The value returned by getPtrNative has to be non-const when the view is non-const.");
             }
 
-            auto const extent = alpaka::extent::getExtentVec(view);
-
             // alpaka::set
             {
                 std::uint8_t const byte(static_cast<uint8_t>(42u));
-                alpaka::memset(queue, view, byte, extent);
+                alpaka::memset(queue, view, byte);
                 alpaka::wait(queue);
                 verifyBytesSet<TAcc>(view, byte);
             }
@@ -269,12 +267,13 @@ namespace alpaka
                 using Idx = alpaka::Idx<TView>;
 
                 auto const devAcc = alpaka::getDev(view);
+                auto const extent = alpaka::extent::getExtentVec(view);
 
                 // alpaka::copy into given view
                 {
                     auto srcBufAcc = alpaka::allocBuf<Elem, Idx>(devAcc, extent);
                     iotaFillView(queue, srcBufAcc);
-                    alpaka::memcpy(queue, view, srcBufAcc, extent);
+                    alpaka::memcpy(queue, view, srcBufAcc);
                     alpaka::wait(queue);
                     verifyViewsEqual<TAcc>(view, srcBufAcc);
                 }
@@ -282,7 +281,7 @@ namespace alpaka
                 // alpaka::copy from given view
                 {
                     auto dstBufAcc = alpaka::allocBuf<Elem, Idx>(devAcc, extent);
-                    alpaka::memcpy(queue, dstBufAcc, view, extent);
+                    alpaka::memcpy(queue, dstBufAcc, view);
                     alpaka::wait(queue);
                     verifyViewsEqual<TAcc>(dstBufAcc, view);
                 }

--- a/test/integ/axpy/src/axpy.cpp
+++ b/test/integ/axpy/src/axpy.cpp
@@ -148,8 +148,8 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
     auto memBufAccY = alpaka::allocBuf<Val, Idx>(devAcc, extent);
 
     // Copy Host -> Acc.
-    alpaka::memcpy(queue, memBufAccX, memBufHostX, extent);
-    alpaka::memcpy(queue, memBufAccY, memBufHostOrigY, extent);
+    alpaka::memcpy(queue, memBufAccX, memBufHostX);
+    alpaka::memcpy(queue, memBufAccY, memBufHostOrigY);
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
     alpaka::wait(queue);
@@ -176,7 +176,7 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
               << std::endl;
 
     // Copy back the result.
-    alpaka::memcpy(queue, memBufHostY, memBufAccY, extent);
+    alpaka::memcpy(queue, memBufHostY, memBufAccY);
 
     // Wait for the queue to finish the memory operation.
     alpaka::wait(queue);

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -315,7 +315,7 @@ TEMPLATE_LIST_TEST_CASE("mandelbrot", "[mandelbrot]", TestAccs)
     auto bufColorAcc = alpaka::allocBuf<Val, Idx>(devAcc, extent);
 
     // Copy Host -> Acc.
-    alpaka::memcpy(queue, bufColorAcc, bufColorHost, extent);
+    alpaka::memcpy(queue, bufColorAcc, bufColorHost);
 
     // Create the kernel execution task.
     auto const taskKernel = alpaka::createTaskKernel<Acc>(
@@ -336,7 +336,7 @@ TEMPLATE_LIST_TEST_CASE("mandelbrot", "[mandelbrot]", TestAccs)
               << std::endl;
 
     // Copy back the result.
-    alpaka::memcpy(queue, bufColorHost, bufColorAcc, extent);
+    alpaka::memcpy(queue, bufColorHost, bufColorAcc);
 
     // Wait for the queue to finish the memory operation.
     alpaka::wait(queue);

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -237,7 +237,7 @@ TEMPLATE_LIST_TEST_CASE("matMul", "[matMul]", TestAccs)
 
     // Allocate C and set it to zero.
     auto bufCHost = alpaka::allocBuf<Val, Idx>(devHost, extentC);
-    alpaka::memset(queueHost, bufCHost, 0u, extentC);
+    alpaka::memset(queueHost, bufCHost, 0u);
 
     // Allocate the buffers on the accelerator.
     auto bufAAcc = alpaka::allocBuf<Val, Idx>(devAcc, extentA);
@@ -245,10 +245,10 @@ TEMPLATE_LIST_TEST_CASE("matMul", "[matMul]", TestAccs)
     auto bufCAcc = alpaka::allocBuf<Val, Idx>(devAcc, extentC);
 
     // Copy Host -> Acc.
-    alpaka::memcpy(queueAcc, bufAAcc, bufAHost, extentA);
-    alpaka::memcpy(queueAcc, bufBAcc, bufBHost, extentB);
+    alpaka::memcpy(queueAcc, bufAAcc, bufAHost);
+    alpaka::memcpy(queueAcc, bufBAcc, bufBHost);
     alpaka::wait(queueHost);
-    alpaka::memcpy(queueAcc, bufCAcc, bufCHost, extentC);
+    alpaka::memcpy(queueAcc, bufCAcc, bufCHost);
 
     auto const pitchA = alpaka::getPitchBytes<1u>(bufAAcc);
     auto const pitchB = alpaka::getPitchBytes<1u>(bufBAcc);
@@ -280,7 +280,7 @@ TEMPLATE_LIST_TEST_CASE("matMul", "[matMul]", TestAccs)
               << std::endl;
 
     // Copy back the result.
-    alpaka::memcpy(queueAcc, bufCHost, bufCAcc, extentC);
+    alpaka::memcpy(queueAcc, bufCHost, bufCAcc);
 
     // Wait for the queue to finish the memory operation.
     alpaka::wait(queueAcc);

--- a/test/integ/separableCompilation/src/main.cpp
+++ b/test/integ/separableCompilation/src/main.cpp
@@ -123,8 +123,8 @@ TEMPLATE_LIST_TEST_CASE("separableCompilation", "[separableCompilation]", TestAc
     auto memBufAccC(alpaka::allocBuf<Val, Idx>(devAcc, extent));
 
     // Copy Host -> Acc.
-    alpaka::memcpy(queueAcc, memBufAccA, memBufHostA, extent);
-    alpaka::memcpy(queueAcc, memBufAccB, memBufHostB, extent);
+    alpaka::memcpy(queueAcc, memBufAccA, memBufHostA);
+    alpaka::memcpy(queueAcc, memBufAccB, memBufHostB);
 
     // Create the executor task.
     auto const taskKernel = alpaka::createTaskKernel<Acc>(
@@ -140,7 +140,7 @@ TEMPLATE_LIST_TEST_CASE("separableCompilation", "[separableCompilation]", TestAc
               << std::endl;
 
     // Copy back the result.
-    alpaka::memcpy(queueAcc, memBufHostC, memBufAccC, extent);
+    alpaka::memcpy(queueAcc, memBufHostC, memBufAccC);
     alpaka::wait(queueAcc);
 
     bool resultCorrect(true);

--- a/test/unit/math/src/Buffer.hpp
+++ b/test/unit/math/src/Buffer.hpp
@@ -76,14 +76,14 @@ namespace alpaka
                     template<typename Queue>
                     auto copyToDevice(Queue queue) -> void
                     {
-                        alpaka::memcpy(queue, devBuffer, hostBuffer, Tcapacity);
+                        alpaka::memcpy(queue, devBuffer, hostBuffer);
                     }
 
                     // Copy Acc -> Host.
                     template<typename Queue>
                     auto copyFromDevice(Queue queue) -> void
                     {
-                        alpaka::memcpy(queue, hostBuffer, devBuffer, Tcapacity);
+                        alpaka::memcpy(queue, hostBuffer, devBuffer);
                     }
 
                     ALPAKA_FN_ACC

--- a/test/unit/mem/fence/src/FenceTest.cpp
+++ b/test/unit/mem/fence/src/FenceTest.cpp
@@ -122,7 +122,7 @@ TEMPLATE_LIST_TEST_CASE("FenceTest", "[fence]", TestAccs)
     pVarsHost[0] = 1;
     pVarsHost[1] = 2;
 
-    alpaka::memcpy(queue, vars_dev, vars_host, extent);
+    alpaka::memcpy(queue, vars_dev, vars_host);
     alpaka::wait(queue);
 
     DeviceFenceTestKernel deviceKernel;

--- a/test/unit/mem/p2p/src/P2P.cpp
+++ b/test/unit/mem/p2p/src/P2P.cpp
@@ -46,11 +46,11 @@ static auto testP2P(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& ext
 
     // fill each byte with value 42
     std::uint8_t const byte(static_cast<uint8_t>(42u));
-    alpaka::memset(queue1, buf1, byte, extent);
+    alpaka::memset(queue1, buf1, byte);
     alpaka::wait(queue1);
 
     // copy buffer from device 1 into device 0 buffer
-    alpaka::memcpy(queue0, buf0, buf1, extent);
+    alpaka::memcpy(queue0, buf0, buf1);
     alpaka::wait(queue0);
     // verify buffer on device 0
     alpaka::test::verifyBytesSet<TAcc>(buf0, byte);

--- a/test/unit/mem/view/src/Accessor.cpp
+++ b/test/unit/mem/view/src/Accessor.cpp
@@ -240,7 +240,7 @@ TEST_CASE("projection", "[accessor]")
     auto dstBuffer = alpaka::allocBuf<int, Size>(devAcc, Size{1});
 
     std::array<int, 1> host{{42}};
-    alpaka::memcpy(queue, srcBuffer, host, 1);
+    alpaka::memcpy(queue, srcBuffer, host);
 
     auto const workdiv = alpaka::WorkDivMembers<Dim, Size>{
         alpaka::Vec<Dim, Size>{Size{1}},
@@ -248,7 +248,7 @@ TEST_CASE("projection", "[accessor]")
         alpaka::Vec<Dim, Size>{Size{1}}};
     alpaka::exec<Acc>(queue, workdiv, CopyKernel{}, alpakaex::readAccess(srcBuffer), alpakaex::writeAccess(dstBuffer));
 
-    alpaka::memcpy(queue, host, dstBuffer, 1);
+    alpaka::memcpy(queue, host, dstBuffer);
 
     REQUIRE(host[0] == 84);
 }

--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -73,7 +73,7 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAc
         auto viewConstantMemUninitialized
             = alpaka::createStaticDevMemView(&g_constantMemory2DUninitialized[0u][0u], devAcc, extent);
 
-        alpaka::memcpy(queueAcc, viewConstantMemUninitialized, bufHost, extent);
+        alpaka::memcpy(queueAcc, viewConstantMemUninitialized, bufHost);
         alpaka::wait(queueAcc);
 
         REQUIRE(fixture(kernel, alpaka::getPtrNative(viewConstantMemUninitialized)));
@@ -114,7 +114,7 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryConstant", "[viewStaticAccMem]", Test
         auto viewGlobalMemUninitialized
             = alpaka::createStaticDevMemView(&g_globalMemory2DUninitialized[0u][0u], devAcc, extent);
 
-        alpaka::memcpy(queueAcc, viewGlobalMemUninitialized, bufHost, extent);
+        alpaka::memcpy(queueAcc, viewGlobalMemUninitialized, bufHost);
         alpaka::wait(queueAcc);
 
         REQUIRE(fixture(kernel, alpaka::getPtrNative(viewGlobalMemUninitialized)));


### PR DESCRIPTION
When the extent parameter is not given, let the memory operations apply to the whole buffer:
  - `alpaka::memset` takes the extent from the buffer itself;
  - `alpaka::mempcy` takes the extent from the source buffer.