### PR TITLE
Run clang-tidy modernize checks

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -22,7 +22,7 @@
 #include <iostream>
 
 template<size_t width>
-ALPAKA_FN_ACC size_t linIdxToPitchedIdx(size_t const globalIdx, size_t const pitch)
+ALPAKA_FN_ACC auto linIdxToPitchedIdx(size_t const globalIdx, size_t const pitch) -> size_t
 {
     const size_t idx_x = globalIdx % width;
     const size_t idx_y = globalIdx / width;

--- a/example/heatEquation/src/heatEquation.cpp
+++ b/example/heatEquation/src/heatEquation.cpp
@@ -66,7 +66,7 @@ struct HeatEquationKernel
 //!
 //! \param x value of x
 //! \param t value of t
-double exactSolution(double const x, double const t)
+auto exactSolution(double const x, double const t) -> double
 {
     constexpr double pi = 3.14159265358979323846;
     return std::exp(-pi * pi * t) * std::sin(pi * x);

--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -70,30 +70,27 @@ struct OpenMPScheduleTraitKernel : public OpenMPScheduleDefaultKernel
 {
 };
 
-namespace alpaka
+namespace alpaka::traits
 {
-    namespace traits
+    //! Schedule trait specialization for OpenMPScheduleTraitKernel.
+    //! This is the most general way to define a schedule.
+    //! In case neither the trait nor the member are provided, there will be no schedule() clause.
+    template<typename TAcc>
+    struct OmpSchedule<OpenMPScheduleTraitKernel, TAcc>
     {
-        //! Schedule trait specialization for OpenMPScheduleTraitKernel.
-        //! This is the most general way to define a schedule.
-        //! In case neither the trait nor the member are provided, there will be no schedule() clause.
-        template<typename TAcc>
-        struct OmpSchedule<OpenMPScheduleTraitKernel, TAcc>
+        template<typename TDim, typename... TArgs>
+        ALPAKA_FN_HOST static auto getOmpSchedule(
+            OpenMPScheduleTraitKernel const& /* kernelFnObj */,
+            Vec<TDim, Idx<TAcc>> const& /* blockThreadExtent */,
+            Vec<TDim, Idx<TAcc>> const& /* threadElemExtent */,
+            TArgs const&... /* args */) -> alpaka::omp::Schedule
         {
-            template<typename TDim, typename... TArgs>
-            ALPAKA_FN_HOST static auto getOmpSchedule(
-                OpenMPScheduleTraitKernel const& /* kernelFnObj */,
-                Vec<TDim, Idx<TAcc>> const& /* blockThreadExtent */,
-                Vec<TDim, Idx<TAcc>> const& /* threadElemExtent */,
-                TArgs const&... /* args */) -> alpaka::omp::Schedule
-            {
-                // Determine schedule at runtime for the given kernel and run parameters.
-                // For this particular example kernel, TArgs is an empty pack and can be removed.
-                return alpaka::omp::Schedule{alpaka::omp::Schedule::Dynamic, 2};
-            }
-        };
-    } // namespace traits
-} // namespace alpaka
+            // Determine schedule at runtime for the given kernel and run parameters.
+            // For this particular example kernel, TArgs is an empty pack and can be removed.
+            return alpaka::omp::Schedule{alpaka::omp::Schedule::Dynamic, 2};
+        }
+    };
+} // namespace alpaka::traits
 
 auto main() -> int
 {

--- a/example/reduce/src/alpakaConfig.hpp
+++ b/example/reduce/src/alpakaConfig.hpp
@@ -33,7 +33,7 @@ using WorkDiv = alpaka::WorkDivMembers<Dim, Extent>;
 //! \tparam TAcc The accelerator object.
 //! \tparam TSize The desired size.
 template<typename TAcc, uint64_t TSize>
-static constexpr uint64_t getMaxBlockSize()
+static constexpr auto getMaxBlockSize() -> uint64_t
 {
     return (TAcc::MaxBlockSize::value > TSize) ? TSize : TAcc::MaxBlockSize::value;
 }

--- a/example/reduce/src/iterator.hpp
+++ b/example/reduce/src/iterator.hpp
@@ -147,7 +147,7 @@ public:
     }
 
     //! Returns the iterator for the last item.
-    ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto end() const -> IteratorCpu
+    [[nodiscard]] ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto end() const -> IteratorCpu
     {
         auto ret = *this;
         ret.mIndex = this->mMaximum;

--- a/example/reduce/src/kernel.hpp
+++ b/example/reduce/src/kernel.hpp
@@ -30,7 +30,7 @@ struct cheapArray
     //! \param index The index of the element to be accessed.
     //!
     //! Returns the requested element per reference.
-    ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE T& operator[](uint64_t index)
+    ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto operator[](uint64_t index) -> T&
     {
         return data[index];
     }
@@ -40,7 +40,7 @@ struct cheapArray
     //! \param index The index of the element to be accessed.
     //!
     //! Returns the requested element per constant reference.
-    ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE const T& operator[](uint64_t index) const
+    ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE auto operator[](uint64_t index) const -> const T&
     {
         return data[index];
     }
@@ -77,12 +77,12 @@ struct ReduceKernel
     {
         auto& sdata(alpaka::declareSharedVar<cheapArray<T, TBlockSize>, __COUNTER__>(acc));
 
-        const uint32_t blockIndex(static_cast<uint32_t>(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0]));
-        const uint32_t threadIndex(static_cast<uint32_t>(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0]));
-        const uint32_t gridDimension(static_cast<uint32_t>(alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0]));
+        const auto blockIndex(static_cast<uint32_t>(alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc)[0]));
+        const auto threadIndex(static_cast<uint32_t>(alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc)[0]));
+        const auto gridDimension(static_cast<uint32_t>(alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc)[0]));
 
         // equivalent to blockIndex * TBlockSize + threadIndex
-        const uint32_t linearizedIndex(static_cast<uint32_t>(alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0]));
+        const auto linearizedIndex(static_cast<uint32_t>(alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc)[0]));
 
         typename GetIterator<T, TElem, TAcc>::Iterator it(acc, source, linearizedIndex, gridDimension * TBlockSize, n);
 

--- a/example/reduce/src/reduce.cpp
+++ b/example/reduce/src/reduce.cpp
@@ -58,20 +58,20 @@ using MaxBlockSize = Accelerator::MaxBlockSize;
 //!
 //! Returns true if the reduction was correct and false otherwise.
 template<typename T, typename DevHost, typename DevAcc, typename TFunc>
