### PR TITLE
Refactor alpaka/rand

### DIFF
--- a/include/alpaka/rand/Philox/PhiloxBaseCudaArray.hpp
+++ b/include/alpaka/rand/Philox/PhiloxBaseCudaArray.hpp
@@ -63,9 +63,8 @@ namespace alpaka::rand::engine
             = meta::CudaVectorArrayWrapper<unsigned, 4>; ///< Counter type = array-like interface to CUDA uint4
         using Key = meta::CudaVectorArrayWrapper<unsigned, 2>; ///< Key type = array-like interface to CUDA uint2
         template<typename TDistributionResultScalar>
-        using ResultContainer =
-            typename traits::PhiloxResultContainer<TDistributionResultScalar>; ///< Vector template for
-                                                                               ///< distribution results
+        using ResultContainer = traits::PhiloxResultContainer<TDistributionResultScalar>; ///< Vector template for
+                                                                                          ///< distribution results
     };
 } // namespace alpaka::rand::engine
 

--- a/include/alpaka/rand/Philox/PhiloxBaseTraits.hpp
+++ b/include/alpaka/rand/Philox/PhiloxBaseTraits.hpp
@@ -16,46 +16,43 @@
 #    include <alpaka/rand/Philox/PhiloxBaseCudaArray.hpp>
 #endif
 
-namespace alpaka::rand::engine
+namespace alpaka::rand::engine::traits
 {
-    namespace traits
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+    template<typename TAcc>
+    constexpr auto isGPU
+        = std::is_same<typename alpaka::traits::DevType<TAcc>::type, alpaka::DevUniformCudaHipRt>::value;
+#else
+    template<typename TAcc>
+    constexpr bool isGPU = false;
+#endif
+    /** Selection of default backend
+     *
+     * Selects the data backend based on the accelerator device type. As of now, different backends operate
+     * on different array types.
+     *
+     * @tparam TAcc the accelerator as defined in alpaka/acc
+     * @tparam TParams Philox algorithm parameters
+     * @tparam TImpl engine type implementation (CRTP)
+     * @tparam TSfinae internal parameter to stop substitution search and provide the default
+     */
+    template<typename TAcc, typename TParams, typename TImpl, typename TSfinae = void>
+    struct PhiloxBaseTraits
     {
+        // template <typename Acc, typename TParams, typename TImpl>
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-        template<typename TAcc>
-        constexpr auto isGPU
-            = std::is_same<typename alpaka::traits::DevType<TAcc>::type, alpaka::DevUniformCudaHipRt>::value;
+        using Backend
+            = std::conditional_t<isGPU<TAcc>, PhiloxBaseCudaArray<TParams, TImpl>, PhiloxBaseStdArray<TParams, TImpl>>;
 #else
-        template<typename TAcc>
-        constexpr bool isGPU = false;
+        using Backend = PhiloxBaseStdArray<TParams, TImpl>;
 #endif
-        /** Selection of default backend
-         *
-         * Selects the data backend based on the accelerator device type. As of now, different backends operate
-         * on different array types.
-         *
-         * @tparam TAcc the accelerator as defined in alpaka/acc
-         * @tparam TParams Philox algorithm parameters
-         * @tparam TImpl engine type implementation (CRTP)
-         * @tparam TSfinae internal parameter to stop substitution search and provide the default
-         */
-        template<typename TAcc, typename TParams, typename TImpl, typename TSfinae = void>
-        struct PhiloxBaseTraits
-        {
-            // template <typename Acc, typename TParams, typename TImpl>
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-            using Backend = std::
-                conditional_t<isGPU<TAcc>, PhiloxBaseCudaArray<TParams, TImpl>, PhiloxBaseStdArray<TParams, TImpl>>;
-#else
-            using Backend = PhiloxBaseStdArray<TParams, TImpl>;
-#endif
-            using Counter = typename Backend::Counter; ///< Counter array type
-            using Key = typename Backend::Key; ///< Key array type
-            template<typename TDistributionResultScalar>
-            using ResultContainer =
-                typename Backend::template ResultContainer<TDistributionResultScalar>; ///< Distribution
-                                                                                       ///< container type
+        using Counter = typename Backend::Counter; ///< Counter array type
+        using Key = typename Backend::Key; ///< Key array type
+        template<typename TDistributionResultScalar>
+        using ResultContainer =
+            typename Backend::template ResultContainer<TDistributionResultScalar>; ///< Distribution
+                                                                                   ///< container type
 
-            using Base = PhiloxBaseCommon<Backend, TParams, TImpl>; ///< Base type to be inherited from
-        };
-    } // namespace traits
-} // namespace alpaka::rand::engine
+        using Base = PhiloxBaseCommon<Backend, TParams, TImpl>; ///< Base type to be inherited from
+    };
+} // namespace alpaka::rand::engine::traits

