### PR TITLE
Remove namespace alpaka::extent

### DIFF
--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -150,14 +150,14 @@ namespace alpaka
                 return {// m_multiProcessorCount
                         alpaka::core::clipCast<TIdx>(multiProcessorCount),
                         // m_gridBlockExtentMax
-                        extent::getExtentVecEnd<TDim>(Vec<DimInt<3u>, TIdx>(
+                        getExtentVecEnd<TDim>(Vec<DimInt<3u>, TIdx>(
                             alpaka::core::clipCast<TIdx>(maxGridSize[2u]),
                             alpaka::core::clipCast<TIdx>(maxGridSize[1u]),
                             alpaka::core::clipCast<TIdx>(maxGridSize[0u]))),
                         // m_gridBlockCountMax
                         std::numeric_limits<TIdx>::max(),
                         // m_blockThreadExtentMax
-                        extent::getExtentVecEnd<TDim>(Vec<DimInt<3u>, TIdx>(
+                        getExtentVecEnd<TDim>(Vec<DimInt<3u>, TIdx>(
                             alpaka::core::clipCast<TIdx>(maxBlockDim[2u]),
                             alpaka::core::clipCast<TIdx>(maxBlockDim[1u]),
                             alpaka::core::clipCast<TIdx>(maxBlockDim[0u]))),
@@ -177,14 +177,14 @@ namespace alpaka
                 return {// m_multiProcessorCount
                         alpaka::core::clipCast<TIdx>(hipDevProp.multiProcessorCount),
                         // m_gridBlockExtentMax
-                        extent::getExtentVecEnd<TDim>(Vec<DimInt<3u>, TIdx>(
+                        getExtentVecEnd<TDim>(Vec<DimInt<3u>, TIdx>(
                             alpaka::core::clipCast<TIdx>(hipDevProp.maxGridSize[2u]),
                             alpaka::core::clipCast<TIdx>(hipDevProp.maxGridSize[1u]),
                             alpaka::core::clipCast<TIdx>(hipDevProp.maxGridSize[0u]))),
                         // m_gridBlockCountMax
                         std::numeric_limits<TIdx>::max(),
                         // m_blockThreadExtentMax
-                        extent::getExtentVecEnd<TDim>(Vec<DimInt<3u>, TIdx>(
+                        getExtentVecEnd<TDim>(Vec<DimInt<3u>, TIdx>(
                             alpaka::core::clipCast<TIdx>(hipDevProp.maxThreadsDim[2u]),
                             alpaka::core::clipCast<TIdx>(hipDevProp.maxThreadsDim[1u]),
                             alpaka::core::clipCast<TIdx>(hipDevProp.maxThreadsDim[0u]))),

--- a/include/alpaka/core/Cuda.hpp
+++ b/include/alpaka/core/Cuda.hpp
@@ -205,9 +205,7 @@ namespace alpaka
         {
             using type = decltype(std::declval<T>().x);
         };
-    } // namespace traits
-    namespace extent::traits
-    {
+
         //! The CUDA vectors extent get trait specialization.
         template<typename TExtent>
         struct GetExtent<
@@ -316,9 +314,7 @@ namespace alpaka
                 extent.w = extentVal;
             }
         };
-    } // namespace extent::traits
-    namespace traits
-    {
+
         //! The CUDA vectors offset get trait specialization.
         template<typename TOffsets>
         struct GetOffset<

--- a/include/alpaka/core/Hip.hpp
+++ b/include/alpaka/core/Hip.hpp
@@ -168,9 +168,7 @@ namespace alpaka
         {
             using type = decltype(std::declval<T>().x);
         };
-    } // namespace traits
-    namespace extent::traits
-    {
+
         //! The HIP vectors extent get trait specialization.
         template<typename TExtent>
         struct GetExtent<
@@ -279,9 +277,7 @@ namespace alpaka
                 extent.w = extentVal;
             }
         };
-    } // namespace extent::traits
-    namespace traits
-    {
+
         //! The HIP vectors offset get trait specialization.
         template<typename TOffsets>
         struct GetOffset<

--- a/include/alpaka/extent/Traits.hpp
+++ b/include/alpaka/extent/Traits.hpp
@@ -18,7 +18,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace alpaka::extent
+namespace alpaka
 {
     //! The extent traits.
     namespace traits
@@ -144,4 +144,4 @@ namespace alpaka::extent
             }
         };
     } // namespace traits
-} // namespace alpaka::extent
+} // namespace alpaka

--- a/include/alpaka/mem/buf/BufOacc.hpp
+++ b/include/alpaka/mem/buf/BufOacc.hpp
@@ -71,7 +71,7 @@ namespace alpaka
                 template<typename TExtent>
                 ALPAKA_FN_HOST BufOaccImpl(DevOacc const& dev, TElem* const pMem, TExtent const& extent)
                     : m_dev(dev)
-                    , m_extentElements(extent::getExtentVecEnd<TDim>(extent))
+                    , m_extentElements(getExtentVecEnd<TDim>(extent))
                     , m_pitchBytes(calculatePitchesFromExtents(m_extentElements))
                     , m_pMem(pMem)
                 {
@@ -163,29 +163,20 @@ namespace alpaka
         {
             using type = TElem;
         };
-    } // namespace traits
 
-    namespace extent
-    {
-        namespace traits
+        //! The BufOacc extent get trait specialization.
+        template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
+        struct GetExtent<
+            TIdxIntegralConst,
+            BufOacc<TElem, TDim, TIdx>,
+            typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
         {
-            //! The BufOacc extent get trait specialization.
-            template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
-            struct GetExtent<
-                TIdxIntegralConst,
-                BufOacc<TElem, TDim, TIdx>,
-                typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
+            ALPAKA_FN_HOST static auto getExtent(BufOacc<TElem, TDim, TIdx> const& extent) -> TIdx
             {
-                ALPAKA_FN_HOST static auto getExtent(BufOacc<TElem, TDim, TIdx> const& extent) -> TIdx
-                {
-                    return extent.extentElements()[TIdxIntegralConst::value];
-                }
-            };
-        } // namespace traits
-    } // namespace extent
+                return extent.extentElements()[TIdxIntegralConst::value];
+            }
+        };
 
-    namespace traits
-    {
         //! The BufOacc native pointer get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrNative<BufOacc<TElem, TDim, TIdx>>
@@ -247,7 +238,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                auto const width(extent::getWidth(extent));
+                auto const width(getWidth(extent));
                 auto const widthBytes(width * static_cast<TIdx>(sizeof(TElem)));
 
                 dev.makeCurrent();
@@ -271,7 +262,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                const std::size_t size = static_cast<std::size_t>(extent::getExtentVec(extent).prod()) * sizeof(TElem);
+                const std::size_t size = static_cast<std::size_t>(getExtentVec(extent).prod()) * sizeof(TElem);
 
                 dev.makeCurrent();
                 void* memPtr = acc_malloc(size);

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -69,7 +69,7 @@ namespace alpaka
             template<typename TExtent>
             ALPAKA_FN_HOST BufOmp5Impl(DevOmp5 const& dev, TElem* const pMem, TExtent const& extent)
                 : m_dev(dev)
-                , m_extentElements(extent::getExtentVecEnd<TDim>(extent))
+                , m_extentElements(getExtentVecEnd<TDim>(extent))
                 , m_pitchBytes(calculatePitchesFromExtents(m_extentElements))
                 , m_pMem(pMem)
             {
@@ -159,27 +159,20 @@ namespace alpaka
         {
             using type = TElem;
         };
-    } // namespace traits
-    namespace extent
-    {
-        namespace traits
+
+        //! The BufOmp5 extent get trait specialization.
+        template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
+        struct GetExtent<
+            TIdxIntegralConst,
+            BufOmp5<TElem, TDim, TIdx>,
+            typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
         {
-            //! The BufOmp5 extent get trait specialization.
-            template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
-            struct GetExtent<
-                TIdxIntegralConst,
-                BufOmp5<TElem, TDim, TIdx>,
-                typename std::enable_if<(TDim::value > TIdxIntegralConst::value)>::type>
+            ALPAKA_FN_HOST static auto getExtent(BufOmp5<TElem, TDim, TIdx> const& extent) -> TIdx
             {
-                ALPAKA_FN_HOST static auto getExtent(BufOmp5<TElem, TDim, TIdx> const& extent) -> TIdx
-                {
-                    return extent.extentElements()[TIdxIntegralConst::value];
-                }
-            };
-        } // namespace traits
-    } // namespace extent
-    namespace traits
-    {
+                return extent.extentElements()[TIdxIntegralConst::value];
+            }
+        };
+
         //! The BufOmp5 native pointer get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrNative<BufOmp5<TElem, TDim, TIdx>>
@@ -241,7 +234,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                auto const width(extent::getWidth(extent));
+                auto const width(getWidth(extent));
                 auto const widthBytes(width * static_cast<TIdx>(sizeof(TElem)));
 
                 void* memPtr
