### PR TITLE
Sphinx Doc: advanced installation documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /docs/doxygen/*
+/docs/source/_build
+/docs/cheatsheet/cheatsheet.pdf
 
 **/build*
 
@@ -34,6 +36,7 @@ spack-build*
 /.settings/
 
 # Visual Studio Code project files
+.vscode/
 .cache/
 
 # Visual Studio project files

--- a/docs/source/advanced/cmake.rst
+++ b/docs/source/advanced/cmake.rst
@@ -1,7 +1,7 @@
 CMake Arguments
 ===============
 
-Alpaka configures a lot of its functionality at compile time. Therefore a lot of compiler and link flags are needed, which are set by ``CMake`` arguments. The beginning of this section introduces the general Alpaca flag. The last parts of the section describe back-end specific flags.
+Alpaka configures a lot of its functionality at compile time. Therefore a lot of compiler and link flags are needed, which are set by CMake arguments. The beginning of this section introduces the general Alpaca flag. The last parts of the section describe back-end specific flags.
 
 .. hint::
 

--- a/docs/source/basic/example.rst
+++ b/docs/source/basic/example.rst
@@ -1,0 +1,78 @@
+Code Example
+============
+
+The following example shows a small hello word example written with alpaka that can be run on different processors.
+
+.. literalinclude:: ../../../example/helloWorld/src/helloWorld.cpp
+   :language: C++
+   :caption: helloWorld.cpp
+
+Use alpaka in your project
+++++++++++++++++++++++++++
+
+We recommend to use CMake for integrating alpaka into your own project. There are two possible methods.
+
+Use alpaka via ``find_package``
+-------------------------------
+
+The ``find_package`` method requires alpaka to be :doc:`installed </basic/install>` in a location where CMake can find it. 
+
+.. hint::
+
+    If you do not install alpaka in a default path such as ``/usr/local/`` you have to set the CMake argument ``-Dalpaka_ROOT=/path/to/alpaka/install``.
+
+The following example shows a minimal example of a ``CMakeLists.txt`` that uses alpaka:
+
+.. code-block:: cmake
+   :caption: CMakeLists.txt
+
+   cmake_minimum_required(VERSION 3.18)
+
+   set(_TARGET_NAME myProject)
+   project(${_TARGET_NAME})
+
+   find_package(alpaka REQUIRED)
+
+   alpaka_add_executable(${_TARGET_NAME} helloWorld.cpp)
+   target_link_libraries(
+     ${_TARGET_NAME}
+     PUBLIC alpaka::alpaka)
+
+In the CMake configuration phase of the project, you must activate the accelerator you want to use:
+
+.. code-block:: bash
+
+    cd <path/to/the/project/root>
+    mkdir build && cd build
+    # enable the CUDA accelerator
+    cmake .. -DALPAKA_ACC_GPU_CUDA_ENABLE=ON
+    # compile and link
+    cmake --build .
+    # execute application
+    ./myProject
+
+A complete list of CMake flags for the  accelerator can be found :doc:`here </advanced/cmake>`.
+
+If the configuration was successful and CMake found the CUDA SDK, the C++ template accelerator type ``alpaka::acc::AccGpuCudaRt`` is available.
+
+Use alpaka via ``add_subdirectory``
+-----------------------------------
+
+The ``add_subdirectory`` method does not require alpaka to be installed. Instead, the alpaka project folder must be part of your project hierarchy. The following example expects alpaka to be found in the ``project_path/thirdParty/alpaka``:
+
+.. code-block:: cmake
+   :caption: CMakeLists.txt
+
+   cmake_minimum_required(VERSION 3.18)
+
+   set(_TARGET_NAME myProject)
+   project(${_TARGET_NAME})
+
+   add_subdirectory(thirdParty/alpaka)
+
+   alpaka_add_executable(${_TARGET_NAME} helloWorld.cpp)
+   target_link_libraries(
+     ${_TARGET_NAME}
+     PUBLIC alpaka::alpaka)
+
+The CMake configure and build commands are the same as for the ``find_package`` approach.

--- a/docs/source/basic/install.rst
+++ b/docs/source/basic/install.rst
@@ -3,44 +3,61 @@
 Installation
 ============
 
-* Clone alpaka from github.com
-
 .. code-block::
 
-  git clone https://github.com/alpaka-group/alpaka
+  # Clone alpaka from github.com
+  git clone --branch 0.8.0 https://github.com/alpaka-group/alpaka.git
   cd alpaka
-
-* Install alpaka
-
-.. code-block::
-
-  # git clone https://github.com/alpaka-group/alpaka
-  # cd alpaka
   mkdir build && cd build
   cmake -DCMAKE_INSTALL_PREFIX=/install/ ..
   cmake --install .
 