--- a/include/alpaka/rand/Philox/PhiloxVector.hpp
+++ b/include/alpaka/rand/Philox/PhiloxVector.hpp
@@ -46,7 +46,7 @@ namespace alpaka::rand::engine
     {
     public:
         /// Specialization for different TAcc backends
-        using Traits = typename traits::PhiloxBaseTraits<TAcc, TParams, PhiloxVector<TAcc, TParams>>;
+        using Traits = traits::PhiloxBaseTraits<TAcc, TParams, PhiloxVector<TAcc, TParams>>;
 
         using Counter = typename Traits::Counter; ///< Backend-dependent Counter type
         using Key = typename Traits::Key; ///< Backend-dependent Key type

--- a/include/alpaka/rand/RandDefault.hpp
+++ b/include/alpaka/rand/RandDefault.hpp
@@ -24,197 +24,185 @@ namespace alpaka::rand
     {
     };
 
-    namespace distribution
+    namespace distribution::gpu
     {
-        namespace gpu
+        namespace detail
         {
-            namespace detail
-            {
-                template<typename TFloat>
-                struct BitsType;
+            template<typename TFloat>
+            struct BitsType;
 
-                template<>
-                struct BitsType<float>
-                {
-                    using type = std::uint32_t;
-                };
-                template<>
-                struct BitsType<double>
-                {
-                    using type = std::uint64_t;
-                };
-            } // namespace detail
-
-            //! The GPU random number normal distribution.
-            template<typename T>
-            class UniformUint
-            {
-                static_assert(std::is_integral<T>::value, "Return type of UniformUint must be integral.");
-
-            public:
-                UniformUint() = default;
-
-                template<typename TEngine>
-                ALPAKA_FN_HOST_ACC auto operator()(TEngine& engine) -> T
-                {
-                    using BitsT = typename TEngine::result_type;
-                    T ret = 0;
-                    constexpr auto N = sizeof(T) / sizeof(BitsT);
-                    for(unsigned int a = 0; a < N; ++a)
-                    {
-                        ret
-                            ^= (static_cast<T>(engine())
-                                << (sizeof(BitsT) * std::numeric_limits<unsigned char>::digits * a));
-                    }
-                    return ret;
-                }
-            };
-
-            //! The GPU random number uniform distribution.
-            template<typename T>
-            class UniformReal
-            {
-                static_assert(std::is_floating_point<T>::value, "Return type of UniformReal must be floating point.");
-
-                using BitsT = typename detail::BitsType<T>::type;
-
-            public:
-                UniformReal() = default;
-
-                template<typename TEngine>
-                ALPAKA_FN_HOST_ACC auto operator()(TEngine& engine) -> T
-                {
-                    constexpr BitsT limit = static_cast<BitsT>(1) << std::numeric_limits<T>::digits;
-                    const BitsT b = UniformUint<BitsT>()(engine);
-                    const auto ret = static_cast<T>(b & (limit - 1)) / limit;
-                    return ret;
-                }
-            };
-
-            /*! The GPU random number normal distribution.
-             *
-             * \note
-             * This type contains state and is not thread-safe: To be used
-             * per thread, not shared.
-             *
-             * \note When reproducibility is a concern, each instance of
-             * this class should be used with only on random engine
-             * instance, or two consecutive number should be generated with
-             * each engine used. This is due to the implicit caching of one
-             * Gaussian random number.
-             */
-            template<typename Acc, typename T>
-            class NormalReal
-            {
-                static_assert(std::is_floating_point<T>::value, "Return type of NormalReal must be floating point.");
-
-                const Acc& m_acc;
-                T m_cache = std::numeric_limits<T>::quiet_NaN();
-
-            public:
-                /*! \warning Retains a reference to \p acc, thus must not
-                 * outlive it.
-                 */
-                NormalReal(const Acc& acc) : m_acc(acc)
-                {
-                }
-
-                NormalReal(const NormalReal& o) = delete;
-
-                //! The move ctor clears `m_cache` of source.
-                //! \todo This is to be deleted when moving to C++17
-                NormalReal(NormalReal&& o) : m_acc(o.m_acc), m_cache(o.m_cache)
-                {
-                    o.m_cache = std::numeric_limits<T>::quiet_NaN();
-                }
-
-                template<typename TEngine>
-                ALPAKA_FN_HOST_ACC auto operator()(TEngine& engine) -> T
-                {
-                    constexpr T sigma = 1., mu = 0.;
-                    if(math::isnan(m_acc, m_cache))
-                    {
-                        UniformReal<T> uni;
-
-                        T u1, u2;
-                        do
-                        {
-                            u1 = uni(engine);
-                            u2 = uni(engine);
-                        } while(u1 <= std::numeric_limits<T>::epsilon());
-
-                        // compute z0 and z1
-                        const T mag = sigma * math::sqrt(m_acc, static_cast<T>(-2.) * math::log(m_acc, u1));
-                        constexpr T twoPi = static_cast<T>(2. * M_PI);
-                        // getting two normal number out of this, store one for later
-                        m_cache = mag * static_cast<T>(math::cos(m_acc, twoPi * u2)) + mu;
-
-                        return mag * static_cast<T>(math::sin(m_acc, twoPi * u2)) + mu;
-                    }
-                    else
-                    {
-                        const T ret = m_cache;
-                        m_cache = std::numeric_limits<T>::quiet_NaN();
-                        return ret;
-                    }
-                }
-            };
-        } // namespace gpu
-    } // namespace distribution
-
-    namespace distribution
-    {
-        namespace traits
-        {
-            //! The GPU device random number float normal distribution get trait specialization.
-            template<typename T>
-            struct CreateNormalReal<RandDefault, T, std::enable_if_t<std::is_floating_point<T>::value>>
-            {
-                template<typename TAcc>
-                ALPAKA_FN_HOST_ACC static auto createNormalReal(TAcc const& acc)
-                {
-                    return rand::distribution::gpu::NormalReal<TAcc, T>(acc);
-                }
-            };
-            //! The GPU device random number float uniform distribution get trait specialization.
-            template<typename T>
-            struct CreateUniformReal<RandDefault, T, std::enable_if_t<std::is_floating_point<T>::value>>
-            {
-                ALPAKA_FN_HOST_ACC static auto createUniformReal(RandDefault const& /* rand */)
-                {
-                    return rand::distribution::gpu::UniformReal<T>();
-                }
-            };
-            //! The GPU device random number integer uniform distribution get trait specialization.
-            template<typename T>
-            struct CreateUniformUint<RandDefault, T, std::enable_if_t<std::is_integral<T>::value>>
-            {
-                ALPAKA_FN_HOST_ACC static auto createUniformUint(RandDefault const& /* rand */)
-                {
-                    return rand::distribution::gpu::UniformUint<T>();
-                }
-            };
-        } // namespace traits
-    } // namespace distribution
-    namespace engine
-    {
-        namespace traits
-        {
-            //! The GPU device random number default generator get trait specialization.
             template<>
-            struct CreateDefault<RandDefault>
+            struct BitsType<float>
             {
-                template<typename TAcc>
-                ALPAKA_FN_HOST_ACC static auto createDefault(
-                    TAcc const& /* acc */,
-                    std::uint32_t const& seed,
-                    std::uint32_t const& subsequence,
-                    std::uint32_t const& offset) -> rand::Philox4x32x10<TAcc>
-                {
-                    return rand::Philox4x32x10<TAcc>(seed, subsequence, offset);
-                }
+                using type = std::uint32_t;
             };
+            template<>
+            struct BitsType<double>
+            {
+                using type = std::uint64_t;
+            };
+        } // namespace detail
 
-        } // namespace traits
-    } // namespace engine
+        //! The GPU random number normal distribution.
+        template<typename T>
+        class UniformUint
+        {
+            static_assert(std::is_integral<T>::value, "Return type of UniformUint must be integral.");
+
+        public:
+            UniformUint() = default;
+
+            template<typename TEngine>
+            ALPAKA_FN_HOST_ACC auto operator()(TEngine& engine) -> T
+            {
+                using BitsT = typename TEngine::result_type;
+                T ret = 0;
+                constexpr auto N = sizeof(T) / sizeof(BitsT);
+                for(unsigned int a = 0; a < N; ++a)
+                {
+                    ret
+                        ^= (static_cast<T>(engine())
+                            << (sizeof(BitsT) * std::numeric_limits<unsigned char>::digits * a));
+                }
+                return ret;
+            }
+        };
+
+        //! The GPU random number uniform distribution.
+        template<typename T>
+        class UniformReal
+        {
+            static_assert(std::is_floating_point<T>::value, "Return type of UniformReal must be floating point.");
+
+            using BitsT = typename detail::BitsType<T>::type;
+
+        public:
+            UniformReal() = default;
+
+            template<typename TEngine>
+            ALPAKA_FN_HOST_ACC auto operator()(TEngine& engine) -> T
+            {
+                constexpr BitsT limit = static_cast<BitsT>(1) << std::numeric_limits<T>::digits;
+                const BitsT b = UniformUint<BitsT>()(engine);
+                const auto ret = static_cast<T>(b & (limit - 1)) / limit;
+                return ret;
+            }
+        };
+
+        /*! The GPU random number normal distribution.
+         *
+         * \note
+         * This type contains state and is not thread-safe: To be used
+         * per thread, not shared.
+         *
+         * \note When reproducibility is a concern, each instance of
+         * this class should be used with only on random engine
+         * instance, or two consecutive number should be generated with
+         * each engine used. This is due to the implicit caching of one
+         * Gaussian random number.
+         */
+        template<typename Acc, typename T>
+        class NormalReal
+        {
+            static_assert(std::is_floating_point_v<T>, "Return type of NormalReal must be floating point.");
+
+            const Acc* m_acc;
+            T m_cache = std::numeric_limits<T>::quiet_NaN();
+
+        public:
+            /*! \warning Retains a reference to \p acc, thus must not outlive it.
+             */
+            NormalReal(const Acc& acc) : m_acc(acc)
+            {
+            }
+
+            NormalReal(const NormalReal& o) = delete;
+
+            //! The move ctor clears `m_cache` of source.
+            //! \todo This is to be deleted when moving to C++17
+            NormalReal(NormalReal&& o) : m_acc(o.m_acc), m_cache(o.m_cache)
+            {
+                o.m_cache = std::numeric_limits<T>::quiet_NaN();
+            }
+
+            template<typename TEngine>
+            ALPAKA_FN_HOST_ACC auto operator()(TEngine& engine) -> T
+            {
+                constexpr T sigma = 1., mu = 0.;
+                if(math::isnan(*m_acc, m_cache))
+                {
+                    UniformReal<T> uni;
+
+                    T u1, u2;
+                    do
+                    {
+                        u1 = uni(engine);
+                        u2 = uni(engine);
+                    } while(u1 <= std::numeric_limits<T>::epsilon());
+
+                    // compute z0 and z1
+                    const T mag = sigma * math::sqrt(*m_acc, static_cast<T>(-2.) * math::log(*m_acc, u1));
+                    constexpr T twoPi = static_cast<T>(2. * M_PI);
+                    // getting two normal number out of this, store one for later
+                    m_cache = mag * static_cast<T>(math::cos(*m_acc, twoPi * u2)) + mu;
+
+                    return mag * static_cast<T>(math::sin(*m_acc, twoPi * u2)) + mu;
+                }
+
+                const T ret = m_cache;
+                m_cache = std::numeric_limits<T>::quiet_NaN();
+                return ret;
+            }
+        };
+    } // namespace distribution::gpu
+
+    namespace distribution::traits
+    {
+        //! The GPU device random number float normal distribution get trait specialization.
+        template<typename T>
+        struct CreateNormalReal<RandDefault, T, std::enable_if_t<std::is_floating_point_v<T>>>
+        {
+            template<typename TAcc>
+            ALPAKA_FN_HOST_ACC static auto createNormalReal(TAcc const& acc) -> gpu::NormalReal<TAcc, T>
+            {
+                return {acc};
+            }
+        };
+        //! The GPU device random number float uniform distribution get trait specialization.
+        template<typename T>
+        struct CreateUniformReal<RandDefault, T, std::enable_if_t<std::is_floating_point_v<T>>>
+        {
+            ALPAKA_FN_HOST_ACC static auto createUniformReal(RandDefault const& /* rand */) -> gpu::UniformReal<T>
+            {
+                return {};
+            }
+        };
+        //! The GPU device random number integer uniform distribution get trait specialization.
+        template<typename T>
+        struct CreateUniformUint<RandDefault, T, std::enable_if_t<std::is_integral_v<T>>>
+        {
+            ALPAKA_FN_HOST_ACC static auto createUniformUint(RandDefault const& /* rand */) -> gpu::UniformUint<T>
+            {
+                return {};
+            }
+        };
+    } // namespace distribution::traits
+
+    namespace engine::traits
+    {
+        //! The GPU device random number default generator get trait specialization.
+        template<>
+        struct CreateDefault<RandDefault>
+        {
+            template<typename TAcc>
+            ALPAKA_FN_HOST_ACC static auto createDefault(
+                TAcc const& /* acc */,
+                std::uint32_t const& seed,
+                std::uint32_t const& subsequence,
+                std::uint32_t const& offset) -> Philox4x32x10<TAcc>
+            {
+                return {seed, subsequence, offset};
+            }
+        };
+    } // namespace engine::traits
 } // namespace alpaka::rand