@@ -265,11 +258,11 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                const std::size_t size = static_cast<std::size_t>(extent::getExtentVec(extent).prod()) * sizeof(TElem);
+                const std::size_t size = static_cast<std::size_t>(getExtentVec(extent).prod()) * sizeof(TElem);
 
                 void* memPtr = omp_target_alloc(size, dev.m_spDevOmp5Impl->getNativeHandle());
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                std::cout << __func__ << " dim: " << TDim::value << " extent: " << extent::getExtentVec(extent)
+                std::cout << __func__ << " dim: " << TDim::value << " extent: " << getExtentVec(extent)
                           << " ewb: " << size << " ptr: " << memPtr
                           << " device: " << dev.m_spDevOmp5Impl->getNativeHandle() << std::endl;
 #    endif

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -63,7 +63,7 @@ namespace alpaka
             TIdx const& pitchBytes,
             TExtent const& extent)
             : m_dev(dev)
-            , m_extentElements(extent::getExtentVecEnd<TDim>(extent))
+            , m_extentElements(getExtentVecEnd<TDim>(extent))
             , m_spMem(pMem, std::move(deleter))
             , m_pitchBytes(pitchBytes)
         {
@@ -116,27 +116,20 @@ namespace alpaka
         {
             using type = TElem;
         };
-    } // namespace traits
-    namespace extent
-    {
-        namespace traits
+
+        //! The BufUniformCudaHipRt extent get trait specialization.
+        template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
+        struct GetExtent<
+            TIdxIntegralConst,
+            BufUniformCudaHipRt<TElem, TDim, TIdx>,
+            std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
         {
-            //! The BufUniformCudaHipRt extent get trait specialization.
-            template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
-            struct GetExtent<
-                TIdxIntegralConst,
-                BufUniformCudaHipRt<TElem, TDim, TIdx>,
-                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
+            ALPAKA_FN_HOST static auto getExtent(BufUniformCudaHipRt<TElem, TDim, TIdx> const& extent) -> TIdx
             {
-                ALPAKA_FN_HOST static auto getExtent(BufUniformCudaHipRt<TElem, TDim, TIdx> const& extent) -> TIdx
-                {
-                    return extent.m_extentElements[TIdxIntegralConst::value];
-                }
-            };
-        } // namespace traits
-    } // namespace extent
-    namespace traits
-    {
+                return extent.m_extentElements[TIdxIntegralConst::value];
+            }
+        };
+
         //! The BufUniformCudaHipRt native pointer get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrNative<BufUniformCudaHipRt<TElem, TDim, TIdx>>
@@ -236,7 +229,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                auto const width = extent::getWidth(extent);
+                auto const width = getWidth(extent);
                 auto const widthBytes = width * static_cast<TIdx>(sizeof(TElem));
 
                 // Set the current device.
@@ -272,9 +265,9 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                auto const width = extent::getWidth(extent);
+                auto const width = getWidth(extent);
                 auto const widthBytes = width * static_cast<TIdx>(sizeof(TElem));
-                auto const height = extent::getHeight(extent);
+                auto const height = getHeight(extent);
 
                 void* memPtr = nullptr;
                 std::size_t pitchBytes = 0u;
@@ -323,9 +316,9 @@ namespace alpaka
 
                 ALPAKA_API_PREFIX(Extent)
                 const extentVal = ALPAKA_PP_CONCAT(make_, ALPAKA_API_PREFIX(Extent))(
-                    static_cast<std::size_t>(extent::getWidth(extent) * static_cast<TIdx>(sizeof(TElem))),
-                    static_cast<std::size_t>(extent::getHeight(extent)),
-                    static_cast<std::size_t>(extent::getDepth(extent)));
+                    static_cast<std::size_t>(getWidth(extent) * static_cast<TIdx>(sizeof(TElem))),
+                    static_cast<std::size_t>(getHeight(extent)),
+                    static_cast<std::size_t>(getDepth(extent)));
 
                 ALPAKA_API_PREFIX(PitchedPtr) pitchedPtrVal;
                 pitchedPtrVal.ptr = nullptr;
@@ -347,7 +340,7 @@ namespace alpaka
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Free)(reinterpret_cast<void*>(ptr)));
                 };
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                std::cout << __func__ << " ew: " << extent::getWidth(extent) << " eh: " << extentVal.height
+                std::cout << __func__ << " ew: " << getWidth(extent) << " eh: " << extentVal.height
                           << " ed: " << extentVal.depth << " ewb: " << extentVal.width << " ptr: " << pitchedPtrVal.ptr
                           << " pitch: " << pitchedPtrVal.pitch << " wb: " << pitchedPtrVal.xsize
                           << " h: " << pitchedPtrVal.ysize << std::endl;
@@ -431,7 +424,7 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                auto const width = extent::getWidth(extent);
+                auto const width = getWidth(extent);
                 auto const widthBytes = width * static_cast<TIdx>(sizeof(TElem));
 
                 // Set the current device.
@@ -598,7 +591,7 @@ namespace alpaka
                     //   compute capability greater than or equal to 1.1.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(HostRegister)(
                         const_cast<void*>(reinterpret_cast<void const*>(getPtrNative(buf))),
-                        extent::getExtentProduct(buf) * sizeof(Elem<BufCpu<TElem, TDim, TIdx>>),
+                        getExtentProduct(buf) * sizeof(Elem<BufCpu<TElem, TDim, TIdx>>),
                         ALPAKA_API_PREFIX(HostRegisterMapped)));
                 }
             }

--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -63,11 +63,11 @@ namespace alpaka
                 "The source and the destination view are required to have the same element type!");
 
             TaskCopyCpuBase(TViewDst& viewDst, TViewSrc const& viewSrc, TExtent const& extent)
-                : m_extent(extent::getExtentVec(extent))
+                : m_extent(getExtentVec(extent))
                 , m_extentWidthBytes(m_extent[TDim::value - 1u] * static_cast<ExtentSize>(sizeof(Elem)))
 #if(!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-                , m_dstExtent(extent::getExtentVec(viewDst))
-                , m_srcExtent(extent::getExtentVec(viewSrc))
+                , m_dstExtent(getExtentVec(viewDst))
+                , m_srcExtent(getExtentVec(viewSrc))
 #endif
                 , m_dstPitchBytes(getPitchBytesVec(viewDst))
                 , m_srcPitchBytes(getPitchBytesVec(viewSrc))
@@ -217,9 +217,9 @@ namespace alpaka
                 , m_srcMemNative(reinterpret_cast<std::uint8_t const*>(getPtrNative(viewSrc)))
             {
                 // all zero-sized extents are equivalent
-                ALPAKA_ASSERT(extent::getExtentVec(extent).prod() == 1u);
-                ALPAKA_ASSERT(extent::getExtentVec(viewDst).prod() == 1u);
-                ALPAKA_ASSERT(extent::getExtentVec(viewSrc).prod() == 1u);
+                ALPAKA_ASSERT(getExtentVec(extent).prod() == 1u);
+                ALPAKA_ASSERT(getExtentVec(viewDst).prod() == 1u);
+                ALPAKA_ASSERT(getExtentVec(viewSrc).prod() == 1u);
             }
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -47,10 +47,10 @@ namespace alpaka
 
             TaskSetCpuBase(TView& view, std::uint8_t const& byte, TExtent const& extent)
                 : m_byte(byte)
-                , m_extent(extent::getExtentVec(extent))
+                , m_extent(getExtentVec(extent))
                 , m_extentWidthBytes(m_extent[TDim::value - 1u] * static_cast<ExtentSize>(sizeof(Elem)))
 #if(!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-                , m_dstExtent(extent::getExtentVec(view))
+                , m_dstExtent(getExtentVec(view))
 #endif
                 , m_dstPitchBytes(getPitchBytesVec(view))
                 , m_dstMemNative(reinterpret_cast<std::uint8_t*>(getPtrNative(view)))
@@ -169,8 +169,8 @@ namespace alpaka
                 , m_dstMemNative(reinterpret_cast<std::uint8_t*>(getPtrNative(view)))
             {
                 // all zero-sized extents are equivalent
-                ALPAKA_ASSERT(extent::getExtentVec(extent).prod() == 1u);
-                ALPAKA_ASSERT(extent::getExtentVec(view).prod() == 1u);
+                ALPAKA_ASSERT(getExtentVec(extent).prod() == 1u);
+                ALPAKA_ASSERT(getExtentVec(view).prod() == 1u);
             }
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL

--- a/include/alpaka/mem/buf/oacc/Copy.hpp
+++ b/include/alpaka/mem/buf/oacc/Copy.hpp
@@ -98,14 +98,14 @@ namespace alpaka
                     DevOacc const& dev,
                     TCopyPred copyPred)
                     : m_dev(dev)
-                    , m_extent(extent::getExtentVec(extent))
+                    , m_extent(getExtentVec(extent))
                     , m_extentWidthBytes(m_extent[TDim::value - 1u] * static_cast<ExtentSize>(sizeof(Elem)))
                     , m_dstPitchBytes(getPitchBytesVec(viewDst))
                     , m_srcPitchBytes(getPitchBytesVec(viewSrc))
                     ,
 #    if(!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-                    m_dstExtent(extent::getExtentVec(viewDst))
-                    , m_srcExtent(extent::getExtentVec(viewSrc))
+                    m_dstExtent(getExtentVec(viewDst))
+                    , m_srcExtent(getExtentVec(viewSrc))
                     ,
 #    endif
                     m_dstMemNative(reinterpret_cast<std::uint8_t*>(getPtrNative(viewDst)))