-T reduce(
+auto reduce(
     DevHost devHost,
     DevAcc devAcc,
     QueueAcc queue,
     uint64_t n,
     alpaka::Buf<DevHost, T, Dim, Idx> hostMemory,
-    TFunc func)
+    TFunc func) -> T
 {
     static constexpr uint64_t blockSize = getMaxBlockSize<Accelerator, 256>();
 
     // calculate optimal block size (8 times the MP count proved to be
     // relatively near to peak performance in benchmarks)
-    uint32_t blockCount = static_cast<uint32_t>(alpaka::getAccDevProps<Acc>(devAcc).m_multiProcessorCount * 8);
-    uint32_t maxBlockCount = static_cast<uint32_t>((((n + 1) / 2) - 1) / blockSize + 1); // ceil(ceil(n/2.0)/blockSize)
+    auto blockCount = static_cast<uint32_t>(alpaka::getAccDevProps<Acc>(devAcc).m_multiProcessorCount * 8);
+    auto maxBlockCount = static_cast<uint32_t>((((n + 1) / 2) - 1) / blockSize + 1); // ceil(ceil(n/2.0)/blockSize)
 
     if(blockCount > maxBlockCount)
         blockCount = maxBlockCount;
@@ -120,7 +120,7 @@ T reduce(
     return resultGpuHost;
 }
 
-int main()
+auto main() -> int
 {
     // select device and problem size
     const int dev = 0;
@@ -136,7 +136,7 @@ int main()
     // calculate optimal block size (8 times the MP count proved to be
     // relatively near to peak performance in benchmarks)
     uint32_t blockCount = static_cast<uint32_t>(alpaka::getAccDevProps<Acc>(devAcc).m_multiProcessorCount * 8);
-    uint32_t maxBlockCount = static_cast<uint32_t>((((n + 1) / 2) - 1) / blockSize + 1); // ceil(ceil(n/2.0)/blockSize)
+    auto maxBlockCount = static_cast<uint32_t>((((n + 1) / 2) - 1) / blockSize + 1); // ceil(ceil(n/2.0)/blockSize)
 
     if(blockCount > maxBlockCount)
         blockCount = maxBlockCount;

--- a/include/alpaka/atomic/AtomicStdLibLock.hpp
+++ b/include/alpaka/atomic/AtomicStdLibLock.hpp
@@ -31,7 +31,7 @@ namespace alpaka
         template<typename TAtomic, typename TOp, typename T, typename THierarchy, typename TSfinae>
         friend struct traits::AtomicOp;
 
-        static constexpr size_t nextPowerOf2(size_t const value, size_t const bit = 0u)
+        static constexpr auto nextPowerOf2(size_t const value, size_t const bit = 0u) -> size_t
         {
             return value <= (static_cast<size_t>(1u) << bit) ? (static_cast<size_t>(1u) << bit)
                                                              : nextPowerOf2(value, bit + 1u);
@@ -42,9 +42,9 @@ namespace alpaka
         // This is no perfect hash, there will be collisions if the size of pointer type
         // is not a power of two.
         template<typename TPtr>
-        static size_t hash(TPtr const* const ptr)
+        static auto hash(TPtr const* const ptr) -> size_t
         {
-            size_t const ptrAddr = reinterpret_cast<size_t>(ptr);
+            auto const ptrAddr = reinterpret_cast<size_t>(ptr);
             // using power of two for the next division will increase the performance
             constexpr size_t typeSizePowerOf2 = nextPowerOf2(sizeof(TPtr));
             // division removes the stride between indices
@@ -52,7 +52,7 @@ namespace alpaka
         }
 
         template<typename TPtr>
-        std::mutex& getMutex(TPtr const* const ptr) const
+        auto getMutex(TPtr const* const ptr) const -> std::mutex&
         {
             //! get the size of the hash table
             //

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -50,14 +50,14 @@ namespace alpaka
             ALPAKA_ASSERT_OFFLOAD(static_cast<std::uint32_t>(sizeBytes) <= staticAllocBytes());
         }
 
-        uint8_t* dynMemBegin() const
+        auto dynMemBegin() const -> uint8_t*
         {
             return std::data(m_mem);
         }
 
         /*! \return the pointer to the begin of data after the portion allocated as dynamical shared memory.
          */
-        uint8_t* staticMemBegin() const
+        auto staticMemBegin() const -> uint8_t*
         {
             return std::data(m_mem) + m_dynPitch;
         }
@@ -65,7 +65,7 @@ namespace alpaka
         /*! \return the remaining capacity for static block shared memory,
                     returns a 32-bit type for register efficiency on GPUs
             */
-        std::uint32_t staticMemCapacity() const
+        auto staticMemCapacity() const -> std::uint32_t
         {
             return staticAllocBytes() - m_dynPitch;
         }
@@ -73,13 +73,13 @@ namespace alpaka
         //! \return size of statically allocated memory available for both
         //!         dynamic and static shared memory. Value is of a 32-bit type
         //!         for register efficiency on GPUs
-        static constexpr std::uint32_t staticAllocBytes()
+        static constexpr auto staticAllocBytes() -> std::uint32_t
         {
             return detail::BlockSharedMemDynMemberStatic<TStaticAllocKiB>::staticAllocBytes;
         }
 
     private:
-        static std::uint32_t getPitch(std::size_t sizeBytes)
+        static auto getPitch(std::size_t sizeBytes) -> std::uint32_t
         {
             constexpr auto alignment = core::vectorization::defaultAlignment;
             return static_cast<std::uint32_t>((sizeBytes / alignment + (sizeBytes % alignment > 0u)) * alignment);

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynOmp5BuiltIn.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynOmp5BuiltIn.hpp
@@ -36,11 +36,11 @@ namespace alpaka
         }
 
         BlockSharedMemDynOmp5BuiltIn(const BlockSharedMemDynOmp5BuiltIn&) = delete;
-        BlockSharedMemDynOmp5BuiltIn& operator=(const BlockSharedMemDynOmp5BuiltIn&) = delete;
+        auto operator=(const BlockSharedMemDynOmp5BuiltIn&) -> BlockSharedMemDynOmp5BuiltIn& = delete;
         BlockSharedMemDynOmp5BuiltIn(BlockSharedMemDynOmp5BuiltIn&&) = delete;
-        BlockSharedMemDynOmp5BuiltIn& operator=(BlockSharedMemDynOmp5BuiltIn&&) = delete;
+        auto operator=(BlockSharedMemDynOmp5BuiltIn&&) -> BlockSharedMemDynOmp5BuiltIn& = delete;
 
-        std::byte* mem() const
+        [[nodiscard]] auto mem() const -> std::byte*
         {
             return m_mem;
         }
@@ -49,7 +49,7 @@ namespace alpaka
         //!         dynamic and static shared memory. This value is actually
         //!         unknown, will just return the statically defined limit for
         //!         BlockSharedMemDynMember.
-        static constexpr std::uint32_t staticAllocBytes()
+        static constexpr auto staticAllocBytes() -> std::uint32_t
         {
             return BlockSharedDynMemberAllocKiB << 10u;
         }

--- a/include/alpaka/block/shared/st/BlockSharedMemStMemberMasterSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMemberMasterSync.hpp
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include <memory>
+#include <utility>
 #include <vector>
 
 
@@ -34,8 +35,8 @@ namespace alpaka
             std::function<void()> fnSync,
             std::function<bool()> fnIsMasterThread)
             : detail::BlockSharedMemStMemberImpl<TDataAlignBytes>(mem, capacity)
-            , m_syncFn(fnSync)
-            , m_isMasterThreadFn(fnIsMasterThread)
+            , m_syncFn(std::move(fnSync))
+            , m_isMasterThreadFn(std::move(fnIsMasterThread))
         {
         }
 

--- a/include/alpaka/block/shared/st/detail/BlockSharedMemStMemberImpl.hpp
+++ b/include/alpaka/block/shared/st/detail/BlockSharedMemStMemberImpl.hpp
@@ -60,7 +60,7 @@ namespace alpaka
                 // Add meta data chunk in front of the user data
                 m_allocdBytes = varChunkEnd<MetaData>(m_allocdBytes);
                 ALPAKA_ASSERT_OFFLOAD(m_allocdBytes <= m_capacity);
-                MetaData* meta = getLatestVarPtr<MetaData>();
+                auto* meta = getLatestVarPtr<MetaData>();
 
                 // Allocate variable
                 m_allocdBytes = varChunkEnd<T>(m_allocdBytes);
@@ -83,7 +83,7 @@ namespace alpaka
             //! @param id unique id of the variable
             //! @return nullptr if variable with id not exists
             template<typename T>
-            T* getVarPtr(std::uint32_t id) const
+            auto getVarPtr(std::uint32_t id) const -> T*
             {
                 // Offset in bytes to the next unaligned meta data header behind the variable.
                 std::uint32_t off = 0;
@@ -96,7 +96,7 @@ namespace alpaka
                         = varChunkEnd<MetaData>(off) - static_cast<std::uint32_t>(sizeof(MetaData));
                     ALPAKA_ASSERT_OFFLOAD(
                         (alignedMetaDataOffset + static_cast<std::uint32_t>(sizeof(MetaData))) <= m_allocdBytes);
-                    MetaData* metaDataPtr = reinterpret_cast<MetaData*>(m_mem + alignedMetaDataOffset);
+                    auto* metaDataPtr = reinterpret_cast<MetaData*>(m_mem + alignedMetaDataOffset);
                     off = metaDataPtr->offset;
 
                     if(metaDataPtr->id == id)
@@ -109,7 +109,7 @@ namespace alpaka
 
             //! Get last allocated variable.
             template<typename T>
-            T* getLatestVarPtr() const
+            auto getLatestVarPtr() const -> T*
             {
                 return reinterpret_cast<T*>(&m_mem[m_allocdBytes - sizeof(T)]);
             }
@@ -129,9 +129,9 @@ namespace alpaka
             //! \param byteOffset Current byte offset.
             //! \result Byte offset to the end of the data chunk, relative to m_mem..
             template<typename T>
-            std::uint32_t varChunkEnd(std::uint32_t byteOffset) const
+            auto varChunkEnd(std::uint32_t byteOffset) const -> std::uint32_t
             {
-                std::size_t const ptr = reinterpret_cast<std::size_t>(m_mem + byteOffset);
+                auto const ptr = reinterpret_cast<std::size_t>(m_mem + byteOffset);
                 constexpr size_t align = std::max(TMinDataAlignBytes, alignof(T));
                 std::size_t const newPtrAdress = ((ptr + align - 1u) / align) * align + sizeof(T);
                 return static_cast<uint32_t>(newPtrAdress - reinterpret_cast<std::size_t>(m_mem));

--- a/include/alpaka/core/AlignedAlloc.hpp
+++ b/include/alpaka/core/AlignedAlloc.hpp
@@ -24,7 +24,7 @@ namespace alpaka
     {
         //! Rounds to the next higher power of two (if not already power of two).
         // Adapted from llvm/ADT/SmallPtrSet.h
-        ALPAKA_FN_INLINE ALPAKA_FN_HOST void* alignedAlloc(size_t alignment, size_t size)
+        ALPAKA_FN_INLINE ALPAKA_FN_HOST auto alignedAlloc(size_t alignment, size_t size) -> void*
         {
 #if BOOST_OS_WINDOWS
             return _aligned_malloc(size, alignment);

--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -37,11 +37,9 @@ namespace alpaka
             class ThreadSafeQueue : private std::queue<T>
             {
             public:
-                ThreadSafeQueue()
-                {
-                }
+                ThreadSafeQueue() = default;
                 //! \return If the queue is empty.
-                auto empty() const -> bool
+                [[nodiscard]] auto empty() const -> bool
                 {
                     return std::queue<T>::empty();
                 }
@@ -138,7 +136,7 @@ namespace alpaka
 
             private:
                 //! The execution function.
-                virtual auto run() -> void final
+                auto run() -> void final
                 {
                     m_Promise.set_value(this->m_FnObj());
                 }
@@ -147,7 +145,7 @@ namespace alpaka
 // Workaround: Clang can not support this when natively compiling device code. See ConcurrentExecPool.hpp.
 #if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_PTX)
                 //! Sets an exception.
-                virtual auto setException(std::exception_ptr const& exceptPtr) -> void final
+                auto setException(std::exception_ptr const& exceptPtr) -> void final
                 {
                     m_Promise.set_exception(exceptPtr);
                 }
@@ -174,7 +172,7 @@ namespace alpaka
 
             private:
                 //! The execution function.
-                virtual auto run() -> void final
+                auto run() -> void final
                 {
                     this->m_FnObj();
                     m_Promise.set_value();
@@ -184,7 +182,7 @@ namespace alpaka
 // Workaround: Clang can not support this when natively compiling device code. See ConcurrentExecPool.hpp.
 #if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_PTX)
                 //! Sets an exception.
-                virtual auto setException(std::exception_ptr const& exceptPtr) -> void final
+                auto setException(std::exception_ptr const& exceptPtr) -> void final
                 {
                     m_Promise.set_exception(exceptPtr);
                 }
@@ -323,7 +321,7 @@ namespace alpaka
                     return std::size(m_vConcurrentExecs);
                 }
                 //! \return If the thread pool is idle.
-                auto isIdle() const -> bool
+                [[nodiscard]] auto isIdle() const -> bool
                 {
                     return m_numActiveTasks == 0u;
                 }
@@ -490,12 +488,12 @@ namespace alpaka
                     return future;
                 }
                 //! \return The number of concurrent executors available.
-                auto getConcurrentExecutionCount() const -> TIdx
+                [[nodiscard]] auto getConcurrentExecutionCount() const -> TIdx
                 {
                     return std::size(m_vConcurrentExecs);
                 }
                 //! \return If the thread pool is idle.
-                auto isIdle() const -> bool
+                [[nodiscard]] auto isIdle() const -> bool
                 {
                     return m_numActiveTasks == 0u;
                 }

--- a/include/alpaka/core/Debug.hpp
+++ b/include/alpaka/core/Debug.hpp
@@ -13,6 +13,7 @@
 
 #include <iostream>
 #include <string>
+#include <utility>
 
 //! The no debug level.
 #define ALPAKA_DEBUG_DISABLED 0
@@ -36,7 +37,7 @@ namespace alpaka
             class ScopeLogStdOut final
             {
             public:
-                explicit ScopeLogStdOut(std::string const& sScope) : m_sScope(sScope)
+                explicit ScopeLogStdOut(std::string sScope) : m_sScope(std::move(sScope))
                 {
                     std::cout << "[+] " << m_sScope << std::endl;
                 }

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -111,7 +111,7 @@ namespace alpaka
             return !((*this) == rhs);
         }
 
-        ALPAKA_FN_HOST auto getAllQueues() const -> std::vector<std::shared_ptr<cpu::ICpuQueue>>
+        [[nodiscard]] ALPAKA_FN_HOST auto getAllQueues() const -> std::vector<std::shared_ptr<cpu::ICpuQueue>>
         {
             return m_spDevCpuImpl->getAllExistingQueues();
         }

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -91,7 +91,7 @@ namespace alpaka
                     m_queues.push_back(spQueue);
                 }
 
-                int iDevice() const
+                auto iDevice() const -> int
                 {
                     return m_iDevice;
                 }
@@ -155,7 +155,7 @@ namespace alpaka
         {
             return !((*this) == rhs);
         }
-        int iDevice() const
+        [[nodiscard]] auto iDevice() const -> int
         {
             return m_spDevOmp5Impl->iDevice();
         }
@@ -167,7 +167,8 @@ namespace alpaka
             return m_spDevOmp5Impl->mapStatic(pHost, extent);
         }
 
-        ALPAKA_FN_HOST auto getAllQueues() const -> std::vector<std::shared_ptr<IGenericThreadsQueue<DevOmp5>>>
+        [[nodiscard]] ALPAKA_FN_HOST auto getAllQueues() const
+            -> std::vector<std::shared_ptr<IGenericThreadsQueue<DevOmp5>>>
         {
             return m_spDevOmp5Impl->getAllExistingQueues();
         }

--- a/include/alpaka/event/EventGenericThreads.hpp
+++ b/include/alpaka/event/EventGenericThreads.hpp
@@ -20,6 +20,7 @@
 #include <condition_variable>
 #include <future>
 #include <mutex>
+#include <utility>
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
 #    include <iostream>
 #endif
@@ -36,7 +37,7 @@ namespace alpaka
                 : public concepts::Implements<ConceptCurrentThreadWaitFor, EventGenericThreadsImpl<TDev>>
             {
             public:
-                EventGenericThreadsImpl(TDev const& dev) noexcept : m_dev(dev)
+                EventGenericThreadsImpl(TDev dev) noexcept : m_dev(std::move(dev))
                 {
                 }
                 EventGenericThreadsImpl(EventGenericThreadsImpl<TDev> const&) = delete;

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -29,6 +29,7 @@
 #    include <functional>
 #    include <tuple>
 #    include <type_traits>
+#    include <utility>
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
 #        include <iostream>
 #    endif
@@ -41,9 +42,9 @@ namespace alpaka
     {
     public:
         template<typename TWorkDiv>
-        ALPAKA_FN_HOST TaskKernelCpuSerial(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST TaskKernelCpuSerial(TWorkDiv&& workDiv, TKernelFnObj kernelFnObj, TArgs&&... args)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj(kernelFnObj)
+            , m_kernelFnObj(std::move(kernelFnObj))
             , m_args(std::forward<TArgs>(args)...)
         {
             static_assert(

--- a/include/alpaka/math/FloatEqualExact.hpp
+++ b/include/alpaka/math/FloatEqualExact.hpp
@@ -37,7 +37,7 @@ namespace alpaka
          * @return a == b
          */
         template<typename T>
-        ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool floatEqualExactNoWarning(T a, T b)
+        ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC auto floatEqualExactNoWarning(T a, T b) -> bool
         {
             static_assert(
                 std::is_floating_point<T>::value,

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -48,11 +48,11 @@ namespace alpaka
         public:
             template<typename TExtent>
             ALPAKA_FN_HOST BufCpuImpl(
-                DevCpu const& dev,
+                DevCpu dev,
                 TElem* pMem,
                 std::function<void(TElem*)> deleter,
                 TExtent const& extent)
-                : m_dev(dev)
+                : m_dev(std::move(dev))
                 , m_extentElements(extent::getExtentVecEnd<TDim>(extent))
                 , m_pMem(pMem)
                 , m_deleter(std::move(deleter))
@@ -234,7 +234,7 @@ namespace alpaka
                 using Allocator
                     = AllocCpuAligned<std::integral_constant<std::size_t, core::vectorization::defaultAlignment>>;
                 static_assert(std::is_empty_v<Allocator>, "AllocCpuAligned is expected to be stateless");
-                TElem* memPtr
+                auto* memPtr
                     = alpaka::malloc<TElem>(Allocator{}, static_cast<std::size_t>(extent::getExtentProduct(extent)));
                 auto deleter = [](TElem* ptr) { alpaka::free(Allocator{}, ptr); };
 
@@ -259,7 +259,7 @@ namespace alpaka
                 using Allocator
                     = AllocCpuAligned<std::integral_constant<std::size_t, core::vectorization::defaultAlignment>>;
                 static_assert(std::is_empty_v<Allocator>, "AllocCpuAligned is expected to be stateless");
-                TElem* memPtr
+                auto* memPtr
                     = alpaka::malloc<TElem>(Allocator{}, static_cast<std::size_t>(extent::getExtentProduct(extent)));
                 auto deleter = [queue = std::move(queue)](TElem* ptr) mutable
                 {

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -90,7 +90,7 @@ namespace alpaka
             TElem* m_pMem;
 
             BufOmp5Impl(BufOmp5Impl&&) = default;
-            BufOmp5Impl& operator=(BufOmp5Impl&&) = default;
+            auto operator=(BufOmp5Impl&&) -> BufOmp5Impl& = default;
             ~BufOmp5Impl()
             {
                 omp_target_free(m_pMem, m_dev.m_spDevOmp5Impl->iDevice());
@@ -109,16 +109,16 @@ namespace alpaka
         {
         }
 
-        detail::BufOmp5Impl<TElem, TDim, TIdx>& operator*()
+        auto operator*() -> detail::BufOmp5Impl<TElem, TDim, TIdx>&
         {
             return *m_spBufImpl;
         }
-        const detail::BufOmp5Impl<TElem, TDim, TIdx>& operator*() const
+        auto operator*() const -> const detail::BufOmp5Impl<TElem, TDim, TIdx>&
         {
             return *m_spBufImpl;
         }
 
-        inline const Vec<TDim, TIdx>& extentElements() const
+        inline auto extentElements() const -> const Vec<TDim, TIdx>&
         {
             return m_spBufImpl->m_extentElements;
         }

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -47,7 +47,7 @@ namespace alpaka
                 return getPtrNative(*static_cast<TView*>(this));
             }
 
-            ALPAKA_FN_HOST auto data() const -> const_pointer
+            [[nodiscard]] ALPAKA_FN_HOST auto data() const -> const_pointer
             {
                 return getPtrNative(*static_cast<TView const*>(this));
             }
@@ -102,7 +102,7 @@ namespace alpaka
 
         private:
             template<std::size_t TDim, typename TIdx>
-            ALPAKA_FN_HOST auto ptr_at(Vec<DimInt<TDim>, TIdx> index) const -> const_pointer
+            [[nodiscard]] ALPAKA_FN_HOST auto ptr_at(Vec<DimInt<TDim>, TIdx> index) const -> const_pointer
             {
                 using Idx = alpaka::Idx<TView>;
                 static_assert(
@@ -112,7 +112,7 @@ namespace alpaka
                     std::is_convertible_v<TIdx, Idx>,
                     "the index type must be convertible to the index of the Buffer or View");
 
-                uintptr_t ptr = reinterpret_cast<uintptr_t>(data());
+                auto ptr = reinterpret_cast<uintptr_t>(data());
                 if constexpr(TDim > 0)
                 {
                     const auto pitchesInBytes = getPitchBytesVec(*static_cast<TView const*>(this));
@@ -152,7 +152,7 @@ namespace alpaka
             }
 
             template<std::size_t TDim, typename TIdx>
-            ALPAKA_FN_HOST auto at(Vec<DimInt<TDim>, TIdx> index) const -> const_reference
+            [[nodiscard]] ALPAKA_FN_HOST auto at(Vec<DimInt<TDim>, TIdx> index) const -> const_reference
             {
                 auto extent = extent::getExtentVec(*static_cast<TView const*>(this));
                 if(!(index < extent).foldrAll(std::logical_and<bool>()))

--- a/include/alpaka/mem/view/ViewAccessor.hpp
+++ b/include/alpaka/mem/view/ViewAccessor.hpp
@@ -40,7 +40,7 @@ namespace alpaka
                 }
 
                 template<typename U>
-                ALPAKA_FN_HOST_ACC auto& operator=(U&& value)
+                ALPAKA_FN_HOST_ACC auto operator=(U&& value) -> auto&
                 {
                     loc = std::forward<U>(value);
                     return *this;
@@ -150,7 +150,7 @@ namespace alpaka
 
         private:
             template<std::size_t... TIs>
-            ALPAKA_FN_HOST_ACC auto subscript(Vec<DimInt<TDim>, TBufferIdx> index) const -> ReturnType
+            [[nodiscard]] ALPAKA_FN_HOST_ACC auto subscript(Vec<DimInt<TDim>, TBufferIdx> index) const -> ReturnType
             {
 #if BOOST_COMP_GNUC
 #    pragma GCC diagnostic push
@@ -235,7 +235,7 @@ namespace alpaka
                     std::index_sequence<TExtentIs...>)
                 {
                     using TView = std::decay_t<TViewForwardRef>;
-                    static_assert(IsView<TView>::value, "");
+                    static_assert(IsView<TView>::value);
                     using TBufferIdx = Idx<TView>;
                     constexpr auto dim = Dim<TView>::value;
                     using Elem = Elem<TView>;

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -18,6 +18,7 @@
 #include <alpaka/vec/Vec.hpp>
 
 #include <type_traits>
+#include <utility>
 
 namespace alpaka
 {
@@ -31,9 +32,9 @@ namespace alpaka
 
     public:
         template<typename TExtent>
-        ALPAKA_FN_HOST ViewPlainPtr(TElem* pMem, Dev const& dev, TExtent const& extent = TExtent())
+        ALPAKA_FN_HOST ViewPlainPtr(TElem* pMem, Dev dev, TExtent const& extent = TExtent())
             : m_pMem(pMem)
-            , m_dev(dev)
+            , m_dev(std::move(dev))
             , m_extentElements(extent::getExtentVecEnd<TDim>(extent))
             , m_pitchBytes(detail::calculatePitchesFromExtents<TElem>(m_extentElements))
         {

--- a/include/alpaka/queue/QueueGenericThreadsBlocking.hpp
+++ b/include/alpaka/queue/QueueGenericThreadsBlocking.hpp
@@ -42,8 +42,8 @@ namespace alpaka
 #endif
             {
             public:
-                explicit QueueGenericThreadsBlockingImpl(TDev const& dev) noexcept
-                    : m_dev(dev)
+                explicit QueueGenericThreadsBlockingImpl(TDev dev) noexcept
+                    : m_dev(std::move(dev))
                     , m_bCurrentlyExecutingTask(false)
                 {
                 }

--- a/include/alpaka/queue/QueueGenericThreadsNonBlocking.hpp
+++ b/include/alpaka/queue/QueueGenericThreadsNonBlocking.hpp
@@ -57,7 +57,7 @@ namespace alpaka
                     false>; // If the threads should yield.
 
             public:
-                explicit QueueGenericThreadsNonBlockingImpl(TDev const& dev) : m_dev(dev), m_workerThread(1u)
+                explicit QueueGenericThreadsNonBlockingImpl(TDev dev) : m_dev(std::move(dev)), m_workerThread(1u)
                 {
                 }
                 QueueGenericThreadsNonBlockingImpl(QueueGenericThreadsNonBlockingImpl<TDev> const&) = delete;

--- a/include/alpaka/rand/Philox/MultiplyAndSplit64to32.hpp
+++ b/include/alpaka/rand/Philox/MultiplyAndSplit64to32.hpp
@@ -16,13 +16,13 @@ namespace alpaka
     namespace rand
     {
         /// Get high 32 bits of a 64-bit number
-        ALPAKA_FN_HOST_ACC constexpr static std::uint32_t high32Bits(std::uint64_t const x)
+        ALPAKA_FN_HOST_ACC constexpr static auto high32Bits(std::uint64_t const x) -> std::uint32_t
         {
             return static_cast<std::uint32_t>(x >> 32);
         }
 
         /// Get low 32 bits of a 64-bit number
-        ALPAKA_FN_HOST_ACC constexpr static std::uint32_t low32Bits(std::uint64_t const x)
+        ALPAKA_FN_HOST_ACC constexpr static auto low32Bits(std::uint64_t const x) -> std::uint32_t
         {
             return static_cast<std::uint32_t>(x & 0xffffffff);
         }

--- a/include/alpaka/rand/RandPhilox.hpp
+++ b/include/alpaka/rand/RandPhilox.hpp
@@ -68,15 +68,15 @@ namespace alpaka
             // STL UniformRandomBitGenerator concept
             // https://en.cppreference.com/w/cpp/named_req/UniformRandomBitGenerator
             using result_type = std::uint32_t;
-            ALPAKA_FN_HOST_ACC constexpr result_type min()
+            ALPAKA_FN_HOST_ACC constexpr auto min() -> result_type
             {
                 return 0;
             }
-            ALPAKA_FN_HOST_ACC constexpr result_type max()
+            ALPAKA_FN_HOST_ACC constexpr auto max() -> result_type
             {
                 return std::numeric_limits<result_type>::max();
             }
-            ALPAKA_FN_HOST_ACC result_type operator()()
+            ALPAKA_FN_HOST_ACC auto operator()() -> result_type
             {
                 return engineVariant();
             }
@@ -126,15 +126,15 @@ namespace alpaka
 
             using ResultInt = std::uint32_t;
             using ResultVec = decltype(engineVariant());
-            ALPAKA_FN_HOST_ACC constexpr ResultInt min()
+            ALPAKA_FN_HOST_ACC constexpr auto min() -> ResultInt
             {
                 return 0;
             }
-            ALPAKA_FN_HOST_ACC constexpr ResultInt max()
+            ALPAKA_FN_HOST_ACC constexpr auto max() -> ResultInt
             {
                 return std::numeric_limits<ResultInt>::max();
             }
-            ALPAKA_FN_HOST_ACC ResultVec operator()()
+            ALPAKA_FN_HOST_ACC auto operator()() -> ResultVec
             {
                 return engineVariant();
             }
@@ -181,7 +181,7 @@ namespace alpaka
             }
 
             template<typename TEngine>
-            ALPAKA_FN_HOST_ACC TResult operator()(TEngine& engine)
+            ALPAKA_FN_HOST_ACC auto operator()(TEngine& engine) -> TResult
             {
                 if constexpr(meta::IsArrayOrVector<TResult>::value)
                 {

--- a/include/alpaka/rand/RandStdLib.hpp
+++ b/include/alpaka/rand/RandStdLib.hpp
@@ -64,15 +64,15 @@ namespace alpaka
 
                     // STL UniformRandomBitGenerator concept interface
                     using result_type = std::mt19937::result_type;
-                    ALPAKA_FN_HOST constexpr static result_type min()
+                    ALPAKA_FN_HOST constexpr static auto min() -> result_type
                     {
                         return std::mt19937::min();
                     }
-                    ALPAKA_FN_HOST constexpr static result_type max()
+                    ALPAKA_FN_HOST constexpr static auto max() -> result_type
                     {
                         return std::mt19937::max();
                     }
-                    ALPAKA_FN_HOST result_type operator()()
+                    ALPAKA_FN_HOST auto operator()() -> result_type
                     {
                         return state();
                     }
@@ -107,15 +107,15 @@ namespace alpaka
 
                     // STL UniformRandomBitGenerator concept interface
                     using result_type = TinyMTengine::result_type;
-                    ALPAKA_FN_HOST constexpr static result_type min()
+                    ALPAKA_FN_HOST constexpr static auto min() -> result_type
                     {
                         return TinyMTengine::min();
                     }
-                    ALPAKA_FN_HOST constexpr static result_type max()
+                    ALPAKA_FN_HOST constexpr static auto max() -> result_type
                     {
                         return TinyMTengine::max();
                     }
-                    ALPAKA_FN_HOST result_type operator()()
+                    ALPAKA_FN_HOST auto operator()() -> result_type
                     {
                         return state();
                     }
@@ -148,15 +148,15 @@ namespace alpaka
 
                     // STL UniformRandomBitGenerator concept interface
                     using result_type = std::random_device::result_type;
-                    ALPAKA_FN_HOST constexpr static result_type min()
+                    ALPAKA_FN_HOST constexpr static auto min() -> result_type
                     {
                         return std::random_device::min();
                     }
-                    ALPAKA_FN_HOST constexpr static result_type max()
+                    ALPAKA_FN_HOST constexpr static auto max() -> result_type
                     {
                         return std::random_device::max();
                     }
-                    ALPAKA_FN_HOST result_type operator()()
+                    ALPAKA_FN_HOST auto operator()() -> result_type
                     {
                         return state();
                     }

--- a/include/alpaka/rand/TinyMT/Engine.hpp
+++ b/include/alpaka/rand/TinyMT/Engine.hpp
@@ -27,7 +27,7 @@ namespace alpaka
                 {
                     using result_type = std::uint32_t;
 
-                    static constexpr result_type default_seed()
+                    static constexpr auto default_seed() -> result_type
                     {
                         return 42u;
                     }
@@ -53,17 +53,17 @@ namespace alpaka
                         seed(magicSeed);
                     }
 
-                    result_type operator()()
+                    auto operator()() -> result_type
                     {
                         return tinymt32_generate_uint32(&prng);
                     }
 
-                    static constexpr result_type min()
+                    static constexpr auto min() -> result_type
                     {
                         return 0u;
                     }
 
-                    static constexpr result_type max()
+                    static constexpr auto max() -> result_type
                     {
                         return UINT32_MAX;
                     }

--- a/include/alpaka/test/Array.hpp
+++ b/include/alpaka/test/Array.hpp
@@ -22,13 +22,13 @@ namespace alpaka
             TType m_data[TSize];
 
             template<typename T_Idx>
-            ALPAKA_FN_HOST_ACC const TType& operator[](const T_Idx idx) const
+            ALPAKA_FN_HOST_ACC auto operator[](const T_Idx idx) const -> const TType&
             {
                 return m_data[idx];
             }
 
             template<typename TIdx>
-            ALPAKA_FN_HOST_ACC TType& operator[](const TIdx idx)
+            ALPAKA_FN_HOST_ACC auto operator[](const TIdx idx) -> TType&
             {
                 return m_data[idx];
             }

--- a/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/include/alpaka/test/KernelExecutionFixture.hpp
@@ -22,6 +22,8 @@
 #include <alpaka/test/Check.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 
+#include <utility>
+
 namespace alpaka
 {
     namespace test
@@ -53,11 +55,11 @@ namespace alpaka
                       alpaka::GridBlockExtentSubDivRestrictions::Unrestricted))
             {
             }
-            KernelExecutionFixture(WorkDiv const& workDiv)
+            KernelExecutionFixture(WorkDiv workDiv)
                 : m_devHost(alpaka::getDevByIdx<PltfCpu>(0u))
                 , m_devAcc(alpaka::getDevByIdx<PltfAcc>(0u))
                 , m_queue(m_devAcc)
-                , m_workDiv(workDiv)
+                , m_workDiv(std::move(workDiv))
             {
             }
             template<typename TKernelFnObj, typename... TArgs>

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -13,6 +13,7 @@
 
 #include <condition_variable>
 #include <mutex>
+#include <utility>
 
 namespace alpaka
 {
@@ -48,8 +49,8 @@ namespace alpaka
                 {
                 public:
                     //! Constructor.
-                    ALPAKA_FN_HOST EventHostManualTriggerCpuImpl(TDev const& dev) noexcept
-                        : m_dev(dev)
+                    ALPAKA_FN_HOST EventHostManualTriggerCpuImpl(TDev dev) noexcept
+                        : m_dev(std::move(dev))
                         , m_mutex()
                         , m_enqueueCount(0u)
                         , m_bIsReady(true)

--- a/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/include/alpaka/test/mem/view/ViewTest.hpp
@@ -251,7 +251,7 @@ namespace alpaka
 
             // alpaka::set
             {
-                std::uint8_t const byte(static_cast<uint8_t>(42u));
+                auto const byte(static_cast<uint8_t>(42u));
                 alpaka::memset(queue, view, byte);
                 alpaka::wait(queue);
                 verifyBytesSet<TAcc>(view, byte);

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -198,7 +198,7 @@ namespace alpaka
         }
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TFnObj, std::size_t... TIndices>
-        ALPAKA_FN_HOST_ACC auto foldrByIndices(
+        [[nodiscard]] ALPAKA_FN_HOST_ACC auto foldrByIndices(
             TFnObj const& f,
             std::integer_sequence<std::size_t, TIndices...> const& /* indices */) const
         {
@@ -206,7 +206,7 @@ namespace alpaka
         }
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TFnObj, std::size_t... TIndices>
-        ALPAKA_FN_HOST_ACC auto foldrByIndices(
+        [[nodiscard]] ALPAKA_FN_HOST_ACC auto foldrByIndices(
             TFnObj const& f,
             std::integer_sequence<std::size_t, TIndices...> const& /* indices */,
             TVal initial) const
@@ -215,13 +215,13 @@ namespace alpaka
         }
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TFnObj>
-        ALPAKA_FN_HOST_ACC auto foldrAll(TFnObj const& f) const
+        [[nodiscard]] ALPAKA_FN_HOST_ACC auto foldrAll(TFnObj const& f) const
         {
             return foldrByIndices(f, IdxSequence());
         }
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TFnObj>
-        ALPAKA_FN_HOST_ACC auto foldrAll(TFnObj const& f, TVal initial) const
+        [[nodiscard]] ALPAKA_FN_HOST_ACC auto foldrAll(TFnObj const& f, TVal initial) const
         {
             return foldrByIndices(f, IdxSequence(), initial);
         }
@@ -232,7 +232,7 @@ namespace alpaka
 #endif
         //! \return The product of all values.
         ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC auto prod() const -> TVal
+        [[nodiscard]] ALPAKA_FN_HOST_ACC auto prod() const -> TVal
         {
             return foldrAll(std::multiplies<TVal>(), TVal(1));
         }
@@ -241,30 +241,30 @@ namespace alpaka
 #endif
         //! \return The sum of all values.
         ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC auto sum() const -> TVal
+        [[nodiscard]] ALPAKA_FN_HOST_ACC auto sum() const -> TVal
         {
             return foldrAll(std::plus<TVal>(), TVal(0));
         }
         //! \return The min of all values.
         ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC auto min() const -> TVal
+        [[nodiscard]] ALPAKA_FN_HOST_ACC auto min() const -> TVal
         {
             return foldrAll(meta::min<TVal>());
         }
         //! \return The max of all values.
         ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC auto max() const -> TVal
+        [[nodiscard]] ALPAKA_FN_HOST_ACC auto max() const -> TVal
         {
             return foldrAll(meta::max<TVal>());
         }
         //! \return The index of the minimal element.
-        ALPAKA_FN_HOST auto minElem() const -> typename TDim::value_type
+        [[nodiscard]] ALPAKA_FN_HOST auto minElem() const -> typename TDim::value_type
         {
             return static_cast<typename TDim::value_type>(
                 std::distance(std::begin(m_data), std::min_element(std::begin(m_data), std::end(m_data))));
         }
         //! \return The index of the maximal element.
-        ALPAKA_FN_HOST auto maxElem() const -> typename TDim::value_type
+        [[nodiscard]] ALPAKA_FN_HOST auto maxElem() const -> typename TDim::value_type
         {
             return static_cast<typename TDim::value_type>(
                 std::distance(std::begin(m_data), std::max_element(std::begin(m_data), std::end(m_data))));
@@ -277,7 +277,7 @@ namespace alpaka
         }
 
         template<size_t I>
-        ALPAKA_FN_HOST_ACC auto get() const -> TVal
+        [[nodiscard]] ALPAKA_FN_HOST_ACC auto get() const -> TVal
         {
             return (*this)[I];
         }

--- a/test/integ/hostOnlyAPI/src/hostOnlyAPI.cpp
+++ b/test/integ/hostOnlyAPI/src/hostOnlyAPI.cpp
@@ -18,7 +18,7 @@
 
 // fill an trivial type with std::memset
 template<typename T>
-constexpr T memset_value(int c)
+constexpr auto memset_value(int c) -> T
 {
     T t;
     std::memset(&t, c, sizeof(T));

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -31,8 +31,7 @@ public:
     {
     }
     ALPAKA_NO_HOST_ACC_WARNING
-    ALPAKA_FN_INLINE
-    ALPAKA_FN_HOST_ACC auto absSq() const -> T
+    [[nodiscard]] ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC auto absSq() const -> T
     {
         return r * r + i * i;
     }
@@ -182,7 +181,8 @@ public:
 #else
     //! This uses a simple mapping from iteration count to colors.
     //! This leads to banding but allows a all pixels to be colored.
-    ALPAKA_FN_ACC auto iterationCountToRepeatedColor(std::uint32_t const& iterationCount) const -> std::uint32_t
+    [[nodiscard]] ALPAKA_FN_ACC auto iterationCountToRepeatedColor(std::uint32_t const& iterationCount) const
+        -> std::uint32_t
     {
         return m_colors[iterationCount % 16];
     }

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -121,39 +121,35 @@ public:
     }
 };
 
-namespace alpaka
+namespace alpaka::traits
 {
-    namespace traits
+    //! The trait for getting the size of the block shared dynamic memory for a kernel.
+    template<typename TAcc>
+    struct BlockSharedMemDynSizeBytes<MatMulKernel, TAcc>
     {
-        //! The trait for getting the size of the block shared dynamic memory for a kernel.
-        template<typename TAcc>
-        struct BlockSharedMemDynSizeBytes<MatMulKernel, TAcc>
+        //! \return The size of the shared memory allocated for a block.
+        template<typename TVec, typename TIndex, typename TElem>
+        ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
+            MatMulKernel const& /* matMulKernel */,
+            TVec const& blockThreadExtent,
+            TVec const& threadElemExtent,
+            TIndex const& /* m */,
+            TIndex const& /* n */,
+            TIndex const& /* k */,
+            TElem const& /* alpha */,
+            TElem const* const /* A */,
+            TIndex const& /* lda */,
+            TElem const* const /* B */,
+            TIndex const& /* ldb */,
+            TElem const& /* beta */,
+            TElem* const /* C */,
+            TIndex const& /* ldc */)
         {
-            //! \return The size of the shared memory allocated for a block.
-            template<typename TVec, typename TIndex, typename TElem>
-            ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
-                MatMulKernel const& /* matMulKernel */,
-                TVec const& blockThreadExtent,
-                TVec const& threadElemExtent,
-                TIndex const& /* m */,
-                TIndex const& /* n */,
-                TIndex const& /* k */,
-                TElem const& /* alpha */,
-                TElem const* const /* A */,
-                TIndex const& /* lda */,
-                TElem const* const /* B */,
-                TIndex const& /* ldb */,
-                TElem const& /* beta */,
-                TElem* const /* C */,
-                TIndex const& /* ldc */)
-            {
-                // Reserve the buffer for the two blocks of A and B.
-                return static_cast<std::size_t>(2u * blockThreadExtent.prod() * threadElemExtent.prod())
-                    * sizeof(TElem);
-            }
-        };
-    } // namespace traits
-} // namespace alpaka
+            // Reserve the buffer for the two blocks of A and B.
+            return static_cast<std::size_t>(2u * blockThreadExtent.prod() * threadElemExtent.prod()) * sizeof(TElem);
+        }
+    };
+} // namespace alpaka::traits
 
 using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<2u>, std::uint32_t>;
 

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -87,27 +87,24 @@ public:
     }
 };
 
-namespace alpaka
+namespace alpaka::traits
 {
-    namespace traits
+    //! The trait for getting the size of the block shared dynamic memory for a kernel.
+    template<typename TnumUselessWork, typename Val, typename TAcc>
+    struct BlockSharedMemDynSizeBytes<SharedMemKernel<TnumUselessWork, Val>, TAcc>
     {
-        //! The trait for getting the size of the block shared dynamic memory for a kernel.
-        template<typename TnumUselessWork, typename Val, typename TAcc>
-        struct BlockSharedMemDynSizeBytes<SharedMemKernel<TnumUselessWork, Val>, TAcc>
+        //! \return The size of the shared memory allocated for a block.
+        template<typename TVec, typename... TArgs>
+        ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
+            SharedMemKernel<TnumUselessWork, Val> const& /* sharedMemKernel */,
+            TVec const& blockThreadExtent,
+            TVec const& threadElemExtent,
+            TArgs&&...) -> std::size_t
         {
-            //! \return The size of the shared memory allocated for a block.
-            template<typename TVec, typename... TArgs>
-            ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
-                SharedMemKernel<TnumUselessWork, Val> const& /* sharedMemKernel */,
-                TVec const& blockThreadExtent,
-                TVec const& threadElemExtent,
-                TArgs&&...) -> std::size_t
-            {
-                return static_cast<std::size_t>(blockThreadExtent.prod() * threadElemExtent.prod()) * sizeof(Val);
-            }
-        };
-    } // namespace traits
-} // namespace alpaka
+            return static_cast<std::size_t>(blockThreadExtent.prod() * threadElemExtent.prod()) * sizeof(Val);
+        }
+    };
+} // namespace alpaka::traits
 
 using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, std::uint32_t>;
 

--- a/test/integ/zeroDimBuffer/src/zeroDimBuffer.cpp
+++ b/test/integ/zeroDimBuffer/src/zeroDimBuffer.cpp
@@ -22,7 +22,7 @@
 
 // fill an trivial type with std::memset
 template<typename T>
-constexpr T memset_value(int c)
+constexpr auto memset_value(int c) -> T
 {
     T t;
     std::memset(&t, c, sizeof(T));

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -18,17 +18,17 @@
 #include <type_traits>
 
 template<typename T1, typename T2>
-ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool equals(T1 a, T2 b)
+ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC auto equals(T1 a, T2 b) -> bool
 {
     return a == b;
 }
 
-ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool equals(float a, float b)
+ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC auto equals(float a, float b) -> bool
 {
     return alpaka::math::floatEqualExactNoWarning(a, b);
 }
 
-ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC bool equals(double a, double b)
+ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC auto equals(double a, double b) -> bool
 {
     return alpaka::math::floatEqualExactNoWarning(a, b);
 }

--- a/test/unit/block/shared/src/BlockSharedMemDyn.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemDyn.cpp
@@ -35,28 +35,25 @@ public:
     }
 };
 
-namespace alpaka
+namespace alpaka::traits
 {
-    namespace traits
+    //! The trait for getting the size of the block shared dynamic memory for a kernel.
+    template<typename TAcc>
+    struct BlockSharedMemDynSizeBytes<BlockSharedMemDynTestKernel, TAcc>
     {
-        //! The trait for getting the size of the block shared dynamic memory for a kernel.
-        template<typename TAcc>
-        struct BlockSharedMemDynSizeBytes<BlockSharedMemDynTestKernel, TAcc>
+        //! \return The size of the shared memory allocated for a block.
+        template<typename TVec>
+        ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
+            BlockSharedMemDynTestKernel const& /* blockSharedMemDyn */,
+            TVec const& blockThreadExtent,
+            TVec const& threadElemExtent,
+            bool* /* success */) -> std::size_t
         {
-            //! \return The size of the shared memory allocated for a block.
-            template<typename TVec>
-            ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
-                BlockSharedMemDynTestKernel const& /* blockSharedMemDyn */,
-                TVec const& blockThreadExtent,
-                TVec const& threadElemExtent,
-                bool* /* success */) -> std::size_t
-            {
-                auto const gridSize = blockThreadExtent.prod() * threadElemExtent.prod();
-                return static_cast<std::size_t>(gridSize) * sizeof(std::uint32_t);
-            }
-        };
-    } // namespace traits
-} // namespace alpaka
+            auto const gridSize = blockThreadExtent.prod() * threadElemExtent.prod();
+            return static_cast<std::size_t>(gridSize) * sizeof(std::uint32_t);
+        }
+    };
+} // namespace alpaka::traits
 
 TEMPLATE_LIST_TEST_CASE("sameNonNullAdress", "[blockSharedMemDyn]", alpaka::test::TestAccs)
 {

--- a/test/unit/block/sharedSharing/src/BlockSharedMemSharing.cpp
+++ b/test/unit/block/sharedSharing/src/BlockSharedMemSharing.cpp
@@ -122,27 +122,24 @@ public:
     }
 };
 
-namespace alpaka
+namespace alpaka::traits
 {
-    namespace traits
+    //! The trait for getting the size of the block shared dynamic memory for a kernel.
+    template<typename TAcc>
+    struct BlockSharedMemDynSizeBytes<BlockSharedMemDynSharingTestKernel, TAcc>
     {
-        //! The trait for getting the size of the block shared dynamic memory for a kernel.
-        template<typename TAcc>
-        struct BlockSharedMemDynSizeBytes<BlockSharedMemDynSharingTestKernel, TAcc>
+        //! \return The size of the shared memory allocated for a block.
+        template<typename TVec>
+        ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
+            BlockSharedMemDynSharingTestKernel const& /* blockSharedMemDyn */,
+            TVec const& /* blockThreadExtent */,
+            TVec const& /* threadElemExtent */,
+            std::uint32_t* /* sums */) -> std::size_t
         {
-            //! \return The size of the shared memory allocated for a block.
-            template<typename TVec>
-            ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
-                BlockSharedMemDynSharingTestKernel const& /* blockSharedMemDyn */,
-                TVec const& /* blockThreadExtent */,
-                TVec const& /* threadElemExtent */,
-                std::uint32_t* /* sums */) -> std::size_t
-            {
-                return sizeof(std::uint32_t);
-            }
-        };
-    } // namespace traits
-} // namespace alpaka
+            return sizeof(std::uint32_t);
+        }
+    };
+} // namespace alpaka::traits
 
 TEMPLATE_LIST_TEST_CASE("blockSharedMemDyn", "[blockSharedMemSharing]", TestAccs)
 {

--- a/test/unit/block/sync/src/BlockSync.cpp
+++ b/test/unit/block/sync/src/BlockSync.cpp
@@ -47,28 +47,25 @@ public:
     }
 };
 
