### PR TITLE
Use generic container interfaces

### DIFF
--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Jeffrey Kelling
+/* Copyright 2022 Jeffrey Kelling, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -55,14 +55,14 @@ namespace alpaka
 
         uint8_t* dynMemBegin() const
         {
-            return m_mem.data();
+            return std::data(m_mem);
         }
 
         /*! \return the pointer to the begin of data after the portion allocated as dynamical shared memory.
          */
         uint8_t* staticMemBegin() const
         {
-            return m_mem.data() + m_dynPitch;
+            return std::data(m_mem) + m_dynPitch;
         }
 
         /*! \return the remaining capacity for static block shared memory,

--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, René Widera
+/* Copyright 2022 Benjamin Worpitz, René Widera, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -325,7 +325,7 @@ namespace alpaka
                 //! \return The number of concurrent executors available.
                 auto getConcurrentExecutionCount() const -> TIdx
                 {
-                    return m_vConcurrentExecs.size();
+                    return std::size(m_vConcurrentExecs);
                 }
                 //! \return If the thread pool is idle.
                 auto isIdle() const -> bool
@@ -497,7 +497,7 @@ namespace alpaka
                 //! \return The number of concurrent executors available.
                 auto getConcurrentExecutionCount() const -> TIdx
                 {
-                    return m_vConcurrentExecs.size();
+                    return std::size(m_vConcurrentExecs);
                 }
                 //! \return If the thread pool is idle.
                 auto isIdle() const -> bool

--- a/include/alpaka/core/UniformCudaHip.hpp
+++ b/include/alpaka/core/UniformCudaHip.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Axel Huebl, Benjamin Worpitz, Matthias Werner, René Widera
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, René Widera, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -82,8 +82,8 @@ namespace alpaka
                     std::array<Error_t, sizeof...(ignoredErrorCodes)> const aIgnoredErrorCodes{ignoredErrorCodes...};
 
                     // If the error code is not one of the ignored ones.
-                    if(std::find(aIgnoredErrorCodes.cbegin(), aIgnoredErrorCodes.cend(), error)
-                       == aIgnoredErrorCodes.cend())
+                    if(std::find(std::cbegin(aIgnoredErrorCodes), std::cend(aIgnoredErrorCodes), error)
+                       == std::cend(aIgnoredErrorCodes))
                     {
                         rtCheck(error, ("'" + std::string(cmd) + "' returned error ").c_str(), file, line);
                     }

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Axel Huebl, Benjamin Worpitz, Matthias Werner
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -55,9 +55,9 @@ namespace alpaka
                     std::vector<std::shared_ptr<cpu::ICpuQueue>> vspQueues;
 
                     std::lock_guard<std::mutex> lk(m_Mutex);
-                    vspQueues.reserve(m_queues.size());
+                    vspQueues.reserve(std::size(m_queues));
 
-                    for(auto it = m_queues.begin(); it != m_queues.end();)
+                    for(auto it = std::begin(m_queues); it != std::end(m_queues);)
                     {
                         auto spQueue(it->lock());
                         if(spQueue)

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz
+/* Copyright 2022 Benjamin Worpitz, Jan Stephan
  *
  * This file is part of Alpaka.
  *
@@ -64,9 +64,9 @@ namespace alpaka
                     std::vector<std::shared_ptr<IGenericThreadsQueue<DevOacc>>> vspQueues;
 
                     std::lock_guard<std::mutex> lk(m_Mutex);
-                    vspQueues.reserve(m_queues.size());
+                    vspQueues.reserve(std::size(m_queues));
 
-                    for(auto it = m_queues.begin(); it != m_queues.end();)
+                    for(auto it = std::begin(m_queues); it != std::end(m_queues);)
                     {
                         auto spQueue(it->lock());
                         if(spQueue)

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz
+/* Copyright 2022 Benjamin Worpitz, Jan Stephan
  *
  * This file is part of Alpaka.
  *
@@ -63,9 +63,9 @@ namespace alpaka
                     std::vector<std::shared_ptr<IGenericThreadsQueue<DevOmp5>>> vspQueues;
 
                     std::lock_guard<std::mutex> lk(m_Mutex);
-                    vspQueues.reserve(m_queues.size());
+                    vspQueues.reserve(std::size(m_queues));
 
-                    for(auto it = m_queues.begin(); it != m_queues.end();)
+                    for(auto it = std::begin(m_queues); it != std::end(m_queues);)
                     {
                         auto spQueue(it->lock());
                         if(spQueue)

--- a/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Axel Huebl, Benjamin Worpitz, Matthias Werner
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -65,7 +65,7 @@ namespace alpaka
                 alpaka::ignore_unused(workDiv);
                 auto const fiberId(boost::this_fiber::get_id());
                 auto const fiberEntry(idx.m_fibersToIndices.find(fiberId));
-                ALPAKA_ASSERT(fiberEntry != idx.m_fibersToIndices.end());
+                ALPAKA_ASSERT(fiberEntry != std::end(idx.m_fibersToIndices));
                 return fiberEntry->second;
             }
         };

--- a/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Axel Huebl, Benjamin Worpitz, Matthias Werner
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -65,7 +65,7 @@ namespace alpaka
                 alpaka::ignore_unused(workDiv);
                 auto const threadId = std::this_thread::get_id();
                 auto const threadEntry = idx.m_threadToIndexMap.find(threadId);
-                ALPAKA_ASSERT(threadEntry != idx.m_threadToIndexMap.end());
+                ALPAKA_ASSERT(threadEntry != std::end(idx.m_threadToIndexMap));
                 return threadEntry->second;
             }
         };

--- a/include/alpaka/kernel/TaskKernelCpuFibers.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuFibers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, René Widera
+/* Copyright 2022 Benjamin Worpitz, René Widera, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -166,10 +166,9 @@ namespace alpaka
             meta::ndLoopIncIdx(blockThreadExtent, boundBlockThreadExecHost);
 
             // Wait for the completion of the block thread kernels.
-            std::for_each(
-                futuresInBlock.begin(),
-                futuresInBlock.end(),
-                [](boost::fibers::future<void>& t) { t.wait(); });
+            for(auto& t : futuresInBlock)
+                t.wait();
+
             // Clean up.
             futuresInBlock.clear();
 

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, René Widera
+/* Copyright 2022 Benjamin Worpitz, René Widera, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -158,7 +158,8 @@ namespace alpaka
 // Workaround: Clang can not support this when natively compiling device code. See ConcurrentExecPool.hpp.
 #    if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_PTX)
             // Wait for the completion of the block thread kernels.
-            std::for_each(futuresInBlock.begin(), futuresInBlock.end(), [](std::future<void>& t) { t.wait(); });
+            for(auto& t : futuresInBlock)
+                t.wait();
 #    endif
             // Clean up.
             futuresInBlock.clear();

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Axel Huebl, Benjamin Worpitz, Matthias Werner, Andrea Bocci
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Andrea Bocci, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -435,55 +435,30 @@ namespace alpaka
         return traits::CreateViewPlainPtr<TDev>::createViewPlainPtr(dev, pMem, extent, pitch);
     }
 
-    //! Creates a view to a device std::vector
+    //! Creates a view to a contiguous container of device-accessible memory.
     //!
-    //! \param dev Device from where vec can be accessed.
-    //! \param vec std::vector container. The data hold by the container the must be accessible from the given device.
+    //! \param dev Device from which the container can be accessed.
+    //! \param con Contiguous container. The container must provide a `data()` method. The data held by the container
+    //!            must be accessible from the given device. The `GetExtent` trait must be defined for the container.
     //! \return A view to device memory.
-    template<typename TDev, typename TElem, typename TAllocator>
-    auto createView(TDev const& dev, std::vector<TElem, TAllocator>& vec)
+    template<typename TDev, typename TContainer>
+    auto createView(TDev const& dev, TContainer& con)
     {
-        //! \todo With C++17 use std::data() and add support for all contiguous container
-        return createView(dev, vec.data(), extent::getExtent(vec));
+        return createView(dev, std::data(con), extent::getExtent(con));
     }
 
-    //! Creates a view to a device std::vector
+    //! Creates a view to a contiguous container of device-accessible memory.
     //!
-    //! \param dev Device from where pMem can be accessed.
-    //! \param vec std::vector container. The data hold by the container the must be accessible from the given device.
-    //! \param extent Number of elements represented by vec.
-    //!               Using a multi dimensional extent will result in a multi dimension view to the memory represented
-    //!               by vec.
+    //! \param dev Device from which the container can be accessed.
+    //! \param con Contiguous container. The container must provide a `data()` method. The data held by the container
+    //!            must be accessible from the given device. The `GetExtent` trait must be defined for the container.
+    //! \param extent Number of elements held by the container. Using a multi-dimensional extent will result in a
+    //!               multi-dimensional view to the memory represented by the container.
     //! \return A view to device memory.
-    template<typename TDev, typename TElem, typename TAllocator, typename TExtent>
-    auto createView(TDev const& dev, std::vector<TElem, TAllocator>& vec, TExtent const& extent)
+    template<typename TDev, typename TContainer, typename TExtent>
+    auto createView(TDev const& dev, TContainer& con, TExtent const& extent)
     {
-        return createView(dev, vec.data(), extent);
-    }
-
-    //! Creates a view to a device std::array
-    //!
-    //! \param dev Device from where array can be accessed.
-    //! \param array std::array container. The data hold by the container the must be accessible from the given device.
-    //! \return A view to device memory.
-    template<typename TDev, typename TElem, std::size_t Tsize>
-    auto createView(TDev const& dev, std::array<TElem, Tsize>& array)
-    {
-        return createView(dev, array.data(), extent::getExtent(array));
-    }
-
-    //! Creates a view to a device std::vector
-    //!
-    //! \param dev Device from where array can be accessed.
-    //! \param array std::array container. The data hold by the container the must be accessible from the given device
-    //! \param extent Number of elements represented by array.
-    //!               Using a multi dimensional extent will result in a multi dimension view to the memory represented
-    //!               by array.
-    //! \return A view to device memory.
-    template<typename TDev, typename TElem, std::size_t Tsize, typename TExtent>
-    auto createView(TDev const& dev, std::array<TElem, Tsize>& array, TExtent const& extent)
-    {
-        return createView(dev, array.data(), extent);
+        return createView(dev, std::data(con), extent);
     }
 
     //! Creates a sub view to an existing view.

--- a/include/alpaka/mem/view/ViewStdArray.hpp
+++ b/include/alpaka/mem/view/ViewStdArray.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Axel Huebl, Benjamin Worpitz
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -6,6 +6,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+
+/* TODO: Once C++20 is available remove this file and replace with a generic ContiguousContainer solution based on
+ * concepts. It should be sufficient to check for the existence of Container.size() and Container.data() */
 
 #pragma once
 