--- a/include/alpaka/mem/buf/oacc/Set.hpp
+++ b/include/alpaka/mem/buf/oacc/Set.hpp
@@ -49,7 +49,7 @@ namespace alpaka
             {
                 using Idx = typename traits::IdxType<TExtent>::type;
                 auto pitch = getPitchBytesVec(view);
-                auto byteExtent = extent::getExtentVec(extent);
+                auto byteExtent = getExtentVec(extent);
                 byteExtent[TDim::value - 1] *= static_cast<Idx>(sizeof(Elem<TView>));
                 constexpr auto lastDim = TDim::value - 1;
 

--- a/include/alpaka/mem/buf/omp5/Copy.hpp
+++ b/include/alpaka/mem/buf/omp5/Copy.hpp
@@ -64,15 +64,15 @@ namespace alpaka
                 int const& iSrcDevice)
                 : m_iDstDevice(iDstDevice)
                 , m_iSrcDevice(iSrcDevice)
-                , m_extent(castVec<size_t>(extent::getExtentVec(extent)))
+                , m_extent(castVec<size_t>(getExtentVec(extent)))
                 , m_dstPitchBytes(castVec<size_t>(getPitchBytesVec(viewDst)))
                 , m_srcPitchBytes(castVec<size_t>(getPitchBytesVec(viewSrc)))
                 , m_dstMemNative(reinterpret_cast<void*>(getPtrNative(viewDst)))
                 , m_srcMemNative(reinterpret_cast<void const*>(getPtrNative(viewSrc)))
             {
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                const auto dstExtent(castVec<size_t>(extent::getExtentVec(viewDst)));
-                const auto srcExtent(castVec<size_t>(extent::getExtentVec(viewSrc)));
+                const auto dstExtent(castVec<size_t>(getExtentVec(viewDst)));
+                const auto srcExtent(castVec<size_t>(getExtentVec(viewSrc)));
                 for(auto i = static_cast<decltype(TDim::value)>(0u); i < TDim::value; ++i)
                 {
                     ALPAKA_ASSERT(m_extent[i] <= dstExtent[i]);
@@ -234,11 +234,11 @@ namespace alpaka
                 : m_iDstDevice(iDstDevice)
                 , m_iSrcDevice(iSrcDevice)
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                , m_extentWidth(extent::getWidth(extent))
-                , m_dstWidth(static_cast<Idx>(extent::getWidth(viewDst)))
-                , m_srcWidth(static_cast<Idx>(extent::getWidth(viewSrc)))
+                , m_extentWidth(getWidth(extent))
+                , m_dstWidth(static_cast<Idx>(getWidth(viewDst)))
+                , m_srcWidth(static_cast<Idx>(getWidth(viewSrc)))
 #    endif
-                , m_extentWidthBytes(extent::getWidth(extent) * static_cast<Idx>(sizeof(Elem<TViewDst>)))
+                , m_extentWidthBytes(getWidth(extent) * static_cast<Idx>(sizeof(Elem<TViewDst>)))
                 , m_dstMemNative(reinterpret_cast<void*>(getPtrNative(viewDst)))
                 , m_srcMemNative(reinterpret_cast<void const*>(getPtrNative(viewSrc)))
             {

--- a/include/alpaka/mem/buf/omp5/Set.hpp
+++ b/include/alpaka/mem/buf/omp5/Set.hpp
@@ -46,7 +46,7 @@ namespace alpaka
             {
                 using Idx = typename alpaka::traits::IdxType<TExtent>::type;
                 auto pitch = getPitchBytesVec(view);
-                auto byteExtent = extent::getExtentVec(extent);
+                auto byteExtent = getExtentVec(extent);
                 constexpr auto lastDim = TDim::value - 1;
                 byteExtent[lastDim] *= static_cast<Idx>(sizeof(Elem<TView>));
 

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -68,8 +68,8 @@ namespace alpaka
                 , m_iDstDevice(iDstDevice)
                 , m_iSrcDevice(iSrcDevice)
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                , m_dstWidth(static_cast<Idx>(extent::getWidth(viewDst)))
-                , m_srcWidth(static_cast<Idx>(extent::getWidth(viewSrc)))
+                , m_dstWidth(static_cast<Idx>(getWidth(viewDst)))
+                , m_srcWidth(static_cast<Idx>(getWidth(viewSrc)))
 #    endif
                 , m_dstMemNative(reinterpret_cast<void*>(getPtrNative(viewDst)))
                 , m_srcMemNative(reinterpret_cast<void const*>(getPtrNative(viewSrc)))
@@ -150,11 +150,11 @@ namespace alpaka
                 , m_iDstDevice(iDstDevice)
                 , m_iSrcDevice(iSrcDevice)
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                , m_extentWidth(extent::getWidth(extent))
-                , m_dstWidth(static_cast<Idx>(extent::getWidth(viewDst)))
-                , m_srcWidth(static_cast<Idx>(extent::getWidth(viewSrc)))
+                , m_extentWidth(getWidth(extent))
+                , m_dstWidth(static_cast<Idx>(getWidth(viewDst)))
+                , m_srcWidth(static_cast<Idx>(getWidth(viewSrc)))
 #    endif
-                , m_extentWidthBytes(extent::getWidth(extent) * static_cast<Idx>(sizeof(Elem<TViewDst>)))
+                , m_extentWidthBytes(getWidth(extent) * static_cast<Idx>(sizeof(Elem<TViewDst>)))
                 , m_dstMemNative(reinterpret_cast<void*>(getPtrNative(viewDst)))
                 , m_srcMemNative(reinterpret_cast<void const*>(getPtrNative(viewSrc)))
             {
@@ -241,15 +241,15 @@ namespace alpaka
                 , m_iDstDevice(iDstDevice)
                 , m_iSrcDevice(iSrcDevice)
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                , m_extentWidth(extent::getWidth(extent))
+                , m_extentWidth(getWidth(extent))
 #    endif
-                , m_extentWidthBytes(extent::getWidth(extent) * static_cast<Idx>(sizeof(Elem<TViewDst>)))
-                , m_dstWidth(static_cast<Idx>(extent::getWidth(viewDst)))
-                , m_srcWidth(static_cast<Idx>(extent::getWidth(viewSrc)))
-                , m_extentHeight(extent::getHeight(extent))
+                , m_extentWidthBytes(getWidth(extent) * static_cast<Idx>(sizeof(Elem<TViewDst>)))
+                , m_dstWidth(static_cast<Idx>(getWidth(viewDst)))
+                , m_srcWidth(static_cast<Idx>(getWidth(viewSrc)))
+                , m_extentHeight(getHeight(extent))
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                , m_dstHeight(static_cast<Idx>(extent::getHeight(viewDst)))
-                , m_srcHeight(static_cast<Idx>(extent::getHeight(viewSrc)))
+                , m_dstHeight(static_cast<Idx>(getHeight(viewDst)))
+                , m_srcHeight(static_cast<Idx>(getHeight(viewSrc)))
 #    endif
                 , m_dstpitchBytesX(static_cast<Idx>(getPitchBytes<Dim<TViewDst>::value - 1u>(viewDst)))
                 , m_srcpitchBytesX(static_cast<Idx>(getPitchBytes<Dim<TViewSrc>::value - 1u>(viewSrc)))
@@ -362,17 +362,17 @@ namespace alpaka
                 : m_uniformMemCpyKind(uniformMemcpyKind)
                 , m_iDstDevice(iDstDevice)
                 , m_iSrcDevice(iSrcDevice)
-                , m_extentWidth(extent::getWidth(extent))
+                , m_extentWidth(getWidth(extent))
                 , m_extentWidthBytes(m_extentWidth * static_cast<Idx>(sizeof(Elem<TViewDst>)))
-                , m_dstWidth(static_cast<Idx>(extent::getWidth(viewDst)))
-                , m_srcWidth(static_cast<Idx>(extent::getWidth(viewSrc)))
-                , m_extentHeight(extent::getHeight(extent))
-                , m_extentDepth(extent::getDepth(extent))
+                , m_dstWidth(static_cast<Idx>(getWidth(viewDst)))
+                , m_srcWidth(static_cast<Idx>(getWidth(viewSrc)))
+                , m_extentHeight(getHeight(extent))
+                , m_extentDepth(getDepth(extent))
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                , m_dstHeight(static_cast<Idx>(extent::getHeight(viewDst)))
-                , m_srcHeight(static_cast<Idx>(extent::getHeight(viewSrc)))
-                , m_dstDepth(static_cast<Idx>(extent::getDepth(viewDst)))
-                , m_srcDepth(static_cast<Idx>(extent::getDepth(viewSrc)))
+                , m_dstHeight(static_cast<Idx>(getHeight(viewDst)))
+                , m_srcHeight(static_cast<Idx>(getHeight(viewSrc)))
+                , m_dstDepth(static_cast<Idx>(getDepth(viewDst)))
+                , m_srcDepth(static_cast<Idx>(getDepth(viewSrc)))
 #    endif
                 , m_dstpitchBytesX(static_cast<Idx>(getPitchBytes<Dim<TViewDst>::value - 1u>(viewDst)))
                 , m_srcpitchBytesX(static_cast<Idx>(getPitchBytes<Dim<TViewSrc>::value - 1u>(viewSrc)))

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -86,7 +86,7 @@ namespace alpaka
 
                 auto& view = this->m_view;
 #    if !defined(NDEBUG)
-                auto const dstWidth = extent::getWidth(view);
+                auto const dstWidth = getWidth(view);
 #    endif
                 auto const dstNativePtr = reinterpret_cast<void*>(getPtrNative(view));
                 ALPAKA_ASSERT(1u <= dstWidth);
@@ -124,7 +124,7 @@ namespace alpaka
                 auto& view = this->m_view;
                 auto const& extent = this->m_extent;
 
-                auto const extentWidth = extent::getWidth(extent);
+                auto const extentWidth = getWidth(extent);
 
                 if(extentWidth == 0)
                 {
@@ -133,7 +133,7 @@ namespace alpaka
 
                 auto const extentWidthBytes = extentWidth * static_cast<Idx>(sizeof(Elem<TView>));
 #    if !defined(NDEBUG)
-                auto const dstWidth = extent::getWidth(view);
+                auto const dstWidth = getWidth(view);
 #    endif
                 auto const dstNativePtr = reinterpret_cast<void*>(getPtrNative(view));
                 ALPAKA_ASSERT(extentWidth <= dstWidth);
@@ -171,8 +171,8 @@ namespace alpaka
                 auto& view = this->m_view;
                 auto const& extent = this->m_extent;
 
-                auto const extentWidth = extent::getWidth(extent);
-                auto const extentHeight = extent::getHeight(extent);
+                auto const extentWidth = getWidth(extent);
+                auto const extentHeight = getHeight(extent);
 
                 if(extentWidth == 0 || extentHeight == 0)
                 {
@@ -182,8 +182,8 @@ namespace alpaka
                 auto const extentWidthBytes = extentWidth * static_cast<Idx>(sizeof(Elem<TView>));
 
 #    if !defined(NDEBUG)
-                auto const dstWidth = extent::getWidth(view);
-                auto const dstHeight = extent::getHeight(view);
+                auto const dstWidth = getWidth(view);
+                auto const dstHeight = getHeight(view);
 #    endif
                 auto const dstPitchBytesX = getPitchBytes<Dim<TView>::value - 1u>(view);
                 auto const dstNativePtr = reinterpret_cast<void*>(getPtrNative(view));
@@ -226,9 +226,9 @@ namespace alpaka
                 auto& view = this->m_view;
                 auto const& extent = this->m_extent;
 
-                auto const extentWidth = extent::getWidth(extent);
-                auto const extentHeight = extent::getHeight(extent);
-                auto const extentDepth = extent::getDepth(extent);
+                auto const extentWidth = getWidth(extent);
+                auto const extentHeight = getHeight(extent);
+                auto const extentDepth = getDepth(extent);
 
                 // This is not only an optimization but also prevents a division by zero.
                 if(extentWidth == 0 || extentHeight == 0 || extentDepth == 0)
@@ -236,10 +236,10 @@ namespace alpaka
                     return;
                 }
 
-                auto const dstWidth = extent::getWidth(view);
+                auto const dstWidth = getWidth(view);
 #    if !defined(NDEBUG)
-                auto const dstHeight = extent::getHeight(view);
-                auto const dstDepth = extent::getDepth(view);
+                auto const dstHeight = getHeight(view);
+                auto const dstDepth = getDepth(view);
 #    endif
                 auto const dstPitchBytesX = getPitchBytes<Dim<TView>::value - 1u>(view);
                 auto const dstPitchBytesY = getPitchBytes<Dim<TView>::value - (2u % Dim<TView>::value)>(view);

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -65,7 +65,7 @@ namespace alpaka
             {
                 ALPAKA_FN_HOST static auto getPitchBytesDefault(TView const& view) -> Idx<TView>
                 {
-                    return extent::getExtent<TIdx::value>(view)
+                    return getExtent<TIdx::value>(view)
                         * GetPitchBytes<DimInt<TIdx::value + 1>, TView>::getPitchBytes(view);
                 }
             };
@@ -74,7 +74,7 @@ namespace alpaka
             {
                 ALPAKA_FN_HOST static auto getPitchBytesDefault(TView const& view) -> Idx<TView>
                 {
-                    return extent::getExtent<Dim<TView>::value - 1u>(view) * sizeof(Elem<TView>);
+                    return getExtent<Dim<TView>::value - 1u>(view) * sizeof(Elem<TView>);
                 }
             };
             template<typename TView>
@@ -198,7 +198,7 @@ namespace alpaka
     template<typename TView, typename TQueue>
     ALPAKA_FN_HOST auto memset(TQueue& queue, TView& view, std::uint8_t const& byte) -> void
     {
-        enqueue(queue, createTaskMemset(view, byte, extent::getExtentVec(view)));
+        enqueue(queue, createTaskMemset(view, byte, getExtentVec(view)));
     }
 
     //! Creates a memory copy task.
@@ -246,7 +246,7 @@ namespace alpaka
     template<typename TViewSrc, typename TViewDst, typename TQueue>
     ALPAKA_FN_HOST auto memcpy(TQueue& queue, TViewDst& viewDst, TViewSrc const& viewSrc) -> void
     {
-        enqueue(queue, createTaskMemcpy(viewDst, viewSrc, extent::getExtentVec(viewSrc)));
+        enqueue(queue, createTaskMemcpy(viewDst, viewSrc, getExtentVec(viewSrc)));
     }
 
     namespace detail
@@ -337,7 +337,7 @@ namespace alpaka
         detail::Print<DimInt<0u>, TView>::print(
             view,
             getPtrNative(view),
-            extent::getExtentVec(view),
+            getExtentVec(view),
             os,
             elementSeparator,
             rowSeparator,
@@ -440,7 +440,7 @@ namespace alpaka
     template<typename TDev, typename TContainer>
     auto createView(TDev const& dev, TContainer& con)
     {
-        return createView(dev, std::data(con), extent::getExtent(con));
+        return createView(dev, std::data(con), getExtent(con));
     }
 
     //! Creates a view to a contiguous container of device-accessible memory.

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -127,7 +127,7 @@ namespace alpaka::internal
         template<std::size_t TDim, typename TIdx>
         ALPAKA_FN_HOST auto at(Vec<DimInt<TDim>, TIdx> index) -> reference
         {
-            auto extent = extent::getExtentVec(*static_cast<TView*>(this));
+            auto extent = getExtentVec(*static_cast<TView*>(this));
             if(!(index < extent).foldrAll(std::logical_and<bool>()))
             {
                 std::stringstream msg;
@@ -140,7 +140,7 @@ namespace alpaka::internal
         template<std::size_t TDim, typename TIdx>
         [[nodiscard]] ALPAKA_FN_HOST auto at(Vec<DimInt<TDim>, TIdx> index) const -> const_reference
         {
-            auto extent = extent::getExtentVec(*static_cast<TView const*>(this));
+            auto extent = getExtentVec(*static_cast<TView const*>(this));
             if(!(index < extent).foldrAll(std::logical_and<bool>()))
             {
                 std::stringstream msg;

--- a/include/alpaka/mem/view/ViewAccessor.hpp
+++ b/include/alpaka/mem/view/ViewAccessor.hpp
@@ -202,7 +202,7 @@ namespace alpaka::experimental
                     Dim<TView>,
                     decltype(getPtrNative(std::declval<TView>())),
                     decltype(getPitchBytes<0>(std::declval<TView>())),
-                    decltype(extent::getExtent<0>(std::declval<TView>()))>> : std::true_type
+                    decltype(getExtent<0>(std::declval<TView>()))>> : std::true_type
             {
             };
 
@@ -249,7 +249,7 @@ namespace alpaka::experimental
                 return Accessor<Elem*, Elem, TBufferIdx, dim, AccessModeList>{
                     const_cast<Elem*>(p), // strip constness, this is handled the the access modes
                     {getPitchBytes<TPitchIs + 1>(view)...},
-                    {extent::getExtent<TExtentIs>(view)...}};
+                    {getExtent<TExtentIs>(view)...}};
             }
         } // namespace internal
 

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -35,7 +35,7 @@ namespace alpaka
         ALPAKA_FN_HOST ViewPlainPtr(TElem* pMem, Dev dev, TExtent const& extent = TExtent())
             : m_pMem(pMem)
             , m_dev(std::move(dev))
-            , m_extentElements(extent::getExtentVecEnd<TDim>(extent))
+            , m_extentElements(getExtentVecEnd<TDim>(extent))
             , m_pitchBytes(detail::calculatePitchesFromExtents<TElem>(m_extentElements))
         {
         }
@@ -44,7 +44,7 @@ namespace alpaka
         ALPAKA_FN_HOST ViewPlainPtr(TElem* pMem, Dev const dev, TExtent const& extent, TPitch const& pitchBytes)
             : m_pMem(pMem)
             , m_dev(dev)
-            , m_extentElements(extent::getExtentVecEnd<TDim>(extent))
+            , m_extentElements(getExtentVecEnd<TDim>(extent))
             , m_pitchBytes(subVecEnd<TDim>(static_cast<Vec<TDim, TIdx>>(pitchBytes)))
         {
         }
@@ -104,7 +104,7 @@ namespace alpaka
             using type = TElem;
         };
     } // namespace traits
-    namespace extent::traits
+    namespace traits
     {
         //! The ViewPlainPtr width get trait specialization.
         template<typename TIdxIntegralConst, typename TDev, typename TElem, typename TDim, typename TIdx>
@@ -120,7 +120,7 @@ namespace alpaka
                 return extent.m_extentElements[TIdxIntegralConst::value];
             }
         };
-    } // namespace extent::traits
+    } // namespace traits
 
     namespace traits
     {

--- a/include/alpaka/mem/view/ViewStdArray.hpp
+++ b/include/alpaka/mem/view/ViewStdArray.hpp
@@ -19,100 +19,89 @@
 
 #include <array>
 
-namespace alpaka
+namespace alpaka::traits
 {
-    namespace traits
+    //! The std::array device type trait specialization.
+    template<typename TElem, std::size_t Tsize>
+    struct DevType<std::array<TElem, Tsize>>
     {
-        //! The std::array device type trait specialization.
-        template<typename TElem, std::size_t Tsize>
-        struct DevType<std::array<TElem, Tsize>>
-        {
-            using type = DevCpu;
-        };
+        using type = DevCpu;
+    };
 
-        //! The std::array device get trait specialization.
-        template<typename TElem, std::size_t Tsize>
-        struct GetDev<std::array<TElem, Tsize>>
-        {
-            ALPAKA_FN_HOST static auto getDev(std::array<TElem, Tsize> const& /* view */) -> DevCpu
-            {
-                return getDevByIdx<PltfCpu>(0u);
-            }
-        };
-
-        //! The std::array dimension getter trait specialization.
-        template<typename TElem, std::size_t Tsize>
-        struct DimType<std::array<TElem, Tsize>>
-        {
-            using type = DimInt<1u>;
-        };
-
-        //! The std::array memory element type get trait specialization.
-        template<typename TElem, std::size_t Tsize>
-        struct ElemType<std::array<TElem, Tsize>>
-        {
-            using type = TElem;
-        };
-    } // namespace traits
-    namespace extent
+    //! The std::array device get trait specialization.
+    template<typename TElem, std::size_t Tsize>
+    struct GetDev<std::array<TElem, Tsize>>
     {
-        namespace traits
+        ALPAKA_FN_HOST static auto getDev(std::array<TElem, Tsize> const& /* view */) -> DevCpu
         {
-            //! The std::array width get trait specialization.
-            template<typename TElem, std::size_t Tsize>
-            struct GetExtent<DimInt<0u>, std::array<TElem, Tsize>>
-            {
-                ALPAKA_FN_HOST static constexpr auto getExtent(std::array<TElem, Tsize> const& extent)
-                    -> Idx<std::array<TElem, Tsize>>
-                {
-                    return std::size(extent);
-                }
-            };
-        } // namespace traits
-    } // namespace extent
+            return getDevByIdx<PltfCpu>(0u);
+        }
+    };
 
-    namespace traits
+    //! The std::array dimension getter trait specialization.
+    template<typename TElem, std::size_t Tsize>
+    struct DimType<std::array<TElem, Tsize>>
     {
-        //! The std::array native pointer get trait specialization.
-        template<typename TElem, std::size_t Tsize>
-        struct GetPtrNative<std::array<TElem, Tsize>>
-        {
-            ALPAKA_FN_HOST static auto getPtrNative(std::array<TElem, Tsize> const& view) -> TElem const*
-            {
-                return std::data(view);
-            }
-            ALPAKA_FN_HOST static auto getPtrNative(std::array<TElem, Tsize>& view) -> TElem*
-            {
-                return std::data(view);
-            }
-        };
+        using type = DimInt<1u>;
+    };
 
-        //! The std::array pitch get trait specialization.
-        template<typename TElem, std::size_t Tsize>
-        struct GetPitchBytes<DimInt<0u>, std::array<TElem, Tsize>>
-        {
-            ALPAKA_FN_HOST static auto getPitchBytes(std::array<TElem, Tsize> const& pitch)
-                -> Idx<std::array<TElem, Tsize>>
-            {
-                return sizeof(TElem) * std::size(pitch);
-            }
-        };
+    //! The std::array memory element type get trait specialization.
+    template<typename TElem, std::size_t Tsize>
+    struct ElemType<std::array<TElem, Tsize>>
+    {
+        using type = TElem;
+    };
 
-        //! The std::array offset get trait specialization.
-        template<typename TIdx, typename TElem, std::size_t Tsize>
-        struct GetOffset<TIdx, std::array<TElem, Tsize>>
+    //! The std::array width get trait specialization.
+    template<typename TElem, std::size_t Tsize>
+    struct GetExtent<DimInt<0u>, std::array<TElem, Tsize>>
+    {
+        ALPAKA_FN_HOST static constexpr auto getExtent(std::array<TElem, Tsize> const& extent)
+            -> Idx<std::array<TElem, Tsize>>
         {
-            ALPAKA_FN_HOST static auto getOffset(std::array<TElem, Tsize> const&) -> Idx<std::array<TElem, Tsize>>
-            {
-                return 0u;
-            }
-        };
+            return std::size(extent);
+        }
+    };
 
-        //! The std::vector idx type trait specialization.
-        template<typename TElem, std::size_t Tsize>
-        struct IdxType<std::array<TElem, Tsize>>
+    //! The std::array native pointer get trait specialization.
+    template<typename TElem, std::size_t Tsize>
+    struct GetPtrNative<std::array<TElem, Tsize>>
+    {
+        ALPAKA_FN_HOST static auto getPtrNative(std::array<TElem, Tsize> const& view) -> TElem const*
         {
-            using type = std::size_t;
-        };
-    } // namespace traits
-} // namespace alpaka
+            return std::data(view);
+        }
+        ALPAKA_FN_HOST static auto getPtrNative(std::array<TElem, Tsize>& view) -> TElem*
+        {
+            return std::data(view);
+        }
+    };
+
+    //! The std::array pitch get trait specialization.
+    template<typename TElem, std::size_t Tsize>
+    struct GetPitchBytes<DimInt<0u>, std::array<TElem, Tsize>>
+    {
+        ALPAKA_FN_HOST static auto getPitchBytes(std::array<TElem, Tsize> const& pitch)
+            -> Idx<std::array<TElem, Tsize>>
+        {
+            return sizeof(TElem) * std::size(pitch);
+        }
+    };
+
+    //! The std::array offset get trait specialization.
+    template<typename TIdx, typename TElem, std::size_t Tsize>
+    struct GetOffset<TIdx, std::array<TElem, Tsize>>
+    {
+        ALPAKA_FN_HOST static auto getOffset(std::array<TElem, Tsize> const&) -> Idx<std::array<TElem, Tsize>>
+        {
+            return 0u;
+        }
+    };
+
+    //! The std::vector idx type trait specialization.
+    template<typename TElem, std::size_t Tsize>
+    struct IdxType<std::array<TElem, Tsize>>
+    {
+        using type = std::size_t;
+    };
+} // namespace alpaka::traits

