### PR TITLE
add `getNativeHandle()` to alpaka devices

### DIFF
--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -117,31 +117,31 @@ namespace alpaka
                 // cuda https://devblogs.nvidia.com/cuda-pro-tip-the-fast-way-to-query-device-properties/
                 int multiProcessorCount = {};
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&multiProcessorCount, cudaDevAttrMultiProcessorCount, dev.m_iDevice));
+                    cudaDeviceGetAttribute(&multiProcessorCount, cudaDevAttrMultiProcessorCount, dev.iDevice()));
 
                 int maxGridSize[3] = {};
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxGridSize[0], cudaDevAttrMaxGridDimX, dev.m_iDevice));
+                    cudaDeviceGetAttribute(&maxGridSize[0], cudaDevAttrMaxGridDimX, dev.iDevice()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxGridSize[1], cudaDevAttrMaxGridDimY, dev.m_iDevice));
+                    cudaDeviceGetAttribute(&maxGridSize[1], cudaDevAttrMaxGridDimY, dev.iDevice()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxGridSize[2], cudaDevAttrMaxGridDimZ, dev.m_iDevice));
+                    cudaDeviceGetAttribute(&maxGridSize[2], cudaDevAttrMaxGridDimZ, dev.iDevice()));
 
                 int maxBlockDim[3] = {};
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxBlockDim[0], cudaDevAttrMaxBlockDimX, dev.m_iDevice));
+                    cudaDeviceGetAttribute(&maxBlockDim[0], cudaDevAttrMaxBlockDimX, dev.iDevice()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxBlockDim[1], cudaDevAttrMaxBlockDimY, dev.m_iDevice));
+                    cudaDeviceGetAttribute(&maxBlockDim[1], cudaDevAttrMaxBlockDimY, dev.iDevice()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxBlockDim[2], cudaDevAttrMaxBlockDimZ, dev.m_iDevice));
+                    cudaDeviceGetAttribute(&maxBlockDim[2], cudaDevAttrMaxBlockDimZ, dev.iDevice()));
 
                 int maxThreadsPerBlock = {};
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxThreadsPerBlock, cudaDevAttrMaxThreadsPerBlock, dev.m_iDevice));
+                    cudaDeviceGetAttribute(&maxThreadsPerBlock, cudaDevAttrMaxThreadsPerBlock, dev.iDevice()));
 
                 int sharedMemSizeBytes = {};
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&sharedMemSizeBytes, cudaDevAttrMaxSharedMemoryPerBlock, dev.m_iDevice));
+                    cudaDeviceGetAttribute(&sharedMemSizeBytes, cudaDevAttrMaxSharedMemoryPerBlock, dev.iDevice()));
 
                 return {// m_multiProcessorCount
                         alpaka::core::clipCast<TIdx>(multiProcessorCount),
@@ -168,7 +168,7 @@ namespace alpaka
 
 #    else
                 hipDeviceProp_t hipDevProp;
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipGetDeviceProperties(&hipDevProp, dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipGetDeviceProperties(&hipDevProp, dev.iDevice()));
 
                 return {// m_multiProcessorCount
                         alpaka::core::clipCast<TIdx>(hipDevProp.multiProcessorCount),

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, René Widera, Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, René Widera, Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of alpaka.
  *

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -116,32 +116,36 @@ namespace alpaka
                 // Reading only the necessary attributes with cudaDeviceGetAttribute is faster than reading all with
                 // cuda https://devblogs.nvidia.com/cuda-pro-tip-the-fast-way-to-query-device-properties/
                 int multiProcessorCount = {};
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&multiProcessorCount, cudaDevAttrMultiProcessorCount, dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
+                    &multiProcessorCount,
+                    cudaDevAttrMultiProcessorCount,
+                    dev.getNativeHandle()));
 
                 int maxGridSize[3] = {};
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxGridSize[0], cudaDevAttrMaxGridDimX, dev.iDevice()));
+                    cudaDeviceGetAttribute(&maxGridSize[0], cudaDevAttrMaxGridDimX, dev.getNativeHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxGridSize[1], cudaDevAttrMaxGridDimY, dev.iDevice()));
+                    cudaDeviceGetAttribute(&maxGridSize[1], cudaDevAttrMaxGridDimY, dev.getNativeHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxGridSize[2], cudaDevAttrMaxGridDimZ, dev.iDevice()));
+                    cudaDeviceGetAttribute(&maxGridSize[2], cudaDevAttrMaxGridDimZ, dev.getNativeHandle()));
 
                 int maxBlockDim[3] = {};
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxBlockDim[0], cudaDevAttrMaxBlockDimX, dev.iDevice()));
+                    cudaDeviceGetAttribute(&maxBlockDim[0], cudaDevAttrMaxBlockDimX, dev.getNativeHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxBlockDim[1], cudaDevAttrMaxBlockDimY, dev.iDevice()));
+                    cudaDeviceGetAttribute(&maxBlockDim[1], cudaDevAttrMaxBlockDimY, dev.getNativeHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxBlockDim[2], cudaDevAttrMaxBlockDimZ, dev.iDevice()));
+                    cudaDeviceGetAttribute(&maxBlockDim[2], cudaDevAttrMaxBlockDimZ, dev.getNativeHandle()));
 
                 int maxThreadsPerBlock = {};
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxThreadsPerBlock, cudaDevAttrMaxThreadsPerBlock, dev.iDevice()));
+                    cudaDeviceGetAttribute(&maxThreadsPerBlock, cudaDevAttrMaxThreadsPerBlock, dev.getNativeHandle()));
 
                 int sharedMemSizeBytes = {};
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&sharedMemSizeBytes, cudaDevAttrMaxSharedMemoryPerBlock, dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
+                    &sharedMemSizeBytes,
+                    cudaDevAttrMaxSharedMemoryPerBlock,
+                    dev.getNativeHandle()));
 
                 return {// m_multiProcessorCount
                         alpaka::core::clipCast<TIdx>(multiProcessorCount),
@@ -168,7 +172,7 @@ namespace alpaka
 
 #    else
                 hipDeviceProp_t hipDevProp;
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipGetDeviceProperties(&hipDevProp, dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipGetDeviceProperties(&hipDevProp, dev.getNativeHandle()));
 
                 return {// m_multiProcessorCount
                         alpaka::core::clipCast<TIdx>(hipDevProp.multiProcessorCount),

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -119,33 +119,35 @@ namespace alpaka
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
                     &multiProcessorCount,
                     cudaDevAttrMultiProcessorCount,
-                    dev.getNativeHandle()));
+                    dev.getNativeDeviceHandle()));
 
                 int maxGridSize[3] = {};
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxGridSize[0], cudaDevAttrMaxGridDimX, dev.getNativeHandle()));
+                    cudaDeviceGetAttribute(&maxGridSize[0], cudaDevAttrMaxGridDimX, dev.getNativeDeviceHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxGridSize[1], cudaDevAttrMaxGridDimY, dev.getNativeHandle()));
+                    cudaDeviceGetAttribute(&maxGridSize[1], cudaDevAttrMaxGridDimY, dev.getNativeDeviceHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxGridSize[2], cudaDevAttrMaxGridDimZ, dev.getNativeHandle()));
+                    cudaDeviceGetAttribute(&maxGridSize[2], cudaDevAttrMaxGridDimZ, dev.getNativeDeviceHandle()));
 
                 int maxBlockDim[3] = {};
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxBlockDim[0], cudaDevAttrMaxBlockDimX, dev.getNativeHandle()));
+                    cudaDeviceGetAttribute(&maxBlockDim[0], cudaDevAttrMaxBlockDimX, dev.getNativeDeviceHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxBlockDim[1], cudaDevAttrMaxBlockDimY, dev.getNativeHandle()));
+                    cudaDeviceGetAttribute(&maxBlockDim[1], cudaDevAttrMaxBlockDimY, dev.getNativeDeviceHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxBlockDim[2], cudaDevAttrMaxBlockDimZ, dev.getNativeHandle()));
+                    cudaDeviceGetAttribute(&maxBlockDim[2], cudaDevAttrMaxBlockDimZ, dev.getNativeDeviceHandle()));
 
                 int maxThreadsPerBlock = {};
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxThreadsPerBlock, cudaDevAttrMaxThreadsPerBlock, dev.getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
+                    &maxThreadsPerBlock,
+                    cudaDevAttrMaxThreadsPerBlock,
+                    dev.getNativeDeviceHandle()));
 
                 int sharedMemSizeBytes = {};
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
                     &sharedMemSizeBytes,
                     cudaDevAttrMaxSharedMemoryPerBlock,
-                    dev.getNativeHandle()));
+                    dev.getNativeDeviceHandle()));
 
                 return {// m_multiProcessorCount
                         alpaka::core::clipCast<TIdx>(multiProcessorCount),
@@ -172,7 +174,7 @@ namespace alpaka
 
 #    else
                 hipDeviceProp_t hipDevProp;
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipGetDeviceProperties(&hipDevProp, dev.getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipGetDeviceProperties(&hipDevProp, dev.getNativeDeviceHandle()));
 
                 return {// m_multiProcessorCount
                         alpaka::core::clipCast<TIdx>(hipDevProp.multiProcessorCount),

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -119,35 +119,33 @@ namespace alpaka
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
                     &multiProcessorCount,
                     cudaDevAttrMultiProcessorCount,
-                    dev.getNativeDeviceHandle()));
+                    dev.getNativeHandle()));
 
                 int maxGridSize[3] = {};
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxGridSize[0], cudaDevAttrMaxGridDimX, dev.getNativeDeviceHandle()));
+                    cudaDeviceGetAttribute(&maxGridSize[0], cudaDevAttrMaxGridDimX, dev.getNativeHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxGridSize[1], cudaDevAttrMaxGridDimY, dev.getNativeDeviceHandle()));
+                    cudaDeviceGetAttribute(&maxGridSize[1], cudaDevAttrMaxGridDimY, dev.getNativeHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxGridSize[2], cudaDevAttrMaxGridDimZ, dev.getNativeDeviceHandle()));
+                    cudaDeviceGetAttribute(&maxGridSize[2], cudaDevAttrMaxGridDimZ, dev.getNativeHandle()));
 
                 int maxBlockDim[3] = {};
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxBlockDim[0], cudaDevAttrMaxBlockDimX, dev.getNativeDeviceHandle()));
+                    cudaDeviceGetAttribute(&maxBlockDim[0], cudaDevAttrMaxBlockDimX, dev.getNativeHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxBlockDim[1], cudaDevAttrMaxBlockDimY, dev.getNativeDeviceHandle()));
+                    cudaDeviceGetAttribute(&maxBlockDim[1], cudaDevAttrMaxBlockDimY, dev.getNativeHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    cudaDeviceGetAttribute(&maxBlockDim[2], cudaDevAttrMaxBlockDimZ, dev.getNativeDeviceHandle()));
+                    cudaDeviceGetAttribute(&maxBlockDim[2], cudaDevAttrMaxBlockDimZ, dev.getNativeHandle()));
 
                 int maxThreadsPerBlock = {};
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
-                    &maxThreadsPerBlock,
-                    cudaDevAttrMaxThreadsPerBlock,
-                    dev.getNativeDeviceHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    cudaDeviceGetAttribute(&maxThreadsPerBlock, cudaDevAttrMaxThreadsPerBlock, dev.getNativeHandle()));
 
                 int sharedMemSizeBytes = {};
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaDeviceGetAttribute(
                     &sharedMemSizeBytes,
                     cudaDevAttrMaxSharedMemoryPerBlock,
-                    dev.getNativeDeviceHandle()));
+                    dev.getNativeHandle()));
 
                 return {// m_multiProcessorCount
                         alpaka::core::clipCast<TIdx>(multiProcessorCount),
@@ -174,7 +172,7 @@ namespace alpaka
 
 #    else
                 hipDeviceProp_t hipDevProp;
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipGetDeviceProperties(&hipDevProp, dev.getNativeDeviceHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipGetDeviceProperties(&hipDevProp, dev.getNativeHandle()));
 
                 return {// m_multiProcessorCount
                         alpaka::core::clipCast<TIdx>(hipDevProp.multiProcessorCount),

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2022 Axel Huebl, Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Bernhard Manfred Gruber,
- *                Jan Stephan
+ *                Jan Stephan, Antonio Di Pilato
  *
  * This file is part of alpaka.
  *
@@ -187,6 +187,8 @@
 #include <alpaka/queue/Traits.hpp>
 // time
 #include <alpaka/time/Traits.hpp>
+// traits
+#include <alpaka/traits/Traits.hpp>
 // wait
 #include <alpaka/wait/Traits.hpp>
 // workdiv

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -120,6 +120,11 @@ namespace alpaka
             m_spDevCpuImpl->registerQueue(spQueue);
         }
 
+        int getNativeHandle()
+        {
+            return 0;
+        }
+
     public:
         std::shared_ptr<cpu::detail::DevCpuImpl> m_spDevCpuImpl;
     };

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Jan Stephan, Bernhard Manfred Gruber,
+ * Antonio Di Pilato
  *
  * This file is part of alpaka.
  *

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -188,8 +188,7 @@ namespace alpaka
         template<>
         struct NativeHandle<DevCpu>
         {
-            using type = int;
-            static auto getNativeHandle(DevCpu const& dev) -> type
+            static auto getNativeHandle(DevCpu const& dev)
             {
                 return dev.getNativeHandle();
             }

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -19,6 +19,7 @@
 #include <alpaka/queue/QueueGenericThreadsNonBlocking.hpp>
 #include <alpaka/queue/Traits.hpp>
 #include <alpaka/queue/cpu/IGenericThreadsQueue.hpp>
+#include <alpaka/traits/Traits.hpp>
 #include <alpaka/wait/Traits.hpp>
 
 #include <algorithm>
@@ -121,7 +122,7 @@ namespace alpaka
             m_spDevCpuImpl->registerQueue(spQueue);
         }
 