-* Configure Accelerators
+Tests and Examples
+++++++++++++++++++
 
-.. code-block::
-
-  # ..
-  cmake -DALPAKA_ACC_GPU_CUDA_ENABLE=ON ..
-
-* Build an example
+**Build and run examples:**
 
 .. code-block::
 
   # ..
   cmake -Dalpaka_BUILD_EXAMPLES=ON ..
-  make vectorAdd
+  cmake --build . -t vectorAdd
   ./example/vectorAdd/vectorAdd # execution
 
-* Build and run tests
+**Build and run tests:**
 
 .. code-block::
 
   # ..
   cmake -DBUILD_TESTING=ON ..
-  make
+  cmake --build .
   ctest
+
+**Enable accelerators:**
+
+Alpaka uses different accelerators to execute kernels on different processors. To use a specific accelerator in alpaka, two steps are required.
+
+1. Enable the accelerator during the CMake configuration time of the project.
+2. Select a specific accelerator in the source code.
+
+By default, no accelerator is enabled because some combinations of compilers and accelerators do not work, see the table of `supported compilers <https://github.com/alpaka-group/alpaka#supported-compilers>`_. To enable an accelerator, you must set a CMake flag via ``cmake .. -DALPAKA_ACC_<acc>_ENABLE=ON`` when you create a new build. The following example shows how to enable the CUDA accelerator and build an alpaka project:
+
+.. code-block::
+
+  # create build folder
+  mkdir build && cd build
+  # run cmake configure with enable CUDA backend
+  cmake -DALPAKA_ACC_GPU_CUDA_ENABLE=ON ..
+  # compile source code
+  cmake --build .
+
+In the overview of :doc:`cmake arguments </advanced/cmake>` you will find all CMake flags for activating the different accelerators. How to select an accelerator in the source code is described on the :doc:`example page </basic/example>`.
+
+.. warning::
+
+  If an accelerator is selected in the source code that is not activated during CMake configuration time, a compiler error occurs.
+
+
+.. hint::
+
+  When the test or examples are activated, the alpaka build system automatically activates the ``serial backend``, as it is needed for many tests. Therefore, the tests are run with the ``serial backend`` by default. If you want to test another backend, you have to activate it at CMake configuration time, for example the ``HIP`` backend: ``cmake .. -DBUILD_TESTING=ON -DALPAKA_ACC_GPU_HIP_ENABLE=ON``. The alpaka tests use a selector algorithm to choose a specific accelerator for the test cases. The selector works with accelerator priorities. Therefore, it is recommended to enable only one accelerator for a build to make sure that the right one is used.

--- a/docs/source/basic/intro.rst
+++ b/docs/source/basic/intro.rst
@@ -10,34 +10,6 @@ The policy-based C++ template interface provided allows for straightforward user
 
 The library name *alpaka* is an acronym standing for **A**\ bstraction **L**\ ibrary for **Pa**\ rallel **K**\ ernel **A**\ cceleration.
 
-Example
--------
-
-.. literalinclude:: ../../../example/helloWorld/src/helloWorld.cpp
-   :language: C++
-   :caption: helloWorld.cpp
-
-.. code-block:: cmake
-   :caption: CMakeLists.txt
-
-   cmake_minimum_required(VERSION 3.18)
-
-   set(_TARGET_NAME helloWorld)
-   project(${_TARGET_NAME})
-
-   find_package(alpaka REQUIRED)
-
-   alpaka_add_executable(${_TARGET_NAME} helloWorld.cpp)
-   target_link_libraries(
-     ${_TARGET_NAME}
-     PUBLIC alpaka::alpaka)
-
-You can integrate alpaka into your project via ``find_package()`` in your ``CMakeLists.txt``.
-This requires, that you :doc:`install </basic/install>` alpaka.
-If you do not install alpaka in a default path such as ``/usr/local/`` you have to set the ``CMake`` argument ``-Dalpaka_ROOT=/path/to/alpaka/install``.
-
-The cmake configuration decides which alpaka accelerators are available during compiling. For example, if you configure your ``cmake`` build with the CUDA back-end (``-DALPAKA_ACC_GPU_CUDA_ENABLE=ON``), ``cmake`` checks, if the CUDA SDK is available and if it found, the C++ template ``alpaka::acc::AccGpuCudaRt`` is available during compiling.
-
 About alpaka
 ------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,6 +39,7 @@ Individual chapters are based on the information of the chapters before.
 
    basic/intro.rst
    basic/install.rst
+   basic/example.rst
    basic/abstraction.rst
    basic/library.rst
    basic/cheatsheet.rst


### PR DESCRIPTION
Improve readability of the installation and usage documentation of alpaka. Put example code from the introduction page in a extra section for a better structure of the documentation.