### PR TITLE
Add hasAsyncBufSupport trait, and update tests to use it

### DIFF
--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -277,6 +277,12 @@ namespace alpaka
                 return BufCpu<TElem, TDim, TIdx>(dev, memPtr, std::move(deleter), extent);
             }
         };
+        //! The BufCpu stream-ordered memory allocation capability trait specialization.
+        template<typename TDim>
+        struct HasAsyncBufSupport<TDim, DevCpu> : public std::true_type
+        {
+        };
+
         //! The BufCpu memory mapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Map<BufCpu<TElem, TDim, TIdx>, DevCpu>

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -468,6 +468,18 @@ namespace alpaka
                 meta::DependentFalseType<TElem>::value,
                 "HIP/CUDA devices support only one-dimensional stream-ordered memory buffers.");
         };
+#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && (CUDA_VERSION >= 11020)
+        //! The CUDA/HIP stream-ordered scalar memory allocation capability trait specialization.
+        template<>
+        struct HasAsyncBufSupport<DimInt<0u>, DevUniformCudaHipRt> : public std::true_type
+        {
+        };
+        //! The CUDA/HIP stream-ordered 1D memory allocation capability trait specialization.
+        template<>
+        struct HasAsyncBufSupport<DimInt<1u>, DevUniformCudaHipRt> : public std::true_type
+        {
+        };
+#    endif
 
         //! The BufUniformCudaHipRt CUDA/HIP device memory mapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -98,8 +98,17 @@ namespace alpaka
     //!
     //! TDev is the type of device to allocate the buffer on.
     //! TDim is the dimensionality of the buffer to allocate.
+    /* TODO: Remove the following pragmas once support for clang 5 and 6 is removed. They are necessary because these
+    /  clang versions incorrectly warn about a missing 'extern'. */
+#if BOOST_COMP_CLANG
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wmissing-variable-declarations"
+#endif
     template<typename TDev, typename TDim>
     constexpr inline bool hasAsyncBufSupport = traits::HasAsyncBufSupport<TDim, TDev>::value;
+#if BOOST_COMP_CLANG
+#    pragma clang diagnostic pop
+#endif
 
     //! Maps the buffer into the memory of the given device.
     //!

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -29,6 +29,12 @@ namespace alpaka
         template<typename TElem, typename TDim, typename TIdx, typename TDev, typename TSfinae = void>
         struct AsyncBufAlloc;
 
+        //! The stream-ordered memory allocator capability trait.
+        template<typename TDim, typename TDev>
+        struct HasAsyncBufSupport : public std::false_type
+        {
+        };
+
         //! The memory mapping trait.
         template<typename TBuf, typename TDev, typename TSfinae = void>
         struct Map;
@@ -87,6 +93,13 @@ namespace alpaka
     {
         return traits::AsyncBufAlloc<TElem, Dim<TExtent>, TIdx, alpaka::Dev<TQueue>>::allocAsyncBuf(queue, extent);
     }
+
+    //! Check if the given device can allocate a stream-ordered memory buffer of the given dimensionality.
+    //!
+    //! TDev is the type of device to allocate the buffer on.
+    //! TDim is the dimensionality of the buffer to allocate.
+    template<typename TDev, typename TDim>
+    constexpr inline bool hasAsyncBufSupport = traits::HasAsyncBufSupport<TDim, TDev>::value;
 
     //! Maps the buffer into the memory of the given device.
     //!

--- a/test/integ/hostOnlyAPI/src/hostOnlyAPI.cpp
+++ b/test/integ/hostOnlyAPI/src/hostOnlyAPI.cpp
@@ -25,51 +25,12 @@ constexpr T memset_value(int c)
     return t;
 }
 
-//! check if asynchronous (queue-ordered) memory buffers are supported by the given Accelerator
-template<typename TDev, typename TDim>
-static constexpr auto isAsyncBufferSupported() -> bool
-{
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-    if constexpr(std::is_same_v<TDev, alpaka::DevCudaRt>)
-    {
-        return (CUDA_VERSION >= 11020) && (TDim::value == 1);
-    }
-    else
-#endif // ALPAKA_ACC_GPU_CUDA_ENABLED
-
-#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-        if constexpr(std::is_same_v<TDev, alpaka::DevHipRt>)
-    {
-        return false;
-    }
-    else
-#endif // ALPAKA_ACC_GPU_HIP_ENABLED
-
-#ifdef ALPAKA_ACC_ANY_BT_OACC_ENABLED
-        if constexpr(std::is_same_v<TDev, alpaka::DevOacc>)
-    {
-        return false;
-    }
-    else
-#endif // ALPAKA_ACC_ANY_BT_OACC_ENABLED
-
-#ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-        if constexpr(std::is_same_v<TDev, alpaka::DevOmp5>)
-    {
-        return false;
-    }
-    else
-#endif // ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-
-        return true;
-}
-
 template<typename TElem, typename TQueue, typename TExtent>
 auto allocAsyncBufIfSupported(TQueue const& queue, TExtent const& extent)
     -> alpaka::Buf<alpaka::Dev<TQueue>, TElem, alpaka::Dim<TExtent>, alpaka::Idx<TExtent>>
 {
     using Idx = alpaka::Idx<TExtent>;
-    if constexpr(isAsyncBufferSupported<alpaka::Dev<TQueue>, alpaka::Dim<TExtent>>())
+    if constexpr(alpaka::hasAsyncBufSupport<alpaka::Dev<TQueue>, alpaka::Dim<TExtent>>)
     {
         return alpaka::allocAsyncBuf<TElem, Idx>(queue, extent);
     }

--- a/test/integ/zeroDimBuffer/src/zeroDimBuffer.cpp
+++ b/test/integ/zeroDimBuffer/src/zeroDimBuffer.cpp
@@ -29,52 +29,11 @@ constexpr T memset_value(int c)
     return t;
 }
 
