### PR TITLE
Support the CUDA/HIP host API without a CUDA/HIP compiler (alt version)

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -388,12 +388,12 @@ if(ALPAKA_ACC_GPU_CUDA_ENABLE)
             # libstdc++ since version 7 when GNU extensions are enabled (e.g. -std=gnu++11)
             # uses `__CUDACC__` to avoid defining overloads using non-standard `__float128`.
             # This is fixed in clang-11: https://github.com/llvm/llvm-project/commit/8e20516540444618ad32dd11e835c05804053697
-            if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11.0)
-                target_compile_definitions(alpaka INTERFACE "__CUDACC__")
+            if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.0)
+                target_compile_definitions(alpaka INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:__CUDACC__>)
             endif()
 
-            if(CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 11.0)
-                target_compile_options(alpaka INTERFACE "-Wno-unknown-cuda-version")
+            if(CMAKE_CUDA_COMPILER_VERSION GREATER_EQUAL 11.0)
+                target_compile_options(alpaka INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:-Wno-unknown-cuda-version>)
             endif()
 
             # This flag silences the warning produced by the Dummy.cpp files:

--- a/include/alpaka/acc/AccGpuCudaRt.hpp
+++ b/include/alpaka/acc/AccGpuCudaRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, René Widera
+/* Copyright 2022 Benjamin Worpitz, René Widera, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -10,12 +10,6 @@
 #pragma once
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
 
 // Base classes.
 #    include <alpaka/acc/AccGpuUniformCudaHipRt.hpp>
@@ -49,7 +43,7 @@ namespace alpaka
             "Index type is not supported, consider using int or a larger type.");
 
     public:
-        __device__ AccGpuCudaRt(Vec<TDim, TIdx> const& threadElemExtent)
+        ALPAKA_FN_HOST_ACC AccGpuCudaRt(Vec<TDim, TIdx> const& threadElemExtent)
             : AccGpuUniformCudaHipRt<TDim, TIdx>(threadElemExtent)
         {
         }

--- a/include/alpaka/acc/AccGpuHipRt.hpp
+++ b/include/alpaka/acc/AccGpuHipRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, Matthias Werner, René Widera
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -10,12 +10,6 @@
 #pragma once
 
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
 
 // Base classes.
 #    include <alpaka/acc/AccGpuUniformCudaHipRt.hpp>
@@ -49,7 +43,7 @@ namespace alpaka
             "Index type is not supported, consider using int or a larger type.");
 
     public:
-        __device__ AccGpuHipRt(Vec<TDim, TIdx> const& threadElemExtent)
+        ALPAKA_FN_HOST_ACC AccGpuHipRt(Vec<TDim, TIdx> const& threadElemExtent)
             : AccGpuUniformCudaHipRt<TDim, TIdx>(threadElemExtent)
         {
         }

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Benjamin Worpitz, René Widera, Jan Stephan
+/* Copyright 2022 Benjamin Worpitz, René Widera, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -10,16 +10,6 @@
 #pragma once
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
 
 // Base classes.
 #    include <alpaka/atomic/AtomicHierarchy.hpp>
@@ -46,6 +36,7 @@
 
 // Implementation details.
 #    include <alpaka/core/ClipCast.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/Cuda.hpp>
 #    include <alpaka/dev/DevUniformCudaHipRt.hpp>
 
@@ -87,7 +78,7 @@ namespace alpaka
             "Index type is not supported, consider using int or a larger type.");
 
     public:
-        __device__ AccGpuUniformCudaHipRt(Vec<TDim, TIdx> const& threadElemExtent)
+        ALPAKA_FN_HOST_ACC AccGpuUniformCudaHipRt(Vec<TDim, TIdx> const& threadElemExtent)
             : WorkDivUniformCudaHipBuiltIn<TDim, TIdx>(threadElemExtent)
             , gb::IdxGbUniformCudaHipBuiltIn<TDim, TIdx>()
             , bt::IdxBtUniformCudaHipBuiltIn<TDim, TIdx>()

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, René Widera
+/* Copyright 2022 Benjamin Worpitz, René Widera, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,17 +11,9 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
-
 #    include <alpaka/block/shared/dyn/Traits.hpp>
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 
 #    include <type_traits>
 
@@ -32,6 +24,16 @@ namespace alpaka
         : public concepts::Implements<ConceptBlockSharedDyn, BlockSharedMemDynUniformCudaHipBuiltIn>
     {
     };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
     namespace traits
     {
@@ -49,6 +51,9 @@ namespace alpaka
             }
         };
     } // namespace traits
+
+#    endif
+
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/block/shared/st/BlockSharedMemStUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, Erik Zenker, René Widera, Matthias Werner
+/* Copyright 2022 Benjamin Worpitz, Erik Zenker, René Widera, Matthias Werner, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,17 +11,9 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
-
 #    include <alpaka/block/shared/st/Traits.hpp>
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 
 #    include <cstdint>
 #    include <type_traits>
@@ -33,6 +25,16 @@ namespace alpaka
         : public concepts::Implements<ConceptBlockSharedSt, BlockSharedMemStUniformCudaHipBuiltIn>
     {
     };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
     namespace traits
     {
@@ -54,6 +56,9 @@ namespace alpaka
             }
         };
     } // namespace traits
+
+#    endif
+
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, Matthias Werner
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,17 +11,9 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
-
 #    include <alpaka/block/sync/Traits.hpp>
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 
 namespace alpaka
 {
@@ -30,6 +22,16 @@ namespace alpaka
         : public concepts::Implements<ConceptBlockSync, BlockSyncUniformCudaHipBuiltIn>
     {
     };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
     namespace traits
     {
@@ -49,7 +51,7 @@ namespace alpaka
                 BlockSyncUniformCudaHipBuiltIn const& /*blockSync*/,
                 int predicate) -> int
             {
-#    if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__ == 0 && BOOST_COMP_HIP
+#        if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__ == 0 && BOOST_COMP_HIP
                 // workaround for unsupported syncthreads_* operation on AMD hardware without sync extension
                 __shared__ int tmp;
                 __syncthreads();
@@ -61,9 +63,9 @@ namespace alpaka
                 __syncthreads();
 
                 return tmp;
-#    else
+#        else
                 return __syncthreads_count(predicate);
-#    endif
+#        endif
             }
         };
 
@@ -74,7 +76,7 @@ namespace alpaka
                 BlockSyncUniformCudaHipBuiltIn const& /*blockSync*/,
                 int predicate) -> int
             {
-#    if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__ == 0 && BOOST_COMP_HIP
+#        if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__ == 0 && BOOST_COMP_HIP
                 // workaround for unsupported syncthreads_* operation on AMD hardware without sync extension
                 __shared__ int tmp;
                 __syncthreads();
@@ -86,9 +88,9 @@ namespace alpaka
                 __syncthreads();
 
                 return tmp;
-#    else
+#        else
                 return __syncthreads_and(predicate);
-#    endif
+#        endif
             }
         };
 
@@ -99,7 +101,7 @@ namespace alpaka
                 BlockSyncUniformCudaHipBuiltIn const& /*blockSync*/,
                 int predicate) -> int
             {
-#    if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__ == 0 && BOOST_COMP_HIP
+#        if defined(__HIP_ARCH_HAS_SYNC_THREAD_EXT__) && __HIP_ARCH_HAS_SYNC_THREAD_EXT__ == 0 && BOOST_COMP_HIP
                 // workaround for unsupported syncthreads_* operation on AMD hardware without sync extension
                 __shared__ int tmp;
                 __syncthreads();
@@ -111,12 +113,15 @@ namespace alpaka
                 __syncthreads();
 
                 return tmp;
-#    else
+#        else
                 return __syncthreads_or(predicate);
-#    endif
+#        endif
             }
         };
     } // namespace traits
+
+#    endif
+
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/core/Cuda.hpp
+++ b/include/alpaka/core/Cuda.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Axel Huebl, Benjamin Worpitz, Matthias Werner, René Widera
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -12,11 +12,6 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #    include <alpaka/core/BoostPredef.hpp>
-
-#    if !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
 #    include <alpaka/elem/Traits.hpp>
 #    include <alpaka/extent/Traits.hpp>
 #    include <alpaka/idx/Traits.hpp>