--- a/include/alpaka/mem/view/ViewStdVector.hpp
+++ b/include/alpaka/mem/view/ViewStdVector.hpp
@@ -19,100 +19,90 @@
 
 #include <vector>
 
-namespace alpaka
+namespace alpaka::traits
 {
-    namespace traits
+    //! The std::vector device type trait specialization.
+    template<typename TElem, typename TAllocator>
+    struct DevType<std::vector<TElem, TAllocator>>
     {
-        //! The std::vector device type trait specialization.
-        template<typename TElem, typename TAllocator>
-        struct DevType<std::vector<TElem, TAllocator>>
-        {
-            using type = DevCpu;
-        };
+        using type = DevCpu;
+    };
 
-        //! The std::vector device get trait specialization.
-        template<typename TElem, typename TAllocator>
-        struct GetDev<std::vector<TElem, TAllocator>>
-        {
-            ALPAKA_FN_HOST static auto getDev(std::vector<TElem, TAllocator> const& /* view */) -> DevCpu
-            {
-                return getDevByIdx<PltfCpu>(0u);
-            }
-        };
-
-        //! The std::vector dimension getter trait specialization.
-        template<typename TElem, typename TAllocator>
-        struct DimType<std::vector<TElem, TAllocator>>
-        {
-            using type = DimInt<1u>;
-        };
-
-        //! The std::vector memory element type get trait specialization.
-        template<typename TElem, typename TAllocator>
-        struct ElemType<std::vector<TElem, TAllocator>>
-        {
-            using type = TElem;
-        };
-    } // namespace traits
-    namespace extent
+    //! The std::vector device get trait specialization.
+    template<typename TElem, typename TAllocator>
+    struct GetDev<std::vector<TElem, TAllocator>>
     {
-        namespace traits
+        ALPAKA_FN_HOST static auto getDev(std::vector<TElem, TAllocator> const& /* view */) -> DevCpu
         {
-            //! The std::vector width get trait specialization.
-            template<typename TElem, typename TAllocator>
-            struct GetExtent<DimInt<0u>, std::vector<TElem, TAllocator>>
-            {
-                ALPAKA_FN_HOST static auto getExtent(std::vector<TElem, TAllocator> const& extent)
-                    -> Idx<std::vector<TElem, TAllocator>>
-                {
-                    return std::size(extent);
-                }
-            };
-        } // namespace traits
-    } // namespace extent
-    namespace traits
+            return getDevByIdx<PltfCpu>(0u);
+        }
+    };
+
+    //! The std::vector dimension getter trait specialization.
+    template<typename TElem, typename TAllocator>
+    struct DimType<std::vector<TElem, TAllocator>>
     {
-        //! The std::vector native pointer get trait specialization.
-        template<typename TElem, typename TAllocator>
-        struct GetPtrNative<std::vector<TElem, TAllocator>>
-        {
-            ALPAKA_FN_HOST static auto getPtrNative(std::vector<TElem, TAllocator> const& view) -> TElem const*
-            {
-                return std::data(view);
-            }
-            ALPAKA_FN_HOST static auto getPtrNative(std::vector<TElem, TAllocator>& view) -> TElem*
-            {
-                return std::data(view);
-            }
-        };
+        using type = DimInt<1u>;
+    };
 
