### PR TITLE
Update BoostPredef.hpp

### DIFF
--- a/include/alpaka/core/BoostPredef.hpp
+++ b/include/alpaka/core/BoostPredef.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, Matthias Werner
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -10,12 +10,6 @@
 #pragma once
 
 #include <boost/predef.h>
-
-// In boost since 1.68.0
-// BOOST_PREDEF_MAKE_10_VVRRP(V)
-#if !defined(BOOST_PREDEF_MAKE_10_VVRRP)
-#    define BOOST_PREDEF_MAKE_10_VVRRP(V) BOOST_VERSION_NUMBER(((V) / 1000) % 100, ((V) / 10) % 100, (V) % 10)
-#endif
 
 //---------------------------------------HIP-----------------------------------
 // __HIPCC__ is defined by hipcc (if either __CUDACC__ is defined)
@@ -56,56 +50,6 @@
 #    endif
 #endif
 
-// In boost since 1.68.0
-// CUDA language detection
-// - clang defines __CUDA__ and __CUDACC__ when compiling CUDA code ('-x cuda')
-// - nvcc defines __CUDACC__ when compiling CUDA code
-#if !defined(BOOST_LANG_CUDA)
-#    if defined(__CUDA__) || defined(__CUDACC__)
-#        include <cuda.h>
-#        define BOOST_LANG_CUDA BOOST_PREDEF_MAKE_10_VVRRP(CUDA_VERSION)
-#    else
-#        define BOOST_LANG_CUDA BOOST_VERSION_NUMBER_NOT_AVAILABLE
-#    endif
-#endif
-
-// In boost since 1.68.0
-// CUDA device architecture detection
-#if !defined(BOOST_ARCH_PTX)
-#    if defined(__CUDA_ARCH__)
-#        define BOOST_ARCH_PTX BOOST_PREDEF_MAKE_10_VRP(__CUDA_ARCH__)
-#    else
-#        define BOOST_ARCH_PTX BOOST_VERSION_NUMBER_NOT_AVAILABLE
-#    endif
-#endif
-
-// In boost since 1.68.0
-// nvcc CUDA compiler detection
-
-#include <boost/version.hpp>
-#if BOOST_VERSION >= 106800
-// BOOST_COMP_NVCC_EMULATED is defined by boost instead of BOOST_COMP_NVCC
-#    if defined(BOOST_COMP_NVCC) && defined(BOOST_COMP_NVCC_EMULATED)
-#        undef BOOST_COMP_NVCC
-#        define BOOST_COMP_NVCC BOOST_COMP_NVCC_EMULATED
-#    endif
-#endif
-
-#if !defined(BOOST_COMP_NVCC)
-#    if defined(__NVCC__)
-// The __CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__ and __CUDACC_VER_BUILD__
-// have been added with nvcc 7.5 and have not been available before.
-#        if !defined(__CUDACC_VER_MAJOR__) || !defined(__CUDACC_VER_MINOR__) || !defined(__CUDACC_VER_BUILD__)
-#            define BOOST_COMP_NVCC BOOST_VERSION_NUMBER_AVAILABLE
-#        else
-#            define BOOST_COMP_NVCC                                                                                   \
-                BOOST_VERSION_NUMBER(__CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__, __CUDACC_VER_BUILD__)
-#        endif
-#    else
-#        define BOOST_COMP_NVCC BOOST_VERSION_NUMBER_NOT_AVAILABLE
-#    endif
-#endif
-
 // clang CUDA compiler detection
 // Currently __CUDA__ is only defined by clang when compiling CUDA code.
 #if defined(__clang__) && defined(__CUDA__)
@@ -115,14 +59,18 @@
 #endif
 
 // Intel compiler detection
-// BOOST_COMP_INTEL_EMULATED is defined by boost instead of BOOST_COMP_INTEL
+// As of Boost 1.74, Boost.Predef's compiler detection is a bit weird. Recent Intel compilers will be identified as
+// BOOST_COMP_INTEL_EMULATED. Boost.Predef has lackluster front-end support and mistakes the EDG front-end
+// for an actual compiler.
+// TODO: Whenever you look at this code please check whether https://github.com/boostorg/predef/issues/28 and
+// https://github.com/boostorg/predef/issues/51 have been resolved.
 #if defined(BOOST_COMP_INTEL) && defined(BOOST_COMP_INTEL_EMULATED)
 #    undef BOOST_COMP_INTEL
 #    define BOOST_COMP_INTEL BOOST_COMP_INTEL_EMULATED
 #endif
 
 // PGI and NV HPC SDK compiler detection
-// BOOST_COMP_PGI_EMULATED is defined by boost instead of BOOST_COMP_PGI
+// BOOST_COMP_PGI_EMULATED is defined by boost instead of BOOST_COMP_PGI (probably the same problem as for Intel)
 #if defined(BOOST_COMP_PGI) && defined(BOOST_COMP_PGI_EMULATED)
 #    undef BOOST_COMP_PGI
 #    define BOOST_COMP_PGI BOOST_COMP_PGI_EMULATED

--- a/include/alpaka/core/Utility.hpp
+++ b/include/alpaka/core/Utility.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, René Widera, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, René Widera, Bernhard Manfred Gruber, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -18,7 +18,7 @@
 
 namespace alpaka::core
 {
-    //! convert any type to a reverence type
+    //! convert any type to a reference type
     //
     // This function is equivalent to std::declval() but can be used
     // within an alpaka accelerator kernel too.


### PR DESCRIPTION
Since we have updated to Boost 1.74 recently we can remove some of our handmade solutions for earlier Boost versions. ~~I also simplified some of the preprocessor checks in a few places.~~ Nevermind, the simplifications just broke things.

Fixes #611.