--- a/include/alpaka/core/CudaHipMath.hpp
+++ b/include/alpaka/core/CudaHipMath.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019-2021 Benjamin Worpitz, René Widera, Sergei Bastrakov
+/* Copyright 2022 Benjamin Worpitz, René Widera, Sergei Bastrakov, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <alpaka/core/BoostPredef.hpp>
 #include <alpaka/core/UniformCudaHip.hpp>
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)

--- a/include/alpaka/core/UniformCudaHip.hpp
+++ b/include/alpaka/core/UniformCudaHip.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, René Widera, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, René Widera, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -12,14 +12,6 @@
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
 #    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
 
 // Backend specific includes.
 #    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz
+/* Copyright 2022 Benjamin Worpitz, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,16 +11,7 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
-
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/dev/Traits.hpp>
 #    include <alpaka/mem/buf/Traits.hpp>
 #    include <alpaka/pltf/Traits.hpp>

--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz
+/* Copyright 2022 Benjamin Worpitz, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,16 +11,7 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
-
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/dev/DevUniformCudaHipRt.hpp>
 #    include <alpaka/dev/Traits.hpp>
 #    include <alpaka/event/Traits.hpp>

--- a/include/alpaka/idx/bt/IdxBtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/idx/bt/IdxBtUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, René Widera, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, René Widera, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -12,15 +12,6 @@
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
 #    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
-
 #    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/Positioning.hpp>
 #    include <alpaka/idx/Traits.hpp>
@@ -45,6 +36,16 @@ namespace alpaka
         };
     } // namespace bt
 
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
+
     namespace traits
     {
         //! The GPU CUDA/HIP accelerator index dimension get trait specialization.
@@ -63,14 +64,14 @@ namespace alpaka
             __device__ static auto getIdx(bt::IdxBtUniformCudaHipBuiltIn<TDim, TIdx> const& /* idx */, TWorkDiv const&)
                 -> Vec<TDim, TIdx>
             {
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                 return castVec<TIdx>(getOffsetVecEnd<TDim>(threadIdx));
-#    else
+#        else
                 return getOffsetVecEnd<TDim>(Vec<std::integral_constant<typename TDim::value_type, 3>, TIdx>(
                     static_cast<TIdx>(hipThreadIdx_z),
                     static_cast<TIdx>(hipThreadIdx_y),
                     static_cast<TIdx>(hipThreadIdx_x)));
-#    endif
+#        endif
             }
         };
 
@@ -81,6 +82,9 @@ namespace alpaka
             using type = TIdx;
         };
     } // namespace traits
+
+#    endif
+
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/idx/gb/IdxGbUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/idx/gb/IdxGbUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, René Widera, Matthias Werner, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, René Widera, Matthias Werner, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -12,15 +12,6 @@
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
 #    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
-
 #    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/Positioning.hpp>
 #    include <alpaka/idx/Traits.hpp>
@@ -45,6 +36,16 @@ namespace alpaka
         };
     } // namespace gb
 
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
+
     namespace traits
     {
         //! The GPU CUDA/HIP accelerator index dimension get trait specialization.
@@ -63,14 +64,14 @@ namespace alpaka
             __device__ static auto getIdx(gb::IdxGbUniformCudaHipBuiltIn<TDim, TIdx> const& /* idx */, TWorkDiv const&)
                 -> Vec<TDim, TIdx>
             {
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                 return castVec<TIdx>(getOffsetVecEnd<TDim>(blockIdx));
-#    else
+#        else
                 return getOffsetVecEnd<TDim>(Vec<std::integral_constant<typename TDim::value_type, 3>, TIdx>(
                     static_cast<TIdx>(hipBlockIdx_z),
                     static_cast<TIdx>(hipBlockIdx_y),
                     static_cast<TIdx>(hipBlockIdx_x)));
-#    endif
+#        endif
             }
         };
 
@@ -81,6 +82,9 @@ namespace alpaka
             using type = TIdx;
         };
     } // namespace traits
+
+#    endif
+
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/intrinsic/IntrinsicUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/intrinsic/IntrinsicUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Sergei Bastrakov
+/* Copyright 2022 Sergei Bastrakov, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -12,15 +12,7 @@
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
 #    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
-
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/intrinsic/Traits.hpp>
 
 namespace alpaka
@@ -31,6 +23,16 @@ namespace alpaka
     {
     };
 
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
+
     namespace traits
     {
         template<>
@@ -39,21 +41,21 @@ namespace alpaka
             __device__ static auto popcount(IntrinsicUniformCudaHipBuiltIn const& /*intrinsic*/, std::uint32_t value)
                 -> std::int32_t
             {
-#    if BOOST_COMP_CLANG && BOOST_LANG_CUDA
+#        if BOOST_COMP_CLANG && BOOST_LANG_CUDA
                 return __popc(static_cast<int>(value));
-#    else
+#        else
                 return static_cast<std::int32_t>(__popc(static_cast<unsigned int>(value)));
-#    endif
+#        endif
             }
 
             __device__ static auto popcount(IntrinsicUniformCudaHipBuiltIn const& /*intrinsic*/, std::uint64_t value)
                 -> std::int32_t
             {
-#    if BOOST_COMP_CLANG && BOOST_LANG_CUDA
+#        if BOOST_COMP_CLANG && BOOST_LANG_CUDA
                 return __popcll(static_cast<long long>(value));
-#    else
+#        else
                 return static_cast<std::int32_t>(__popcll(static_cast<unsigned long long>(value)));
-#    endif
+#        endif
             }
         };
 
@@ -73,6 +75,9 @@ namespace alpaka
             }
         };
     } // namespace traits