--- a/include/alpaka/rand/RandPhilox.hpp
+++ b/include/alpaka/rand/RandPhilox.hpp
@@ -60,8 +60,6 @@ namespace alpaka::rand
         {
         }
 
-        EngineVariant engineVariant;
-
         // STL UniformRandomBitGenerator concept
         // https://en.cppreference.com/w/cpp/named_req/UniformRandomBitGenerator
         using result_type = std::uint32_t;
@@ -77,6 +75,9 @@ namespace alpaka::rand
         {
             return engineVariant();
         }
+
+    private:
+        EngineVariant engineVariant;
     };
 
     /** Most common Philox engine variant, outputs a 4-vector of floats
@@ -117,12 +118,11 @@ namespace alpaka::rand
         {
         }
 
-        EngineVariant engineVariant;
         template<typename TScalar>
         using ResultContainer = typename EngineVariant::template ResultContainer<TScalar>;
 
         using ResultInt = std::uint32_t;
-        using ResultVec = decltype(engineVariant());
+        using ResultVec = decltype(std::declval<EngineVariant>()());
         ALPAKA_FN_HOST_ACC constexpr auto min() -> ResultInt
         {
             return 0;
@@ -135,8 +135,10 @@ namespace alpaka::rand
         {
             return engineVariant();
         }
-    };
 
+    private:
+        EngineVariant engineVariant;
+    };
 
     // The following exists because you "cannot call __device__ function from a __host__ __device__ function"
     // directly, but wrapping that call in a struct is just fine.

--- a/include/alpaka/rand/RandStdLib.hpp
+++ b/include/alpaka/rand/RandStdLib.hpp
@@ -36,255 +36,237 @@ namespace alpaka::rand
     {
     };
 
-    namespace engine
+    namespace engine::cpu
     {
-        namespace cpu
+        //! The standard library mersenne twister random number generator.
+        //!
+        //! size of state: 19937 bytes
+        class MersenneTwister
         {
-            //! The standard library mersenne twister random number generator.
-            //!
-            //! size of state: 19937 bytes
-            class MersenneTwister
+            std::mt19937 state;
+
+        public:
+            MersenneTwister() = default;
+
+            ALPAKA_FN_HOST MersenneTwister(
+                std::uint32_t const& seed,
+                std::uint32_t const& subsequence = 0,
+                std::uint32_t const& offset = 0)
+                : // NOTE: XOR the seed and the subsequence to generate a unique seed.
+                state((seed ^ subsequence) + offset)
             {
-            public:
-                std::mt19937 state;
+            }
 
-            public:
-                MersenneTwister() = default;
-
-                ALPAKA_FN_HOST MersenneTwister(
-                    std::uint32_t const& seed,
-                    std::uint32_t const& subsequence = 0,
-                    std::uint32_t const& offset = 0)
-                    : // NOTE: XOR the seed and the subsequence to generate a unique seed.
-                    state((seed ^ subsequence) + offset)
-                {
-                }
-
-                // STL UniformRandomBitGenerator concept interface
-                using result_type = std::mt19937::result_type;
-                ALPAKA_FN_HOST constexpr static auto min() -> result_type
-                {
-                    return std::mt19937::min();
-                }
-                ALPAKA_FN_HOST constexpr static auto max() -> result_type
-                {
-                    return std::mt19937::max();
-                }
-                ALPAKA_FN_HOST auto operator()() -> result_type
-                {
-                    return state();
-                }
-            };
-
-            //! "Tiny" state mersenne twister implementation
-            //!
-            //! repository: github.com/MersenneTwister-Lab/TinyMT
-            //!
-            //! license: 3-clause BSD
-            //!
-            //! @author Mutsuo Saito (Hiroshima University)Tokio University.
-            //! @author Makoto Matsumoto (The University of Tokyo)
-            //!
-            //! size of state: 28 bytes (127 bits?!)
-            class TinyMersenneTwister
+            // STL UniformRandomBitGenerator concept interface
+            using result_type = std::mt19937::result_type;
+            ALPAKA_FN_HOST constexpr static auto min() -> result_type
             {
-            public:
-                TinyMTengine state;
-
-            public:
-                TinyMersenneTwister() = default;
-
-                ALPAKA_FN_HOST TinyMersenneTwister(
-                    std::uint32_t const& seed,
-                    std::uint32_t const& subsequence = 0,
-                    std::uint32_t const& offset = 0)
-                    : // NOTE: XOR the seed and the subsequence to generate a unique seed.
-                    state((seed ^ subsequence) + offset)
-                {
-                }
-
-                // STL UniformRandomBitGenerator concept interface
-                using result_type = TinyMTengine::result_type;
-                ALPAKA_FN_HOST constexpr static auto min() -> result_type
-                {
-                    return TinyMTengine::min();
-                }
-                ALPAKA_FN_HOST constexpr static auto max() -> result_type
-                {
-                    return TinyMTengine::max();
-                }
-                ALPAKA_FN_HOST auto operator()() -> result_type
-                {
-                    return state();
-                }
-            };
-
-            //! The standard library's random device based on the local entropy pool.
-            //!
-            //! Warning: the entropy pool on many devices degrates quickly and performance
-            //!          will drop significantly when this point occures.
-            //!
-            //! size of state: 1 byte
-            class RandomDevice
+                return std::mt19937::min();
+            }
+            ALPAKA_FN_HOST constexpr static auto max() -> result_type
             {
-            public:
-                std::random_device state;
+                return std::mt19937::max();
+            }
+            ALPAKA_FN_HOST auto operator()() -> result_type
+            {
+                return state();
+            }
+        };
 
-            public:
-                RandomDevice() = default;
-                RandomDevice(RandomDevice&&) : state{}
-                {
-                }
+        //! "Tiny" state mersenne twister implementation
+        //!
+        //! repository: github.com/MersenneTwister-Lab/TinyMT
+        //!
+        //! license: 3-clause BSD
+        //!
+        //! @author Mutsuo Saito (Hiroshima University)Tokio University.
+        //! @author Makoto Matsumoto (The University of Tokyo)
+        //!
+        //! size of state: 28 bytes (127 bits?!)
+        class TinyMersenneTwister
+        {
+            TinyMTengine state;
 
-                ALPAKA_FN_HOST RandomDevice(std::uint32_t const&, std::uint32_t const& = 0, std::uint32_t const& = 0)
-                    : state{}
-                {
-                }
+        public:
+            TinyMersenneTwister() = default;
 
-                // STL UniformRandomBitGenerator concept interface
-                using result_type = std::random_device::result_type;
-                ALPAKA_FN_HOST constexpr static auto min() -> result_type
-                {
-                    return std::random_device::min();
-                }
-                ALPAKA_FN_HOST constexpr static auto max() -> result_type
-                {
-                    return std::random_device::max();
-                }
-                ALPAKA_FN_HOST auto operator()() -> result_type
-                {
-                    return state();
-                }
-            };
-        } // namespace cpu
-    } // namespace engine
+            ALPAKA_FN_HOST TinyMersenneTwister(
+                std::uint32_t const& seed,
+                std::uint32_t const& subsequence = 0,
+                std::uint32_t const& offset = 0)
+                : // NOTE: XOR the seed and the subsequence to generate a unique seed.
+                state((seed ^ subsequence) + offset)
+            {
+            }
 
-    namespace distribution
+            // STL UniformRandomBitGenerator concept interface
+            using result_type = TinyMTengine::result_type;
+            ALPAKA_FN_HOST constexpr static auto min() -> result_type
+            {
+                return TinyMTengine::min();
+            }
+            ALPAKA_FN_HOST constexpr static auto max() -> result_type
+            {
+                return TinyMTengine::max();
+            }
+            ALPAKA_FN_HOST auto operator()() -> result_type
+            {
+                return state();
+            }
+        };
+
+        //! The standard library's random device based on the local entropy pool.
+        //!
+        //! Warning: the entropy pool on many devices degrates quickly and performance
+        //!          will drop significantly when this point occures.
+        //!
+        //! size of state: 1 byte
+        class RandomDevice
+        {
+            std::random_device state;
+
+        public:
+            RandomDevice() = default;
+
+            ALPAKA_FN_HOST RandomDevice(std::uint32_t const&, std::uint32_t const& = 0, std::uint32_t const& = 0)
+            {
+            }
+
+            // STL UniformRandomBitGenerator concept interface
+            using result_type = std::random_device::result_type;
+            ALPAKA_FN_HOST constexpr static auto min() -> result_type
+            {
+                return std::random_device::min();
+            }
+            ALPAKA_FN_HOST constexpr static auto max() -> result_type
+            {
+                return std::random_device::max();
+            }
+            ALPAKA_FN_HOST auto operator()() -> result_type
+            {
+                return state();
+            }
+        };
+    } // namespace engine::cpu
+
+    namespace distribution::cpu
     {
-        namespace cpu
+        //! The CPU random number normal distribution.
+        template<typename T>
+        struct NormalReal
         {
-            //! The CPU random number normal distribution.
-            template<typename T>
-            class NormalReal
+            template<typename TEngine>
+            ALPAKA_FN_HOST auto operator()(TEngine& engine) -> T
             {
-            public:
-                template<typename TEngine>
-                ALPAKA_FN_HOST auto operator()(TEngine& engine) -> T
-                {
-                    return m_dist(engine);
-                }
-                std::normal_distribution<T> m_dist;
-            };
+                return m_dist(engine);
+            }
 
-            //! The CPU random number uniform distribution.
-            template<typename T>
-            class UniformReal
+        private:
+            std::normal_distribution<T> m_dist;
+        };
+
+        //! The CPU random number uniform distribution.
+        template<typename T>
+        struct UniformReal
+        {
+            template<typename TEngine>
+            ALPAKA_FN_HOST auto operator()(TEngine& engine) -> T
             {
-            public:
-                template<typename TEngine>
-                ALPAKA_FN_HOST auto operator()(TEngine& engine) -> T
-                {
-                    return m_dist(engine);
-                }
-                std::uniform_real_distribution<T> m_dist;
-            };
+                return m_dist(engine);
+            }
 
-            //! The CPU random number normal distribution.
-            template<typename T>
-            class UniformUint
+        private:
+            std::uniform_real_distribution<T> m_dist;
+        };
+
+        //! The CPU random number normal distribution.
+        template<typename T>
+        struct UniformUint
+        {
+            template<typename TEngine>
+            ALPAKA_FN_HOST auto operator()(TEngine& engine) -> T
             {
-            public:
-                template<typename TEngine>
-                ALPAKA_FN_HOST auto operator()(TEngine& engine) -> T
-                {
-                    return m_dist(engine);
-                }
-                std::uniform_int_distribution<T> m_dist{
-                    0, // For signed integer: std::numeric_limits<T>::lowest()
-                    std::numeric_limits<T>::max()};
-            };
-        } // namespace cpu
-    } // namespace distribution
+                return m_dist(engine);
+            }
 
-    namespace distribution
+        private:
+            std::uniform_int_distribution<T> m_dist{
+                0, // For signed integer: std::numeric_limits<T>::lowest()
+                std::numeric_limits<T>::max()};
+        };
+    } // namespace distribution::cpu
+
+    namespace distribution::traits
     {
-        namespace traits
+        //! The CPU device random number float normal distribution get trait specialization.
+        template<typename T>
+        struct CreateNormalReal<RandStdLib, T, std::enable_if_t<std::is_floating_point<T>::value>>
         {
-            //! The CPU device random number float normal distribution get trait specialization.
-            template<typename T>
-            struct CreateNormalReal<RandStdLib, T, std::enable_if_t<std::is_floating_point<T>::value>>
+            ALPAKA_FN_HOST static auto createNormalReal(RandStdLib const& /* rand */) -> cpu::NormalReal<T>
             {
-                ALPAKA_FN_HOST static auto createNormalReal(RandStdLib const& /* rand */)
-                    -> rand::distribution::cpu::NormalReal<T>
-                {
-                    return rand::distribution::cpu::NormalReal<T>();
-                }
-            };
-            //! The CPU device random number float uniform distribution get trait specialization.
-            template<typename T>
-            struct CreateUniformReal<RandStdLib, T, std::enable_if_t<std::is_floating_point<T>::value>>
+                return {};
+            }
+        };
+        //! The CPU device random number float uniform distribution get trait specialization.
+        template<typename T>
+        struct CreateUniformReal<RandStdLib, T, std::enable_if_t<std::is_floating_point<T>::value>>
+        {
+            ALPAKA_FN_HOST static auto createUniformReal(RandStdLib const& /* rand */) -> cpu::UniformReal<T>
             {
-                ALPAKA_FN_HOST static auto createUniformReal(RandStdLib const& /* rand */)
-                    -> rand::distribution::cpu::UniformReal<T>
-                {
-                    return rand::distribution::cpu::UniformReal<T>();
-                }
-            };
-            //! The CPU device random number integer uniform distribution get trait specialization.
-            template<typename T>
-            struct CreateUniformUint<RandStdLib, T, std::enable_if_t<std::is_integral<T>::value>>
+                return {};
+            }
+        };
+        //! The CPU device random number integer uniform distribution get trait specialization.
+        template<typename T>
+        struct CreateUniformUint<RandStdLib, T, std::enable_if_t<std::is_integral<T>::value>>
+        {
+            ALPAKA_FN_HOST static auto createUniformUint(RandStdLib const& /* rand */) -> cpu::UniformUint<T>
             {
-                ALPAKA_FN_HOST static auto createUniformUint(RandStdLib const& /* rand */)
-                    -> rand::distribution::cpu::UniformUint<T>
-                {
-                    return rand::distribution::cpu::UniformUint<T>();
-                }
-            };
-        } // namespace traits
-    } // namespace distribution
-    namespace engine
+                return {};
+            }
+        };
+    } // namespace distribution::traits
+
+    namespace engine::traits
     {
-        namespace traits
+        //! The CPU device random number default generator get trait specialization.
+        template<>
+        struct CreateDefault<TinyMersenneTwister>
         {
-            //! The CPU device random number default generator get trait specialization.
-            template<>
-            struct CreateDefault<TinyMersenneTwister>
+            ALPAKA_FN_HOST static auto createDefault(
+                TinyMersenneTwister const& /* rand */,
+                std::uint32_t const& seed = 0,
+                std::uint32_t const& subsequence = 0,
+                std::uint32_t const& offset = 0) -> cpu::TinyMersenneTwister
             {
-                ALPAKA_FN_HOST static auto createDefault(
-                    TinyMersenneTwister const& /* rand */,
-                    std::uint32_t const& seed = 0,
-                    std::uint32_t const& subsequence = 0,
-                    std::uint32_t const& offset = 0) -> rand::engine::cpu::TinyMersenneTwister
-                {
-                    return rand::engine::cpu::TinyMersenneTwister(seed, subsequence, offset);
-                }
-            };
+                return {seed, subsequence, offset};
+            }
+        };
 
