### PR TITLE
Add Accessor-like interface to memory buffers and views

### DIFF
--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -13,6 +13,7 @@
 #include <alpaka/dev/DevCpu.hpp>
 #include <alpaka/dev/Traits.hpp>
 #include <alpaka/mem/buf/Traits.hpp>
+#include <alpaka/mem/view/ViewAccessOps.hpp>
 #include <alpaka/vec/Vec.hpp>
 
 // Backend specific includes.
@@ -103,7 +104,7 @@ namespace alpaka
 
     //! The CPU memory buffer.
     template<typename TElem, typename TDim, typename TIdx>
-    class BufCpu
+    class BufCpu : public internal::ViewAccessOps<BufCpu<TElem, TDim, TIdx>>
     {
     public:
         template<typename TExtent, typename Deleter>

--- a/include/alpaka/mem/buf/BufOacc.hpp
+++ b/include/alpaka/mem/buf/BufOacc.hpp
@@ -20,6 +20,7 @@
 #    include <alpaka/dev/Traits.hpp>
 #    include <alpaka/dim/DimIntegralConst.hpp>
 #    include <alpaka/mem/buf/Traits.hpp>
+#    include <alpaka/mem/view/ViewAccessOps.hpp>
 #    include <alpaka/queue/QueueOaccBlocking.hpp>
 #    include <alpaka/vec/Vec.hpp>
 
@@ -102,7 +103,7 @@ namespace alpaka
     } // namespace oacc
 
     template<typename TElem, typename TDim, typename TIdx>
-    class BufOacc
+    class BufOacc : public internal::ViewAccessOps<BufOacc<TElem, TDim, TIdx>>
     {
     public:
         //! Constructor

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -20,6 +20,7 @@
 #    include <alpaka/dev/Traits.hpp>
 #    include <alpaka/dim/DimIntegralConst.hpp>
 #    include <alpaka/mem/buf/Traits.hpp>
+#    include <alpaka/mem/view/ViewAccessOps.hpp>
 #    include <alpaka/queue/QueueOmp5Blocking.hpp>
 #    include <alpaka/vec/Vec.hpp>
 
@@ -98,7 +99,7 @@ namespace alpaka
     } // namespace detail
 
     template<typename TElem, typename TDim, typename TIdx>