-        //! The std::vector pitch get trait specialization.
-        template<typename TElem, typename TAllocator>
-        struct GetPitchBytes<DimInt<0u>, std::vector<TElem, TAllocator>>
-        {
-            ALPAKA_FN_HOST static auto getPitchBytes(std::vector<TElem, TAllocator> const& pitch)
-                -> Idx<std::vector<TElem, TAllocator>>
-            {
-                return sizeof(TElem) * std::size(pitch);
-            }
-        };
+    //! The std::vector memory element type get trait specialization.
+    template<typename TElem, typename TAllocator>
+    struct ElemType<std::vector<TElem, TAllocator>>
+    {
+        using type = TElem;
+    };
 
-        //! The std::vector offset get trait specialization.
-        template<typename TIdx, typename TElem, typename TAllocator>
-        struct GetOffset<TIdx, std::vector<TElem, TAllocator>>
+    //! The std::vector width get trait specialization.
+    template<typename TElem, typename TAllocator>
+    struct GetExtent<DimInt<0u>, std::vector<TElem, TAllocator>>
+    {
+        ALPAKA_FN_HOST static auto getExtent(std::vector<TElem, TAllocator> const& extent)
+            -> Idx<std::vector<TElem, TAllocator>>
         {
-            ALPAKA_FN_HOST static auto getOffset(std::vector<TElem, TAllocator> const&)
-                -> Idx<std::vector<TElem, TAllocator>>
-            {
-                return 0u;
-            }
-        };
+            return std::size(extent);
+        }
+    };
 