-            template<>
-            struct CreateDefault<MersenneTwister>
+        template<>
+        struct CreateDefault<MersenneTwister>
+        {
+            ALPAKA_FN_HOST static auto createDefault(
+                MersenneTwister const& /* rand */,
+                std::uint32_t const& seed = 0,
+                std::uint32_t const& subsequence = 0,
+                std::uint32_t const& offset = 0) -> cpu::MersenneTwister
             {
-                ALPAKA_FN_HOST static auto createDefault(
-                    MersenneTwister const& /* rand */,
-                    std::uint32_t const& seed = 0,
-                    std::uint32_t const& subsequence = 0,
-                    std::uint32_t const& offset = 0) -> rand::engine::cpu::MersenneTwister
-                {
-                    return rand::engine::cpu::MersenneTwister(seed, subsequence, offset);
-                }
-            };
+                return {seed, subsequence, offset};
+            }
+        };
 
-            template<>
-            struct CreateDefault<RandomDevice>
+        template<>
+        struct CreateDefault<RandomDevice>
+        {
+            ALPAKA_FN_HOST static auto createDefault(
+                RandomDevice const& /* rand */,
+                std::uint32_t const& seed = 0,
+                std::uint32_t const& subsequence = 0,
+                std::uint32_t const& offset = 0) -> cpu::RandomDevice
             {
-                ALPAKA_FN_HOST static auto createDefault(
-                    RandomDevice const& /* rand */,
-                    std::uint32_t const& seed = 0,
-                    std::uint32_t const& subsequence = 0,
-                    std::uint32_t const& offset = 0) -> rand::engine::cpu::RandomDevice
-                {
-                    return rand::engine::cpu::RandomDevice(seed, subsequence, offset);
-                }
-            };
-        } // namespace traits
-    } // namespace engine
+                return {seed, subsequence, offset};
+            }
+        };
+    } // namespace engine::traits
 } // namespace alpaka::rand