+
+#    endif
+
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Jan Stephan
+/* Copyright 2022 Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,55 +11,57 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-#    include <alpaka/core/BoostPredef.hpp>
+#    if !defined(ALPAKA_HOST_ONLY)
 
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
+#        include <alpaka/core/BoostPredef.hpp>
 
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
 // Specialized traits.
-#    include <alpaka/acc/Traits.hpp>
-#    include <alpaka/dev/Traits.hpp>
-#    include <alpaka/dim/Traits.hpp>
-#    include <alpaka/idx/Traits.hpp>
-#    include <alpaka/pltf/Traits.hpp>
-#    include <alpaka/queue/Traits.hpp>
-
-// Backend specific includes.
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-#        include <alpaka/core/Cuda.hpp>
-#    else
-#        include <alpaka/core/Hip.hpp>
-#    endif
-
-// Implementation details.
-#    include <alpaka/acc/AccGpuUniformCudaHipRt.hpp>
-#    include <alpaka/core/Decay.hpp>
-#    include <alpaka/core/RemoveRestrict.hpp>
-#    include <alpaka/dev/DevUniformCudaHipRt.hpp>
-#    include <alpaka/kernel/Traits.hpp>
-#    include <alpaka/queue/QueueUniformCudaHipRtBlocking.hpp>
-#    include <alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp>
-#    include <alpaka/workdiv/WorkDivMembers.hpp>
-
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
 #        include <alpaka/acc/Traits.hpp>
 #        include <alpaka/dev/Traits.hpp>
-#        include <alpaka/workdiv/WorkDivHelpers.hpp>
-#    endif
+#        include <alpaka/dim/Traits.hpp>
+#        include <alpaka/idx/Traits.hpp>
+#        include <alpaka/pltf/Traits.hpp>
+#        include <alpaka/queue/Traits.hpp>
 
-#    include <alpaka/core/BoostPredef.hpp>
+// Backend specific includes.
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#            include <alpaka/core/Cuda.hpp>
+#        else
+#            include <alpaka/core/Hip.hpp>
+#        endif
 
-#    include <stdexcept>
-#    include <tuple>
-#    include <type_traits>
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
-#        include <iostream>
-#    endif
+// Implementation details.
+#        include <alpaka/acc/AccGpuUniformCudaHipRt.hpp>
+#        include <alpaka/core/Decay.hpp>
+#        include <alpaka/core/RemoveRestrict.hpp>
+#        include <alpaka/dev/DevUniformCudaHipRt.hpp>
+#        include <alpaka/kernel/Traits.hpp>
+#        include <alpaka/queue/QueueUniformCudaHipRtBlocking.hpp>
+#        include <alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp>
+#        include <alpaka/workdiv/WorkDivMembers.hpp>
+
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
+#            include <alpaka/acc/Traits.hpp>
+#            include <alpaka/dev/Traits.hpp>
+#            include <alpaka/workdiv/WorkDivHelpers.hpp>
+#        endif
+
+#        include <alpaka/core/BoostPredef.hpp>
+
+#        include <stdexcept>
+#        include <tuple>
+#        include <type_traits>
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
+#            include <iostream>
+#        endif
 
 namespace alpaka
 {
@@ -75,18 +77,18 @@ namespace alpaka
                 TKernelFnObj const kernelFnObj,
                 TArgs... args)
             {
-#    if BOOST_ARCH_PTX && (BOOST_ARCH_PTX < BOOST_VERSION_NUMBER(2, 0, 0))
-#        error "Device capability >= 2.0 is required!"
-#    endif
+#        if BOOST_ARCH_PTX && (BOOST_ARCH_PTX < BOOST_VERSION_NUMBER(2, 0, 0))
+#            error "Device capability >= 2.0 is required!"
+#        endif
 
                 const TAcc acc(threadElemExtent);
 
 // with clang it is not possible to query std::result_of for a pure device lambda created on the host side
-#    if !(BOOST_COMP_CLANG_CUDA && BOOST_COMP_CLANG)
+#        if !(BOOST_COMP_CLANG_CUDA && BOOST_COMP_CLANG)
                 static_assert(
                     std::is_same<decltype(kernelFnObj(const_cast<TAcc const&>(acc), args...)), void>::value,
                     "The TKernelFnObj is required to return void!");
-#    endif
+#        endif
                 kernelFnObj(const_cast<TAcc const&>(acc), args...);
             }
 
@@ -192,14 +194,14 @@ namespace alpaka
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
                 // TODO: Check that (sizeof(TKernelFnObj) * m_3uiBlockThreadExtent.prod()) < available memory idx
 
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 // std::size_t printfFifoSize;
                 // cudaDeviceGetLimit(&printfFifoSize, cudaLimitPrintfFifoSize);
                 // std::cout << __func__ << "INFO: printfFifoSize: " << printfFifoSize << std::endl;
                 // cudaDeviceSetLimit(cudaLimitPrintfFifoSize, printfFifoSize*10);
                 // cudaDeviceGetLimit(&printfFifoSize, cudaLimitPrintfFifoSize);
                 // std::cout << __func__ << "INFO: printfFifoSize: " <<  printfFifoSize << std::endl;
-#    endif
+#        endif
                 auto const gridBlockExtent = getWorkDiv<Grid, Blocks>(task);
                 auto const blockThreadExtent = getWorkDiv<Block, Threads>(task);
                 auto const threadElemExtent = getWorkDiv<Thread, Elems>(task);
@@ -208,12 +210,12 @@ namespace alpaka
                 dim3 const blockDim = uniform_cuda_hip::detail::convertVecToUniformCudaHipDim(blockThreadExtent);
                 uniform_cuda_hip::detail::checkVecOnly3Dim(threadElemExtent);
 
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " gridDim: " << gridDim.z << " " << gridDim.y << " " << gridDim.x
                           << " blockDim: " << blockDim.z << " " << blockDim.y << " " << blockDim.x << std::endl;
-#    endif
+#        endif
 
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                 // This checks for a valid work division that is also compliant with the maxima of the accelerator.
                 if(!isValidWorkDiv<TAcc>(getDev(queue), task))
                 {
@@ -221,7 +223,7 @@ namespace alpaka
                         "The given work division is not valid or not supported by the device of type "
                         + getAccName<AccGpuUniformCudaHipRt<TDim, TIdx>>() + "!");
                 }
-#    endif
+#        endif
 
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes = std::apply(
@@ -234,16 +236,16 @@ namespace alpaka
                     },
                     task.m_args);
 
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 // Log the block shared memory idx.
                 std::cout << __func__ << " BlockSharedMemDynSizeBytes: " << blockSharedMemDynSizeBytes << " B"
                           << std::endl;
-#    endif
+#        endif
                 auto kernelName = uniform_cuda_hip::detail::
                     uniformCudaHipKernel<TAcc, TDim, TIdx, TKernelFnObj, remove_restrict_t<std::decay_t<TArgs>>...>;
 
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+#            if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
 
                 // Log the function attributes.
                 cudaFuncAttributes funcAttrs;
@@ -254,8 +256,8 @@ namespace alpaka
                           << " maxThreadsPerBlock: " << funcAttrs.maxThreadsPerBlock
                           << " numRegs: " << funcAttrs.numRegs << " ptxVersion: " << funcAttrs.ptxVersion
                           << " sharedSizeBytes: " << funcAttrs.sharedSizeBytes << " B" << std::endl;
+#            endif
 #        endif
-#    endif
 
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.m_iDevice));
@@ -268,7 +270,7 @@ namespace alpaka
                 std::apply(
                     [&](remove_restrict_t<ALPAKA_DECAY_T(TArgs)> const&... args)
                     {
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                         kernelName<<<
                             gridDim,
                             blockDim,
@@ -277,7 +279,7 @@ namespace alpaka
                             threadElemExtent,
                             task.m_kernelFnObj,
                             args...);
-#    else
+#        else
                         hipLaunchKernelGGL(
                             HIP_KERNEL_NAME(kernelName),
                             gridDim,
@@ -287,11 +289,11 @@ namespace alpaka
                             threadElemExtent,
                             task.m_kernelFnObj,
                             args...);
-#    endif
+#        endif
                     },
                     task.m_args);
 
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                 // Wait for the kernel execution to finish but do not check error return of this call.
                 // Do not use the alpaka::wait method because it checks the error itself but we want to give a custom
                 // error message.
@@ -299,7 +301,7 @@ namespace alpaka
                 std::string const msg(
                     "'execution of kernel: '" + std::string(typeid(TKernelFnObj).name()) + "' failed with");
                 ::alpaka::uniform_cuda_hip::detail::rtCheckLastError(msg.c_str(), __FILE__, __LINE__);
-#    endif
+#        endif
             }
         };
         //! The CUDA/HIP synchronous kernel enqueue trait specialization.
@@ -315,35 +317,35 @@ namespace alpaka
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
                 // TODO: Check that (sizeof(TKernelFnObj) * m_3uiBlockThreadExtent.prod()) < available memory idx
 
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 // std::size_t printfFifoSize;
                 // cudaDeviceGetLimit(&printfFifoSize, cudaLimitPrintfFifoSize);
                 // std::cout << __func__ << "INFO: printfFifoSize: " << printfFifoSize << std::endl;
                 // cudaDeviceSetLimit(cudaLimitPrintfFifoSize, printfFifoSize*10);
                 // cudaDeviceGetLimit(&printfFifoSize, cudaLimitPrintfFifoSize);
                 // std::cout << __func__ << "INFO: printfFifoSize: " <<  printfFifoSize << std::endl;
-#    endif
+#        endif
                 auto const gridBlockExtent = getWorkDiv<Grid, Blocks>(task);
                 auto const blockThreadExtent = getWorkDiv<Block, Threads>(task);
                 auto const threadElemExtent = getWorkDiv<Thread, Elems>(task);
 
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                 dim3 const gridDim = uniform_cuda_hip::detail::convertVecToUniformCudaHipDim(gridBlockExtent);
                 dim3 const blockDim = uniform_cuda_hip::detail::convertVecToUniformCudaHipDim(blockThreadExtent);
-#    else
+#        else
                 dim3 gridDim = uniform_cuda_hip::detail::convertVecToUniformCudaHipDim(gridBlockExtent);
                 dim3 blockDim = uniform_cuda_hip::detail::convertVecToUniformCudaHipDim(blockThreadExtent);
-#    endif
+#        endif
                 uniform_cuda_hip::detail::checkVecOnly3Dim(threadElemExtent);
 
 
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << "gridDim: " << gridDim.z << " " << gridDim.y << " " << gridDim.x << std::endl;
                 std::cout << __func__ << "blockDim: " << blockDim.z << " " << blockDim.y << " " << blockDim.x
                           << std::endl;
-#    endif
+#        endif
 
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                 // This checks for a valid work division that is also compliant with the maxima of the accelerator.
                 if(!isValidWorkDiv<TAcc>(getDev(queue), task))
                 {
@@ -351,7 +353,7 @@ namespace alpaka
                         "The given work division is not valid or not supported by the device of type "
                         + getAccName<AccGpuUniformCudaHipRt<TDim, TIdx>>() + "!");
                 }
-#    endif
+#        endif
 
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes = std::apply(
@@ -364,20 +366,20 @@ namespace alpaka
                     },
                     task.m_args);
 
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 // Log the block shared memory idx.
                 std::cout << __func__ << " BlockSharedMemDynSizeBytes: " << blockSharedMemDynSizeBytes << " B"
                           << std::endl;
-#    endif
+#        endif
 
                 auto kernelName = uniform_cuda_hip::detail::
                     uniformCudaHipKernel<TAcc, TDim, TIdx, TKernelFnObj, remove_restrict_t<std::decay_t<TArgs>>...>;
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 // hipFuncAttributes not ported from HIP to HIP.
                 // TODO why this is currently not possible
                 //
                 // Log the function attributes.
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#            if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                 ALPAKA_API_PREFIX(FuncAttributes) funcAttrs;
                 ALPAKA_API_PREFIX(FuncGetAttributes)(&funcAttrs, kernelName);
                 std::cout << __func__ << " binaryVersion: " << funcAttrs.binaryVersion
@@ -386,8 +388,8 @@ namespace alpaka
                           << " maxThreadsPerBlock: " << funcAttrs.maxThreadsPerBlock
                           << " numRegs: " << funcAttrs.numRegs << " ptxVersion: " << funcAttrs.ptxVersion
                           << " sharedSizeBytes: " << funcAttrs.sharedSizeBytes << " B" << std::endl;
+#            endif
 #        endif
-#    endif
 
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.m_iDevice));
@@ -396,7 +398,7 @@ namespace alpaka
                 std::apply(
                     [&](remove_restrict_t<ALPAKA_DECAY_T(TArgs)> const&... args)
                     {
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                         kernelName<<<
                             gridDim,
                             blockDim,
@@ -405,7 +407,7 @@ namespace alpaka
                             threadElemExtent,
                             task.m_kernelFnObj,
                             args...);
-#    else
+#        else
                         hipLaunchKernelGGL(
                             HIP_KERNEL_NAME(kernelName),
                             gridDim,
@@ -415,7 +417,7 @@ namespace alpaka
                             threadElemExtent,
                             task.m_kernelFnObj,
                             args...);
-#    endif
+#        endif
                     },
                     task.m_args);
 
@@ -423,14 +425,16 @@ namespace alpaka
                 // Do not use the alpaka::wait method because it checks the error itself but we want to give a custom
                 // error message.
                 std::ignore = ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->m_UniformCudaHipQueue);
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                 std::string const msg(
                     "'execution of kernel: '" + std::string(typeid(TKernelFnObj).name()) + "' failed with");
                 ::alpaka::uniform_cuda_hip::detail::rtCheckLastError(msg.c_str(), __FILE__, __LINE__);
-#    endif
+#        endif
             }
         };
     } // namespace traits
 } // namespace alpaka
+
+#    endif
 
 #endif

--- a/include/alpaka/math/abs/AbsUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class AbsUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathAbs, AbsUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -52,6 +64,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/acos/AcosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class AcosUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathAcos, AcosUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/asin/AsinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class AsinUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathAsin, AsinUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/atan/AtanUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class AtanUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathAtan, AtanUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/atan2/Atan2UniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2UniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class Atan2UniformCudaHipBuiltIn : public concepts::Implements<ConceptMathAtan2, Atan2UniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -50,6 +62,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/cbrt/CbrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class CbrtUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathCbrt, CbrtUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/ceil/CeilUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class CeilUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathCeil, CeilUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/cos/CosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class CosUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathCos, CosUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/erf/ErfUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class ErfUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathErf, ErfUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/exp/ExpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class ExpUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathExp, ExpUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/floor/FloorUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class FloorUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathFloor, FloorUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/fmod/FmodUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class FmodUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathFmod, FmodUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -52,6 +64,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/isfinite/IsfiniteUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/isfinite/IsfiniteUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jeffrey Kelling, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jeffrey Kelling, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/math/isfinite/Traits.hpp>
 
@@ -26,6 +28,16 @@ namespace alpaka
         {
         };
 
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
+
         namespace traits
         {
             //! The CUDA isfinite trait specialization.
@@ -38,6 +50,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/isinf/IsinfUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/isinf/IsinfUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jeffrey Kelling, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jeffrey Kelling, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/math/isinf/Traits.hpp>
 
@@ -25,6 +27,16 @@ namespace alpaka
         {
         };
 
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
+
         namespace traits
         {
             //! The CUDA isinf trait specialization.
@@ -37,6 +49,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/isnan/IsnanUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/isnan/IsnanUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jeffrey Kelling, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jeffrey Kelling, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/math/isnan/Traits.hpp>
 
@@ -25,6 +27,16 @@ namespace alpaka
         {
         };
 
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
+
         namespace traits
         {
             //! The CUDA isnan trait specialization.
@@ -37,6 +49,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/log/LogUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/log/LogUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class LogUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathLog, LogUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/max/MaxStdLib.hpp
+++ b/include/alpaka/math/max/MaxStdLib.hpp
@@ -45,6 +45,8 @@ namespace alpaka
                         return fmax(x, y);
                     else
                         static_assert(!sizeof(Tx), "Unsupported data type");
+
+                    ALPAKA_UNREACHABLE(std::common_type_t<Tx, Ty>{});
                 }
             };
         } // namespace traits

--- a/include/alpaka/math/max/MaxUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -6,10 +6,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+
 #pragma once
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -25,6 +28,16 @@ namespace alpaka
         class MaxUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathMax, MaxUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -59,6 +72,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/min/MinStdLib.hpp
+++ b/include/alpaka/math/min/MinStdLib.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <alpaka/core/Decay.hpp>
+#include <alpaka/core/Unreachable.hpp>
 #include <alpaka/math/min/Traits.hpp>
 
 #include <algorithm>
@@ -45,6 +46,8 @@ namespace alpaka
                         return fmin(x, y);
                     else
                         static_assert(!sizeof(Tx), "Unsupported data type");
+
+                    ALPAKA_UNREACHABLE(std::common_type_t<Tx, Ty>{});
                 }
             };
         } // namespace traits

--- a/include/alpaka/math/min/MinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/min/MinUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Alexander Matthes, Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Alexander Matthes, Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class MinUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathMin, MinUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -60,6 +72,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/pow/PowUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class PowUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathPow, PowUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -55,6 +67,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/remainder/RemainderUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -27,6 +29,16 @@ namespace alpaka
             : public concepts::Implements<ConceptMathRemainder, RemainderUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -56,6 +68,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/round/RoundUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class RoundUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathRound, RoundUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -82,6 +94,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/rsqrt/RsqrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Valentin Gehrke, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Valentin Gehrke, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class RsqrtUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathRsqrt, RsqrtUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/sin/SinUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Valentin Gehrke, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Valentin Gehrke, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class SinUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathSin, SinUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/sincos/SinCosUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sincos/SinCosUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Jan Stephan
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class SinCosUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathSinCos, SinCosUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -48,6 +60,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/sqrt/SqrtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Valentin Gehrke, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Valentin Gehrke, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class SqrtUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathSqrt, SqrtUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/tan/TanUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class TanUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathTan, TanUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/math/trunc/TruncUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, René Widera, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Bert Wesarg, René Widera, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
+#    include <alpaka/core/BoostPredef.hpp>
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/CudaHipMath.hpp>
 #    include <alpaka/core/Decay.hpp>
 #    include <alpaka/core/Unreachable.hpp>
@@ -26,6 +28,16 @@ namespace alpaka
         class TruncUniformCudaHipBuiltIn : public concepts::Implements<ConceptMathTrunc, TruncUniformCudaHipBuiltIn>
         {
         };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
         namespace traits
         {
@@ -46,6 +58,9 @@ namespace alpaka
                 }
             };
         } // namespace traits
+
+#    endif
+
     } // namespace math
 } // namespace alpaka
 

--- a/include/alpaka/mem/alloc/AllocCpuAligned.hpp
+++ b/include/alpaka/mem/alloc/AllocCpuAligned.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,7 @@
 
 #include <alpaka/core/AlignedAlloc.hpp>
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Concepts.hpp>
 #include <alpaka/mem/alloc/Traits.hpp>
 
 #include <algorithm>
@@ -35,7 +36,7 @@ namespace alpaka
                 AllocCpuAligned<TAlignment> const& /* alloc */,
                 std::size_t const& sizeElems) -> T*
             {
-#if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
                 // For CUDA host memory must be aligned to 4 kib to pin it with `cudaHostRegister`,
                 // this was described in older programming guides but was removed later.
                 // From testing with PIConGPU and cuda-memcheck we found out that the alignment is still required.

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -56,7 +56,7 @@ namespace alpaka
                 , m_pMem(pMem)
                 , m_deleter(std::move(deleter))
                 , m_pitchBytes(static_cast<TIdx>(extent::getWidth(extent) * static_cast<TIdx>(sizeof(TElem))))
-#if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
                 , m_bPinned(false)
 #endif
             {
@@ -81,7 +81,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-#if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
                 // Unpin this memory if it is currently pinned.
                 unpin(*this);
 #endif
@@ -95,7 +95,7 @@ namespace alpaka
             TElem* const m_pMem;
             std::function<void(TElem*)> m_deleter;
             TIdx const m_pitchBytes;
-#if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
             bool m_bPinned;
 #endif
         };
@@ -316,7 +316,7 @@ namespace alpaka
 
                 if(!isPinned(buf))
                 {
-#if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
                     if(buf.m_spBufCpuImpl->m_extentElements.prod() != 0)
                     {
                         // - cudaHostRegisterDefault:
@@ -360,7 +360,7 @@ namespace alpaka
 
                 if(isPinned(bufImpl))
                 {
-#if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
                         ALPAKA_API_PREFIX(HostUnregister)(
                             const_cast<void*>(reinterpret_cast<void const*>(bufImpl.m_pMem))),
@@ -393,7 +393,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-#if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
                 return bufImpl.m_bPinned;
 #else
                 return false;
@@ -409,7 +409,7 @@ namespace alpaka
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
                 // to optimize the data transfer performance between a cuda/hip device the cpu buffer has to be pinned,
                 // for exclusive cpu use, no preparing is needed
-#if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
                 pin(buf);
 #endif
             }

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -11,16 +11,6 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
-
 // Backend specific includes.
 #    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
 #        include <alpaka/core/Cuda.hpp>
@@ -422,7 +412,7 @@ namespace alpaka
         template<typename TElem, typename TIdx>
         struct AsyncBufAlloc<TElem, DimInt<1u>, TIdx, DevUniformCudaHipRt>
         {
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && (BOOST_LANG_CUDA < BOOST_VERSION_NUMBER(11, 2, 0))
+#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && (CUDA_VERSION < 11020)
             static_assert(
                 meta::DependentFalseType<TElem>::value,
                 "Support for stream-ordered memory buffers requires CUDA 11.2 or higher.");

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -10,16 +10,6 @@
 #pragma once
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
-
 #    include <alpaka/core/Assert.hpp>
 #    include <alpaka/dev/DevCpu.hpp>
 #    include <alpaka/dev/DevUniformCudaHipRt.hpp>
@@ -64,7 +54,7 @@ namespace alpaka
                 std::is_same<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>::value,
                 "The source and the destination views are required to have the same element type!");
 
-            using Idx = Idx<TExtent>;
+            using Idx = alpaka::Idx<TExtent>;
 
             ALPAKA_FN_HOST TaskCopyUniformCudaHip(
                 TViewDst& viewDst,
@@ -129,6 +119,7 @@ namespace alpaka
             void* m_dstMemNative;
             void const* m_srcMemNative;
         };
+
         //! The 1D CUDA/HIP memory copy trait.
         template<typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyUniformCudaHip<DimInt<1u>, TViewDst, TViewSrc, TExtent>
@@ -145,7 +136,7 @@ namespace alpaka
                 std::is_same<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>::value,
                 "The source and the destination views are required to have the same element type!");
 
-            using Idx = Idx<TExtent>;
+            using Idx = alpaka::Idx<TExtent>;
 
             ALPAKA_FN_HOST TaskCopyUniformCudaHip(
                 TViewDst& viewDst,
@@ -219,6 +210,7 @@ namespace alpaka
             void* m_dstMemNative;
             void const* m_srcMemNative;
         };
+
         //! The 2D CUDA/HIP memory copy trait.
         template<typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyUniformCudaHip<DimInt<2u>, TViewDst, TViewSrc, TExtent>
@@ -235,7 +227,7 @@ namespace alpaka
                 std::is_same<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>::value,
                 "The source and the destination views are required to have the same element type!");
 
-            using Idx = Idx<TExtent>;
+            using Idx = alpaka::Idx<TExtent>;
 
             ALPAKA_FN_HOST TaskCopyUniformCudaHip(
                 TViewDst& viewDst,
@@ -320,7 +312,6 @@ namespace alpaka
             MemcpyKind m_uniformMemCpyKind;
             int m_iDstDevice;
             int m_iSrcDevice;
-
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
             Idx m_extentWidth;
 #    endif
@@ -338,10 +329,10 @@ namespace alpaka
             Idx m_dstPitchBytesY;
             Idx m_srcPitchBytesY;
 
-
             void* m_dstMemNative;
             void const* m_srcMemNative;
         };
+
         //! The 3D CUDA/HIP memory copy trait.
         template<typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyUniformCudaHip<DimInt<3u>, TViewDst, TViewSrc, TExtent>
@@ -358,7 +349,7 @@ namespace alpaka
                 std::is_same<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>::value,
                 "The source and the destination views are required to have the same element type!");
 