-        //! The std::vector idx type trait specialization.
-        template<typename TElem, typename TAllocator>
-        struct IdxType<std::vector<TElem, TAllocator>>
+    //! The std::vector native pointer get trait specialization.
+    template<typename TElem, typename TAllocator>
+    struct GetPtrNative<std::vector<TElem, TAllocator>>
+    {
+        ALPAKA_FN_HOST static auto getPtrNative(std::vector<TElem, TAllocator> const& view) -> TElem const*
         {
-            using type = std::size_t;
-        };
-    } // namespace traits
-} // namespace alpaka
+            return std::data(view);
+        }
+        ALPAKA_FN_HOST static auto getPtrNative(std::vector<TElem, TAllocator>& view) -> TElem*
+        {
+            return std::data(view);
+        }
+    };
+
+    //! The std::vector pitch get trait specialization.
+    template<typename TElem, typename TAllocator>
+    struct GetPitchBytes<DimInt<0u>, std::vector<TElem, TAllocator>>
+    {
+        ALPAKA_FN_HOST static auto getPitchBytes(std::vector<TElem, TAllocator> const& pitch)
+            -> Idx<std::vector<TElem, TAllocator>>
+        {
+            return sizeof(TElem) * std::size(pitch);
+        }
+    };
+
+    //! The std::vector offset get trait specialization.
+    template<typename TIdx, typename TElem, typename TAllocator>
+    struct GetOffset<TIdx, std::vector<TElem, TAllocator>>
+    {
+        ALPAKA_FN_HOST static auto getOffset(std::vector<TElem, TAllocator> const&)
+            -> Idx<std::vector<TElem, TAllocator>>
+        {
+            return 0u;
+        }
+    };
+
+    //! The std::vector idx type trait specialization.
+    template<typename TElem, typename TAllocator>
+    struct IdxType<std::vector<TElem, TAllocator>>
+    {
+        using type = std::size_t;
+    };
+} // namespace alpaka::traits

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -44,8 +44,8 @@ namespace alpaka
             TView const& view,
             TExtent const& extentElements,
             TOffsets const& relativeOffsetsElements = TOffsets())
-            : m_viewParentView(getPtrNative(view), getDev(view), extent::getExtentVec(view), getPitchBytesVec(view))
-            , m_extentElements(extent::getExtentVec(extentElements))
+            : m_viewParentView(getPtrNative(view), getDev(view), getExtentVec(view), getPitchBytesVec(view))
+            , m_extentElements(getExtentVec(extentElements))
             , m_offsetsElements(getOffsetVec(relativeOffsetsElements))
         {
             ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -74,8 +74,8 @@ namespace alpaka
                 std::is_same<TDim, Dim<TOffsets>>::value,
                 "The dim type of TOffsets and the TDim template parameter have to be identical!");
 
-            ALPAKA_ASSERT(((m_offsetsElements + m_extentElements) <= extent::getExtentVec(view))
-                              .foldrAll(std::logical_and<bool>()));
+            ALPAKA_ASSERT(
+                ((m_offsetsElements + m_extentElements) <= getExtentVec(view)).foldrAll(std::logical_and<bool>()));
         }
         //! Constructor.
         //! \param view The view this view is a sub-view of.
@@ -83,8 +83,8 @@ namespace alpaka
         //! \param relativeOffsetsElements The offsets in elements.
         template<typename TView, typename TOffsets, typename TExtent>
         ViewSubView(TView& view, TExtent const& extentElements, TOffsets const& relativeOffsetsElements = TOffsets())
-            : m_viewParentView(getPtrNative(view), getDev(view), extent::getExtentVec(view), getPitchBytesVec(view))
-            , m_extentElements(extent::getExtentVec(extentElements))
+            : m_viewParentView(getPtrNative(view), getDev(view), getExtentVec(view), getPitchBytesVec(view))
+            , m_extentElements(getExtentVec(extentElements))
             , m_offsetsElements(getOffsetVec(relativeOffsetsElements))
         {
             ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -113,8 +113,8 @@ namespace alpaka
                 std::is_same<TDim, Dim<TOffsets>>::value,
                 "The dim type of TOffsets and the TDim template parameter have to be identical!");
 
-            ALPAKA_ASSERT(((m_offsetsElements + m_extentElements) <= extent::getExtentVec(view))
-                              .foldrAll(std::logical_and<bool>()));
+            ALPAKA_ASSERT(
+                ((m_offsetsElements + m_extentElements) <= getExtentVec(view)).foldrAll(std::logical_and<bool>()));
         }
 
         //! \param view The view this view is a sub-view of.
@@ -170,27 +170,20 @@ namespace alpaka
         {
             using type = TElem;
         };
-    } // namespace traits
-    namespace extent
-    {
-        namespace traits
+
+        //! The ViewSubView width get trait specialization.
+        template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TDev, typename TIdx>
+        struct GetExtent<
+            TIdxIntegralConst,
+            ViewSubView<TDev, TElem, TDim, TIdx>,
+            std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
         {
-            //! The ViewSubView width get trait specialization.
-            template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TDev, typename TIdx>
-            struct GetExtent<
-                TIdxIntegralConst,
-                ViewSubView<TDev, TElem, TDim, TIdx>,
-                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
+            ALPAKA_FN_HOST static auto getExtent(ViewSubView<TDev, TElem, TDim, TIdx> const& extent) -> TIdx
             {
-                ALPAKA_FN_HOST static auto getExtent(ViewSubView<TDev, TElem, TDim, TIdx> const& extent) -> TIdx
-                {
-                    return extent.m_extentElements[TIdxIntegralConst::value];
-                }
-            };
-        } // namespace traits
-    } // namespace extent
-    namespace traits
-    {
+                return extent.m_extentElements[TIdxIntegralConst::value];
+            }
+        };
+
 #if BOOST_COMP_GNUC
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored                                                                                    \

--- a/include/alpaka/test/mem/view/Iterator.hpp
+++ b/include/alpaka/test/mem/view/Iterator.hpp
@@ -43,7 +43,7 @@ namespace alpaka
                 ALPAKA_FN_HOST IteratorView(TView& view, Idx const idx)
                     : m_nativePtr(alpaka::getPtrNative(view))
                     , m_currentIdx(idx)
-                    , m_extents(alpaka::extent::getExtentVec(view))
+                    , m_extents(alpaka::getExtentVec(view))
                     , m_pitchBytes(alpaka::getPitchBytesVec(view))
                 {
                 }
@@ -149,7 +149,7 @@ namespace alpaka
             {
                 ALPAKA_FN_HOST static auto end(TView& view) -> IteratorView<TView>
                 {
-                    auto extents = alpaka::extent::getExtentVec(view);
+                    auto extents = alpaka::getExtentVec(view);
                     return IteratorView<TView>(view, extents.prod());
                 }
             };

--- a/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/include/alpaka/test/mem/view/ViewTest.hpp
@@ -57,9 +57,9 @@ namespace alpaka
                     "The element type of the view has to be equal to the specified one.");
             }
 
-            // alpaka::extent::traits::GetExtent
+            // alpaka::traits::GetExtent
             {
-                REQUIRE(extent == alpaka::extent::getExtentVec(view));
+                REQUIRE(extent == alpaka::getExtentVec(view));
             }
 
             // alpaka::traits::GetPitchBytes
@@ -93,7 +93,7 @@ namespace alpaka
                     std::is_const<std::remove_pointer_t<NativePtr>>::value,
                     "The value returned by getPtrNative has to be const when the view is const.");
 