-namespace alpaka
+namespace alpaka::traits
 {
-    namespace traits
+    //! The trait for getting the size of the block shared dynamic memory for a kernel.
+    template<typename TAcc>
+    struct BlockSharedMemDynSizeBytes<BlockSyncTestKernel, TAcc>
     {
-        //! The trait for getting the size of the block shared dynamic memory for a kernel.
-        template<typename TAcc>
-        struct BlockSharedMemDynSizeBytes<BlockSyncTestKernel, TAcc>
+        //! \return The size of the shared memory allocated for a block.
+        template<typename TVec>
+        ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
+            BlockSyncTestKernel const& /* blockSharedMemDyn */,
+            TVec const& blockThreadExtent,
+            TVec const& /* threadElemExtent */,
+            bool* /* success */) -> std::size_t
         {
-            //! \return The size of the shared memory allocated for a block.
-            template<typename TVec>
-            ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
-                BlockSyncTestKernel const& /* blockSharedMemDyn */,
-                TVec const& blockThreadExtent,
-                TVec const& /* threadElemExtent */,
-                bool* /* success */) -> std::size_t
-            {
-                using Idx = alpaka::Idx<TAcc>;
-                return static_cast<std::size_t>(blockThreadExtent.prod()) * sizeof(Idx);
-            }
-        };
-    } // namespace traits
-} // namespace alpaka
+            using Idx = alpaka::Idx<TAcc>;
+            return static_cast<std::size_t>(blockThreadExtent.prod()) * sizeof(Idx);
+        }
+    };
+} // namespace alpaka::traits
 
 TEMPLATE_LIST_TEST_CASE("synchronize", "[blockSync]", alpaka::test::TestAccs)
 {

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -76,26 +76,23 @@ struct KernelWithTrait : TBase
 {
 };
 
-namespace alpaka
+namespace alpaka::traits
 {
-    namespace traits
+    // Specialize the trait for kernels of type KernelWithTrait<>
+    template<typename TBase, typename TAcc>
+    struct OmpSchedule<KernelWithTrait<TBase>, TAcc>
     {
-        // Specialize the trait for kernels of type KernelWithTrait<>
-        template<typename TBase, typename TAcc>
-        struct OmpSchedule<KernelWithTrait<TBase>, TAcc>
+        template<typename TDim, typename... TArgs>
+        ALPAKA_FN_HOST static auto getOmpSchedule(
+            KernelWithTrait<TBase> const& /* kernelFnObj */,
+            Vec<TDim, Idx<TAcc>> const& /* blockThreadExtent */,
+            Vec<TDim, Idx<TAcc>> const& /* threadElemExtent */,
+            TArgs const&... /* args */) -> alpaka::omp::Schedule
         {
-            template<typename TDim, typename... TArgs>
-            ALPAKA_FN_HOST static auto getOmpSchedule(
-                KernelWithTrait<TBase> const& /* kernelFnObj */,
-                Vec<TDim, Idx<TAcc>> const& /* blockThreadExtent */,
-                Vec<TDim, Idx<TAcc>> const& /* threadElemExtent */,
-                TArgs const&... /* args */) -> alpaka::omp::Schedule
-            {
-                return alpaka::omp::Schedule{alpaka::omp::Schedule::Static, 4};
-            }
-        };
-    } // namespace traits
-} // namespace alpaka
+            return alpaka::omp::Schedule{alpaka::omp::Schedule::Static, 4};
+        }
+    };
+} // namespace alpaka::traits
 
 // Generic testing routine for the given kernel type
 template<typename TAcc, typename TKernel>