-        auto getNativeDeviceHandle() const noexcept
+        auto getNativeHandle() const noexcept
         {
             return 0;
         }
@@ -185,9 +186,13 @@ namespace alpaka
 
         //! The CPU device native handle type trait specialization.
         template<>
-        struct NativeHandleDeviceType<DevCpu>
+        struct NativeHandle<DevCpu>
         {
             using type = int;
+            static auto getNativeHandle(DevCpu const& dev)
+            {
+                return dev.getNativeHandle();
+            }
         };
     } // namespace traits
 

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -121,7 +121,7 @@ namespace alpaka
             m_spDevCpuImpl->registerQueue(spQueue);
         }
 
-        int getNativeHandle() const noexcept
+        auto getNativeDeviceHandle() const noexcept
         {
             return 0;
         }
@@ -181,6 +181,13 @@ namespace alpaka
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
                 // The CPU does nothing on reset.
             }
+        };
+
+        //! The CPU device native handle type trait specialization.
+        template<>
+        struct NativeHandleDeviceType<DevCpu>
+        {
+            using type = int;
         };
     } // namespace traits
 

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -120,7 +120,7 @@ namespace alpaka
             m_spDevCpuImpl->registerQueue(spQueue);
         }
 
-        int getNativeHandle()
+        int getNativeHandle() const noexcept
         {
             return 0;
         }

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -189,7 +189,7 @@ namespace alpaka
         struct NativeHandle<DevCpu>
         {
             using type = int;
-            static auto getNativeHandle(DevCpu const& dev)
+            static auto getNativeHandle(DevCpu const& dev) -> type
             {
                 return dev.getNativeHandle();
             }

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -278,8 +278,7 @@ namespace alpaka
         template<>
         struct NativeHandle<DevOacc>
         {
-            using type = int;
-            static auto getNativeHandle(DevOacc const& dev) -> type
+            static auto getNativeHandle(DevOacc const& dev)
             {
                 return dev.getNativeHandle();
             }

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -279,7 +279,7 @@ namespace alpaka
         struct NativeHandle<DevOacc>
         {
             using type = int;
-            static auto getNativeHandle(DevOacc const& dev)
+            static auto getNativeHandle(DevOacc const& dev) -> type
             {
                 return dev.getNativeHandle();
             }

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -24,6 +24,7 @@
 #    include <alpaka/queue/QueueGenericThreadsNonBlocking.hpp>
 #    include <alpaka/queue/Traits.hpp>
 #    include <alpaka/queue/cpu/IGenericThreadsQueue.hpp>
+#    include <alpaka/traits/Traits.hpp>
 #    include <alpaka/wait/Traits.hpp>
 
 #    include <openacc.h>
@@ -174,15 +175,15 @@ namespace alpaka
     public:
         ALPAKA_FN_HOST auto operator==(DevOacc const& rhs) const -> bool
         {
-            return m_devOaccImpl->getNativeDeviceHandle() == rhs.m_devOaccImpl->getNativeDeviceHandle();
+            return m_devOaccImpl->getNativeHandle() == rhs.m_devOaccImpl->getNativeHandle();
         }
         ALPAKA_FN_HOST auto operator!=(DevOacc const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        auto getNativeDeviceHandle() const noexcept
+        auto getNativeHandle() const noexcept
         {
-            return m_devOaccImpl->getNativeDeviceHandle();
+            return m_devOaccImpl->getNativeHandle();
         }
         acc_device_t deviceType() const
         {
@@ -239,7 +240,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevOacc const& dev) -> std::size_t
             {
-                return acc_get_property(dev.getNativeDeviceHandle(), dev.deviceType(), acc_property_memory);
+                return acc_get_property(dev.getNativeHandle(), dev.deviceType(), acc_property_memory);
             }
         };
 
@@ -249,7 +250,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevOacc const& dev) -> std::size_t
             {
-                return acc_get_property(dev.getNativeDeviceHandle(), dev.deviceType(), acc_property_free_memory);
+                return acc_get_property(dev.getNativeHandle(), dev.deviceType(), acc_property_free_memory);
             }
         };
 
@@ -273,11 +274,15 @@ namespace alpaka
             }
         };
 
-        //! The OpenACC device native handle type trait specialization.
+        //! The OpenACC device native handle trait specialization.
         template<>
-        struct NativeHandleDeviceType<DevOacc>
+        struct NativeHandle<DevOacc>
         {
             using type = int;
+            static auto getNativeHandle(DevOacc const& dev)
+            {
+                return dev.getNativeHandle();
+            }
         };
     } // namespace traits
 

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -87,7 +87,7 @@ namespace alpaka
                 m_queues.push_back(std::move(spQueue));
             }
 
-            int getNativeHandle() const
+            int getNativeHandle() const noexcept
             {
                 return m_iDevice;
             }

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Jan Stephan, Bernhard Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of Alpaka.
  *
@@ -180,7 +180,7 @@ namespace alpaka
         {
             return !((*this) == rhs);
         }
-        int getNativeHandle() const
+        int getNativeHandle() const noexcept
         {
             return m_devOaccImpl->getNativeHandle();
         }

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -87,7 +87,7 @@ namespace alpaka
                 m_queues.push_back(std::move(spQueue));
             }
 
-            int iDevice() const
+            int getNativeHandle() const
             {
                 return m_iDevice;
             }
@@ -99,9 +99,9 @@ namespace alpaka
             void makeCurrent() const
             {
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                std::cout << "acc_set_device_num( " << iDevice() << ", [type] )" << std::endl;
+                std::cout << "acc_set_device_num( " << getNativeHandle() << ", [type] )" << std::endl;
 #    endif
-                acc_set_device_num(iDevice(), deviceType());
+                acc_set_device_num(getNativeHandle(), deviceType());
             }
 
             std::uint32_t* gridsLock() const
@@ -174,15 +174,15 @@ namespace alpaka
     public:
         ALPAKA_FN_HOST auto operator==(DevOacc const& rhs) const -> bool
         {
-            return m_devOaccImpl->iDevice() == rhs.m_devOaccImpl->iDevice();
+            return m_devOaccImpl->getNativeHandle() == rhs.m_devOaccImpl->getNativeHandle();
         }
         ALPAKA_FN_HOST auto operator!=(DevOacc const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        int iDevice() const
+        int getNativeHandle() const
         {
-            return m_devOaccImpl->iDevice();
+            return m_devOaccImpl->getNativeHandle();
         }
         acc_device_t deviceType() const
         {
@@ -239,7 +239,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevOacc const& dev) -> std::size_t
             {
-                return acc_get_property(dev.iDevice(), dev.deviceType(), acc_property_memory);
+                return acc_get_property(dev.getNativeHandle(), dev.deviceType(), acc_property_memory);
             }
         };
 
@@ -249,7 +249,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevOacc const& dev) -> std::size_t
             {
-                return acc_get_property(dev.iDevice(), dev.deviceType(), acc_property_free_memory);
+                return acc_get_property(dev.getNativeHandle(), dev.deviceType(), acc_property_free_memory);
             }
         };
 

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -174,15 +174,15 @@ namespace alpaka
     public:
         ALPAKA_FN_HOST auto operator==(DevOacc const& rhs) const -> bool
         {
-            return m_devOaccImpl->getNativeHandle() == rhs.m_devOaccImpl->getNativeHandle();
+            return m_devOaccImpl->getNativeDeviceHandle() == rhs.m_devOaccImpl->getNativeDeviceHandle();
         }
         ALPAKA_FN_HOST auto operator!=(DevOacc const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        int getNativeHandle() const noexcept
+        auto getNativeDeviceHandle() const noexcept
         {
-            return m_devOaccImpl->getNativeHandle();
+            return m_devOaccImpl->getNativeDeviceHandle();
         }
         acc_device_t deviceType() const
         {
@@ -239,7 +239,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevOacc const& dev) -> std::size_t
             {
-                return acc_get_property(dev.getNativeHandle(), dev.deviceType(), acc_property_memory);
+                return acc_get_property(dev.getNativeDeviceHandle(), dev.deviceType(), acc_property_memory);
             }
         };
 
@@ -249,7 +249,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevOacc const& dev) -> std::size_t
             {
-                return acc_get_property(dev.getNativeHandle(), dev.deviceType(), acc_property_free_memory);
+                return acc_get_property(dev.getNativeDeviceHandle(), dev.deviceType(), acc_property_free_memory);
             }
         };
 
@@ -271,6 +271,13 @@ namespace alpaka
             {
                 //! \TODO
             }
+        };
+
+        //! The OpenACC device native handle type trait specialization.
+        template<>
+        struct NativeHandleDeviceType<DevOacc>
+        {
+            using type = int;
         };
     } // namespace traits
 
@@ -354,7 +361,6 @@ namespace alpaka
                 return {static_cast<int>(devIdx)};
             }
         };