--- a/include/alpaka/rand/RandUniformCudaHipRand.hpp
+++ b/include/alpaka/rand/RandUniformCudaHipRand.hpp
@@ -52,236 +52,235 @@ namespace alpaka::rand
 #            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #        endif
 
-    namespace engine
+    namespace distribution::uniform_cuda_hip
     {
-        namespace uniform_cuda_hip
+        //! The CUDA/HIP random number floating point normal distribution.
+        template<typename T>
+        class NormalReal;
+
+        //! The CUDA/HIP random number floating point uniform distribution.
+        template<typename T>
+        class UniformReal;
+
+        //! The CUDA/HIP random number integer uniform distribution.
+        template<typename T>
+        class UniformUint;
+    } // namespace distribution::uniform_cuda_hip
+
+    namespace engine::uniform_cuda_hip
+    {
+        //! The CUDA/HIP Xor random number generator engine.
+        class Xor
         {
-            //! The CUDA/HIP Xor random number generator engine.
-            class Xor
-            {
-            public:
-                // After calling this constructor the instance is not valid initialized and
-                // need to be overwritten with a valid object
+        public:
+            // After calling this constructor the instance is not valid initialized and
+            // need to be overwritten with a valid object
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                ALPAKA_FN_HOST_ACC Xor() : state(curandStateXORWOW_t{})
+            ALPAKA_FN_HOST_ACC Xor() : state(curandStateXORWOW_t{})
 #        else
-                ALPAKA_FN_HOST_ACC Xor() : state(hiprandStateXORWOW_t{})
+            ALPAKA_FN_HOST_ACC Xor() : state(hiprandStateXORWOW_t{})
 #        endif
-                {
-                }
+            {
+            }
 
-                __device__ Xor(
-                    std::uint32_t const& seed,
-                    std::uint32_t const& subsequence = 0,
-                    std::uint32_t const& offset = 0)
-                {
+            __device__ Xor(
+                std::uint32_t const& seed,
+                std::uint32_t const& subsequence = 0,
+                std::uint32_t const& offset = 0)
+            {
 #        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                    curand_init(seed, subsequence, offset, &state);
+                curand_init(seed, subsequence, offset, &state);
 #        else
-                    hiprand_init(seed, subsequence, offset, &state);
+                hiprand_init(seed, subsequence, offset, &state);
 #        endif
-                }
+            }
 
-            public:
+        private:
+            template<typename T>
+            friend class distribution::uniform_cuda_hip::NormalReal;
+            template<typename T>
+            friend class distribution::uniform_cuda_hip::UniformReal;
+            template<typename T>
+            friend class distribution::uniform_cuda_hip::UniformUint;
+
 #        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                curandStateXORWOW_t state;
+            curandStateXORWOW_t state;
 #        else
-                hiprandStateXORWOW_t state;
+            hiprandStateXORWOW_t state;
 #        endif
 
-                // STL UniformRandomBitGenerator concept. This is not strictly necessary as the distributions
-                // contained in this file are aware of the API specifics of the CUDA/HIP XORWOW engine and STL
-                // distributions might not work on the device, but it servers a compatibility bridge to other
-                // potentially compatible alpaka distributions.
+        public:
+            // STL UniformRandomBitGenerator concept. This is not strictly necessary as the distributions
+            // contained in this file are aware of the API specifics of the CUDA/HIP XORWOW engine and STL
+            // distributions might not work on the device, but it servers a compatibility bridge to other
+            // potentially compatible alpaka distributions.
 #        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                using result_type = decltype(curand(&state));
+            using result_type = decltype(curand(&state));
 #        else
-                using result_type = decltype(hiprand(&state));
+            using result_type = decltype(hiprand(&state));
 #        endif
-                ALPAKA_FN_HOST_ACC constexpr static result_type min()
-                {
-                    return std::numeric_limits<result_type>::min();
-                }
-                ALPAKA_FN_HOST_ACC constexpr static result_type max()
-                {
-                    return std::numeric_limits<result_type>::max();
-                }
-                __device__ result_type operator()()
-                {
+            ALPAKA_FN_HOST_ACC constexpr static result_type min()
+            {
+                return std::numeric_limits<result_type>::min();
+            }
+            ALPAKA_FN_HOST_ACC constexpr static result_type max()
+            {
+                return std::numeric_limits<result_type>::max();
+            }
+            __device__ result_type operator()()
+            {
 #        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                    return curand(&state);
+                return curand(&state);
 #        else
-                    return hiprand(&state);
+                return hiprand(&state);
 #        endif
-                }
-            };
-        } // namespace uniform_cuda_hip
-    } // namespace engine
+            }
+        };
+    } // namespace engine::uniform_cuda_hip
 