--- a/test/unit/math/src/Buffer.hpp
+++ b/test/unit/math/src/Buffer.hpp
@@ -99,7 +99,7 @@ namespace alpaka
                     }
 
                     ALPAKA_FN_HOST
-                    friend std::ostream& operator<<(std::ostream& os, const Buffer& buffer)
+                    friend auto operator<<(std::ostream& os, const Buffer& buffer) -> std::ostream&
                     {
                         os << "capacity: " << capacity << "\n";
                         for(size_t i = 0; i < capacity; ++i)

--- a/test/unit/math/src/Defines.hpp
+++ b/test/unit/math/src/Defines.hpp
@@ -48,7 +48,7 @@ namespace alpaka
 
                     T arg[arity_nr]; // represents arg0, arg1, ...
 
-                    friend std::ostream& operator<<(std::ostream& os, const ArgsItem& argsItem)
+                    friend auto operator<<(std::ostream& os, const ArgsItem& argsItem) -> std::ostream&
                     {
                         os.precision(17);
                         os << "[ ";

--- a/test/unit/math/src/sincos.cpp
+++ b/test/unit/math/src/sincos.cpp
@@ -18,11 +18,8 @@
 
 // https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
 template<typename TAcc, typename FP>
-ALPAKA_FN_ACC std::enable_if_t<!std::numeric_limits<FP>::is_integer, bool> almost_equal(
-    TAcc const& acc,
-    FP x,
-    FP y,
-    int ulp)
+ALPAKA_FN_ACC auto almost_equal(TAcc const& acc, FP x, FP y, int ulp)
+    -> std::enable_if_t<!std::numeric_limits<FP>::is_integer, bool>
 {
     // the machine epsilon has to be scaled to the magnitude of the values used
     // and multiplied by the desired precision in ULPs (units in the last place)

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -229,7 +229,7 @@ static auto testBufferAccessorAdaptor(
     INFO("buffer pitch: " << pitch << " bytes")
     CHECK((index < extent).foldrAll(std::logical_and<bool>()));
 
-    uintptr_t base = reinterpret_cast<uintptr_t>(std::data(buf));
+    auto base = reinterpret_cast<uintptr_t>(std::data(buf));
     uintptr_t expected = base;
     if constexpr(Dim::value > 1)
     {

--- a/test/unit/mem/fence/src/FenceTest.cpp
+++ b/test/unit/mem/fence/src/FenceTest.cpp
@@ -73,27 +73,24 @@ public:
     }
 };
 
-namespace alpaka
+namespace alpaka::traits
 {
-    namespace traits
+    //! The trait for getting the size of the block shared dynamic memory for a kernel.
+    template<typename TAcc>
+    struct BlockSharedMemDynSizeBytes<BlockFenceTestKernel, TAcc>
     {
-        //! The trait for getting the size of the block shared dynamic memory for a kernel.
-        template<typename TAcc>
-        struct BlockSharedMemDynSizeBytes<BlockFenceTestKernel, TAcc>
+        //! \return The size of the shared memory allocated for a block.
+        template<typename TVec, typename... TArgs>
+        ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
+            BlockFenceTestKernel const&,
+            TVec const&,
+            TVec const&,
+            TArgs&&...) -> std::size_t
         {
-            //! \return The size of the shared memory allocated for a block.
-            template<typename TVec, typename... TArgs>
-            ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
-                BlockFenceTestKernel const&,
-                TVec const&,
-                TVec const&,
-                TArgs&&...) -> std::size_t
-            {
-                return 2 * sizeof(int);
-            }
-        };
-    } // namespace traits
-} // namespace alpaka
+            return 2 * sizeof(int);
+        }
+    };
+} // namespace alpaka::traits
 
 using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, std::size_t>;
 