-
     } // namespace traits
 } // namespace alpaka
 

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -146,16 +146,16 @@ namespace alpaka
     public:
         ALPAKA_FN_HOST auto operator==(DevOmp5 const& rhs) const -> bool
         {
-            return m_spDevOmp5Impl->getNativeHandle() == rhs.m_spDevOmp5Impl->getNativeHandle();
+            return m_spDevOmp5Impl->getNativeDeviceHandle() == rhs.m_spDevOmp5Impl->getNativeDeviceHandle();
         }
         ALPAKA_FN_HOST auto operator!=(DevOmp5 const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        
-        int getNativeHandle() const noexcept
+
+        [[nodiscard]] auto getNativeDeviceHandle() const noexcept
         {
-            return m_spDevOmp5Impl->getNativeHandle();
+            return m_spDevOmp5Impl->getNativeDeviceHandle();
         }
 
         //! Create and/or return staticlly mapped device pointer of host address.
@@ -237,6 +237,13 @@ namespace alpaka
             {
                 //! \TODO
             }
+        };
+
+        //! The OpenMP 5.0 device native handle type trait specialization.
+        template<>
+        struct NativeHandleDeviceType<DevOmp5>
+        {
+            using type = int; // N.B. this can be negative
         };
     } // namespace traits
 

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -245,7 +245,7 @@ namespace alpaka
         struct NativeHandle<DevOmp5>
         {
             using type = int; // N.B. this can be negative
-            static auto getNativeHandle(DevOmp5 const& dev)
+            static auto getNativeHandle(DevOmp5 const& dev) -> type
             {
                 return dev.getNativeHandle();
             }

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -244,8 +244,7 @@ namespace alpaka
         template<>
         struct NativeHandle<DevOmp5>
         {
-            using type = int; // N.B. this can be negative
-            static auto getNativeHandle(DevOmp5 const& dev) -> type
+            static auto getNativeHandle(DevOmp5 const& dev)
             {
                 return dev.getNativeHandle();
             }

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -48,12 +48,24 @@ namespace alpaka
         public:
             DevOmp5Impl(int iDevice) noexcept : m_iDevice(iDevice)
             {
+<<<<<<< HEAD
             }
             ~DevOmp5Impl()
             {
                 for(auto& a : m_staticMemMap)
                     omp_target_free(a.second.first, iDevice());
             }
+=======
+            public:
+                DevOmp5Impl(int iDevice) noexcept : m_iDevice(iDevice)
+                {
+                }
+                ~DevOmp5Impl()
+                {
+                    for(auto& a : m_staticMemMap)
+                        omp_target_free(a.second.first, getNativeHandle());
+                }
+>>>>>>> Renamed iDevice() method for DevOmp5
 
             ALPAKA_FN_HOST auto getAllExistingQueues() const
                 -> std::vector<std::shared_ptr<IGenericThreadsQueue<DevOmp5>>>
@@ -89,7 +101,7 @@ namespace alpaka
                 m_queues.push_back(spQueue);
             }
 
-            auto iDevice() const -> int
+            auto getNativeHandle() const -> int
             {
                 return m_iDevice;
             }
@@ -112,13 +124,13 @@ namespace alpaka
                     return reinterpret_cast<TElem*>(m->second.first);
                 }
 
-                void* pDev = omp_target_alloc(sizeB, iDevice());
+                void* pDev = omp_target_alloc(sizeB, getNativeHandle());
                 if(!pDev)
                     return nullptr;
 
                 /*! Associating pointers for good measure. Not actually
                  * required as long a not `target enter data` is done */
-                omp_target_associate_ptr(pHost, pDev, sizeB, 0u, iDevice());
+                omp_target_associate_ptr(pHost, pDev, sizeB, 0u, getNativeHandle());
 
                 m_staticMemMap[pHost] = std::make_pair(pDev, sizeB);
                 return reinterpret_cast<TElem*>(pDev);
@@ -146,15 +158,16 @@ namespace alpaka
     public:
         ALPAKA_FN_HOST auto operator==(DevOmp5 const& rhs) const -> bool
         {
-            return m_spDevOmp5Impl->iDevice() == rhs.m_spDevOmp5Impl->iDevice();
+            return m_spDevOmp5Impl->getNativeHandle() == rhs.m_spDevOmp5Impl->getNativeHandle();
         }
         ALPAKA_FN_HOST auto operator!=(DevOmp5 const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        [[nodiscard]] auto iDevice() const -> int
+
+        int getNativeHandle() const
         {
-            return m_spDevOmp5Impl->iDevice();
+            return m_spDevOmp5Impl->getNativeHandle();
         }
 
         //! Create and/or return staticlly mapped device pointer of host address.

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Jan Stephan, Bernhard Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of Alpaka.
  *
@@ -152,8 +152,8 @@ namespace alpaka
         {
             return !((*this) == rhs);
         }
-
-        int getNativeHandle() const
+        
+        int getNativeHandle() const noexcept
         {
             return m_spDevOmp5Impl->getNativeHandle();
         }

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -48,24 +48,12 @@ namespace alpaka
         public:
             DevOmp5Impl(int iDevice) noexcept : m_iDevice(iDevice)
             {
-<<<<<<< HEAD
             }
             ~DevOmp5Impl()
             {
                 for(auto& a : m_staticMemMap)
-                    omp_target_free(a.second.first, iDevice());
+                    omp_target_free(a.second.first, getNativeHandle());
             }
-=======
-            public:
-                DevOmp5Impl(int iDevice) noexcept : m_iDevice(iDevice)
-                {
-                }
-                ~DevOmp5Impl()
-                {
-                    for(auto& a : m_staticMemMap)
-                        omp_target_free(a.second.first, getNativeHandle());
-                }
->>>>>>> Renamed iDevice() method for DevOmp5
 
             ALPAKA_FN_HOST auto getAllExistingQueues() const
                 -> std::vector<std::shared_ptr<IGenericThreadsQueue<DevOmp5>>>
@@ -101,7 +89,7 @@ namespace alpaka
                 m_queues.push_back(spQueue);
             }
 
-            auto getNativeHandle() const -> int
+            auto getNativeHandle() const noexcept -> int
             {
                 return m_iDevice;
             }

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -24,6 +24,7 @@
 #    include <alpaka/queue/QueueGenericThreadsNonBlocking.hpp>
 #    include <alpaka/queue/Traits.hpp>
 #    include <alpaka/queue/cpu/IGenericThreadsQueue.hpp>
+#    include <alpaka/traits/Traits.hpp>
 #    include <alpaka/wait/Traits.hpp>
 
 #    include <map>
@@ -146,16 +147,16 @@ namespace alpaka
     public:
         ALPAKA_FN_HOST auto operator==(DevOmp5 const& rhs) const -> bool
         {
-            return m_spDevOmp5Impl->getNativeDeviceHandle() == rhs.m_spDevOmp5Impl->getNativeDeviceHandle();
+            return m_spDevOmp5Impl->getNativeHandle() == rhs.m_spDevOmp5Impl->getNativeHandle();
         }
         ALPAKA_FN_HOST auto operator!=(DevOmp5 const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
 
-        [[nodiscard]] auto getNativeDeviceHandle() const noexcept
+        [[nodiscard]] auto getNativeHandle() const noexcept
         {
-            return m_spDevOmp5Impl->getNativeDeviceHandle();
+            return m_spDevOmp5Impl->getNativeHandle();
         }
 
         //! Create and/or return staticlly mapped device pointer of host address.
@@ -239,11 +240,15 @@ namespace alpaka
             }
         };
 
-        //! The OpenMP 5.0 device native handle type trait specialization.
+        //! The OpenMP 5.0 device native handle trait specialization.
         template<>
-        struct NativeHandleDeviceType<DevOmp5>
+        struct NativeHandle<DevOmp5>
         {
             using type = int; // N.B. this can be negative
+            static auto getNativeHandle(DevOmp5 const& dev)
+            {
+                return dev.getNativeHandle();
+            }
         };
     } // namespace traits
 

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -171,7 +171,7 @@ namespace alpaka
         struct NativeHandle<DevUniformCudaHipRt>
         {
             using type = int;
-            static auto getNativeHandle(DevUniformCudaHipRt const& dev)
+            static auto getNativeHandle(DevUniformCudaHipRt const& dev) -> type
             {
                 return dev.getNativeHandle();
             }

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -48,6 +48,10 @@ namespace alpaka
         DevUniformCudaHipRt() = default;
 
     public:
+        DevUniformCudaHipRt(int iDevice) : m_iDevice(iDevice)
+        {
+        }
+
         ALPAKA_FN_HOST auto operator==(DevUniformCudaHipRt const& rhs) const -> bool
         {
             return m_iDevice == rhs.m_iDevice;
@@ -56,13 +60,9 @@ namespace alpaka
         {
             return !((*this) == rhs);
         }
-        int iDevice() const
+        int getNativeHandle() const
         {
             return m_iDevice;
-        }
-        int setDevice(int devIdx)
-        {
-            return m_iDevice = devIdx;
         }
 
     private:
@@ -91,7 +91,8 @@ namespace alpaka
 #    else
                 hipDeviceProp_t devProp;
 #    endif
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeHandle()));
 
                 return std::string(devProp.name);
             }
@@ -104,7 +105,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt const& dev) -> std::size_t
             {
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
 
                 std::size_t freeInternal(0u);
                 std::size_t totalInternal(0u);
@@ -122,7 +123,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevUniformCudaHipRt const& dev) -> std::size_t
             {
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
 
                 std::size_t freeInternal(0u);
                 std::size_t totalInternal(0u);
@@ -144,7 +145,8 @@ namespace alpaka
 #    else
                 hipDeviceProp_t devProp;
 #    endif
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeHandle()));
 
                 return static_cast<std::size_t>(devProp.warpSize);
             }
@@ -159,7 +161,7 @@ namespace alpaka
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(DeviceReset)());
             }
         };
@@ -196,7 +198,7 @@ namespace alpaka
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(DeviceSynchronize)());
             }
         };

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -170,8 +170,7 @@ namespace alpaka
         template<>
         struct NativeHandle<DevUniformCudaHipRt>
         {
-            using type = int;
-            static auto getNativeHandle(DevUniformCudaHipRt const& dev) -> type
+            static auto getNativeHandle(DevUniformCudaHipRt const& dev)
             {
                 return dev.getNativeHandle();
             }

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -56,7 +56,7 @@ namespace alpaka
         {
             return !((*this) == rhs);
         }
-        int getNativeHandle() const noexcept
+        auto getNativeDeviceHandle() const noexcept
         {
             return m_iDevice;
         }
@@ -91,7 +91,7 @@ namespace alpaka
                 hipDeviceProp_t devProp;
 #    endif
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeHandle()));
+                    ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeDeviceHandle()));
 
                 return std::string(devProp.name);
             }
@@ -104,7 +104,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt const& dev) -> std::size_t
             {
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
 
                 std::size_t freeInternal(0u);
                 std::size_t totalInternal(0u);
@@ -122,7 +122,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevUniformCudaHipRt const& dev) -> std::size_t
             {
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
 
                 std::size_t freeInternal(0u);
                 std::size_t totalInternal(0u);
@@ -145,7 +145,7 @@ namespace alpaka
                 hipDeviceProp_t devProp;
 #    endif
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeHandle()));
+                    ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeDeviceHandle()));
 
                 return static_cast<std::size_t>(devProp.warpSize);
             }
@@ -160,9 +160,16 @@ namespace alpaka
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(DeviceReset)());
             }
+        };
+
+        //! The CUDA/HIP RT device native handle type trait specialization.
+        template<>
+        struct NativeHandleDeviceType<DevUniformCudaHipRt>
+        {
+            using type = int;
         };
     } // namespace traits
 