@@ -64,8 +67,7 @@ namespace alpaka
                 ALPAKA_FN_HOST static constexpr auto getExtent(std::array<TElem, Tsize> const& extent)
                     -> Idx<std::array<TElem, Tsize>>
                 {
-                    alpaka::ignore_unused(extent);
-                    return Tsize;
+                    return std::size(extent);
                 }
             };
         } // namespace traits
@@ -79,11 +81,11 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getPtrNative(std::array<TElem, Tsize> const& view) -> TElem const*
             {
-                return view.data();
+                return std::data(view);
             }
             ALPAKA_FN_HOST static auto getPtrNative(std::array<TElem, Tsize>& view) -> TElem*
             {
-                return view.data();
+                return std::data(view);
             }
         };
 
@@ -94,7 +96,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getPitchBytes(std::array<TElem, Tsize> const& pitch)
                 -> Idx<std::array<TElem, Tsize>>
             {
-                return sizeof(TElem) * pitch.size();
+                return sizeof(TElem) * std::size(pitch);
             }
         };
 

--- a/include/alpaka/mem/view/ViewStdVector.hpp
+++ b/include/alpaka/mem/view/ViewStdVector.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Axel Huebl, Benjamin Worpitz
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -6,6 +6,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+
+/* TODO: Once C++20 is available remove this file and replace with a generic ContiguousContainer solution based on
+ * concepts. It should be sufficient to check for the existence of Container.size() and Container.data() */
 
 #pragma once
 