-            using Idx = Idx<TExtent>;
+            using Idx = alpaka::Idx<TExtent>;
 
             ALPAKA_FN_HOST TaskCopyUniformCudaHip(
                 TViewDst& viewDst,
@@ -528,6 +519,7 @@ namespace alpaka
                     iDevice);
             }
         };
+
         //! The CPU to CUDA/HIP memory copy trait specialization.
         template<typename TDim>
         struct CreateTaskMemcpy<TDim, DevUniformCudaHipRt, DevCpu>
@@ -551,6 +543,7 @@ namespace alpaka
                     iDevice);
             }
         };
+
         //! The CUDA/HIP to CUDA/HIP memory copy trait specialization.
         template<typename TDim>
         struct CreateTaskMemcpy<TDim, DevUniformCudaHipRt, DevUniformCudaHipRt>
@@ -588,6 +581,7 @@ namespace alpaka
                 task.enqueue(queue);
             }
         };
+
         //! The CUDA/HIP blocking device queue scalar copy enqueue trait specialization.
         template<typename TExtent, typename TViewSrc, typename TViewDst>
         struct Enqueue<
@@ -606,6 +600,7 @@ namespace alpaka
                     ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->m_UniformCudaHipQueue));
             }
         };
+
         //! The CUDA/HIP non-blocking device queue 1D copy enqueue trait specialization.
         template<typename TExtent, typename TViewSrc, typename TViewDst>
         struct Enqueue<