-    class BufOmp5
+    class BufOmp5 : public internal::ViewAccessOps<BufOmp5<TElem, TDim, TIdx>>
     {
     public:
         //! Constructor

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -33,6 +33,7 @@
 #    include <alpaka/dev/Traits.hpp>
 #    include <alpaka/dim/DimIntegralConst.hpp>
 #    include <alpaka/mem/buf/Traits.hpp>
+#    include <alpaka/mem/view/ViewAccessOps.hpp>
 #    include <alpaka/meta/DependentFalseType.hpp>
 #    include <alpaka/vec/Vec.hpp>
 
@@ -49,7 +50,7 @@ namespace alpaka
 
     //! The CUDA/HIP memory buffer.
     template<typename TElem, typename TDim, typename TIdx>
-    class BufUniformCudaHipRt
+    class BufUniformCudaHipRt : public internal::ViewAccessOps<BufUniformCudaHipRt<TElem, TDim, TIdx>>
     {
         static_assert(
             !std::is_const<TElem>::value,

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -1,0 +1,169 @@
+/* Copyright 2022 Andrea Bocci
+
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS” AND ISC DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+ * IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <alpaka/dim/Traits.hpp>
+#include <alpaka/extent/Traits.hpp>
+#include <alpaka/mem/view/ViewAccessor.hpp>
+
+#include <sstream>
+#include <type_traits>
+
+namespace alpaka
+{
+    namespace internal
+    {
+        template<typename TView>
+        struct ViewAccessOps
+        {
+        private:
+            using value_type = Elem<TView>;
+            using pointer = value_type*;
+            using const_pointer = value_type const*;
+            using reference = value_type&;
+            using const_reference = value_type const&;
+
+        public:
+            ViewAccessOps()
+            {
+                static_assert(experimental::traits::internal::IsView<TView>::value);
+            }
+
+            ALPAKA_FN_HOST auto data() -> pointer
+            {
+                return getPtrNative(*static_cast<TView*>(this));
+            }
+
+            ALPAKA_FN_HOST auto data() const -> const_pointer
+            {
+                return getPtrNative(*static_cast<TView const*>(this));
+            }
+
+            ALPAKA_FN_HOST auto operator*() -> reference
+            {
+                static_assert(
+                    alpaka::Dim<TView>::value == 0,
+                    "operator* is only valid for Buffers and Views of dimension 0");
+                return *data();
+            }
+
+            ALPAKA_FN_HOST auto operator*() const -> const_reference
+            {
+                static_assert(
+                    alpaka::Dim<TView>::value == 0,
+                    "operator* is only valid for Buffers and Views of dimension 0");
+                return *data();
+            }
+
+            ALPAKA_FN_HOST auto operator->() -> pointer
+            {
+                static_assert(
+                    alpaka::Dim<TView>::value == 0,
+                    "operator-> is only valid for Buffers and Views of dimension 0");
+                return data();
+            }
+
+            ALPAKA_FN_HOST auto operator->() const -> const_pointer
+            {
+                static_assert(
+                    alpaka::Dim<TView>::value == 0,
+                    "operator-> is only valid for Buffers and Views of dimension 0");
+                return data();
+            }
+
+            ALPAKA_FN_HOST auto operator[](std::size_t i) -> reference
+            {
+                static_assert(
+                    alpaka::Dim<TView>::value == 1,
+                    "operator[i] is only valid for Buffers and Views of dimension 1");
+                return data()[i];
+            }
+
+            ALPAKA_FN_HOST auto operator[](std::size_t i) const -> const_reference
+            {
+                static_assert(
+                    alpaka::Dim<TView>::value == 1,
+                    "operator[i] is only valid for Buffers and Views of dimension 1");
+                return data()[i];
+            }
+
+        private:
+            template<std::size_t TDim, typename TIdx>
+            ALPAKA_FN_HOST auto ptr_at(Vec<DimInt<TDim>, TIdx> index) const -> const_pointer
+            {
+                using Idx = alpaka::Idx<TView>;
+                static_assert(
+                    alpaka::Dim<TView>::value == TDim,
+                    "the index type must have the same dimensionality as the Buffer or View");
+                static_assert(
+                    std::is_convertible_v<TIdx, Idx>,
+                    "the index type must be convertible to the index of the Buffer or View");
+
+                uintptr_t ptr = reinterpret_cast<uintptr_t>(data());
+                if constexpr(TDim > 0)
+                {
+                    const auto pitchesInBytes = getPitchBytesVec(*static_cast<TView const*>(this));
+                    for(std::size_t i = 0u; i < TDim; i++)
+                    {
+                        const Idx pitch = i + 1 < TDim ? pitchesInBytes[i + 1] : static_cast<Idx>(sizeof(value_type));
+                        ptr += static_cast<uintptr_t>(index[i] * pitch);
+                    }
+                }
+                return reinterpret_cast<const_pointer>(ptr);
+            }
+
+        public:
+            template<std::size_t TDim, typename TIdx>
+            ALPAKA_FN_HOST auto operator[](Vec<DimInt<TDim>, TIdx> index) -> reference
+            {
+                return *const_cast<pointer>(ptr_at(index));
+            }
+
+            template<std::size_t TDim, typename TIdx>
+            ALPAKA_FN_HOST auto operator[](Vec<DimInt<TDim>, TIdx> index) const -> const_reference
+            {
+                return *ptr_at(index);
+            }
+
+            template<std::size_t TDim, typename TIdx>
+            ALPAKA_FN_HOST auto at(Vec<DimInt<TDim>, TIdx> index) -> reference
+            {
+                auto extent = extent::getExtentVec(*static_cast<TView*>(this));
+                if(!(index < extent).foldrAll(std::logical_and<bool>()))
+                {
+                    std::stringstream msg;
+                    msg << "index " << index << " is outside of the Buffer or View extent " << extent;
+                    throw std::out_of_range(msg.str());
+                }
+                return *const_cast<pointer>(ptr_at(index));
+            }
+
+            template<std::size_t TDim, typename TIdx>
+            ALPAKA_FN_HOST auto at(Vec<DimInt<TDim>, TIdx> index) const -> const_reference
+            {
+                auto extent = extent::getExtentVec(*static_cast<TView const*>(this));
+                if(!(index < extent).foldrAll(std::logical_and<bool>()))
+                {
+                    std::stringstream msg;
+                    msg << "index " << index << " is outside of the Buffer or View extent " << extent;
+                    throw std::out_of_range(msg.str());
+                }
+                return *ptr_at(index);
+            }
+        };
+
+    } // namespace internal
+} // namespace alpaka

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -14,6 +14,7 @@
 #include <alpaka/dev/DevOmp5.hpp>
 #include <alpaka/dev/DevUniformCudaHipRt.hpp>
 #include <alpaka/mem/view/Traits.hpp>
+#include <alpaka/mem/view/ViewAccessOps.hpp>
 #include <alpaka/vec/Vec.hpp>
 
 #include <type_traits>
@@ -22,7 +23,7 @@ namespace alpaka
 {
     //! The memory view to wrap plain pointers.
     template<typename TDev, typename TElem, typename TDim, typename TIdx>
-    class ViewPlainPtr final
+    class ViewPlainPtr final : public internal::ViewAccessOps<ViewPlainPtr<TDev, TElem, TDim, TIdx>>
     {
         static_assert(!std::is_const<TIdx>::value, "The idx type of the view can not be const!");
 

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -16,6 +16,7 @@
 #include <alpaka/extent/Traits.hpp>
 #include <alpaka/idx/Traits.hpp>
 #include <alpaka/mem/view/Traits.hpp>
+#include <alpaka/mem/view/ViewAccessOps.hpp>
 #include <alpaka/mem/view/ViewPlainPtr.hpp>
 #include <alpaka/offset/Traits.hpp>
 #include <alpaka/vec/Vec.hpp>
@@ -27,7 +28,7 @@ namespace alpaka
 {
     //! A sub-view to a view.
     template<typename TDev, typename TElem, typename TDim, typename TIdx>
-    class ViewSubView
+    class ViewSubView : public internal::ViewAccessOps<ViewSubView<TDev, TElem, TDim, TIdx>>
     {
         static_assert(!std::is_const<TIdx>::value, "The idx type of the view can not be const!");
 

--- a/test/integ/zeroDimBuffer/src/zeroDimBuffer.cpp
+++ b/test/integ/zeroDimBuffer/src/zeroDimBuffer.cpp
@@ -118,13 +118,13 @@ TEMPLATE_LIST_TEST_CASE("zeroDimBuffer", "[zeroDimBuffer]", TestAccs)
     // host buffer
     auto h_buffer1 = alpaka::allocBuf<int, Idx>(host, Scalar{});
     INFO(
-        "host buffer allocated at " << alpaka::getPtrNative(h_buffer1) << " with "
-                                    << alpaka::extent::getExtentProduct(h_buffer1) << " element(s)")
+        "host buffer allocated at " << std::data(h_buffer1) << " with " << alpaka::extent::getExtentProduct(h_buffer1)
+                                    << " element(s)")
 
     // async host buffer
     auto h_buffer2 = allocAsyncBufIfSupported<HostAcc, int, Idx>(hostQueue, Scalar{});
     INFO(
-        "second host buffer allocated at " << alpaka::getPtrNative(h_buffer2) << " with "
+        "second host buffer allocated at " << std::data(h_buffer2) << " with "
                                            << alpaka::extent::getExtentProduct(h_buffer2) << " element(s)")
 
     // host-side buffer memset
@@ -133,7 +133,7 @@ TEMPLATE_LIST_TEST_CASE("zeroDimBuffer", "[zeroDimBuffer]", TestAccs)
     INFO("host-side buffer memset")
     alpaka::memset(hostQueue, h_buffer1, value1);
     alpaka::wait(hostQueue);
-    CHECK(expected1 == *alpaka::getPtrNative(h_buffer1));
+    CHECK(expected1 == *h_buffer1);
 
     // host-side async buffer memset
     const int value2 = 99;
@@ -141,16 +141,16 @@ TEMPLATE_LIST_TEST_CASE("zeroDimBuffer", "[zeroDimBuffer]", TestAccs)
     INFO("host-side async buffer memset")
     alpaka::memset(hostQueue, h_buffer2, value2);
     alpaka::wait(hostQueue);
-    CHECK(expected2 == *alpaka::getPtrNative(h_buffer2));
+    CHECK(expected2 == *h_buffer2);
 
     // host-host copies
     INFO("buffer host-host copies")
     alpaka::memcpy(hostQueue, h_buffer2, h_buffer1);
     alpaka::wait(hostQueue);
-    CHECK(expected1 == *alpaka::getPtrNative(h_buffer2));
+    CHECK(expected1 == *h_buffer2);
     alpaka::memcpy(hostQueue, h_buffer1, h_buffer2);
     alpaka::wait(hostQueue);
-    CHECK(expected1 == *alpaka::getPtrNative(h_buffer1));
+    CHECK(expected1 == *h_buffer1);
 
     // GPU device
     auto const device = alpaka::getDevByIdx<Device>(0u);
@@ -160,13 +160,13 @@ TEMPLATE_LIST_TEST_CASE("zeroDimBuffer", "[zeroDimBuffer]", TestAccs)
     // device buffer
     auto d_buffer1 = alpaka::allocBuf<int, Idx>(device, Scalar{});
     INFO(
-        "device buffer allocated at " << alpaka::getPtrNative(d_buffer1) << " with "
+        "device buffer allocated at " << std::data(d_buffer1) << " with "
                                       << alpaka::extent::getExtentProduct(d_buffer1) << " element(s)")
 
     // async or second sync device buffer
     auto d_buffer2 = allocAsyncBufIfSupported<DeviceAcc, int, Idx>(deviceQueue, Scalar{});
     INFO(
-        "second device buffer allocated at " << alpaka::getPtrNative(d_buffer2) << " with "
+        "second device buffer allocated at " << std::data(d_buffer2) << " with "
                                              << alpaka::extent::getExtentProduct(d_buffer2) << " element(s)")
 
     // host-device copies
@@ -190,6 +190,6 @@ TEMPLATE_LIST_TEST_CASE("zeroDimBuffer", "[zeroDimBuffer]", TestAccs)
     alpaka::memcpy(deviceQueue, h_buffer2, d_buffer2);
 
     alpaka::wait(deviceQueue);
-    CHECK(expected1 == *alpaka::getPtrNative(h_buffer1));
-    CHECK(expected2 == *alpaka::getPtrNative(h_buffer2));
+    CHECK(expected1 == *h_buffer1);
+    CHECK(expected2 == *h_buffer2);
 }


### PR DESCRIPTION
Memory buffers and views with different dimensions implement different operators:
  - 0-dimensional (scalar) types implement the indirection operator `*` and dereference operator `->`;
  - 1-dimensional type implement the array subscript operator `[]` with an integer argument;
  - all N-dimensional types implement the array subscript operator `[]` with an N-dimensional vector argument.

Update the buffer unit test and zero-dimensional buffer integration test to test the new interface.