-                if(alpaka::extent::getExtentProduct(view) != static_cast<TIdx>(0u))
+                if(alpaka::getExtentProduct(view) != static_cast<TIdx>(0u))
                 {
                     // The pointer is only required to be non-null when the extent is > 0.
                     TElem const* const invalidPtr(nullptr);
@@ -221,7 +221,7 @@ namespace alpaka
 
             DevHost const devHost = alpaka::getDevByIdx<PltfHost>(0);
 
-            auto const extent = alpaka::extent::getExtentVec(view);
+            auto const extent = alpaka::getExtentVec(view);
 
             // Init buf with increasing values
             std::vector<Elem> v(static_cast<std::size_t>(extent.prod()), static_cast<Elem>(0));
@@ -263,7 +263,7 @@ namespace alpaka
                 using Idx = alpaka::Idx<TView>;
 
                 auto const devAcc = alpaka::getDev(view);
-                auto const extent = alpaka::extent::getExtentVec(view);
+                auto const extent = alpaka::getExtentVec(view);
 
                 // alpaka::copy into given view
                 {

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -487,6 +487,7 @@ namespace alpaka
             }
         };
     } // namespace detail
+
     namespace traits
     {
         //! CastVec specialization for Vec.
@@ -526,6 +527,7 @@ namespace alpaka
             }
         };
     } // namespace detail
+
     namespace traits
     {
         //! ReverseVec specialization for Vec.
@@ -565,6 +567,7 @@ namespace alpaka
             }
         };
     } // namespace detail
+
     namespace traits
     {
         //! Concatenation specialization for Vec.
@@ -582,42 +585,41 @@ namespace alpaka
         };
     } // namespace traits
 
-    namespace extent
+    namespace detail
     {
-        namespace detail
+        //! A function object that returns the extent for each index.
+        template<std::size_t Tidx>
+        struct CreateExtent
         {
-            //! A function object that returns the extent for each index.
-            template<std::size_t Tidx>
-            struct CreateExtent
+            ALPAKA_NO_HOST_ACC_WARNING
+            template<typename TExtent>
+            ALPAKA_FN_HOST_ACC static auto create(TExtent const& extent) -> Idx<TExtent>
             {
-                ALPAKA_NO_HOST_ACC_WARNING
-                template<typename TExtent>
-                ALPAKA_FN_HOST_ACC static auto create(TExtent const& extent) -> Idx<TExtent>
-                {
-                    return extent::getExtent<Tidx>(extent);
-                }
-            };
-        } // namespace detail
-        //! \tparam TExtent has to specialize extent::GetExtent.
-        //! \return The extent vector.
-        ALPAKA_NO_HOST_ACC_WARNING
-        template<typename TExtent>
-        ALPAKA_FN_HOST_ACC auto getExtentVec(TExtent const& extent = TExtent()) -> Vec<Dim<TExtent>, Idx<TExtent>>
-        {
-            return createVecFromIndexedFn<Dim<TExtent>, detail::CreateExtent>(extent);
-        }
-        //! \tparam TExtent has to specialize extent::GetExtent.
-        //! \return The extent but only the last N elements.
-        ALPAKA_NO_HOST_ACC_WARNING
-        template<typename TDim, typename TExtent>
-        ALPAKA_FN_HOST_ACC auto getExtentVecEnd(TExtent const& extent = TExtent()) -> Vec<TDim, Idx<TExtent>>
-        {
-            using IdxOffset = std::integral_constant<
-                std::intmax_t,
-                static_cast<std::intmax_t>(Dim<TExtent>::value) - static_cast<std::intmax_t>(TDim::value)>;
-            return createVecFromIndexedFnOffset<TDim, detail::CreateExtent, IdxOffset>(extent);
-        }
-    } // namespace extent
+                return getExtent<Tidx>(extent);
+            }
+        };
+    } // namespace detail
+
+    //! \tparam TExtent has to specialize GetExtent.
+    //! \return The extent vector.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TExtent>
+    ALPAKA_FN_HOST_ACC auto getExtentVec(TExtent const& extent = TExtent()) -> Vec<Dim<TExtent>, Idx<TExtent>>
+    {
+        return createVecFromIndexedFn<Dim<TExtent>, detail::CreateExtent>(extent);
+    }
+
+    //! \tparam TExtent has to specialize GetExtent.
+    //! \return The extent but only the last N elements.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TDim, typename TExtent>
+    ALPAKA_FN_HOST_ACC auto getExtentVecEnd(TExtent const& extent = TExtent()) -> Vec<TDim, Idx<TExtent>>
+    {
+        using IdxOffset = std::integral_constant<
+            std::intmax_t,
+            static_cast<std::intmax_t>(Dim<TExtent>::value) - static_cast<std::intmax_t>(TDim::value)>;
+        return createVecFromIndexedFnOffset<TDim, detail::CreateExtent, IdxOffset>(extent);
+    }
 
     namespace detail
     {
@@ -633,6 +635,7 @@ namespace alpaka
             }
         };
     } // namespace detail
+
     //! \tparam TOffsets has to specialize GetOffset.
     //! \return The offset vector.
     ALPAKA_NO_HOST_ACC_WARNING
@@ -641,6 +644,7 @@ namespace alpaka
     {
         return createVecFromIndexedFn<Dim<TOffsets>, detail::CreateOffset>(offsets);
     }
+
     //! \tparam TOffsets has to specialize GetOffset.
     //! \return The offset vector but only the last N elements.
     ALPAKA_NO_HOST_ACC_WARNING
@@ -653,41 +657,37 @@ namespace alpaka
                 static_cast<std::intmax_t>(Dim<TOffsets>::value) - static_cast<std::intmax_t>(TDim::value))>;
         return createVecFromIndexedFnOffset<TDim, detail::CreateOffset, IdxOffset>(offsets);
     }
-    namespace extent
-    {
-        namespace traits
-        {
-            //! The Vec extent get trait specialization.
-            template<typename TIdxIntegralConst, typename TDim, typename TVal>
-            struct GetExtent<
-                TIdxIntegralConst,
-                Vec<TDim, TVal>,
-                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
-            {
-                ALPAKA_NO_HOST_ACC_WARNING
-                ALPAKA_FN_HOST_ACC static auto getExtent(Vec<TDim, TVal> const& extent) -> TVal
-                {
-                    return extent[TIdxIntegralConst::value];
-                }
-            };
-            //! The Vec extent set trait specialization.
-            template<typename TIdxIntegralConst, typename TDim, typename TVal, typename TExtentVal>
-            struct SetExtent<
-                TIdxIntegralConst,
-                Vec<TDim, TVal>,
-                TExtentVal,
-                std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
-            {
-                ALPAKA_NO_HOST_ACC_WARNING
-                ALPAKA_FN_HOST_ACC static auto setExtent(Vec<TDim, TVal>& extent, TExtentVal const& extentVal) -> void
-                {
-                    extent[TIdxIntegralConst::value] = extentVal;
-                }
-            };
-        } // namespace traits
-    } // namespace extent
+
     namespace traits
     {
+        //! The Vec extent get trait specialization.
+        template<typename TIdxIntegralConst, typename TDim, typename TVal>
+        struct GetExtent<
+            TIdxIntegralConst,
+            Vec<TDim, TVal>,
+            std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
+        {
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_HOST_ACC static auto getExtent(Vec<TDim, TVal> const& extent) -> TVal
+            {
+                return extent[TIdxIntegralConst::value];
+            }
+        };
+        //! The Vec extent set trait specialization.
+        template<typename TIdxIntegralConst, typename TDim, typename TVal, typename TExtentVal>
+        struct SetExtent<
+            TIdxIntegralConst,
+            Vec<TDim, TVal>,
+            TExtentVal,
+            std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
+        {
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_HOST_ACC static auto setExtent(Vec<TDim, TVal>& extent, TExtentVal const& extentVal) -> void
+            {
+                extent[TIdxIntegralConst::value] = extentVal;
+            }
+        };
+
         //! The Vec offset get trait specialization.
         template<typename TIdxIntegralConst, typename TDim, typename TVal>
         struct GetOffset<

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -364,8 +364,8 @@ namespace alpaka
             "The idx type of TAcc and the idx type of TThreadElemExtent have to be identical!");
 
         return subDivideGridElems(
-            extent::getExtentVec(gridElemExtent),
-            extent::getExtentVec(threadElemExtents),
+            getExtentVec(gridElemExtent),
+            getExtentVec(threadElemExtents),
             getAccDevProps<TAcc>(dev),
             requireBlockThreadExtentToDivideGridThreadExtent,
             gridBlockExtentSubDivRestrictions);

--- a/include/alpaka/workdiv/WorkDivMembers.hpp
+++ b/include/alpaka/workdiv/WorkDivMembers.hpp
@@ -30,9 +30,9 @@ namespace alpaka
             TGridBlockExtent const& gridBlockExtent = TGridBlockExtent(),
             TBlockThreadExtent const& blockThreadExtent = TBlockThreadExtent(),
             TThreadElemExtent const& threadElemExtent = TThreadElemExtent())