@@ -621,6 +616,7 @@ namespace alpaka
                 task.enqueue(queue);
             }
         };
+
         //! The CUDA/HIP blocking device queue 1D copy enqueue trait specialization.
         template<typename TExtent, typename TViewSrc, typename TViewDst>
         struct Enqueue<
@@ -639,6 +635,7 @@ namespace alpaka
                     ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->m_UniformCudaHipQueue));
             }
         };
+
         //! The CUDA/HIP non-blocking device queue 2D copy enqueue trait specialization.
         template<typename TExtent, typename TViewSrc, typename TViewDst>
         struct Enqueue<
@@ -654,6 +651,7 @@ namespace alpaka
                 task.enqueue(queue);
             }
         };
+
         //! The CUDA/HIP blocking device queue 2D copy enqueue trait specialization.
         template<typename TExtent, typename TViewSrc, typename TViewDst>
         struct Enqueue<
@@ -672,6 +670,7 @@ namespace alpaka
                     ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->m_UniformCudaHipQueue));
             }
         };
+
         //! The CUDA/HIP non-blocking device queue 3D copy enqueue trait specialization.
         template<typename TExtent, typename TViewSrc, typename TViewDst>
         struct Enqueue<
@@ -687,6 +686,7 @@ namespace alpaka
                 task.enqueue(queue);
             }
         };
+
         //! The CUDA/HIP blocking device queue 3D copy enqueue trait specialization.
         template<typename TExtent, typename TViewSrc, typename TViewDst>
         struct Enqueue<

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -11,12 +11,6 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if !BOOST_LANG_CUDA && !BOOST_LANG_HIP
-#        error Compiler has to support CUDA/HIP!
-#    endif
-
 #    include <alpaka/core/Assert.hpp>
 #    include <alpaka/dev/Traits.hpp>
 #    include <alpaka/dim/DimIntegralConst.hpp>