--- a/test/unit/mem/p2p/src/P2P.cpp
+++ b/test/unit/mem/p2p/src/P2P.cpp
@@ -45,7 +45,7 @@ static auto testP2P(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& ext
     auto buf1 = alpaka::allocBuf<Elem, Idx>(dev1, extent);
 
     // fill each byte with value 42
-    std::uint8_t const byte(static_cast<uint8_t>(42u));
+    auto const byte(static_cast<uint8_t>(42u));
     alpaka::memset(queue1, buf1, byte);
     alpaka::wait(queue1);
 

--- a/test/unit/mem/view/src/Accessor.cpp
+++ b/test/unit/mem/view/src/Accessor.cpp
@@ -300,8 +300,8 @@ namespace
             alpakaex::BufferAccessor<TAcc, int, 1, alpakaex::ReadAccess> const r2,
             alpakaex::BufferAccessor<TAcc, int, 1, alpakaex::ReadAccess, TIdx> const r3) const noexcept
         {
-            static_assert(std::is_same<decltype(r1), decltype(r2)>::value, "");
-            static_assert(std::is_same<decltype(r2), decltype(r3)>::value, "");
+            static_assert(std::is_same<decltype(r1), decltype(r2)>::value);
+            static_assert(std::is_same<decltype(r2), decltype(r3)>::value);
         }
     };
 