@@ -197,7 +204,7 @@ namespace alpaka
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(DeviceSynchronize)());
             }
         };

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -56,8 +56,16 @@ namespace alpaka
         {
             return !((*this) == rhs);
         }
+        int iDevice() const
+        {
+            return m_iDevice;
+        }
+        int setDevice(int devIdx)
+        {
+            return m_iDevice = devIdx;
+        }
 
-    public:
+    private:
         int m_iDevice;
     };
 
@@ -83,7 +91,7 @@ namespace alpaka
 #    else
                 hipDeviceProp_t devProp;
 #    endif
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.iDevice()));
 
                 return std::string(devProp.name);
             }
@@ -96,7 +104,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt const& dev) -> std::size_t
             {
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
 
                 std::size_t freeInternal(0u);
                 std::size_t totalInternal(0u);
@@ -114,7 +122,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevUniformCudaHipRt const& dev) -> std::size_t
             {
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
 
                 std::size_t freeInternal(0u);
                 std::size_t totalInternal(0u);
@@ -136,7 +144,7 @@ namespace alpaka
 #    else
                 hipDeviceProp_t devProp;
 #    endif
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.iDevice()));
 
                 return static_cast<std::size_t>(devProp.warpSize);
             }
@@ -151,7 +159,7 @@ namespace alpaka
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(DeviceReset)());
             }
         };
@@ -188,7 +196,7 @@ namespace alpaka
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(DeviceSynchronize)());
             }
         };

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -17,6 +17,7 @@
 #    include <alpaka/pltf/Traits.hpp>
 #    include <alpaka/queue/Properties.hpp>
 #    include <alpaka/queue/Traits.hpp>
+#    include <alpaka/traits/Traits.hpp>
 #    include <alpaka/wait/Traits.hpp>
 
 // Backend specific includes.
@@ -56,7 +57,7 @@ namespace alpaka
         {
             return !((*this) == rhs);
         }
-        auto getNativeDeviceHandle() const noexcept
+        auto getNativeHandle() const noexcept
         {
             return m_iDevice;
         }
@@ -91,7 +92,7 @@ namespace alpaka
                 hipDeviceProp_t devProp;
 #    endif
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeDeviceHandle()));
+                    ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeHandle()));
 
                 return std::string(devProp.name);
             }
@@ -104,7 +105,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt const& dev) -> std::size_t
             {
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
 
                 std::size_t freeInternal(0u);
                 std::size_t totalInternal(0u);
@@ -122,7 +123,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevUniformCudaHipRt const& dev) -> std::size_t
             {
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
 
                 std::size_t freeInternal(0u);
                 std::size_t totalInternal(0u);
@@ -145,7 +146,7 @@ namespace alpaka
                 hipDeviceProp_t devProp;
 #    endif
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeDeviceHandle()));
+                    ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeHandle()));
 
                 return static_cast<std::size_t>(devProp.warpSize);
             }
@@ -160,16 +161,20 @@ namespace alpaka
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(DeviceReset)());
             }
         };
 
-        //! The CUDA/HIP RT device native handle type trait specialization.
+        //! The CUDA/HIP RT device native handle trait specialization.
         template<>
-        struct NativeHandleDeviceType<DevUniformCudaHipRt>
+        struct NativeHandle<DevUniformCudaHipRt>
         {
             using type = int;
+            static auto getNativeHandle(DevUniformCudaHipRt const& dev)
+            {
+                return dev.getNativeHandle();
+            }
         };
     } // namespace traits
 
@@ -204,7 +209,7 @@ namespace alpaka
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                 // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(DeviceSynchronize)());
             }
         };

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -60,7 +60,7 @@ namespace alpaka
         {
             return !((*this) == rhs);
         }
-        int getNativeHandle() const
+        int getNativeHandle() const noexcept
         {
             return m_iDevice;
         }

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Andrea Bocci, Bernhard Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of alpaka.
  *
@@ -48,10 +48,6 @@ namespace alpaka
         DevUniformCudaHipRt() = default;
 
     public:
-        DevUniformCudaHipRt(int iDevice) : m_iDevice(iDevice)
-        {
-        }
-
         ALPAKA_FN_HOST auto operator==(DevUniformCudaHipRt const& rhs) const -> bool
         {
             return m_iDevice == rhs.m_iDevice;
@@ -66,6 +62,9 @@ namespace alpaka
         }
 
     private:
+        DevUniformCudaHipRt(int iDevice) : m_iDevice(iDevice)
+        {
+        }
         int m_iDevice;
     };
 

--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of alpaka.
  *
@@ -44,11 +44,19 @@ namespace alpaka
         //! The device reset trait.
         template<typename T, typename TSfinae = void>
         struct Reset;
+
+        //! The device native handle type trait.
+        template<typename TDev>
+        struct NativeHandleDeviceType;
     } // namespace traits
 
     //! The device type trait alias template to remove the ::type.
     template<typename T>
     using Dev = typename traits::DevType<T>::type;
+
+    //! The device native handle type trait alias template to remove the ::type.
+    template<typename TDev>
+    using NativeHandleDevice = typename traits::NativeHandleDeviceType<TDev>::type;
 
     struct ConceptGetDev;
 

--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -44,19 +44,11 @@ namespace alpaka
         //! The device reset trait.
         template<typename T, typename TSfinae = void>
         struct Reset;
-
-        //! The device native handle type trait.
-        template<typename TDev>
-        struct NativeHandleDeviceType;
     } // namespace traits
 
     //! The device type trait alias template to remove the ::type.
     template<typename T>
     using Dev = typename traits::DevType<T>::type;
-
-    //! The device native handle type trait alias template to remove the ::type.
-    template<typename TDev>
-    using NativeHandleDevice = typename traits::NativeHandleDeviceType<TDev>::type;
 
     struct ConceptGetDev;
 

--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber, Antonio Di Pilato
+/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *

--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -230,7 +230,7 @@ namespace alpaka
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     ALPAKA_API_PREFIX(StreamWaitEvent)(nullptr, event.m_spEventImpl->m_UniformCudaHipEvent, 0));

--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Andrea Bocci, Bernhard Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of alpaka.
  *

--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -230,7 +230,7 @@ namespace alpaka
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     ALPAKA_API_PREFIX(StreamWaitEvent)(nullptr, event.m_spEventImpl->m_UniformCudaHipEvent, 0));

--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -46,7 +46,7 @@ namespace alpaka
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.getNativeHandle()));
 
                 // Create the event on the current device with the specified flags. Valid flags include:
                 // - cuda/hip-EventDefault: Default event creation flag.
@@ -230,7 +230,7 @@ namespace alpaka
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     ALPAKA_API_PREFIX(StreamWaitEvent)(nullptr, event.m_spEventImpl->m_UniformCudaHipEvent, 0));

--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -46,7 +46,7 @@ namespace alpaka
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.iDevice()));
 
                 // Create the event on the current device with the specified flags. Valid flags include:
                 // - cuda/hip-EventDefault: Default event creation flag.
@@ -230,7 +230,7 @@ namespace alpaka
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     ALPAKA_API_PREFIX(StreamWaitEvent)(nullptr, event.m_spEventImpl->m_UniformCudaHipEvent, 0));

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -262,7 +262,7 @@ namespace alpaka
 
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.getNativeHandle()));
+                    ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.getNativeDeviceHandle()));
                 // Enqueue the kernel execution.
                 // \NOTE: No const reference (const &) is allowed as the parameter type because the kernel launch
                 // language extension expects the arguments by value. This forces the type of a float argument given
@@ -395,7 +395,7 @@ namespace alpaka
 
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.getNativeHandle()));
+                    ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.getNativeDeviceHandle()));
 
                 // Enqueue the kernel execution.
                 std::apply(

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -261,7 +261,7 @@ namespace alpaka
 #        endif
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.iDevice()));
                 // Enqueue the kernel execution.
                 // \NOTE: No const reference (const &) is allowed as the parameter type because the kernel launch
                 // language extension expects the arguments by value. This forces the type of a float argument given
@@ -393,7 +393,7 @@ namespace alpaka
 #        endif
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.iDevice()));
 
                 // Enqueue the kernel execution.
                 std::apply(

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2022 Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Jan Stephan, Andrea Bocci, Bernhard
- * Manfred Gruber
+ * Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of alpaka.
  *

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -262,7 +262,7 @@ namespace alpaka
 
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.getNativeDeviceHandle()));
+                    ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.getNativeHandle()));
                 // Enqueue the kernel execution.
                 // \NOTE: No const reference (const &) is allowed as the parameter type because the kernel launch
                 // language extension expects the arguments by value. This forces the type of a float argument given
@@ -395,7 +395,7 @@ namespace alpaka
 
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.getNativeDeviceHandle()));
+                    ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.getNativeHandle()));
 
                 // Enqueue the kernel execution.
                 std::apply(

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -261,7 +261,8 @@ namespace alpaka
 #        endif
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.getNativeHandle()));
                 // Enqueue the kernel execution.
                 // \NOTE: No const reference (const &) is allowed as the parameter type because the kernel launch
                 // language extension expects the arguments by value. This forces the type of a float argument given