-    namespace distribution
+    namespace distribution::uniform_cuda_hip
     {
-        namespace uniform_cuda_hip
+        //! The CUDA/HIP random number float normal distribution.
+        template<>
+        class NormalReal<float>
         {
-            //! The CUDA/HIP random number floating point normal distribution.
-            template<typename T>
-            class NormalReal;
-
-            //! The CUDA/HIP random number float normal distribution.
-            template<>
-            class NormalReal<float>
+        public:
+            template<typename TEngine>
+            __device__ auto operator()(TEngine& engine) -> float
             {
-            public:
-                template<typename TEngine>
-                __device__ auto operator()(TEngine& engine) -> float
-                {
 #        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                    return curand_normal(&engine.state);
+                return curand_normal(&engine.state);
 #        else
-                    return hiprand_normal(&engine.state);
+                return hiprand_normal(&engine.state);
 #        endif
-                }
-            };
+            }
+        };
 
-            //! The CUDA/HIP random number float normal distribution.
-            template<>
-            class NormalReal<double>
+        //! The CUDA/HIP random number float normal distribution.
+        template<>
+        class NormalReal<double>
+        {
+        public:
+            template<typename TEngine>
+            __device__ auto operator()(TEngine& engine) -> double
             {
-            public:
-                template<typename TEngine>
-                __device__ auto operator()(TEngine& engine) -> double
-                {
 #        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                    return curand_normal_double(&engine.state);
+                return curand_normal_double(&engine.state);
 #        else
-                    return hiprand_normal_double(&engine.state);
+                return hiprand_normal_double(&engine.state);
 #        endif
-                }
-            };
+            }
+        };
 