@@ -314,8 +314,8 @@ namespace
             alpakaex::BufferAccessor<TAcc, int, 1, alpakaex::WriteAccess> const w2,
             alpakaex::BufferAccessor<TAcc, int, 1, alpakaex::WriteAccess, TIdx> const w3) const noexcept
         {
-            static_assert(std::is_same<decltype(w1), decltype(w2)>::value, "");
-            static_assert(std::is_same<decltype(w2), decltype(w3)>::value, "");
+            static_assert(std::is_same<decltype(w1), decltype(w2)>::value);
+            static_assert(std::is_same<decltype(w2), decltype(w3)>::value);
         }
     };
     struct BufferAccessorKernelReadWrite
@@ -328,9 +328,9 @@ namespace
             alpakaex::BufferAccessor<TAcc, int, 1, alpakaex::ReadWriteAccess> const rw3,
             alpakaex::BufferAccessor<TAcc, int, 1, alpakaex::ReadWriteAccess, TIdx> const rw4) const noexcept
         {
-            static_assert(std::is_same<decltype(rw1), decltype(rw2)>::value, "");
-            static_assert(std::is_same<decltype(rw2), decltype(rw3)>::value, "");
-            static_assert(std::is_same<decltype(rw3), decltype(rw4)>::value, "");
+            static_assert(std::is_same<decltype(rw1), decltype(rw2)>::value);
+            static_assert(std::is_same<decltype(rw2), decltype(rw3)>::value);
+            static_assert(std::is_same<decltype(rw3), decltype(rw4)>::value);
         }
     };
 } // namespace