@@ -393,7 +394,8 @@ namespace alpaka
 #        endif
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(SetDevice)(queue.m_spQueueImpl->m_dev.getNativeHandle()));
 
                 // Enqueue the kernel execution.
                 std::apply(

--- a/include/alpaka/kernel/TaskKernelOmp5.hpp
+++ b/include/alpaka/kernel/TaskKernelOmp5.hpp
@@ -135,7 +135,7 @@ namespace alpaka
             // `When an if(scalar-expression) evaluates to false, the structured block is executed on the host.`
             auto argsD = m_args;
             auto kernelFnObj = m_kernelFnObj;
-            const auto iDevice = dev.getNativeHandle();
+            const auto iDevice = dev.getNativeDeviceHandle();
 #    pragma omp target device(iDevice)
             {
 #    pragma omp teams distribute num_teams(teamCount) // thread_limit(blockThreadCount)

--- a/include/alpaka/kernel/TaskKernelOmp5.hpp
+++ b/include/alpaka/kernel/TaskKernelOmp5.hpp
@@ -135,7 +135,7 @@ namespace alpaka
             // `When an if(scalar-expression) evaluates to false, the structured block is executed on the host.`
             auto argsD = m_args;
             auto kernelFnObj = m_kernelFnObj;
-            const auto iDevice = dev.getNativeDeviceHandle();
+            const auto iDevice = dev.getNativeHandle();
 #    pragma omp target device(iDevice)
             {
 #    pragma omp teams distribute num_teams(teamCount) // thread_limit(blockThreadCount)

--- a/include/alpaka/kernel/TaskKernelOmp5.hpp
+++ b/include/alpaka/kernel/TaskKernelOmp5.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Benjamin Worpitz, René Widera, Bernhard Manfred Gruber, Antonio Di Pilato
+/* Copyright 2022 Benjamin Worpitz, René Widera, Bernhard Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of alpaka.
  *

--- a/include/alpaka/kernel/TaskKernelOmp5.hpp
+++ b/include/alpaka/kernel/TaskKernelOmp5.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Benjamin Worpitz, René Widera, Bernhard Manfred Gruber
+/* Copyright 2021 Benjamin Worpitz, René Widera, Bernhard Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of alpaka.
  *

--- a/include/alpaka/kernel/TaskKernelOmp5.hpp
+++ b/include/alpaka/kernel/TaskKernelOmp5.hpp
@@ -135,7 +135,7 @@ namespace alpaka
             // `When an if(scalar-expression) evaluates to false, the structured block is executed on the host.`
             auto argsD = m_args;
             auto kernelFnObj = m_kernelFnObj;
-            const auto iDevice = dev.iDevice();
+            const auto iDevice = dev.getNativeHandle();
 #    pragma omp target device(iDevice)
             {
 #    pragma omp teams distribute num_teams(teamCount) // thread_limit(blockThreadCount)

--- a/include/alpaka/mem/buf/BufOacc.hpp
+++ b/include/alpaka/mem/buf/BufOacc.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Jeffrey Kelling, Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred
+/* Copyright 2022 Jeffrey Kelling, Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred
  * Gruber, Antonio Di Pilato
  *
  * This file is part of Alpaka.

--- a/include/alpaka/mem/buf/BufOacc.hpp
+++ b/include/alpaka/mem/buf/BufOacc.hpp
@@ -255,7 +255,7 @@ namespace alpaka
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " ew: " << width << " ewb: " << widthBytes << " ptr: " << memPtr
-                          << " device: " << dev.getNativeDeviceHandle() << std::endl;
+                          << " device: " << dev.getNativeHandle() << std::endl;
 #    endif
                 return BufOacc<TElem, DimInt<1u>, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), extent);
             }
@@ -277,7 +277,7 @@ namespace alpaka
                 void* memPtr = acc_malloc(size);
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << "alloc'd " << TDim::value << "D device ptr: " << memPtr << " on device "
-                          << dev.getNativeDeviceHandle() << " size: " << size << std::endl;
+                          << dev.getNativeHandle() << " size: " << size << std::endl;
 #    endif
                 return BufOacc<TElem, TDim, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), extent);
             }

--- a/include/alpaka/mem/buf/BufOacc.hpp
+++ b/include/alpaka/mem/buf/BufOacc.hpp
@@ -255,7 +255,7 @@ namespace alpaka
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " ew: " << width << " ewb: " << widthBytes << " ptr: " << memPtr
-                          << " device: " << dev.getNativeHandle() << std::endl;
+                          << " device: " << dev.getNativeDeviceHandle() << std::endl;
 #    endif
                 return BufOacc<TElem, DimInt<1u>, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), extent);
             }
@@ -277,7 +277,7 @@ namespace alpaka
                 void* memPtr = acc_malloc(size);
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << "alloc'd " << TDim::value << "D device ptr: " << memPtr << " on device "
-                          << dev.getNativeHandle() << " size: " << size << std::endl;
+                          << dev.getNativeDeviceHandle() << " size: " << size << std::endl;
 #    endif
                 return BufOacc<TElem, TDim, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), extent);
             }

--- a/include/alpaka/mem/buf/BufOacc.hpp
+++ b/include/alpaka/mem/buf/BufOacc.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2021 Jeffrey Kelling, Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred
- * Gruber
+ * Gruber, Antonio Di Pilato
  *
  * This file is part of Alpaka.
  *

--- a/include/alpaka/mem/buf/BufOacc.hpp
+++ b/include/alpaka/mem/buf/BufOacc.hpp
@@ -255,7 +255,7 @@ namespace alpaka
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " ew: " << width << " ewb: " << widthBytes << " ptr: " << memPtr
-                          << " device: " << dev.iDevice() << std::endl;
+                          << " device: " << dev.getNativeHandle() << std::endl;
 #    endif
                 return BufOacc<TElem, DimInt<1u>, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), extent);
             }
@@ -277,7 +277,7 @@ namespace alpaka
                 void* memPtr = acc_malloc(size);
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << "alloc'd " << TDim::value << "D device ptr: " << memPtr << " on device "
-                          << dev.iDevice() << " size: " << size << std::endl;
+                          << dev.getNativeHandle() << " size: " << size << std::endl;
 #    endif
                 return BufOacc<TElem, TDim, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), extent);
             }

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -94,7 +94,7 @@ namespace alpaka
             auto operator=(BufOmp5Impl&&) -> BufOmp5Impl& = default;
             ~BufOmp5Impl()
             {
-                omp_target_free(m_pMem, m_dev.m_spDevOmp5Impl->getNativeHandle());
+                omp_target_free(m_pMem, m_dev.m_spDevOmp5Impl->getNativeDeviceHandle());
             }
         };
     } // namespace detail
@@ -244,12 +244,13 @@ namespace alpaka
                 auto const width(extent::getWidth(extent));
                 auto const widthBytes(width * static_cast<TIdx>(sizeof(TElem)));
 
-                void* memPtr
-                    = omp_target_alloc(static_cast<std::size_t>(widthBytes), dev.m_spDevOmp5Impl->getNativeHandle());
+                void* memPtr = omp_target_alloc(
+                    static_cast<std::size_t>(widthBytes),
+                    dev.m_spDevOmp5Impl->getNativeDeviceHandle());
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " ew: " << width << " ewb: " << widthBytes << " ptr: " << memPtr
-                          << " device: " << dev.m_spDevOmp5Impl->getNativeHandle() << std::endl;
+                          << " device: " << dev.m_spDevOmp5Impl->getNativeDeviceHandle() << std::endl;
 #    endif
                 return BufOmp5<TElem, DimInt<1u>, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), extent);
             }
@@ -267,11 +268,11 @@ namespace alpaka
 
                 const std::size_t size = static_cast<std::size_t>(extent::getExtentVec(extent).prod()) * sizeof(TElem);
 
-                void* memPtr = omp_target_alloc(size, dev.m_spDevOmp5Impl->getNativeHandle());
+                void* memPtr = omp_target_alloc(size, dev.m_spDevOmp5Impl->getNativeDeviceHandle());
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " dim: " << TDim::value << " extent: " << extent::getExtentVec(extent)
                           << " ewb: " << size << " ptr: " << memPtr
-                          << " device: " << dev.m_spDevOmp5Impl->getNativeHandle() << std::endl;
+                          << " device: " << dev.m_spDevOmp5Impl->getNativeDeviceHandle() << std::endl;
 #    endif
                 return BufOmp5<TElem, TDim, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), extent);
             }

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -94,7 +94,7 @@ namespace alpaka
             auto operator=(BufOmp5Impl&&) -> BufOmp5Impl& = default;
             ~BufOmp5Impl()
             {
-                omp_target_free(m_pMem, m_dev.m_spDevOmp5Impl->getNativeDeviceHandle());
+                omp_target_free(m_pMem, m_dev.m_spDevOmp5Impl->getNativeHandle());
             }
         };
     } // namespace detail
@@ -244,13 +244,12 @@ namespace alpaka
                 auto const width(extent::getWidth(extent));
                 auto const widthBytes(width * static_cast<TIdx>(sizeof(TElem)));
 
-                void* memPtr = omp_target_alloc(
-                    static_cast<std::size_t>(widthBytes),
-                    dev.m_spDevOmp5Impl->getNativeDeviceHandle());
+                void* memPtr
+                    = omp_target_alloc(static_cast<std::size_t>(widthBytes), dev.m_spDevOmp5Impl->getNativeHandle());
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " ew: " << width << " ewb: " << widthBytes << " ptr: " << memPtr
-                          << " device: " << dev.m_spDevOmp5Impl->getNativeDeviceHandle() << std::endl;
+                          << " device: " << dev.m_spDevOmp5Impl->getNativeHandle() << std::endl;
 #    endif
                 return BufOmp5<TElem, DimInt<1u>, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), extent);
             }
@@ -268,11 +267,11 @@ namespace alpaka
 
                 const std::size_t size = static_cast<std::size_t>(extent::getExtentVec(extent).prod()) * sizeof(TElem);
 
-                void* memPtr = omp_target_alloc(size, dev.m_spDevOmp5Impl->getNativeDeviceHandle());
+                void* memPtr = omp_target_alloc(size, dev.m_spDevOmp5Impl->getNativeHandle());
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " dim: " << TDim::value << " extent: " << extent::getExtentVec(extent)
                           << " ewb: " << size << " ptr: " << memPtr
-                          << " device: " << dev.m_spDevOmp5Impl->getNativeDeviceHandle() << std::endl;
+                          << " device: " << dev.m_spDevOmp5Impl->getNativeHandle() << std::endl;
 #    endif
                 return BufOmp5<TElem, TDim, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), extent);
             }

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred Gruber, Antonio
+/* Copyright 2022 Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred Gruber, Antonio
  * Di Pilato
  *
  * This file is part of Alpaka.

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -93,7 +93,7 @@ namespace alpaka
             auto operator=(BufOmp5Impl&&) -> BufOmp5Impl& = default;
             ~BufOmp5Impl()
             {
-                omp_target_free(m_pMem, m_dev.m_spDevOmp5Impl->iDevice());
+                omp_target_free(m_pMem, m_dev.m_spDevOmp5Impl->getNativeHandle());
             }
         };
     } // namespace detail
@@ -243,11 +243,12 @@ namespace alpaka
                 auto const width(extent::getWidth(extent));
                 auto const widthBytes(width * static_cast<TIdx>(sizeof(TElem)));
 
-                void* memPtr = omp_target_alloc(static_cast<std::size_t>(widthBytes), dev.m_spDevOmp5Impl->iDevice());
+                void* memPtr
+                    = omp_target_alloc(static_cast<std::size_t>(widthBytes), dev.m_spDevOmp5Impl->getNativeHandle());
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " ew: " << width << " ewb: " << widthBytes << " ptr: " << memPtr
-                          << " device: " << dev.m_spDevOmp5Impl->iDevice() << std::endl;
+                          << " device: " << dev.m_spDevOmp5Impl->getNativeHandle() << std::endl;
 #    endif
                 return BufOmp5<TElem, DimInt<1u>, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), extent);
             }
@@ -265,11 +266,11 @@ namespace alpaka
 
                 const std::size_t size = static_cast<std::size_t>(extent::getExtentVec(extent).prod()) * sizeof(TElem);
 
-                void* memPtr = omp_target_alloc(size, dev.m_spDevOmp5Impl->iDevice());
+                void* memPtr = omp_target_alloc(size, dev.m_spDevOmp5Impl->getNativeHandle());
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " dim: " << TDim::value << " extent: " << extent::getExtentVec(extent)
-                          << " ewb: " << size << " ptr: " << memPtr << " device: " << dev.m_spDevOmp5Impl->iDevice()
-                          << std::endl;
+                          << " ewb: " << size << " ptr: " << memPtr
+                          << " device: " << dev.m_spDevOmp5Impl->getNativeHandle() << std::endl;
 #    endif
                 return BufOmp5<TElem, TDim, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), extent);
             }

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2021 Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred Gruber
+/* Copyright 2021 Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred Gruber, Antonio
+ * Di Pilato
  *
  * This file is part of Alpaka.
  *

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -205,7 +205,7 @@ namespace alpaka
                 ALPAKA_ASSERT(Scalar{} == extent);
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Malloc)(&memPtr, sizeof(TElem)));
@@ -240,7 +240,7 @@ namespace alpaka
                 auto const widthBytes = width * static_cast<TIdx>(sizeof(TElem));
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
@@ -284,7 +284,7 @@ namespace alpaka
 #    endif
                 {
                     // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
                     // Allocate the buffer on this device.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(MallocPitch)(
                         &memPtr,
@@ -336,7 +336,7 @@ namespace alpaka
 #    endif
                 {
                     // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
                     // Allocate the buffer on this device.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Malloc3D)(&pitchedPtrVal, extentVal));
                 }
@@ -387,7 +387,7 @@ namespace alpaka
 
                 // Set the current device.
                 DevUniformCudaHipRt const& dev = getDev(queue);
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
@@ -436,7 +436,7 @@ namespace alpaka
 
                 // Set the current device.
                 DevUniformCudaHipRt const& dev = getDev(queue);
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.m_iDevice));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(MallocAsync)(

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -205,7 +205,7 @@ namespace alpaka
                 ALPAKA_ASSERT(Scalar{} == extent);
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Malloc)(&memPtr, sizeof(TElem)));
@@ -240,7 +240,7 @@ namespace alpaka
                 auto const widthBytes = width * static_cast<TIdx>(sizeof(TElem));
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
@@ -284,7 +284,7 @@ namespace alpaka
 #    endif
                 {
                     // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
                     // Allocate the buffer on this device.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(MallocPitch)(
                         &memPtr,
@@ -336,7 +336,7 @@ namespace alpaka
 #    endif
                 {
                     // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
                     // Allocate the buffer on this device.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Malloc3D)(&pitchedPtrVal, extentVal));
                 }
@@ -387,7 +387,7 @@ namespace alpaka
 
                 // Set the current device.
                 DevUniformCudaHipRt const& dev = getDev(queue);
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
@@ -436,7 +436,7 @@ namespace alpaka
 
                 // Set the current device.
                 DevUniformCudaHipRt const& dev = getDev(queue);
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(MallocAsync)(

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -205,7 +205,7 @@ namespace alpaka
                 ALPAKA_ASSERT(Scalar{} == extent);
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Malloc)(&memPtr, sizeof(TElem)));
@@ -240,7 +240,7 @@ namespace alpaka
                 auto const widthBytes = width * static_cast<TIdx>(sizeof(TElem));
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
@@ -284,7 +284,7 @@ namespace alpaka
 #    endif
                 {
                     // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                     // Allocate the buffer on this device.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(MallocPitch)(
                         &memPtr,
@@ -336,7 +336,7 @@ namespace alpaka
 #    endif
                 {
                     // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                     // Allocate the buffer on this device.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Malloc3D)(&pitchedPtrVal, extentVal));
                 }
@@ -387,7 +387,7 @@ namespace alpaka
 
                 // Set the current device.
                 DevUniformCudaHipRt const& dev = getDev(queue);
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
@@ -436,7 +436,7 @@ namespace alpaka
 
                 // Set the current device.
                 DevUniformCudaHipRt const& dev = getDev(queue);
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.iDevice()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(MallocAsync)(

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2022 Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci, Jan Stephan,
- * Bernhard Manfred Gruber
+ * Bernhard Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of alpaka.
  *

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -205,7 +205,7 @@ namespace alpaka
                 ALPAKA_ASSERT(Scalar{} == extent);
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Malloc)(&memPtr, sizeof(TElem)));
@@ -240,7 +240,7 @@ namespace alpaka
                 auto const widthBytes = width * static_cast<TIdx>(sizeof(TElem));
 
                 // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
@@ -284,7 +284,7 @@ namespace alpaka
 #    endif
                 {
                     // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                     // Allocate the buffer on this device.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(MallocPitch)(
                         &memPtr,
@@ -336,7 +336,7 @@ namespace alpaka
 #    endif
                 {
                     // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                     // Allocate the buffer on this device.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Malloc3D)(&pitchedPtrVal, extentVal));
                 }
@@ -387,7 +387,7 @@ namespace alpaka
 
                 // Set the current device.
                 DevUniformCudaHipRt const& dev = getDev(queue);
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
@@ -436,7 +436,7 @@ namespace alpaka
 
                 // Set the current device.
                 DevUniformCudaHipRt const& dev = getDev(queue);
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeDeviceHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                 // Allocate the buffer on this device.
                 void* memPtr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(MallocAsync)(

--- a/include/alpaka/mem/buf/oacc/Copy.hpp
+++ b/include/alpaka/mem/buf/oacc/Copy.hpp
@@ -121,7 +121,7 @@ namespace alpaka
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 ALPAKA_FN_HOST auto printDebug() const -> void
                 {
-                    std::cout << __func__ << " dev: " << m_dev.iDevice() << " ew: " << m_extent
+                    std::cout << __func__ << " dev: " << m_dev.getNativeHandle() << " ew: " << m_extent
                               << " dw: " << m_dstExtent << " dptr: " << static_cast<const void*>(m_dstMemNative)
                               << " sw: " << m_srcExtent << " sptr: " << static_cast<const void*>(m_srcMemNative)
                               << std::endl;
@@ -247,9 +247,10 @@ namespace alpaka
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 ALPAKA_FN_HOST auto printDebug() const -> void
                 {
-                    std::cout << __func__ << " dev: " << m_dev.iDevice() << " ew: " << Idx(1u) << " dw: " << Idx(1u)
-                              << " dptr: " << static_cast<const void*>(m_dstMemNative) << " sw: " << Idx(1u)
-                              << " sptr: " << static_cast<const void*>(m_srcMemNative) << std::endl;
+                    std::cout << __func__ << " dev: " << m_dev.getNativeHandle() << " ew: " << Idx(1u)
+                              << " dw: " << Idx(1u) << " dptr: " << static_cast<const void*>(m_dstMemNative)
+                              << " sw: " << Idx(1u) << " sptr: " << static_cast<const void*>(m_srcMemNative)
+                              << std::endl;
                 }
 #    endif
 
@@ -337,7 +338,8 @@ namespace alpaka
 
 #    if _OPENACC >= 201510 && (!defined __GNUC__)
                 // acc_memcpy_device is only available since OpenACC2.5, but we want the tests to compile anyway
-                if(getDev(viewDst).m_spDevOaccImpl->iDevice() == getDev(viewSrc).m_spDevOaccImpl->iDevice())
+                if(getDev(viewDst).m_spDevOaccImpl->getNativeHandle()
+                   == getDev(viewSrc).m_spDevOaccImpl->getNativeHandle())
                 {
                     return alpaka::oacc::detail::
                         makeTaskCopyOacc<alpaka::oacc::detail::TaskCopyOacc, TDim, TViewDst, TViewSrc, TExtent>(

--- a/include/alpaka/mem/buf/oacc/Copy.hpp
+++ b/include/alpaka/mem/buf/oacc/Copy.hpp
@@ -121,7 +121,7 @@ namespace alpaka
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 ALPAKA_FN_HOST auto printDebug() const -> void
                 {
-                    std::cout << __func__ << " dev: " << m_dev.getNativeDeviceHandle() << " ew: " << m_extent
+                    std::cout << __func__ << " dev: " << m_dev.getNativeHandle() << " ew: " << m_extent
                               << " dw: " << m_dstExtent << " dptr: " << static_cast<const void*>(m_dstMemNative)
                               << " sw: " << m_srcExtent << " sptr: " << static_cast<const void*>(m_srcMemNative)
                               << std::endl;
@@ -247,7 +247,7 @@ namespace alpaka
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 ALPAKA_FN_HOST auto printDebug() const -> void
                 {
-                    std::cout << __func__ << " dev: " << m_dev.getNativeDeviceHandle() << " ew: " << Idx(1u)
+                    std::cout << __func__ << " dev: " << m_dev.getNativeHandle() << " ew: " << Idx(1u)
                               << " dw: " << Idx(1u) << " dptr: " << static_cast<const void*>(m_dstMemNative)
                               << " sw: " << Idx(1u) << " sptr: " << static_cast<const void*>(m_srcMemNative)
                               << std::endl;
@@ -338,8 +338,8 @@ namespace alpaka
 
 #    if _OPENACC >= 201510 && (!defined __GNUC__)
                 // acc_memcpy_device is only available since OpenACC2.5, but we want the tests to compile anyway
-                if(getDev(viewDst).m_spDevOaccImpl->getNativeDeviceHandle()
-                   == getDev(viewSrc).m_spDevOaccImpl->getNativeDeviceHandle())
+                if(getDev(viewDst).m_spDevOaccImpl->getNativeHandle()
+                   == getDev(viewSrc).m_spDevOaccImpl->getNativeHandle())
                 {
                     return alpaka::oacc::detail::
                         makeTaskCopyOacc<alpaka::oacc::detail::TaskCopyOacc, TDim, TViewDst, TViewSrc, TExtent>(

--- a/include/alpaka/mem/buf/oacc/Copy.hpp
+++ b/include/alpaka/mem/buf/oacc/Copy.hpp
@@ -121,7 +121,7 @@ namespace alpaka
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 ALPAKA_FN_HOST auto printDebug() const -> void
                 {
-                    std::cout << __func__ << " dev: " << m_dev.getNativeHandle() << " ew: " << m_extent
+                    std::cout << __func__ << " dev: " << m_dev.getNativeDeviceHandle() << " ew: " << m_extent
                               << " dw: " << m_dstExtent << " dptr: " << static_cast<const void*>(m_dstMemNative)
                               << " sw: " << m_srcExtent << " sptr: " << static_cast<const void*>(m_srcMemNative)
                               << std::endl;
@@ -247,7 +247,7 @@ namespace alpaka
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 ALPAKA_FN_HOST auto printDebug() const -> void
                 {
-                    std::cout << __func__ << " dev: " << m_dev.getNativeHandle() << " ew: " << Idx(1u)
+                    std::cout << __func__ << " dev: " << m_dev.getNativeDeviceHandle() << " ew: " << Idx(1u)
                               << " dw: " << Idx(1u) << " dptr: " << static_cast<const void*>(m_dstMemNative)
                               << " sw: " << Idx(1u) << " sptr: " << static_cast<const void*>(m_srcMemNative)
                               << std::endl;
@@ -338,8 +338,8 @@ namespace alpaka
 
 #    if _OPENACC >= 201510 && (!defined __GNUC__)
                 // acc_memcpy_device is only available since OpenACC2.5, but we want the tests to compile anyway
-                if(getDev(viewDst).m_spDevOaccImpl->getNativeHandle()
-                   == getDev(viewSrc).m_spDevOaccImpl->getNativeHandle())
+                if(getDev(viewDst).m_spDevOaccImpl->getNativeDeviceHandle()
+                   == getDev(viewSrc).m_spDevOaccImpl->getNativeDeviceHandle())
                 {
                     return alpaka::oacc::detail::
                         makeTaskCopyOacc<alpaka::oacc::detail::TaskCopyOacc, TDim, TViewDst, TViewSrc, TExtent>(

--- a/include/alpaka/mem/buf/oacc/Copy.hpp
+++ b/include/alpaka/mem/buf/oacc/Copy.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2022 Axel Huebl, Benjamin Worpitz, Erik Zenker, Matthias Werner, Andrea Bocci, Jan Stephan, Bernhard
- * Manfred Gruber
+ * Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of Alpaka.
  *

--- a/include/alpaka/mem/buf/omp5/Copy.hpp
+++ b/include/alpaka/mem/buf/omp5/Copy.hpp
@@ -338,7 +338,7 @@ namespace alpaka
                     viewDst,
                     viewSrc,
                     extent,
-                    getDev(viewDst).m_spDevOmp5Impl->getNativeDeviceHandle(),
+                    getDev(viewDst).m_spDevOmp5Impl->getNativeHandle(),
                     omp_get_initial_device());
             }
         };
@@ -360,7 +360,7 @@ namespace alpaka
                     viewSrc,
                     extent,
                     omp_get_initial_device(),
-                    getDev(viewSrc).m_spDevOmp5Impl->getNativeDeviceHandle());
+                    getDev(viewSrc).m_spDevOmp5Impl->getNativeHandle());
             }
         };
 
@@ -380,8 +380,8 @@ namespace alpaka
                     viewDst,
                     viewSrc,
                     extent,
-                    getDev(viewDst).m_spDevOmp5Impl->getNativeDeviceHandle(),
-                    getDev(viewSrc).m_spDevOmp5Impl->getNativeDeviceHandle());
+                    getDev(viewDst).m_spDevOmp5Impl->getNativeHandle(),
+                    getDev(viewSrc).m_spDevOmp5Impl->getNativeHandle());
             }
         };
     } // namespace traits

--- a/include/alpaka/mem/buf/omp5/Copy.hpp
+++ b/include/alpaka/mem/buf/omp5/Copy.hpp
@@ -338,7 +338,7 @@ namespace alpaka
                     viewDst,
                     viewSrc,
                     extent,
-                    getDev(viewDst).m_spDevOmp5Impl->iDevice(),
+                    getDev(viewDst).m_spDevOmp5Impl->getNativeHandle(),
                     omp_get_initial_device());
             }
         };
@@ -360,7 +360,7 @@ namespace alpaka
                     viewSrc,
                     extent,
                     omp_get_initial_device(),
-                    getDev(viewSrc).m_spDevOmp5Impl->iDevice());
+                    getDev(viewSrc).m_spDevOmp5Impl->getNativeHandle());
             }
         };
 
@@ -380,8 +380,8 @@ namespace alpaka
                     viewDst,
                     viewSrc,
                     extent,
-                    getDev(viewDst).m_spDevOmp5Impl->iDevice(),
-                    getDev(viewSrc).m_spDevOmp5Impl->iDevice());
+                    getDev(viewDst).m_spDevOmp5Impl->getNativeHandle(),
+                    getDev(viewSrc).m_spDevOmp5Impl->getNativeHandle());
             }
         };
     } // namespace traits

--- a/include/alpaka/mem/buf/omp5/Copy.hpp
+++ b/include/alpaka/mem/buf/omp5/Copy.hpp
@@ -338,7 +338,7 @@ namespace alpaka
                     viewDst,
                     viewSrc,
                     extent,
-                    getDev(viewDst).m_spDevOmp5Impl->getNativeHandle(),
+                    getDev(viewDst).m_spDevOmp5Impl->getNativeDeviceHandle(),
                     omp_get_initial_device());
             }
         };
@@ -360,7 +360,7 @@ namespace alpaka
                     viewSrc,
                     extent,
                     omp_get_initial_device(),
-                    getDev(viewSrc).m_spDevOmp5Impl->getNativeHandle());
+                    getDev(viewSrc).m_spDevOmp5Impl->getNativeDeviceHandle());
             }
         };
 
@@ -380,8 +380,8 @@ namespace alpaka
                     viewDst,
                     viewSrc,
                     extent,
-                    getDev(viewDst).m_spDevOmp5Impl->getNativeHandle(),
-                    getDev(viewSrc).m_spDevOmp5Impl->getNativeHandle());
+                    getDev(viewDst).m_spDevOmp5Impl->getNativeDeviceHandle(),
+                    getDev(viewSrc).m_spDevOmp5Impl->getNativeDeviceHandle());
             }
         };
     } // namespace traits

--- a/include/alpaka/mem/buf/omp5/Copy.hpp
+++ b/include/alpaka/mem/buf/omp5/Copy.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2022 Axel Huebl, Benjamin Worpitz, Erik Zenker, Matthias Werner, Andrea Bocci, Jan Stephan, Bernhard
- * Manfred Gruber
+ * Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of Alpaka.
  *

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -509,7 +509,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                auto const iDevice = getDev(viewSrc).m_iDevice;
+                auto const iDevice = getDev(viewSrc).iDevice();
 
                 return alpaka::detail::TaskCopyUniformCudaHip<TDim, TViewDst, TViewSrc, TExtent>(
                     viewDst,
@@ -533,7 +533,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                auto const iDevice = getDev(viewDst).m_iDevice;
+                auto const iDevice = getDev(viewDst).iDevice();
 
                 return alpaka::detail::TaskCopyUniformCudaHip<TDim, TViewDst, TViewSrc, TExtent>(
                     viewDst,
@@ -562,8 +562,8 @@ namespace alpaka
                     viewSrc,
                     extent,
                     ALPAKA_API_PREFIX(MemcpyDeviceToDevice),
-                    getDev(viewDst).m_iDevice,
-                    getDev(viewSrc).m_iDevice);
+                    getDev(viewDst).iDevice(),
+                    getDev(viewSrc).iDevice());
             }
         };
 

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -509,7 +509,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                auto const iDevice = getDev(viewSrc).iDevice();
+                auto const iDevice = getDev(viewSrc).getNativeHandle();
 
                 return alpaka::detail::TaskCopyUniformCudaHip<TDim, TViewDst, TViewSrc, TExtent>(
                     viewDst,
@@ -533,7 +533,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                auto const iDevice = getDev(viewDst).iDevice();
+                auto const iDevice = getDev(viewDst).getNativeHandle();
 
                 return alpaka::detail::TaskCopyUniformCudaHip<TDim, TViewDst, TViewSrc, TExtent>(
                     viewDst,
@@ -562,8 +562,8 @@ namespace alpaka
                     viewSrc,
                     extent,
                     ALPAKA_API_PREFIX(MemcpyDeviceToDevice),
-                    getDev(viewDst).iDevice(),
-                    getDev(viewSrc).iDevice());
+                    getDev(viewDst).getNativeHandle(),
+                    getDev(viewSrc).getNativeHandle());
             }
         };
 

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -509,7 +509,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                auto const iDevice = getDev(viewSrc).getNativeHandle();
+                auto const iDevice = getDev(viewSrc).getNativeDeviceHandle();
 
                 return alpaka::detail::TaskCopyUniformCudaHip<TDim, TViewDst, TViewSrc, TExtent>(
                     viewDst,
@@ -533,7 +533,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                auto const iDevice = getDev(viewDst).getNativeHandle();
+                auto const iDevice = getDev(viewDst).getNativeDeviceHandle();
 
                 return alpaka::detail::TaskCopyUniformCudaHip<TDim, TViewDst, TViewSrc, TExtent>(
                     viewDst,
@@ -562,8 +562,8 @@ namespace alpaka
                     viewSrc,
                     extent,
                     ALPAKA_API_PREFIX(MemcpyDeviceToDevice),
-                    getDev(viewDst).getNativeHandle(),
-                    getDev(viewSrc).getNativeHandle());
+                    getDev(viewDst).getNativeDeviceHandle(),
+                    getDev(viewSrc).getNativeDeviceHandle());
             }
         };
 

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -509,7 +509,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                auto const iDevice = getDev(viewSrc).getNativeDeviceHandle();
+                auto const iDevice = getDev(viewSrc).getNativeHandle();
 
                 return alpaka::detail::TaskCopyUniformCudaHip<TDim, TViewDst, TViewSrc, TExtent>(
                     viewDst,
@@ -533,7 +533,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                auto const iDevice = getDev(viewDst).getNativeDeviceHandle();
+                auto const iDevice = getDev(viewDst).getNativeHandle();
 
                 return alpaka::detail::TaskCopyUniformCudaHip<TDim, TViewDst, TViewSrc, TExtent>(
                     viewDst,
@@ -562,8 +562,8 @@ namespace alpaka
                     viewSrc,
                     extent,
                     ALPAKA_API_PREFIX(MemcpyDeviceToDevice),
-                    getDev(viewDst).getNativeDeviceHandle(),
-                    getDev(viewSrc).getNativeDeviceHandle());
+                    getDev(viewDst).getNativeHandle(),
+                    getDev(viewSrc).getNativeHandle());
             }
         };
 

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2022 Axel Huebl, Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Andrea Bocci, Jan Stephan,
- * Bernhard Manfred Gruber
+ * Bernhard Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of alpaka.
  *

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -44,7 +44,7 @@ namespace alpaka
                 : m_view(view)
                 , m_byte(byte)
                 , m_extent(extent)
-                , m_iDevice(getDev(view).getNativeDeviceHandle())
+                , m_iDevice(getDev(view).getNativeHandle())
             {
                 static_assert(!std::is_const<TView>::value, "The destination view can not be const!");
 

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2022 Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Andrea Bocci, Bernhard Manfred Gruber,
+ * Antonio Di Pilato
  *
  * This file is part of alpaka.
  *

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -44,7 +44,7 @@ namespace alpaka
                 : m_view(view)
                 , m_byte(byte)
                 , m_extent(extent)
-                , m_iDevice(getDev(view).getNativeHandle())
+                , m_iDevice(getDev(view).getNativeDeviceHandle())
             {
                 static_assert(!std::is_const<TView>::value, "The destination view can not be const!");
 

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -43,7 +43,7 @@ namespace alpaka
                 : m_view(view)
                 , m_byte(byte)
                 , m_extent(extent)
-                , m_iDevice(getDev(view).m_iDevice)
+                , m_iDevice(getDev(view).getNativeHandle())
             {
                 static_assert(!std::is_const<TView>::value, "The destination view can not be const!");
 

--- a/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
+++ b/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
@@ -83,7 +83,7 @@ namespace alpaka
 
                 if(isDevUsable(devIdx))
                 {
-                    dev.m_iDevice = static_cast<int>(devIdx);
+                    dev.setDevice(static_cast<int>(devIdx));
 
                     // Log this device.
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
@@ -92,7 +92,7 @@ namespace alpaka
 #        else
                     hipDeviceProp_t devProp;
 #        endif
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.m_iDevice));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.iDevice()));
 #    endif
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     printDeviceProperties(devProp);

--- a/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
+++ b/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
@@ -91,7 +91,7 @@ namespace alpaka
                     hipDeviceProp_t devProp;
 #        endif
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeHandle()));
+                        ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeDeviceHandle()));
 #    endif
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     printDeviceProperties(devProp);

--- a/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
+++ b/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
@@ -91,7 +91,7 @@ namespace alpaka
                     hipDeviceProp_t devProp;
 #        endif
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeDeviceHandle()));
+                        ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeHandle()));
 #    endif
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     printDeviceProperties(devProp);

--- a/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
+++ b/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
@@ -70,8 +70,6 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                DevUniformCudaHipRt dev;
-
                 std::size_t const devCount(getDevCount<PltfUniformCudaHipRt>());
                 if(devIdx >= devCount)
                 {
@@ -83,7 +81,7 @@ namespace alpaka
 
                 if(isDevUsable(devIdx))
                 {
-                    dev.setDevice(static_cast<int>(devIdx));
+                    DevUniformCudaHipRt dev(static_cast<int>(devIdx));
 
                     // Log this device.
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
@@ -92,13 +90,15 @@ namespace alpaka
 #        else
                     hipDeviceProp_t devProp;
 #        endif
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.iDevice()));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeHandle()));
 #    endif
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     printDeviceProperties(devProp);
 #    elif ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                     std::cout << __func__ << devProp.name << std::endl;
 #    endif
+                    return dev;
                 }
                 else
                 {
@@ -106,8 +106,6 @@ namespace alpaka
                     ssErr << "Unable to return device handle for device " << devIdx << ". It is not accessible!";
                     throw std::runtime_error(ssErr.str());
                 }
-
-                return dev;
             }
 
         private:

--- a/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
+++ b/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, René Widera, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, René Widera, Andrea Bocci, Bernhard Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of alpaka.
  *

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -44,7 +44,7 @@ namespace alpaka
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                     // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.getNativeDeviceHandle()));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.getNativeHandle()));
 
                     // - [cuda/hip]StreamDefault: Default queue creation flag.
                     // - [cuda/hip]StreamNonBlocking: Specifies that work running in the created queue may run

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2022 Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci, Bernhard Manfred Gruber,
+ * Antonio Di Pilato
  *
  * This file is part of alpaka.
  *

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -44,7 +44,7 @@ namespace alpaka
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                     // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.getNativeHandle()));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.getNativeDeviceHandle()));
 
                     // - [cuda/hip]StreamDefault: Default queue creation flag.
                     // - [cuda/hip]StreamNonBlocking: Specifies that work running in the created queue may run

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -43,7 +43,7 @@ namespace alpaka
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                     // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.iDevice()));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.getNativeHandle()));
 
                     // - [cuda/hip]StreamDefault: Default queue creation flag.
                     // - [cuda/hip]StreamNonBlocking: Specifies that work running in the created queue may run

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -43,7 +43,7 @@ namespace alpaka
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                     // Set the current device.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.m_iDevice));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_dev.iDevice()));
 
                     // - [cuda/hip]StreamDefault: Default queue creation flag.
                     // - [cuda/hip]StreamNonBlocking: Specifies that work running in the created queue may run

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -309,7 +309,7 @@ namespace alpaka
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.getNativeDeviceHandle()));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.getNativeHandle()));
                         // Allocate the buffer on this device.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaMalloc(&m_devMem, static_cast<size_t>(sizeof(int32_t))));
                         // Initiate the memory set.
@@ -332,7 +332,7 @@ namespace alpaka
                         m_bIsReady = true;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.getNativeDeviceHandle()));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.getNativeHandle()));
                         // Initiate the memory set.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             cudaMemset(m_devMem, static_cast<int>(1u), static_cast<size_t>(sizeof(int32_t))));
@@ -390,10 +390,7 @@ namespace alpaka
                 ALPAKA_FN_HOST static auto isSupported(alpaka::DevCudaRt const& dev) -> bool
                 {
                     int result = 0;
-                    cuDeviceGetAttribute(
-                        &result,
-                        CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS,
-                        dev.getNativeDeviceHandle());
+                    cuDeviceGetAttribute(&result, CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS, dev.getNativeHandle());
                     return result != 0;
                 }
             };
@@ -526,7 +523,7 @@ namespace alpaka
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.getNativeDeviceHandle()));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.getNativeHandle()));
                         // Allocate the buffer on this device.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipMalloc(&m_devMem, static_cast<size_t>(sizeof(int32_t))));
                         // Initiate the memory set.
@@ -549,7 +546,7 @@ namespace alpaka
                         m_bIsReady = true;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.getNativeDeviceHandle()));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.getNativeHandle()));
                         // Initiate the memory set.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             hipMemset(m_devMem, static_cast<int>(1u), static_cast<size_t>(sizeof(int32_t))));

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -308,7 +308,7 @@ namespace alpaka
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.iDevice()));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.getNativeHandle()));
                         // Allocate the buffer on this device.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaMalloc(&m_devMem, static_cast<size_t>(sizeof(int32_t))));
                         // Initiate the memory set.
@@ -331,7 +331,7 @@ namespace alpaka
                         m_bIsReady = true;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.iDevice()));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.getNativeHandle()));
                         // Initiate the memory set.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             cudaMemset(m_devMem, static_cast<int>(1u), static_cast<size_t>(sizeof(int32_t))));
@@ -389,7 +389,7 @@ namespace alpaka
                 ALPAKA_FN_HOST static auto isSupported(alpaka::DevCudaRt const& dev) -> bool
                 {
                     int result = 0;
-                    cuDeviceGetAttribute(&result, CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS, dev.iDevice());
+                    cuDeviceGetAttribute(&result, CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS, dev.getNativeHandle());
                     return result != 0;
                 }
             };
@@ -522,7 +522,7 @@ namespace alpaka
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.iDevice()));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.getNativeHandle()));
                         // Allocate the buffer on this device.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipMalloc(&m_devMem, static_cast<size_t>(sizeof(int32_t))));
                         // Initiate the memory set.
@@ -545,7 +545,7 @@ namespace alpaka
                         m_bIsReady = true;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.iDevice()));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.getNativeHandle()));
                         // Initiate the memory set.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             hipMemset(m_devMem, static_cast<int>(1u), static_cast<size_t>(sizeof(int32_t))));

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -308,7 +308,7 @@ namespace alpaka
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.m_iDevice));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.iDevice()));
                         // Allocate the buffer on this device.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaMalloc(&m_devMem, static_cast<size_t>(sizeof(int32_t))));
                         // Initiate the memory set.
@@ -331,7 +331,7 @@ namespace alpaka
                         m_bIsReady = true;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.m_iDevice));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.iDevice()));
                         // Initiate the memory set.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             cudaMemset(m_devMem, static_cast<int>(1u), static_cast<size_t>(sizeof(int32_t))));
@@ -389,7 +389,7 @@ namespace alpaka
                 ALPAKA_FN_HOST static auto isSupported(alpaka::DevCudaRt const& dev) -> bool
                 {
                     int result = 0;
-                    cuDeviceGetAttribute(&result, CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS, dev.m_iDevice);
+                    cuDeviceGetAttribute(&result, CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS, dev.iDevice());
                     return result != 0;
                 }
             };
@@ -522,7 +522,7 @@ namespace alpaka
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.m_iDevice));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.iDevice()));
                         // Allocate the buffer on this device.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipMalloc(&m_devMem, static_cast<size_t>(sizeof(int32_t))));
                         // Initiate the memory set.
@@ -545,7 +545,7 @@ namespace alpaka
                         m_bIsReady = true;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.m_iDevice));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.iDevice()));
                         // Initiate the memory set.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             hipMemset(m_devMem, static_cast<int>(1u), static_cast<size_t>(sizeof(int32_t))));

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -309,7 +309,7 @@ namespace alpaka
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.getNativeHandle()));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.getNativeDeviceHandle()));
                         // Allocate the buffer on this device.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaMalloc(&m_devMem, static_cast<size_t>(sizeof(int32_t))));
                         // Initiate the memory set.
@@ -332,7 +332,7 @@ namespace alpaka
                         m_bIsReady = true;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.getNativeHandle()));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.getNativeDeviceHandle()));
                         // Initiate the memory set.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             cudaMemset(m_devMem, static_cast<int>(1u), static_cast<size_t>(sizeof(int32_t))));
@@ -390,7 +390,10 @@ namespace alpaka
                 ALPAKA_FN_HOST static auto isSupported(alpaka::DevCudaRt const& dev) -> bool
                 {
                     int result = 0;
-                    cuDeviceGetAttribute(&result, CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS, dev.getNativeHandle());
+                    cuDeviceGetAttribute(
+                        &result,
+                        CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS,
+                        dev.getNativeDeviceHandle());
                     return result != 0;
                 }
             };
@@ -523,7 +526,7 @@ namespace alpaka
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.getNativeHandle()));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.getNativeDeviceHandle()));
                         // Allocate the buffer on this device.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipMalloc(&m_devMem, static_cast<size_t>(sizeof(int32_t))));
                         // Initiate the memory set.
@@ -546,7 +549,7 @@ namespace alpaka
                         m_bIsReady = true;
 
                         // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.getNativeHandle()));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.getNativeDeviceHandle()));
                         // Initiate the memory set.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             hipMemset(m_devMem, static_cast<int>(1u), static_cast<size_t>(sizeof(int32_t))));

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber,
+ * Antonio Di Pilato
  *
  * This file is part of alpaka.
  *

--- a/include/alpaka/traits/Traits.hpp
+++ b/include/alpaka/traits/Traits.hpp
@@ -1,0 +1,38 @@
+/* Copyright 2022 Antonio Di Pilato
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/Common.hpp>
+
+namespace alpaka
+{
+    //! The common traits.
+    namespace traits
+    {
+        //! The native handle trait.
+        template<typename TImpl, typename TSfinae = void>
+        struct NativeHandle
+        {
+            static auto getNativeHandle(TImpl const&)
+            {
+                static_assert(!sizeof(TImpl), "This type does not have a native handle!");
+                return 0;
+            }
+        };
+    } // namespace traits
+
+    //! Get the native handle of the alpaka object.
+    //! It will return the alpaka object handle if there is any, otherwise it generates a compile time error.
+    template<typename TImpl>
+    ALPAKA_FN_HOST auto getNativeHandle(TImpl const& impl)
+    {
+        return traits::NativeHandle<TImpl>::getNativeHandle(impl);
+    }
+} // namespace alpaka

--- a/include/alpaka/traits/Traits.hpp
+++ b/include/alpaka/traits/Traits.hpp
@@ -35,4 +35,8 @@ namespace alpaka
     {
         return traits::NativeHandle<TImpl>::getNativeHandle(impl);
     }
+
+    //! Alias to the type of the native handle.
+    template<typename TImpl>
+    using NativeHandle = decltype(getNativeHandle(std::declval<TImpl>()));
 } // namespace alpaka

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2021 Benjamin Worpitz, Jan Stephan
+# Copyright 2015-2022 Benjamin Worpitz, Jan Stephan, Antonio Di Pilato
 #
 # This file is part of alpaka.
 #
@@ -39,6 +39,7 @@ add_subdirectory("meta/")
 add_subdirectory("queue/")
 add_subdirectory("rand/")
 add_subdirectory("time/")
+add_subdirectory("traits/")
 add_subdirectory("vec/")
 add_subdirectory("warp/")
 add_subdirectory("workDiv/")

--- a/test/unit/traits/CMakeLists.txt
+++ b/test/unit/traits/CMakeLists.txt
@@ -1,0 +1,24 @@
+#
+# Copyright 2017-2022 Benjamin Worpitz, Axel Huebl, Jan Stephan, Antonio Di Pilato
+#
+# This file is part of alpaka.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+set(_TARGET_NAME "traitsTest")
+
+append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
+
+alpaka_add_executable(
+    ${_TARGET_NAME}
+    ${_FILES_SOURCE})
+target_link_libraries(
+    ${_TARGET_NAME}
+    PRIVATE common)
+
+set_target_properties(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
+
+add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME} ${_ALPAKA_TEST_OPTIONS})

--- a/test/unit/traits/src/NativeHandleTest.cpp
+++ b/test/unit/traits/src/NativeHandleTest.cpp
@@ -1,0 +1,25 @@
+/* Copyright 2022 Antonio Di Pilato
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <alpaka/acc/Traits.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
+#include <alpaka/traits/Traits.hpp>
+
+#include <catch2/catch.hpp>
+
+TEMPLATE_LIST_TEST_CASE("NativeHandle", "[handle]", alpaka::test::TestAccs)
+{
+    using Dev = alpaka::Dev<TestType>;
+    using Pltf = alpaka::Pltf<Dev>;
+    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto handle = alpaka::getNativeHandle(dev);
+
+    STATIC_REQUIRE(std::is_same_v<alpaka::NativeHandle<Dev>, decltype(handle)>);
+    STATIC_REQUIRE(std::is_same_v<alpaka::NativeHandle<Dev>, int>); // It won't work for SYCL backend
+}


### PR DESCRIPTION
This PR adds a getNativeHandle method to DevUniformCudaHipRt as requested by issue #1427 and will add the same for DevCpu. As for now, Alpaka assumes that there is a single CPU device, which will be set to some number (i.e. 0) and returned by an iDevice public method, but things can change in case we want to distinguish nodes/sockets.