@@ -64,7 +67,7 @@ namespace alpaka
                 ALPAKA_FN_HOST static auto getExtent(std::vector<TElem, TAllocator> const& extent)
                     -> Idx<std::vector<TElem, TAllocator>>
                 {
-                    return extent.size();
+                    return std::size(extent);
                 }
             };
         } // namespace traits
@@ -77,11 +80,11 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getPtrNative(std::vector<TElem, TAllocator> const& view) -> TElem const*
             {
-                return view.data();
+                return std::data(view);
             }
             ALPAKA_FN_HOST static auto getPtrNative(std::vector<TElem, TAllocator>& view) -> TElem*
             {
-                return view.data();
+                return std::data(view);
             }
         };
 
@@ -92,7 +95,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getPitchBytes(std::vector<TElem, TAllocator> const& pitch)
                 -> Idx<std::vector<TElem, TAllocator>>
             {
-                return sizeof(TElem) * pitch.size();
+                return sizeof(TElem) * std::size(pitch);
             }
         };
 

--- a/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/include/alpaka/test/mem/view/ViewTest.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Axel Huebl, Benjamin Worpitz, Matthias Werner
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -229,7 +229,7 @@ namespace alpaka
 
             // Init buf with increasing values
             std::vector<Elem> v(static_cast<std::size_t>(extent.prod()), static_cast<Elem>(0));
