### PR TITLE
Update to Catch2 v2.13.8

### DIFF
--- a/test/catch_main/CMakeLists.txt
+++ b/test/catch_main/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Benjamin Worpitz, Axel Huebl
+# Copyright 2022 Benjamin Worpitz, Axel Huebl, Jan Stephan
 #
 # This file is part of alpaka.
 #
@@ -11,20 +11,18 @@
 option(ALPAKA_USE_INTERNAL_CATCH2 "Use internally shipped Catch2" ON)
 
 if(ALPAKA_USE_INTERNAL_CATCH2)
-    message(STATUS "Catch2: Using INTERNAL version 2.13.7")
+    message(STATUS "Catch2: Using INTERNAL version 2.13.8")
 else()
-    find_package(Catch2 2.13.3 CONFIG REQUIRED)
+    find_package(Catch2 2.13.8 CONFIG REQUIRED)
     set_target_properties(Catch2::Catch2 PROPERTIES IMPORTED_GLOBAL TRUE)
     message(STATUS "Catch2: Found version ${Catch2_VERSION}")
 endif()
 
 add_library(CatchMain src/CatchMain.cpp)
-# target_compile_features(CatchMain PUBLIC cxx_std_17)  # min C++17
+target_compile_features(CatchMain PUBLIC cxx_std_17)
 set_target_properties(CatchMain PROPERTIES
     FOLDER "test"
-    CXX_STANDARD 17
     CXX_EXTENSIONS OFF
-    CXX_STANDARD_REQUIRED ON
     POSITION_INDEPENDENT_CODE ON
     WINDOWS_EXPORT_ALL_SYMBOLS ON
 )

--- a/thirdParty/catch2/include/catch2/catch.hpp
+++ b/thirdParty/catch2/include/catch2/catch.hpp
@@ -1,9 +1,9 @@
 /*
- *  Catch v2.13.7
- *  Generated: 2021-12-16 14:53:26.959816
+ *  Catch v2.13.8
+ *  Generated: 2022-01-03 21:20:09.589503
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
- *  Copyright (c) 2021 Two Blue Cubes Ltd. All rights reserved.
+ *  Copyright (c) 2022 Two Blue Cubes Ltd. All rights reserved.
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -15,7 +15,7 @@
 
 #define CATCH_VERSION_MAJOR 2
 #define CATCH_VERSION_MINOR 13
-#define CATCH_VERSION_PATCH 7
+#define CATCH_VERSION_PATCH 8
 
 #ifdef __clang__
 #    pragma clang system_header
@@ -15387,7 +15387,7 @@ namespace Catch {
     }
 
     Version const& libraryVersion() {
-        static Version version( 2, 13, 7, "", 0 );
+        static Version version( 2, 13, 8, "", 0 );
         return version;
     }
 


### PR DESCRIPTION
A new stable version of Catch2 was released yesterday. Time to move away from our current development version.