-            //! The CUDA/HIP random number floating point uniform distribution.
-            template<typename T>
-            class UniformReal;
-
-            //! The CUDA/HIP random number float uniform distribution.
-            template<>
-            class UniformReal<float>
+        //! The CUDA/HIP random number float uniform distribution.
+        template<>
+        class UniformReal<float>
+        {
+        public:
+            template<typename TEngine>
+            __device__ auto operator()(TEngine& engine) -> float
             {
-            public:
-                template<typename TEngine>
-                __device__ auto operator()(TEngine& engine) -> float
-                {
-                    // (0.f, 1.0f]
+                // (0.f, 1.0f]
 #        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                    float const fUniformRand(curand_uniform(&engine.state));
+                float const fUniformRand(curand_uniform(&engine.state));
 #        else
-                    float const fUniformRand(hiprand_uniform(&engine.state));
+                float const fUniformRand(hiprand_uniform(&engine.state));
 #        endif
-                    // NOTE: (1.0f - curand_uniform) does not work, because curand_uniform seems to return
-                    // denormalized floats around 0.f. [0.f, 1.0f)
-                    return fUniformRand * static_cast<float>(fUniformRand != 1.0f);
-                }
-            };
+                // NOTE: (1.0f - curand_uniform) does not work, because curand_uniform seems to return
+                // denormalized floats around 0.f. [0.f, 1.0f)
+                return fUniformRand * static_cast<float>(fUniformRand != 1.0f);
+            }
+        };
 
-            //! The CUDA/HIP random number float uniform distribution.
-            template<>
-            class UniformReal<double>
+        //! The CUDA/HIP random number float uniform distribution.
+        template<>
+        class UniformReal<double>
+        {
+        public:
+            template<typename TEngine>
+            __device__ auto operator()(TEngine& engine) -> double
             {
-            public:
-                template<typename TEngine>
-                __device__ auto operator()(TEngine& engine) -> double
-                {
-                    // (0.f, 1.0f]
+                // (0.f, 1.0f]
 #        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                    double const fUniformRand(curand_uniform_double(&engine.state));
+                double const fUniformRand(curand_uniform_double(&engine.state));
 #        else
-                    double const fUniformRand(hiprand_uniform_double(&engine.state));
+                double const fUniformRand(hiprand_uniform_double(&engine.state));
 #        endif
-                    // NOTE: (1.0f - curand_uniform_double) does not work, because curand_uniform_double seems to
-                    // return denormalized floats around 0.f. [0.f, 1.0f)
-                    return fUniformRand * static_cast<double>(fUniformRand != 1.0);
-                }
-            };
+                // NOTE: (1.0f - curand_uniform_double) does not work, because curand_uniform_double seems to
+                // return denormalized floats around 0.f. [0.f, 1.0f)
+                return fUniformRand * static_cast<double>(fUniformRand != 1.0);
+            }
+        };
 
-            //! The CUDA/HIP random number integer uniform distribution.
-            template<typename T>
-            class UniformUint;
-
-            //! The CUDA/HIP random number unsigned integer uniform distribution.
-            template<>
-            class UniformUint<unsigned int>
+        //! The CUDA/HIP random number unsigned integer uniform distribution.
+        template<>
+        class UniformUint<unsigned int>
+        {
+        public:
+            template<typename TEngine>
+            __device__ auto operator()(TEngine& engine) -> unsigned int
             {
-            public:
-                template<typename TEngine>
-                __device__ auto operator()(TEngine& engine) -> unsigned int
-                {
 #        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                    return curand(&engine.state);
+                return curand(&engine.state);
 #        else
-                    return hiprand(&engine.state);
+                return hiprand(&engine.state);
 #        endif
-                }
-            };
-        } // namespace uniform_cuda_hip
-    } // namespace distribution
+            }
+        };
+    } // namespace distribution::uniform_cuda_hip
 