-            std::iota(v.begin(), v.end(), static_cast<Elem>(0));
+            std::iota(std::begin(v), std::end(v), static_cast<Elem>(0));
             auto plainBuf = alpaka::createView(devHost, v, extent);
 
             // Copy the generated content into the given view.

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, Matthias Werner
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -279,13 +279,13 @@ namespace alpaka
                     intersects[(i - 1u) % 2u] = gridThreadExtentDivisors[0];
                     intersects[(i) % 2u].clear();
                     set_intersection(
-                        intersects[(i - 1u) % 2u].begin(),
-                        intersects[(i - 1u) % 2u].end(),
-                        gridThreadExtentDivisors[i].begin(),
-                        gridThreadExtentDivisors[i].end(),
-                        std::inserter(intersects[i % 2], intersects[i % 2u].begin()));
+                        std::begin(intersects[(i - 1u) % 2u]),
+                        std::end(intersects[(i - 1u) % 2u]),
+                        std::begin(gridThreadExtentDivisors[i]),
+                        std::end(gridThreadExtentDivisors[i]),
+                        std::inserter(intersects[i % 2], std::begin(intersects[i % 2u])));
                 }
-                TIdx const maxCommonDivisor(*(--intersects[(TDim::value - 1) % 2u].end()));
+                TIdx const maxCommonDivisor(*(--std::end(intersects[(TDim::value - 1) % 2u])));
                 for(typename TDim::value_type i(0u); i < TDim::value; ++i)
                 {
                     blockThreadExtent[i] = maxCommonDivisor;


### PR DESCRIPTION
Fixes #1498.

This PR replaces all occurrences of `Container.{begin,end,data,size}` with `std::{begin,end,data,size}`. In some instances it was even possible to replace a `begin`-`end` pair with a ranged `for` loop.

The `createView` functions are now a bit more generic as they now accept any container which has a `data()` member function and for which the `GetExtent` trait is defined.