--- a/include/alpaka/mem/fence/MemFenceUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/mem/fence/MemFenceUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Jan Stephan
+/* Copyright 2022 Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -12,15 +12,6 @@
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
 #    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
-
 #    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/mem/fence/Traits.hpp>
 
@@ -30,6 +21,16 @@ namespace alpaka
     class MemFenceUniformCudaHipBuiltIn : public concepts::Implements<ConceptMemFence, MemFenceUniformCudaHipBuiltIn>
     {
     };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
     namespace traits
     {
@@ -51,6 +52,9 @@ namespace alpaka
             }
         };
     } // namespace traits
+
+#    endif
+
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
+++ b/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, René Widera
+/* Copyright 2022 Benjamin Worpitz, René Widera, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,16 +11,7 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
-
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/dev/DevUniformCudaHipRt.hpp>
 #    include <alpaka/dev/Traits.hpp>
 

--- a/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, René Widera
+/* Copyright 2022 Benjamin Worpitz, René Widera, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -10,16 +10,6 @@
 #pragma once
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
 
 #    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/dev/DevUniformCudaHipRt.hpp>

--- a/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, Matthias Werner, René Widera
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -10,16 +10,6 @@
 #pragma once
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
 
 #    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/dev/DevUniformCudaHipRt.hpp>

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Matthias Werner, René Widera
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -11,16 +11,6 @@
 
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-
-#    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
 
 #    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/dev/DevUniformCudaHipRt.hpp>

--- a/include/alpaka/rand/RandUniformCudaHipRand.hpp
+++ b/include/alpaka/rand/RandUniformCudaHipRand.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, René Widera
+/* Copyright 2022 Benjamin Worpitz, René Widera, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -12,15 +12,7 @@
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
 #    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
-
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/dev/DevUniformCudaHipRt.hpp>
 #    include <alpaka/rand/Traits.hpp>
 
@@ -41,7 +33,6 @@
 #        pragma clang diagnostic pop
 #    endif
 
-
 #    include <type_traits>
 
 namespace alpaka
@@ -53,6 +44,16 @@ namespace alpaka
         {
         };
 
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
+
         namespace engine
         {
             namespace uniform_cuda_hip
@@ -63,11 +64,11 @@ namespace alpaka
                 public:
                     // After calling this constructor the instance is not valid initialized and
                     // need to be overwritten with a valid object
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                     ALPAKA_FN_HOST_ACC Xor() : state(curandStateXORWOW_t{})
-#    else
+#        else
                     ALPAKA_FN_HOST_ACC Xor() : state(hiprandStateXORWOW_t{})
-#    endif
+#        endif
                     {
                     }
 
@@ -76,29 +77,29 @@ namespace alpaka
                         std::uint32_t const& subsequence = 0,
                         std::uint32_t const& offset = 0)
                     {
-#    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                         curand_init(seed, subsequence, offset, &state);
-#    else
+#        else
                         hiprand_init(seed, subsequence, offset, &state);
-#    endif
+#        endif
                     }
 
                 public:
-#    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                     curandStateXORWOW_t state;
-#    else
+#        else
                     hiprandStateXORWOW_t state;
-#    endif
+#        endif
 
                     // STL UniformRandomBitGenerator concept. This is not strictly necessary as the distributions
                     // contained in this file are aware of the API specifics of the CUDA/HIP XORWOW engine and STL
                     // distributions might not work on the device, but it servers a compatibility bridge to other
                     // potentially compatible alpaka distributions.
-#    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                     using result_type = decltype(curand(&state));
-#    else
+#        else
                     using result_type = decltype(hiprand(&state));
-#    endif
+#        endif
                     ALPAKA_FN_HOST_ACC constexpr static result_type min()
                     {
                         return std::numeric_limits<result_type>::min();
@@ -109,15 +110,16 @@ namespace alpaka
                     }
                     __device__ result_type operator()()
                     {
-#    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                         return curand(&state);
-#    else
+#        else
                         return hiprand(&state);
-#    endif
+#        endif
                     }
                 };
             } // namespace uniform_cuda_hip
         } // namespace engine
+
         namespace distribution
         {
             namespace uniform_cuda_hip
@@ -134,13 +136,14 @@ namespace alpaka
                     template<typename TEngine>
                     __device__ auto operator()(TEngine& engine) -> float
                     {
-#    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                         return curand_normal(&engine.state);
-#    else
+#        else
                         return hiprand_normal(&engine.state);
-#    endif
+#        endif
                     }
                 };
+
                 //! The CUDA/HIP random number float normal distribution.
                 template<>
                 class NormalReal<double>
@@ -149,11 +152,11 @@ namespace alpaka
                     template<typename TEngine>
                     __device__ auto operator()(TEngine& engine) -> double
                     {
-#    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                         return curand_normal_double(&engine.state);
-#    else
+#        else
                         return hiprand_normal_double(&engine.state);
-#    endif
+#        endif
                     }
                 };
 
@@ -170,16 +173,17 @@ namespace alpaka
                     __device__ auto operator()(TEngine& engine) -> float
                     {
                         // (0.f, 1.0f]
-#    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                         float const fUniformRand(curand_uniform(&engine.state));
-#    else
+#        else
                         float const fUniformRand(hiprand_uniform(&engine.state));
-#    endif
+#        endif
                         // NOTE: (1.0f - curand_uniform) does not work, because curand_uniform seems to return
                         // denormalized floats around 0.f. [0.f, 1.0f)
                         return fUniformRand * static_cast<float>(fUniformRand != 1.0f);
                     }
                 };
+
                 //! The CUDA/HIP random number float uniform distribution.
                 template<>
                 class UniformReal<double>
@@ -189,11 +193,11 @@ namespace alpaka
                     __device__ auto operator()(TEngine& engine) -> double
                     {
                         // (0.f, 1.0f]
-#    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                         double const fUniformRand(curand_uniform_double(&engine.state));
-#    else
+#        else
                         double const fUniformRand(hiprand_uniform_double(&engine.state));
-#    endif
+#        endif
                         // NOTE: (1.0f - curand_uniform_double) does not work, because curand_uniform_double seems to
                         // return denormalized floats around 0.f. [0.f, 1.0f)
                         return fUniformRand * static_cast<double>(fUniformRand != 1.0);
@@ -212,11 +216,11 @@ namespace alpaka
                     template<typename TEngine>
                     __device__ auto operator()(TEngine& engine) -> unsigned int
                     {
-#    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                         return curand(&engine.state);
-#    else
+#        else
                         return hiprand(&engine.state);
-#    endif
+#        endif
                     }
                 };
             } // namespace uniform_cuda_hip
@@ -236,6 +240,7 @@ namespace alpaka
                         return rand::distribution::uniform_cuda_hip::NormalReal<T>();
                     }
                 };
+
                 //! The CUDA/HIP random number float uniform distribution get trait specialization.
                 template<typename T>
                 struct CreateUniformReal<RandUniformCudaHipRand, T, std::enable_if_t<std::is_floating_point<T>::value>>
@@ -246,6 +251,7 @@ namespace alpaka
                         return rand::distribution::uniform_cuda_hip::UniformReal<T>();
                     }
                 };
+
                 //! The CUDA/HIP random number integer uniform distribution get trait specialization.
                 template<typename T>
                 struct CreateUniformUint<RandUniformCudaHipRand, T, std::enable_if_t<std::is_integral<T>::value>>
@@ -258,6 +264,7 @@ namespace alpaka
                 };
             } // namespace traits
         } // namespace distribution
+
         namespace engine
         {
             namespace traits
@@ -277,6 +284,9 @@ namespace alpaka
                 };
             } // namespace traits
         } // namespace engine
+
+#    endif
+
     } // namespace rand
 } // namespace alpaka
 

--- a/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/include/alpaka/test/KernelExecutionFixture.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz
+/* Copyright 2022 Benjamin Worpitz, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -10,6 +10,15 @@
 #pragma once
 
 #include <alpaka/alpaka.hpp>
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#    error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#endif
+
+#if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#    error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#endif
+
 #include <alpaka/test/Check.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 

--- a/include/alpaka/test/acc/TestAccs.hpp
+++ b/include/alpaka/test/acc/TestAccs.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, Erik Zenker, Matthias Werner
+/* Copyright 2022 Benjamin Worpitz, Erik Zenker, Matthias Werner, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -120,7 +120,8 @@ namespace alpaka
             template<typename TDim, typename TIdx>
             using AccOaccIfAvailableElseInt = int;
 #endif
-#if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+#if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && (BOOST_LANG_CUDA || defined(ALPAKA_HOST_ONLY)))                           \
+    || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && (BOOST_LANG_HIP || defined(ALPAKA_HOST_ONLY)))
             template<typename TDim, typename TIdx>
             using AccGpuUniformCudaHipRtIfAvailableElseInt = alpaka::AccGpuUniformCudaHipRt<TDim, TIdx>;
 #else
@@ -128,14 +129,14 @@ namespace alpaka
             using AccGpuUniformCudaHipRtIfAvailableElseInt = int;
 #endif
 
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && (BOOST_LANG_CUDA || defined(ALPAKA_HOST_ONLY))
             template<typename TDim, typename TIdx>
             using AccGpuCudaRtIfAvailableElseInt = alpaka::AccGpuCudaRt<TDim, TIdx>;
 #else
             template<typename TDim, typename TIdx>
             using AccGpuCudaRtIfAvailableElseInt = int;
 #endif
-#if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP
+#if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && (BOOST_LANG_HIP || defined(ALPAKA_HOST_ONLY))
             template<typename TDim, typename TIdx>
             using AccGpuHipRtIfAvailableElseInt = typename std::conditional<
                 std::is_same<TDim, alpaka::DimInt<3u>>::value == false,

--- a/include/alpaka/test/dim/TestDims.hpp
+++ b/include/alpaka/test/dim/TestDims.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz
+/* Copyright 2022 Benjamin Worpitz, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -24,11 +24,9 @@ namespace alpaka
             alpaka::DimInt<2u>,
             alpaka::DimInt<3u>
         // The CUDA & HIP accelerators do not currently support 4D buffers and 4D acceleration.
-#if !(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA)
-#    if !(defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
+#if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED)
             ,
             alpaka::DimInt<4u>
-#    endif
 #endif
             >;
     } // namespace test

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Jan Stephan
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -282,7 +282,7 @@ namespace alpaka
 
 #    include <cuda.h>
 
-#    if !BOOST_LANG_CUDA
+#    if !BOOST_LANG_CUDA && !defined(ALPAKA_HOST_ONLY)
 #        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #    endif
 
@@ -496,7 +496,7 @@ namespace alpaka
 
 #    include <hip/hip_runtime.h>
 
-#    if !BOOST_LANG_HIP
+#    if !BOOST_LANG_HIP && !defined(ALPAKA_HOST_ONLY)
 #        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #    endif
 

--- a/include/alpaka/time/TimeUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/time/TimeUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz
+/* Copyright 2022 Benjamin Worpitz, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -12,15 +12,7 @@
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
 #    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
-
+#    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/time/Traits.hpp>
 
 namespace alpaka
@@ -29,6 +21,16 @@ namespace alpaka
     class TimeUniformCudaHipBuiltIn : public concepts::Implements<ConceptTime, TimeUniformCudaHipBuiltIn>
     {
     };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
     namespace traits
     {
@@ -45,6 +47,9 @@ namespace alpaka
             }
         };
     } // namespace traits
+
+#    endif
+
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -186,8 +186,9 @@ namespace alpaka
                         return false;
                     }
                 }
+                return true;
             }
-            return true;
+            ALPAKA_UNREACHABLE(bool{});
         }
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC auto operator!=(Vec const& rhs) const -> bool

--- a/include/alpaka/workdiv/WorkDivUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/workdiv/WorkDivUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -12,14 +12,10 @@
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
 #    include <alpaka/core/BoostPredef.hpp>
-
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#        error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#    endif
-
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#        error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#    endif
+#    include <alpaka/core/Concepts.hpp>
+#    include <alpaka/idx/Traits.hpp>
+#    include <alpaka/vec/Vec.hpp>
+#    include <alpaka/workdiv/Traits.hpp>
 
 // Backend specific includes.
 #    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
@@ -27,10 +23,6 @@
 #    else
 #        include <alpaka/core/Hip.hpp>
 #    endif
-
-#    include <alpaka/idx/Traits.hpp>
-#    include <alpaka/vec/Vec.hpp>
-#    include <alpaka/workdiv/Traits.hpp>
 
 namespace alpaka
 {
@@ -40,7 +32,7 @@ namespace alpaka
         : public concepts::Implements<ConceptWorkDiv, WorkDivUniformCudaHipBuiltIn<TDim, TIdx>>
     {
     public:
-        __device__ WorkDivUniformCudaHipBuiltIn(Vec<TDim, TIdx> const& threadElemExtent)
+        ALPAKA_FN_HOST_ACC WorkDivUniformCudaHipBuiltIn(Vec<TDim, TIdx> const& threadElemExtent)
             : m_threadElemExtent(threadElemExtent)
         {
         }
@@ -50,6 +42,16 @@ namespace alpaka
         // to reduce the register usage.
         Vec<TDim, TIdx> const& m_threadElemExtent;
     };
+
+#    if !defined(ALPAKA_HOST_ONLY)
+
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#        endif
+
+#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#        endif
 
     namespace traits
     {
@@ -75,14 +77,14 @@ namespace alpaka
             __device__ static auto getWorkDiv(WorkDivUniformCudaHipBuiltIn<TDim, TIdx> const& /* workDiv */)
                 -> Vec<TDim, TIdx>
             {
-#    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                 return castVec<TIdx>(extent::getExtentVecEnd<TDim>(gridDim));
-#    else
+#        else
                 return extent::getExtentVecEnd<TDim>(Vec<std::integral_constant<typename TDim::value_type, 3>, TIdx>(
                     static_cast<TIdx>(hipGridDim_z),
                     static_cast<TIdx>(hipGridDim_y),
                     static_cast<TIdx>(hipGridDim_x)));
-#    endif
+#        endif
             }
         };
 