-//! check if asynchronous (queue-ordered) memory buffers are supported by the given Accelerator
-template<typename TAcc>
-static constexpr auto isAsyncBufferSupported() -> bool
-{
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-    if constexpr(std::is_same_v<alpaka::Dev<TAcc>, alpaka::DevCudaRt>)
-    {
-        return (BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(11, 2, 0)) && (alpaka::Dim<TAcc>::value == 1);
-    }
-    else
-#endif // ALPAKA_ACC_GPU_CUDA_ENABLED
-
-#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-        if constexpr(std::is_same_v<alpaka::Dev<TAcc>, alpaka::DevHipRt>)
-    {
-        return false;
-    }
-    else
-#endif // ALPAKA_ACC_GPU_HIP_ENABLED
-
-#ifdef ALPAKA_ACC_ANY_BT_OACC_ENABLED
-        if constexpr(std::is_same_v<alpaka::Dev<TAcc>, alpaka::DevOacc>)
-    {
-        return false;
-    }
-    else
-#endif // ALPAKA_ACC_ANY_BT_OACC_ENABLED
-
-#ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-        if constexpr(std::is_same_v<alpaka::Dev<TAcc>, alpaka::DevOmp5>)
-    {
-        return false;
-    }
-    else
-#endif // ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-
-        return true;
-
-    ALPAKA_UNREACHABLE(bool{});
-}
-
 template<typename TAcc, typename TElem, typename TIdx, typename TQueue, typename TExtent>
 auto allocAsyncBufIfSupported(TQueue const& queue, TExtent const& extent)
     -> alpaka::Buf<alpaka::Dev<TQueue>, TElem, alpaka::Dim<TExtent>, TIdx>
 {
-    if constexpr(isAsyncBufferSupported<TAcc>())
+    if constexpr(alpaka::hasAsyncBufSupport<alpaka::Dev<TAcc>, alpaka::Dim<TExtent>>)
     {
         return alpaka::allocAsyncBuf<TElem, TIdx>(queue, extent);
     }

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -19,46 +19,6 @@
 #include <type_traits>
 
 template<typename TAcc>
-static constexpr auto isAsyncBufferSupported() -> bool
-{
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-    if constexpr(std::is_same_v<alpaka::Dev<TAcc>, alpaka::DevCudaRt>)
-    {
-        return (BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(11, 2, 0)) && (alpaka::Dim<TAcc>::value == 1);
-    }
-    else
-#endif // ALPAKA_ACC_GPU_CUDA_ENABLED
-
-#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-        if constexpr(std::is_same_v<alpaka::Dev<TAcc>, alpaka::DevHipRt>)
-    {
-        return false;
-    }
-    else
-#endif // ALPAKA_ACC_GPU_HIP_ENABLED
-
-#ifdef ALPAKA_ACC_ANY_BT_OACC_ENABLED
-        if constexpr(std::is_same_v<alpaka::Dev<TAcc>, alpaka::DevOacc>)
-    {
-        return false;
-    }
-    else
-#endif // ALPAKA_ACC_ANY_BT_OACC_ENABLED
-
-#ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-        if constexpr(std::is_same_v<alpaka::Dev<TAcc>, alpaka::DevOmp5>)
-    {
-        return false;
-    }
-    else
-#endif // ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-
-        return true;
-
-    ALPAKA_UNREACHABLE(bool{});
-}
-
-template<typename TAcc>
 static auto testBufferMutable(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
 {
     using Dev = alpaka::Dev<TAcc>;
@@ -139,7 +99,7 @@ TEMPLATE_LIST_TEST_CASE("memBufAsyncBasicTest", "[memBuf]", alpaka::test::TestAc
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    if constexpr(isAsyncBufferSupported<Acc>())
+    if constexpr(alpaka::hasAsyncBufSupport<alpaka::Dev<Acc>, Dim>)
     {
         auto const extent
             = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
@@ -157,7 +117,7 @@ TEMPLATE_LIST_TEST_CASE("memBufAsyncZeroSizeTest", "[memBuf]", alpaka::test::Tes
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    if constexpr(isAsyncBufferSupported<Acc>())
+    if constexpr(alpaka::hasAsyncBufSupport<alpaka::Dev<Acc>, Dim>)
     {
         auto const extent = alpaka::Vec<Dim, Idx>::zeros();
         testAsyncBufferMutable<Acc>(extent);
@@ -231,7 +191,7 @@ TEMPLATE_LIST_TEST_CASE("memBufAsyncConstTest", "[memBuf]", alpaka::test::TestAc
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    if constexpr(isAsyncBufferSupported<Acc>())
+    if constexpr(alpaka::hasAsyncBufSupport<alpaka::Dev<Acc>, Dim>)
     {
         auto const extent
             = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();


### PR DESCRIPTION
Implement a new trait, `hasAsyncBufSupport<Dev, Dim>`, to check if the given device supports allocating stream-ordered buffers of the given dimensionality.