--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -26,118 +26,115 @@
         "-Wcast-align" // "cast from 'std::uint8_t*' to 'Elem*' increases required alignment of target type"
 #endif
 
-namespace alpaka
+namespace alpaka::test
 {
-    namespace test
+    template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx>
+    auto testViewPlainPtrImmutable(
+        alpaka::ViewPlainPtr<TDev, TElem, TDim, TIdx> const& view,
+        TDev const& dev,
+        alpaka::Vec<TDim, TIdx> const& extentView,
+        alpaka::Vec<TDim, TIdx> const& offsetView) -> void
     {
-        template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx>
-        auto testViewPlainPtrImmutable(
-            alpaka::ViewPlainPtr<TDev, TElem, TDim, TIdx> const& view,
-            TDev const& dev,
-            alpaka::Vec<TDim, TIdx> const& extentView,
-            alpaka::Vec<TDim, TIdx> const& offsetView) -> void
-        {
-            alpaka::test::testViewImmutable<TElem>(view, dev, extentView, offsetView);
-        }
+        alpaka::test::testViewImmutable<TElem>(view, dev, extentView, offsetView);
+    }
 
-        template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx>
-        auto testViewPlainPtrMutable(
-            alpaka::ViewPlainPtr<TDev, TElem, TDim, TIdx>& view,
-            TDev const& dev,
-            alpaka::Vec<TDim, TIdx> const& extentView,
-            alpaka::Vec<TDim, TIdx> const& offsetView) -> void
-        {
-            testViewPlainPtrImmutable<TAcc>(view, dev, extentView, offsetView);
+    template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx>
+    auto testViewPlainPtrMutable(
+        alpaka::ViewPlainPtr<TDev, TElem, TDim, TIdx>& view,
+        TDev const& dev,
+        alpaka::Vec<TDim, TIdx> const& extentView,
+        alpaka::Vec<TDim, TIdx> const& offsetView) -> void
+    {
+        testViewPlainPtrImmutable<TAcc>(view, dev, extentView, offsetView);
 
-            using Queue = alpaka::test::DefaultQueue<TDev>;
-            Queue queue(dev);
-            alpaka::test::testViewMutable<TAcc>(queue, view);
-        }
+        using Queue = alpaka::test::DefaultQueue<TDev>;
+        Queue queue(dev);
+        alpaka::test::testViewMutable<TAcc>(queue, view);
+    }
 
-        template<typename TAcc, typename TElem>
-        auto testViewPlainPtr() -> void
-        {
-            using Dev = alpaka::Dev<TAcc>;
-            using Pltf = alpaka::Pltf<Dev>;
+    template<typename TAcc, typename TElem>
+    auto testViewPlainPtr() -> void
+    {
+        using Dev = alpaka::Dev<TAcc>;
+        using Pltf = alpaka::Pltf<Dev>;
 
-            using Dim = alpaka::Dim<TAcc>;
-            using Idx = alpaka::Idx<TAcc>;
-            using View = alpaka::ViewPlainPtr<Dev, TElem, Dim, Idx>;
+        using Dim = alpaka::Dim<TAcc>;
+        using Idx = alpaka::Idx<TAcc>;
+        using View = alpaka::ViewPlainPtr<Dev, TElem, Dim, Idx>;
 
-            Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+        Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
 
-            auto const extentBuf
-                = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
+        auto const extentBuf
+            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+        auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
 
-            auto const extentView = extentBuf;
-            auto const offsetView = alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0));
-            View view(
-                alpaka::getPtrNative(buf),
-                alpaka::getDev(buf),
-                alpaka::extent::getExtentVec(buf),
-                alpaka::getPitchBytesVec(buf));
+        auto const extentView = extentBuf;
+        auto const offsetView = alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0));
+        View view(
+            alpaka::getPtrNative(buf),
+            alpaka::getDev(buf),
+            alpaka::extent::getExtentVec(buf),
+            alpaka::getPitchBytesVec(buf));
 
-            alpaka::test::testViewPlainPtrMutable<TAcc>(view, dev, extentView, offsetView);
-        }
+        alpaka::test::testViewPlainPtrMutable<TAcc>(view, dev, extentView, offsetView);
+    }
 
-        template<typename TAcc, typename TElem>
-        auto testViewPlainPtrConst() -> void
-        {
-            using Dev = alpaka::Dev<TAcc>;
-            using Pltf = alpaka::Pltf<Dev>;
+    template<typename TAcc, typename TElem>
+    auto testViewPlainPtrConst() -> void
+    {
+        using Dev = alpaka::Dev<TAcc>;
+        using Pltf = alpaka::Pltf<Dev>;
 
-            using Dim = alpaka::Dim<TAcc>;
-            using Idx = alpaka::Idx<TAcc>;
-            using View = alpaka::ViewPlainPtr<Dev, TElem, Dim, Idx>;
+        using Dim = alpaka::Dim<TAcc>;
+        using Idx = alpaka::Idx<TAcc>;
+        using View = alpaka::ViewPlainPtr<Dev, TElem, Dim, Idx>;
 
-            Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+        Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
 
-            auto const extentBuf
-                = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
+        auto const extentBuf
+            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+        auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
 
-            auto const extentView = extentBuf;
-            auto const offsetView = alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0));
-            View const view(
-                alpaka::getPtrNative(buf),
-                alpaka::getDev(buf),
-                alpaka::extent::getExtentVec(buf),
-                alpaka::getPitchBytesVec(buf));
+        auto const extentView = extentBuf;
+        auto const offsetView = alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0));
+        View const view(
+            alpaka::getPtrNative(buf),
+            alpaka::getDev(buf),
+            alpaka::extent::getExtentVec(buf),
+            alpaka::getPitchBytesVec(buf));
 
-            alpaka::test::testViewPlainPtrImmutable<TAcc>(view, dev, extentView, offsetView);
-        }
+        alpaka::test::testViewPlainPtrImmutable<TAcc>(view, dev, extentView, offsetView);
+    }
 