@@ -94,14 +96,14 @@ namespace alpaka
             __device__ static auto getWorkDiv(WorkDivUniformCudaHipBuiltIn<TDim, TIdx> const& /* workDiv */)
                 -> Vec<TDim, TIdx>
             {
-#    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                 return castVec<TIdx>(extent::getExtentVecEnd<TDim>(blockDim));
-#    else
+#        else
                 return extent::getExtentVecEnd<TDim>(Vec<std::integral_constant<typename TDim::value_type, 3>, TIdx>(
                     static_cast<TIdx>(hipBlockDim_z),
                     static_cast<TIdx>(hipBlockDim_y),
                     static_cast<TIdx>(hipBlockDim_x)));
-#    endif
+#        endif
             }
         };
 
@@ -117,6 +119,9 @@ namespace alpaka
             }
         };
     } // namespace traits
+
+#    endif
+
 } // namespace alpaka
 
 #endif

--- a/test/integ/CMakeLists.txt
+++ b/test/integ/CMakeLists.txt
@@ -22,6 +22,7 @@ project("alpakaIntegTest" LANGUAGES CXX)
 
 add_subdirectory("axpy/")
 add_subdirectory("cudaOnly/")
+add_subdirectory("hostOnlyAPI/")
 add_subdirectory("mandelbrot/")
 add_subdirectory("matMul/")
 add_subdirectory("separableCompilation/")

--- a/test/integ/hostOnlyAPI/CMakeLists.txt
+++ b/test/integ/hostOnlyAPI/CMakeLists.txt
@@ -1,0 +1,28 @@
+#
+# Copyright 2022 Andrea Bocci
+#
+# This file is part of alpaka.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+set(_TARGET_NAME "hostOnlyAPITest")
+
+append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
+
+add_executable(
+    ${_TARGET_NAME}
+    ${_FILES_SOURCE})
+target_link_libraries(
+    ${_TARGET_NAME}
+    PRIVATE common)
+
+target_compile_definitions(${_TARGET_NAME} PRIVATE ALPAKA_HOST_ONLY)
+
+set_target_properties(${_TARGET_NAME} PROPERTIES FOLDER "test/integ")
+
+if(ALPAKA_ACC_GPU_CUDA_ENABLE OR ALPAKA_ACC_GPU_HIP_ENABLE)
+    add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME} ${_ALPAKA_TEST_OPTIONS})
+endif()