-    namespace distribution
+    namespace distribution::traits
     {
-        namespace traits
+        //! The CUDA/HIP random number float normal distribution get trait specialization.
+        template<typename T>
+        struct CreateNormalReal<RandUniformCudaHipRand, T, std::enable_if_t<std::is_floating_point_v<T>>>
         {
-            //! The CUDA/HIP random number float normal distribution get trait specialization.
-            template<typename T>
-            struct CreateNormalReal<RandUniformCudaHipRand, T, std::enable_if_t<std::is_floating_point<T>::value>>
+            __device__ static auto createNormalReal(RandUniformCudaHipRand const& /*rand*/)
+                -> uniform_cuda_hip::NormalReal<T>
             {
-                __device__ static auto createNormalReal(RandUniformCudaHipRand const& /*rand*/)
-                    -> rand::distribution::uniform_cuda_hip::NormalReal<T>
-                {
-                    return rand::distribution::uniform_cuda_hip::NormalReal<T>();
-                }
-            };
+                return {};
+            }
+        };
 
-            //! The CUDA/HIP random number float uniform distribution get trait specialization.
-            template<typename T>
-            struct CreateUniformReal<RandUniformCudaHipRand, T, std::enable_if_t<std::is_floating_point<T>::value>>
+        //! The CUDA/HIP random number float uniform distribution get trait specialization.
+        template<typename T>
+        struct CreateUniformReal<RandUniformCudaHipRand, T, std::enable_if_t<std::is_floating_point_v<T>>>
+        {
+            __device__ static auto createUniformReal(RandUniformCudaHipRand const& /*rand*/)
+                -> uniform_cuda_hip::UniformReal<T>
             {
-                __device__ static auto createUniformReal(RandUniformCudaHipRand const& /*rand*/)
-                    -> rand::distribution::uniform_cuda_hip::UniformReal<T>
-                {
-                    return rand::distribution::uniform_cuda_hip::UniformReal<T>();
-                }
-            };
+                return {};
+            }
+        };
 
-            //! The CUDA/HIP random number integer uniform distribution get trait specialization.
-            template<typename T>
-            struct CreateUniformUint<RandUniformCudaHipRand, T, std::enable_if_t<std::is_integral<T>::value>>
+        //! The CUDA/HIP random number integer uniform distribution get trait specialization.
+        template<typename T>
+        struct CreateUniformUint<RandUniformCudaHipRand, T, std::enable_if_t<std::is_integral_v<T>>>
+        {
+            __device__ static auto createUniformUint(RandUniformCudaHipRand const& /*rand*/)
+                -> uniform_cuda_hip::UniformUint<T>
             {
-                __device__ static auto createUniformUint(RandUniformCudaHipRand const& /*rand*/)
-                    -> rand::distribution::uniform_cuda_hip::UniformUint<T>
-                {
-                    return rand::distribution::uniform_cuda_hip::UniformUint<T>();
-                }
-            };
-        } // namespace traits
-    } // namespace distribution
+                return {};
+            }
+        };
+    } // namespace distribution::traits
 
-    namespace engine
+    namespace engine::traits
     {
-        namespace traits
+        //! The CUDA/HIP random number default generator get trait specialization.
+        template<>
+        struct CreateDefault<RandUniformCudaHipRand>
         {
-            //! The CUDA/HIP random number default generator get trait specialization.
-            template<>
-            struct CreateDefault<RandUniformCudaHipRand>
+            __device__ static auto createDefault(
+                RandUniformCudaHipRand const& /*rand*/,
+                std::uint32_t const& seed = 0,
+                std::uint32_t const& subsequence = 0,
+                std::uint32_t const& offset = 0) -> uniform_cuda_hip::Xor
             {
-                __device__ static auto createDefault(
-                    RandUniformCudaHipRand const& /*rand*/,
-                    std::uint32_t const& seed = 0,
-                    std::uint32_t const& subsequence = 0,
-                    std::uint32_t const& offset = 0) -> rand::engine::uniform_cuda_hip::Xor
-                {
-                    return rand::engine::uniform_cuda_hip::Xor(seed, subsequence, offset);
-                }
-            };
-        } // namespace traits
-    } // namespace engine
+                return {seed, subsequence, offset};
+            }
+        };
+    } // namespace engine::traits
 #    endif
 } // namespace alpaka::rand
 

--- a/include/alpaka/rand/TinyMT/Engine.hpp
+++ b/include/alpaka/rand/TinyMT/Engine.hpp
@@ -13,7 +13,6 @@
 
 #include <cstdint>
 
-
 namespace alpaka::rand::engine::cpu
 {
     //! Implementation of std::UniformRandomBitGenerator for TinyMT32
@@ -43,8 +42,7 @@ namespace alpaka::rand::engine::cpu
 
         TinyMTengine()
         {
-            std::uint32_t const magicSeed = 42u;
-            seed(magicSeed);
+            seed(default_seed());
         }
 
         auto operator()() -> result_type

--- a/include/alpaka/rand/Traits.hpp
+++ b/include/alpaka/rand/Traits.hpp
@@ -44,7 +44,7 @@ namespace alpaka::rand
         template<typename T, typename TRand>
         ALPAKA_FN_HOST_ACC auto createNormalReal(TRand const& rand)
         {
-            static_assert(std::is_floating_point<T>::value, "The value type T has to be a floating point type!");
+            static_assert(std::is_floating_point_v<T>, "The value type T has to be a floating point type!");
 
             using ImplementationBase = concepts::ImplementationBase<ConceptRand, TRand>;
             return traits::CreateNormalReal<ImplementationBase, T>::createNormalReal(rand);
@@ -54,7 +54,7 @@ namespace alpaka::rand
         template<typename T, typename TRand>
         ALPAKA_FN_HOST_ACC auto createUniformReal(TRand const& rand)
         {
-            static_assert(std::is_floating_point<T>::value, "The value type T has to be a floating point type!");
+            static_assert(std::is_floating_point_v<T>, "The value type T has to be a floating point type!");
 
             using ImplementationBase = concepts::ImplementationBase<ConceptRand, TRand>;
             return traits::CreateUniformReal<ImplementationBase, T>::createUniformReal(rand);
@@ -65,7 +65,7 @@ namespace alpaka::rand
         ALPAKA_FN_HOST_ACC auto createUniformUint(TRand const& rand)
         {
             static_assert(
-                std::is_integral<T>::value && std::is_unsigned<T>::value,
+                std::is_integral_v<T> && std::is_unsigned_v<T>,
                 "The value type T has to be a unsigned integral type!");
 
             using ImplementationBase = concepts::ImplementationBase<ConceptRand, TRand>;


### PR DESCRIPTION
Refactors the code in alpaka/rand:

* collapse nested namespaces
* make some state members private

Then, it makes `alpaka::rand::distribution::gpu::NormReal` copyable, since other distributions are also copyable. This makes #1496  obsolete.