-            : m_gridBlockExtent(extent::getExtentVecEnd<TDim>(gridBlockExtent))
-            , m_blockThreadExtent(extent::getExtentVecEnd<TDim>(blockThreadExtent))
-            , m_threadElemExtent(extent::getExtentVecEnd<TDim>(threadElemExtent))
+            : m_gridBlockExtent(getExtentVecEnd<TDim>(gridBlockExtent))
+            , m_blockThreadExtent(getExtentVecEnd<TDim>(blockThreadExtent))
+            , m_threadElemExtent(getExtentVecEnd<TDim>(threadElemExtent))
         {
         }
         ALPAKA_NO_HOST_ACC_WARNING

--- a/include/alpaka/workdiv/WorkDivUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/workdiv/WorkDivUniformCudaHipBuiltIn.hpp
@@ -78,9 +78,9 @@ namespace alpaka
                 -> Vec<TDim, TIdx>
             {
 #        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                return castVec<TIdx>(extent::getExtentVecEnd<TDim>(gridDim));
+                return castVec<TIdx>(getExtentVecEnd<TDim>(gridDim));
 #        else
-                return extent::getExtentVecEnd<TDim>(Vec<std::integral_constant<typename TDim::value_type, 3>, TIdx>(
+                return getExtentVecEnd<TDim>(Vec<std::integral_constant<typename TDim::value_type, 3>, TIdx>(
                     static_cast<TIdx>(hipGridDim_z),
                     static_cast<TIdx>(hipGridDim_y),
                     static_cast<TIdx>(hipGridDim_x)));
@@ -97,9 +97,9 @@ namespace alpaka
                 -> Vec<TDim, TIdx>
             {
 #        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-                return castVec<TIdx>(extent::getExtentVecEnd<TDim>(blockDim));
+                return castVec<TIdx>(getExtentVecEnd<TDim>(blockDim));
 #        else
-                return extent::getExtentVecEnd<TDim>(Vec<std::integral_constant<typename TDim::value_type, 3>, TIdx>(
+                return getExtentVecEnd<TDim>(Vec<std::integral_constant<typename TDim::value_type, 3>, TIdx>(
                     static_cast<TIdx>(hipBlockDim_z),
                     static_cast<TIdx>(hipBlockDim_y),
                     static_cast<TIdx>(hipBlockDim_x)));

--- a/test/integ/hostOnlyAPI/src/hostOnlyAPI.cpp
+++ b/test/integ/hostOnlyAPI/src/hostOnlyAPI.cpp
@@ -65,13 +65,13 @@ TEMPLATE_LIST_TEST_CASE("hostOnlyAPI", "[hostOnlyAPI]", TestAccs)
     auto h_buffer1 = alpaka::allocBuf<int, Idx>(host, Vec1D{Idx{42}});
     INFO(
         "host buffer allocated at " << alpaka::getPtrNative(h_buffer1) << " with "
-                                    << alpaka::extent::getExtentProduct(h_buffer1) << " element(s)")
+                                    << alpaka::getExtentProduct(h_buffer1) << " element(s)")
 
     // async host buffer
     auto h_buffer2 = allocAsyncBufIfSupported<int>(hostQueue, Vec1D{Idx{42}});
     INFO(
         "second host buffer allocated at " << alpaka::getPtrNative(h_buffer2) << " with "
-                                           << alpaka::extent::getExtentProduct(h_buffer2) << " element(s)")
+                                           << alpaka::getExtentProduct(h_buffer2) << " element(s)")
 
     // host-side memset
     const int value1 = 42;
@@ -107,13 +107,13 @@ TEMPLATE_LIST_TEST_CASE("hostOnlyAPI", "[hostOnlyAPI]", TestAccs)
     auto d_buffer1 = alpaka::allocBuf<int, Idx>(device, Vec1D{Idx{42}});
     INFO(
         "device buffer allocated at " << alpaka::getPtrNative(d_buffer1) << " with "
-                                      << alpaka::extent::getExtentProduct(d_buffer1) << " element(s)")
+                                      << alpaka::getExtentProduct(d_buffer1) << " element(s)")
 
     // async or second sync device buffer
     auto d_buffer2 = allocAsyncBufIfSupported<int>(deviceQueue, Vec1D{Idx{42}});
     INFO(
         "second device buffer allocated at " << alpaka::getPtrNative(d_buffer2) << " with "
-                                             << alpaka::extent::getExtentProduct(d_buffer2) << " element(s)")
+                                             << alpaka::getExtentProduct(d_buffer2) << " element(s)")
 
     // host-device copies
     INFO("host-device copies")

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -199,14 +199,14 @@ auto writeTgaColorImage(std::string const& fileName, TBuf const& bufRgba) -> voi
     static_assert(std::is_integral<alpaka::Elem<TBuf>>::value, "The buffer element type has to be integral!");
 
     // The width of the input buffer is in input elements.
-    auto const bufWidthElems = alpaka::extent::getWidth(bufRgba);
+    auto const bufWidthElems = alpaka::getWidth(bufRgba);
     auto const bufWidthBytes = bufWidthElems * sizeof(alpaka::Elem<TBuf>);
     // The row width in bytes has to be dividable by 4 Bytes (RGBA).
     ALPAKA_ASSERT(bufWidthBytes % sizeof(std::uint32_t) == 0);
     // The number of colors in a row.
     auto const bufWidthColors = bufWidthBytes / sizeof(std::uint32_t);
     ALPAKA_ASSERT(bufWidthColors >= 1);
-    auto const bufHeightColors = alpaka::extent::getHeight(bufRgba);
+    auto const bufHeightColors = alpaka::getHeight(bufRgba);
     ALPAKA_ASSERT(bufHeightColors >= 1);
     auto const bufPitchBytes = alpaka::getPitchBytes<alpaka::Dim<TBuf>::value - 1u>(bufRgba);
     ALPAKA_ASSERT(bufPitchBytes >= bufWidthBytes);

--- a/test/integ/zeroDimBuffer/src/zeroDimBuffer.cpp
+++ b/test/integ/zeroDimBuffer/src/zeroDimBuffer.cpp
@@ -77,14 +77,14 @@ TEMPLATE_LIST_TEST_CASE("zeroDimBuffer", "[zeroDimBuffer]", TestAccs)
     // host buffer
     auto h_buffer1 = alpaka::allocBuf<int, Idx>(host, Scalar{});
     INFO(
-        "host buffer allocated at " << std::data(h_buffer1) << " with " << alpaka::extent::getExtentProduct(h_buffer1)
+        "host buffer allocated at " << std::data(h_buffer1) << " with " << alpaka::getExtentProduct(h_buffer1)
                                     << " element(s)")
 
     // async host buffer
     auto h_buffer2 = allocAsyncBufIfSupported<HostAcc, int, Idx>(hostQueue, Scalar{});
     INFO(
-        "second host buffer allocated at " << std::data(h_buffer2) << " with "
-                                           << alpaka::extent::getExtentProduct(h_buffer2) << " element(s)")
+        "second host buffer allocated at " << std::data(h_buffer2) << " with " << alpaka::getExtentProduct(h_buffer2)
+                                           << " element(s)")
 
     // host-side buffer memset
     const int value1 = 42;
@@ -119,14 +119,14 @@ TEMPLATE_LIST_TEST_CASE("zeroDimBuffer", "[zeroDimBuffer]", TestAccs)
     // device buffer
     auto d_buffer1 = alpaka::allocBuf<int, Idx>(device, Scalar{});
     INFO(
-        "device buffer allocated at " << std::data(d_buffer1) << " with "
-                                      << alpaka::extent::getExtentProduct(d_buffer1) << " element(s)")
+        "device buffer allocated at " << std::data(d_buffer1) << " with " << alpaka::getExtentProduct(d_buffer1)
+                                      << " element(s)")
 
     // async or second sync device buffer
     auto d_buffer2 = allocAsyncBufIfSupported<DeviceAcc, int, Idx>(deviceQueue, Scalar{});
     INFO(
-        "second device buffer allocated at " << std::data(d_buffer2) << " with "
-                                             << alpaka::extent::getExtentProduct(d_buffer2) << " element(s)")
+        "second device buffer allocated at " << std::data(d_buffer2) << " with " << alpaka::getExtentProduct(d_buffer2)
+                                             << " element(s)")
 
     // host-device copies
     INFO("host-device copies")

--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -73,7 +73,7 @@ namespace alpaka::test
         View view(
             alpaka::getPtrNative(buf),
             alpaka::getDev(buf),
-            alpaka::extent::getExtentVec(buf),
+            alpaka::getExtentVec(buf),
             alpaka::getPitchBytesVec(buf));
 
         alpaka::test::testViewPlainPtrMutable<TAcc>(view, dev, extentView, offsetView);
@@ -100,7 +100,7 @@ namespace alpaka::test
         View const view(
             alpaka::getPtrNative(buf),
             alpaka::getDev(buf),
-            alpaka::extent::getExtentVec(buf),
+            alpaka::getExtentVec(buf),
             alpaka::getPitchBytesVec(buf));
 
         alpaka::test::testViewPlainPtrImmutable<TAcc>(view, dev, extentView, offsetView);
@@ -125,7 +125,7 @@ namespace alpaka::test
         View view(
             alpaka::getPtrNative(buf),
             alpaka::getDev(buf),
-            alpaka::extent::getExtentVec(buf),
+            alpaka::getExtentVec(buf),
             alpaka::getPitchBytesVec(buf));
 
         // copy-constructor


### PR DESCRIPTION
This PR removes the subnamespace `alpaka::extent` and inlines its content into namespace `alpaka`. See also: #1034.

- [x] Please merge first #1592