-        template<typename TAcc, typename TElem>
-        auto testViewPlainPtrOperators() -> void
-        {
-            using Dev = alpaka::Dev<TAcc>;
-            using Pltf = alpaka::Pltf<Dev>;
+    template<typename TAcc, typename TElem>
+    auto testViewPlainPtrOperators() -> void
+    {
+        using Dev = alpaka::Dev<TAcc>;
+        using Pltf = alpaka::Pltf<Dev>;
 
-            using Dim = alpaka::Dim<TAcc>;
-            using Idx = alpaka::Idx<TAcc>;
-            using View = alpaka::ViewPlainPtr<Dev, TElem, Dim, Idx>;
+        using Dim = alpaka::Dim<TAcc>;
+        using Idx = alpaka::Idx<TAcc>;
+        using View = alpaka::ViewPlainPtr<Dev, TElem, Dim, Idx>;
 
-            Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+        Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
 
-            auto const extentBuf
-                = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
+        auto const extentBuf
+            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+        auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
 
-            View view(
-                alpaka::getPtrNative(buf),
-                alpaka::getDev(buf),
-                alpaka::extent::getExtentVec(buf),
-                alpaka::getPitchBytesVec(buf));
+        View view(
+            alpaka::getPtrNative(buf),
+            alpaka::getDev(buf),
+            alpaka::extent::getExtentVec(buf),
+            alpaka::getPitchBytesVec(buf));
 
-            // copy-constructor
-            View viewCopy(view);
+        // copy-constructor
+        View viewCopy(view);
 
-            // move-constructor
-            View viewMove(std::move(viewCopy));
-        }
-    } // namespace test
-} // namespace alpaka
+        // move-constructor
+        View viewMove(std::move(viewCopy));
+    }
+} // namespace alpaka::test
 #if BOOST_COMP_GNUC
 #    pragma GCC diagnostic pop
 #endif

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -25,136 +25,133 @@
         "-Wcast-align" // "cast from 'std::uint8_t*' to 'Elem*' increases required alignment of target type"
 #endif
 
-namespace alpaka
+namespace alpaka::test
 {
-    namespace test
+    template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx, typename TBuf>
+    auto testViewSubViewImmutable(
+        alpaka::ViewSubView<TDev, TElem, TDim, TIdx> const& view,
+        TBuf& buf,
+        TDev const& dev,
+        alpaka::Vec<TDim, TIdx> const& extentView,
+        alpaka::Vec<TDim, TIdx> const& offsetView) -> void
     {
-        template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx, typename TBuf>
-        auto testViewSubViewImmutable(
-            alpaka::ViewSubView<TDev, TElem, TDim, TIdx> const& view,
-            TBuf& buf,
-            TDev const& dev,
-            alpaka::Vec<TDim, TIdx> const& extentView,
-            alpaka::Vec<TDim, TIdx> const& offsetView) -> void
+        alpaka::test::testViewImmutable<TElem>(view, dev, extentView, offsetView);
+
+        // alpaka::traits::GetPitchBytes
+        // The pitch of the view has to be identical to the pitch of the underlying buffer in all dimensions.
         {
-            alpaka::test::testViewImmutable<TElem>(view, dev, extentView, offsetView);
+            auto const pitchBuf = alpaka::getPitchBytesVec(buf);
+            auto const pitchView = alpaka::getPitchBytesVec(view);
 
-            // alpaka::traits::GetPitchBytes
-            // The pitch of the view has to be identical to the pitch of the underlying buffer in all dimensions.
+            for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
             {
-                auto const pitchBuf = alpaka::getPitchBytesVec(buf);
-                auto const pitchView = alpaka::getPitchBytesVec(view);
-
-                for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
-                {
-                    REQUIRE(pitchBuf[i - static_cast<TIdx>(1u)] == pitchView[i - static_cast<TIdx>(1u)]);
-                }
-            }
-
-            // alpaka::traits::GetPtrNative
-            // The native pointer has to be exactly the value we calculate here.
-            {
-                auto viewPtrNative = reinterpret_cast<std::uint8_t*>(alpaka::getPtrNative(buf));
-                auto const pitchBuf = alpaka::getPitchBytesVec(buf);
-                for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
-                {
-                    auto const pitch
-                        = (i < static_cast<TIdx>(TDim::value)) ? pitchBuf[i] : static_cast<TIdx>(sizeof(TElem));
-                    viewPtrNative += offsetView[i - static_cast<TIdx>(1u)] * pitch;
-                }
-                REQUIRE(reinterpret_cast<TElem*>(viewPtrNative) == alpaka::getPtrNative(view));
+                REQUIRE(pitchBuf[i - static_cast<TIdx>(1u)] == pitchView[i - static_cast<TIdx>(1u)]);
             }
         }
 
-        template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx, typename TBuf>
-        auto testViewSubViewMutable(
-            alpaka::ViewSubView<TDev, TElem, TDim, TIdx>& view,
-            TBuf& buf,
-            TDev const& dev,
-            alpaka::Vec<TDim, TIdx> const& extentView,
-            alpaka::Vec<TDim, TIdx> const& offsetView) -> void
+        // alpaka::traits::GetPtrNative
+        // The native pointer has to be exactly the value we calculate here.
         {
-            testViewSubViewImmutable<TAcc>(view, buf, dev, extentView, offsetView);
-
-            using Queue = alpaka::test::DefaultQueue<TDev>;
-            Queue queue(dev);
-            alpaka::test::testViewMutable<TAcc>(queue, view);
+            auto viewPtrNative = reinterpret_cast<std::uint8_t*>(alpaka::getPtrNative(buf));
+            auto const pitchBuf = alpaka::getPitchBytesVec(buf);
+            for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
+            {
+                auto const pitch
+                    = (i < static_cast<TIdx>(TDim::value)) ? pitchBuf[i] : static_cast<TIdx>(sizeof(TElem));
+                viewPtrNative += offsetView[i - static_cast<TIdx>(1u)] * pitch;
+            }
+            REQUIRE(reinterpret_cast<TElem*>(viewPtrNative) == alpaka::getPtrNative(view));
         }
+    }
 
-        template<typename TAcc, typename TElem>
-        auto testViewSubViewNoOffset() -> void
-        {
-            using Dev = alpaka::Dev<TAcc>;
-            using Pltf = alpaka::Pltf<Dev>;
+    template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx, typename TBuf>
+    auto testViewSubViewMutable(
+        alpaka::ViewSubView<TDev, TElem, TDim, TIdx>& view,
+        TBuf& buf,
+        TDev const& dev,
+        alpaka::Vec<TDim, TIdx> const& extentView,
+        alpaka::Vec<TDim, TIdx> const& offsetView) -> void
+    {
+        testViewSubViewImmutable<TAcc>(view, buf, dev, extentView, offsetView);
 
-            using Dim = alpaka::Dim<TAcc>;
-            using Idx = alpaka::Idx<TAcc>;
-            using View = alpaka::ViewSubView<Dev, TElem, Dim, Idx>;
+        using Queue = alpaka::test::DefaultQueue<TDev>;
+        Queue queue(dev);
+        alpaka::test::testViewMutable<TAcc>(queue, view);
+    }
 
-            Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+    template<typename TAcc, typename TElem>
+    auto testViewSubViewNoOffset() -> void
+    {
+        using Dev = alpaka::Dev<TAcc>;
+        using Pltf = alpaka::Pltf<Dev>;
 
-            auto const extentBuf
-                = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
+        using Dim = alpaka::Dim<TAcc>;
+        using Idx = alpaka::Idx<TAcc>;
+        using View = alpaka::ViewSubView<Dev, TElem, Dim, Idx>;
 
-            auto const extentView = extentBuf;
-            auto const offsetView = alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0));
-            View view(buf);
+        Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
 
-            alpaka::test::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
-        }
+        auto const extentBuf
+            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+        auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
 
-        template<typename TAcc, typename TElem>
-        auto testViewSubViewOffset() -> void
-        {
-            using Dev = alpaka::Dev<TAcc>;
-            using Pltf = alpaka::Pltf<Dev>;
+        auto const extentView = extentBuf;
+        auto const offsetView = alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0));
+        View view(buf);
 
-            using Dim = alpaka::Dim<TAcc>;
-            using Idx = alpaka::Idx<TAcc>;
-            using View = alpaka::ViewSubView<Dev, TElem, Dim, Idx>;
+        alpaka::test::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
+    }
 
-            Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+    template<typename TAcc, typename TElem>
+    auto testViewSubViewOffset() -> void
+    {
+        using Dev = alpaka::Dev<TAcc>;
+        using Pltf = alpaka::Pltf<Dev>;
 
-            auto const extentBuf
-                = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
+        using Dim = alpaka::Dim<TAcc>;
+        using Idx = alpaka::Idx<TAcc>;
+        using View = alpaka::ViewSubView<Dev, TElem, Dim, Idx>;
 
-            auto const extentView = alpaka::
-                createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentSubView>();
-            auto const offsetView
-                = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>();
-            View view(buf, extentView, offsetView);
+        Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
 
-            alpaka::test::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
-        }
+        auto const extentBuf
+            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+        auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
 
-        template<typename TAcc, typename TElem>
-        auto testViewSubViewOffsetConst() -> void
-        {
-            using Dev = alpaka::Dev<TAcc>;
-            using Pltf = alpaka::Pltf<Dev>;
+        auto const extentView
+            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentSubView>();
+        auto const offsetView
+            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>();
+        View view(buf, extentView, offsetView);
 
-            using Dim = alpaka::Dim<TAcc>;
-            using Idx = alpaka::Idx<TAcc>;
-            using View = alpaka::ViewSubView<Dev, TElem, Dim, Idx>;
+        alpaka::test::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
+    }
 
-            Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+    template<typename TAcc, typename TElem>
+    auto testViewSubViewOffsetConst() -> void
+    {
+        using Dev = alpaka::Dev<TAcc>;
+        using Pltf = alpaka::Pltf<Dev>;
 
-            auto const extentBuf
-                = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-            auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
+        using Dim = alpaka::Dim<TAcc>;
+        using Idx = alpaka::Idx<TAcc>;
+        using View = alpaka::ViewSubView<Dev, TElem, Dim, Idx>;
 
-            auto const extentView = alpaka::
-                createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentSubView>();
-            auto const offsetView
-                = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>();
-            View const view(buf, extentView, offsetView);
+        Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
 
-            alpaka::test::testViewSubViewImmutable<TAcc>(view, buf, dev, extentView, offsetView);
-        }
-    } // namespace test
-} // namespace alpaka
+        auto const extentBuf
+            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+        auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
+
+        auto const extentView
+            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentSubView>();
+        auto const offsetView
+            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>();
+        View const view(buf, extentView, offsetView);
+
+        alpaka::test::testViewSubViewImmutable<TAcc>(view, buf, dev, extentView, offsetView);
+    }
+} // namespace alpaka::test
 #if BOOST_COMP_GNUC
 #    pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
This PR just blindly runs `run-clang-tidy-12.py -checks="-*,modernize-*" -header-filter=.* -fix`. Manually revered changes in tinymt32.h and STLTuple.h. Manually revert some refactorings resulting in compile errors.