--- a/test/integ/hostOnlyAPI/src/hostOnlyAPI.cpp
+++ b/test/integ/hostOnlyAPI/src/hostOnlyAPI.cpp
@@ -1,0 +1,181 @@
+/* Copyright 2022 Andrea Bocci
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
+
+#include <catch2/catch.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+
+// fill an trivial type with std::memset
+template<typename T>
+constexpr T memset_value(int c)
+{
+    T t;
+    std::memset(&t, c, sizeof(T));
+    return t;
+}
+
+//! check if asynchronous (queue-ordered) memory buffers are supported by the given Accelerator
+template<typename TAcc>
+static constexpr auto isAsyncBufferSupported() -> bool
+{
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+    if constexpr(std::is_same_v<alpaka::Dev<TAcc>, alpaka::DevCudaRt>)
+    {
+        return (BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(11, 2, 0)) && (alpaka::Dim<TAcc>::value == 1);
+    }
+    else
+#endif // ALPAKA_ACC_GPU_CUDA_ENABLED
+
+#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
+        if constexpr(std::is_same_v<alpaka::Dev<TAcc>, alpaka::DevHipRt>)
+    {
+        return false;
+    }
+    else
+#endif // ALPAKA_ACC_GPU_HIP_ENABLED
+
+#ifdef ALPAKA_ACC_ANY_BT_OACC_ENABLED
+        if constexpr(std::is_same_v<alpaka::Dev<TAcc>, alpaka::DevOacc>)
+    {
+        return false;
+    }
+    else
+#endif // ALPAKA_ACC_ANY_BT_OACC_ENABLED
+
+#ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
+        if constexpr(std::is_same_v<alpaka::Dev<TAcc>, alpaka::DevOmp5>)
+    {
+        return false;
+    }
+    else
+#endif // ALPAKA_ACC_ANY_BT_OMP5_ENABLED
+
+        return true;
+}
+
+template<typename TAcc, typename TElem, typename TIdx, typename TQueue, typename TExtent>
+auto allocAsyncBufIfSupported(TQueue const& queue, TExtent const& extent)
+    -> alpaka::Buf<alpaka::Dev<TQueue>, TElem, alpaka::Dim<TExtent>, TIdx>
+{
+    if constexpr(isAsyncBufferSupported<TAcc>())
+    {
+        return alpaka::allocAsyncBuf<TElem, TIdx>(queue, extent);
+    }
+    else
+    {
+        return alpaka::allocBuf<TElem, TIdx>(alpaka::getDev(queue), extent);
+    }
+}
+
+// 0- and 1- dimensional space
+using Idx = std::size_t;
+using Dim1D = alpaka::DimInt<1u>;
+using Vec1D = alpaka::Vec<Dim1D, Idx>;
+
+// enabled accelerators with 1-dimensional kernel space
+using TestAccs = alpaka::test::EnabledAccs<Dim1D, Idx>;
+
+TEMPLATE_LIST_TEST_CASE("hostOnlyAPI", "[hostOnlyAPI]", TestAccs)
+{
+    using DeviceAcc = TestType;
+    using Device = alpaka::Dev<DeviceAcc>;
+    using DeviceQueue = alpaka::Queue<DeviceAcc, alpaka::NonBlocking>;
+
+    using HostAcc = alpaka::AccCpuSerial<Dim1D, Idx>;
+    using Host = alpaka::DevCpu;
+    using HostQueue = alpaka::Queue<HostAcc, alpaka::Blocking>;
+
+    // CPU host
+    auto const host = alpaka::getDevByIdx<Host>(0u);
+    INFO("Using alpaka accelerator: " << alpaka::getAccName<HostAcc>())
+    HostQueue hostQueue(host);
+
+    // host buffer
+    auto h_buffer1 = alpaka::allocBuf<int, Idx>(host, Vec1D{Idx{42}});
+    INFO(
+        "host buffer allocated at " << alpaka::getPtrNative(h_buffer1) << " with "
+                                    << alpaka::extent::getExtentProduct(h_buffer1) << " element(s)")
+
+    // async host buffer
+    auto h_buffer2 = allocAsyncBufIfSupported<HostAcc, int, Idx>(hostQueue, Vec1D{Idx{42}});
+    INFO(
+        "second host buffer allocated at " << alpaka::getPtrNative(h_buffer2) << " with "
+                                           << alpaka::extent::getExtentProduct(h_buffer2) << " element(s)")
+
+    // host-side memset
+    const int value1 = 42;
+    const int expected1 = memset_value<int>(value1);
+    INFO("host-side memset")
+    alpaka::memset(hostQueue, h_buffer1, value1);
+    alpaka::wait(hostQueue);
+    CHECK(expected1 == *alpaka::getPtrNative(h_buffer1));
+
+    // host-side async memset
+    const int value2 = 99;
+    const int expected2 = memset_value<int>(value2);
+    INFO("host-side async memset")
+    alpaka::memset(hostQueue, h_buffer2, value2);
+    alpaka::wait(hostQueue);
+    CHECK(expected2 == *alpaka::getPtrNative(h_buffer2));
+
+    // host-host copies
+    INFO("buffer host-host copies")
+    alpaka::memcpy(hostQueue, h_buffer2, h_buffer1);
+    alpaka::wait(hostQueue);
+    CHECK(expected1 == *alpaka::getPtrNative(h_buffer2));
+    alpaka::memcpy(hostQueue, h_buffer1, h_buffer2);
+    alpaka::wait(hostQueue);
+    CHECK(expected1 == *alpaka::getPtrNative(h_buffer1));
+
+    // GPU device
+    auto const device = alpaka::getDevByIdx<Device>(0u);
+    INFO("Using alpaka accelerator: " << alpaka::getAccName<DeviceAcc>())
+    DeviceQueue deviceQueue(device);
+
+    // device buffer
+    auto d_buffer1 = alpaka::allocBuf<int, Idx>(device, Vec1D{Idx{42}});
+    INFO(
+        "device buffer allocated at " << alpaka::getPtrNative(d_buffer1) << " with "
+                                      << alpaka::extent::getExtentProduct(d_buffer1) << " element(s)")
+
+    // async or second sync device buffer
+    auto d_buffer2 = allocAsyncBufIfSupported<DeviceAcc, int, Idx>(deviceQueue, Vec1D{Idx{42}});
+    INFO(
+        "second device buffer allocated at " << alpaka::getPtrNative(d_buffer2) << " with "
+                                             << alpaka::extent::getExtentProduct(d_buffer2) << " element(s)")
+
+    // host-device copies
+    INFO("host-device copies")
+    alpaka::memcpy(deviceQueue, d_buffer1, h_buffer1);
+    alpaka::memcpy(deviceQueue, d_buffer2, h_buffer2);
+
+    // device-device copies
+    INFO("device-device copies")
+    alpaka::memcpy(deviceQueue, d_buffer1, d_buffer2);
+    alpaka::memcpy(deviceQueue, d_buffer2, d_buffer1);
+
+    // device-side memset
+    INFO("device-side memset")
+    alpaka::memset(deviceQueue, d_buffer1, value1);
+    alpaka::memset(deviceQueue, d_buffer2, value2);
+
+    // device-host copies
+    INFO("device-host copies")
+    alpaka::memcpy(deviceQueue, h_buffer1, d_buffer1);
+    alpaka::memcpy(deviceQueue, h_buffer2, d_buffer2);
+
+    alpaka::wait(deviceQueue);
+    CHECK(expected1 == *alpaka::getPtrNative(h_buffer1));
+    CHECK(expected2 == *alpaka::getPtrNative(h_buffer2));
+}


### PR DESCRIPTION
This PR is equivalent to #1567, without
```diff
diff --git a/test/integ/hostOnlyAPI/CMakeLists.txt b/test/integ/hostOnlyAPI/CMakeLists.txt
index b67fcaf1db..a12583fda2 100644
--- a/test/integ/hostOnlyAPI/CMakeLists.txt
+++ b/test/integ/hostOnlyAPI/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(
     ${_TARGET_NAME}
     PRIVATE common)
 
-target_compile_definitions(${_TARGET_NAME} PRIVATE ALPAKA_HOST_ONLY)
+target_compile_definitions(${_TARGET_NAME} PRIVATE ALPAKA_HOST_ONLY ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
 
 set_target_properties(${_TARGET_NAME} PROPERTIES FOLDER "test/integ")
 
```