### PR TITLE
Refactor `alpaka::test`

### DIFF
--- a/include/alpaka/test/Array.hpp
+++ b/include/alpaka/test/Array.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -12,26 +12,23 @@
 
 #include <cstddef>
 
-namespace alpaka
+namespace alpaka::test
 {
-    namespace test
+    template<typename TType, size_t TSize>
+    struct Array
     {
-        template<typename TType, size_t TSize>
-        struct Array
+        TType m_data[TSize];
+
+        template<typename T_Idx>
+        ALPAKA_FN_HOST_ACC auto operator[](const T_Idx idx) const -> const TType&
         {
-            TType m_data[TSize];
+            return m_data[idx];
+        }
 
-            template<typename T_Idx>
-            ALPAKA_FN_HOST_ACC auto operator[](const T_Idx idx) const -> const TType&
-            {
-                return m_data[idx];
-            }
-
-            template<typename TIdx>
-            ALPAKA_FN_HOST_ACC auto operator[](const TIdx idx) -> TType&
-            {
-                return m_data[idx];
-            }
-        };
-    } // namespace test
-} // namespace alpaka
+        template<typename TIdx>
+        ALPAKA_FN_HOST_ACC auto operator[](const TIdx idx) -> TType&
+        {
+            return m_data[idx];
+        }
+    };
+} // namespace alpaka::test

--- a/include/alpaka/test/Extent.hpp
+++ b/include/alpaka/test/Extent.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, Matthias Werner
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -13,52 +13,48 @@
 
 #include <cstddef>
 
-namespace alpaka
+namespace alpaka::test
 {
-    //! The test specifics.
-    namespace test
+    template<typename TIdx>
+    struct CreateVecWithIdx
     {
-        template<typename TIdx>
-        struct CreateVecWithIdx
+        //! 1D: (11)
+        //! 2D: (11, 10)
+        //! 3D: (11, 10, 9)
+        //! 4D: (11, 10, 9, 8)
+        template<std::size_t Tidx>
+        struct ForExtentBuf
         {
-            //! 1D: (11)
-            //! 2D: (11, 10)
-            //! 3D: (11, 10, 9)
-            //! 4D: (11, 10, 9, 8)
-            template<std::size_t Tidx>
-            struct ForExtentBuf
+            ALPAKA_FN_HOST_ACC static auto create()
             {
-                ALPAKA_FN_HOST_ACC static auto create()
-                {
-                    return static_cast<TIdx>(11u - Tidx);
-                }
-            };
-
-            //! 1D: (8)
-            //! 2D: (8, 6)
-            //! 3D: (8, 6, 4)
-            //! 4D: (8, 6, 4, 2)
-            template<std::size_t Tidx>
-            struct ForExtentSubView
-            {
-                ALPAKA_FN_HOST_ACC static auto create()
-                {
-                    return static_cast<TIdx>(8u - (Tidx * 2u));
-                }
-            };
-
-            //! 1D: (2)
-            //! 2D: (2, 3)
-            //! 3D: (2, 3, 4)
-            //! 4D: (2, 3, 4, 5)
-            template<std::size_t Tidx>
-            struct ForOffset
-            {
-                ALPAKA_FN_HOST_ACC static auto create()
-                {
-                    return static_cast<TIdx>(2u + Tidx);
-                }
-            };
+                return static_cast<TIdx>(11u - Tidx);
+            }
         };
-    } // namespace test
-} // namespace alpaka
+
+        //! 1D: (8)
+        //! 2D: (8, 6)
+        //! 3D: (8, 6, 4)
+        //! 4D: (8, 6, 4, 2)
+        template<std::size_t Tidx>
+        struct ForExtentSubView
+        {
+            ALPAKA_FN_HOST_ACC static auto create()
+            {
+                return static_cast<TIdx>(8u - (Tidx * 2u));
+            }
+        };
+
+        //! 1D: (2)
+        //! 2D: (2, 3)
+        //! 3D: (2, 3, 4)
+        //! 4D: (2, 3, 4, 5)
+        template<std::size_t Tidx>
+        struct ForOffset
+        {
+            ALPAKA_FN_HOST_ACC static auto create()
+            {
+                return static_cast<TIdx>(2u + Tidx);
+            }
+        };
+    };
+} // namespace alpaka::test

--- a/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/include/alpaka/test/KernelExecutionFixture.hpp
@@ -39,24 +39,22 @@ namespace alpaka::test
         using QueueAcc = test::DefaultQueue<DevAcc>;
         using WorkDiv = WorkDivMembers<Dim, Idx>;
 
-        template<typename TExtent>
-        KernelExecutionFixture(TExtent const& extent)
-            : m_devHost(getDevByIdx<PltfCpu>(0u))
-            , m_devAcc(getDevByIdx<PltfAcc>(0u))
-            , m_queue(m_devAcc)
-            , m_workDiv(getValidWorkDiv<Acc>(
-                  m_devAcc,
-                  extent,
-                  Vec<Dim, Idx>::ones(),
-                  false,
-                  GridBlockExtentSubDivRestrictions::Unrestricted))
-        {
-        }
         KernelExecutionFixture(WorkDiv workDiv)
             : m_devHost(getDevByIdx<PltfCpu>(0u))
             , m_devAcc(getDevByIdx<PltfAcc>(0u))
             , m_queue(m_devAcc)
             , m_workDiv(std::move(workDiv))
+        {
+        }
+
+        template<typename TExtent>
+        KernelExecutionFixture(TExtent const& extent)
+            : KernelExecutionFixture(getValidWorkDiv<Acc>(
+                getDevByIdx<PltfAcc>(0u),
+                extent,
+                Vec<Dim, Idx>::ones(),
+                false,
+                GridBlockExtentSubDivRestrictions::Unrestricted))
         {
         }
 

--- a/include/alpaka/test/MeasureKernelRunTime.hpp
+++ b/include/alpaka/test/MeasureKernelRunTime.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -14,41 +14,35 @@
 #include <type_traits>
 #include <utility>
 
-namespace alpaka
+namespace alpaka::test::integ
 {
-    namespace test
+    //! \return The run time of the given kernel.
+    template<typename TQueue, typename TTask>
+    auto measureTaskRunTimeMs(TQueue& queue, TTask&& task) -> std::chrono::milliseconds::rep
     {
-        namespace integ
-        {
-            //! \return The run time of the given kernel.
-            template<typename TQueue, typename TTask>
-            auto measureTaskRunTimeMs(TQueue& queue, TTask&& task) -> std::chrono::milliseconds::rep
-            {
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
-                std::cout << "measureKernelRunTime("
-                          << " queue: " << typeid(TQueue).name() << " task: " << typeid(std::decay_t<TTask>).name()
-                          << ")" << std::endl;
+        std::cout << "measureKernelRunTime("
+                  << " queue: " << typeid(TQueue).name() << " task: " << typeid(std::decay_t<TTask>).name() << ")"
+                  << std::endl;
 #endif
-                // Wait for the queue to finish all tasks enqueued prior to the giventask.
-                alpaka::wait(queue);
+        // Wait for the queue to finish all tasks enqueued prior to the giventask.
+        alpaka::wait(queue);
 
-                // Take the time prior to the execution.
-                auto const tpStart(std::chrono::high_resolution_clock::now());
+        // Take the time prior to the execution.
+        auto const tpStart(std::chrono::high_resolution_clock::now());
 
-                // Enqueue the task.
-                alpaka::enqueue(queue, std::forward<TTask>(task));
+        // Enqueue the task.
+        alpaka::enqueue(queue, std::forward<TTask>(task));
 
-                // Wait for the queue to finish the task execution to measure its run time.
-                alpaka::wait(queue);
+        // Wait for the queue to finish the task execution to measure its run time.
+        alpaka::wait(queue);
 
-                // Take the time after the execution.
-                auto const tpEnd(std::chrono::high_resolution_clock::now());
+        // Take the time after the execution.
+        auto const tpEnd(std::chrono::high_resolution_clock::now());
 
-                auto const durElapsed(tpEnd - tpStart);
+        auto const durElapsed(tpEnd - tpStart);
 
-                // Return the duration.
-                return std::chrono::duration_cast<std::chrono::milliseconds>(durElapsed).count();
-            }
-        } // namespace integ
-    } // namespace test
-} // namespace alpaka
+        // Return the duration.
+        return std::chrono::duration_cast<std::chrono::milliseconds>(durElapsed).count();
+    }
+} // namespace alpaka::test::integ

--- a/include/alpaka/test/acc/TestAccs.hpp
+++ b/include/alpaka/test/acc/TestAccs.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Erik Zenker, Matthias Werner, Andrea Bocci
+/* Copyright 2022 Benjamin Worpitz, Erik Zenker, Matthias Werner, Andrea Bocci, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -27,55 +27,52 @@
 #    endif
 #endif
 
-namespace alpaka
+namespace alpaka::test
 {
-    //! The test specifics.
-    namespace test
+    //! The detail namespace is used to separate implementation details from user accessible code.
+    namespace detail
     {
-        //! The detail namespace is used to separate implementation details from user accessible code.
-        namespace detail
-        {
 #if defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
-            template<typename TDim, typename TIdx>
-            using AccCpuSerialIfAvailableElseInt = alpaka::AccCpuSerial<TDim, TIdx>;
+        template<typename TDim, typename TIdx>
+        using AccCpuSerialIfAvailableElseInt = AccCpuSerial<TDim, TIdx>;
 #else
-            template<typename TDim, typename TIdx>
-            using AccCpuSerialIfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccCpuSerialIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED) && !defined(ALPAKA_CUDA_CI)
-            template<typename TDim, typename TIdx>
-            using AccCpuThreadsIfAvailableElseInt = alpaka::AccCpuThreads<TDim, TIdx>;
+        template<typename TDim, typename TIdx>
+        using AccCpuThreadsIfAvailableElseInt = AccCpuThreads<TDim, TIdx>;
 #else
-            template<typename TDim, typename TIdx>
-            using AccCpuThreadsIfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccCpuThreadsIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLED)
-            template<typename TDim, typename TIdx>
-            using AccCpuFibersIfAvailableElseInt = alpaka::AccCpuFibers<TDim, TIdx>;
+        template<typename TDim, typename TIdx>
+        using AccCpuFibersIfAvailableElseInt = AccCpuFibers<TDim, TIdx>;
 #else
-            template<typename TDim, typename TIdx>
-            using AccCpuFibersIfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccCpuFibersIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED)
-            template<typename TDim, typename TIdx>
-            using AccCpuTbbIfAvailableElseInt = alpaka::AccCpuTbbBlocks<TDim, TIdx>;
+        template<typename TDim, typename TIdx>
+        using AccCpuTbbIfAvailableElseInt = AccCpuTbbBlocks<TDim, TIdx>;
 #else
-            template<typename TDim, typename TIdx>
-            using AccCpuTbbIfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccCpuTbbIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
-            template<typename TDim, typename TIdx>
-            using AccCpuOmp2BlocksIfAvailableElseInt = alpaka::AccCpuOmp2Blocks<TDim, TIdx>;
+        template<typename TDim, typename TIdx>
+        using AccCpuOmp2BlocksIfAvailableElseInt = AccCpuOmp2Blocks<TDim, TIdx>;
 #else
-            template<typename TDim, typename TIdx>
-            using AccCpuOmp2BlocksIfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccCpuOmp2BlocksIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED) && !defined(ALPAKA_CUDA_CI)
-            template<typename TDim, typename TIdx>
-            using AccCpuOmp2ThreadsIfAvailableElseInt = alpaka::AccCpuOmp2Threads<TDim, TIdx>;
+        template<typename TDim, typename TIdx>
+        using AccCpuOmp2ThreadsIfAvailableElseInt = AccCpuOmp2Threads<TDim, TIdx>;
 #else
-            template<typename TDim, typename TIdx>
-            using AccCpuOmp2ThreadsIfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccCpuOmp2ThreadsIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_ANY_BT_OMP5_ENABLED) && !defined(TEST_UNIT_KERNEL_KERNEL_STD_FUNCTION)                         \
     && !(                                                                                                             \
@@ -90,11 +87,11 @@ namespace alpaka
         !defined(ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST)                                                                    \
         && (defined(TEST_UNIT_ATOMIC) /* clang nvptx atomic ICEs */                                                   \
             ))
-            template<typename TDim, typename TIdx>
-            using AccOmp5IfAvailableElseInt = alpaka::AccOmp5<TDim, TIdx>;
+        template<typename TDim, typename TIdx>
+        using AccOmp5IfAvailableElseInt = AccOmp5<TDim, TIdx>;
 #else
-            template<typename TDim, typename TIdx>
-            using AccOmp5IfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccOmp5IfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_ANY_BT_OACC_ENABLED) && !(defined(TEST_UNIT_KERNEL_KERNEL_STD_FUNCTION))                       \
     && !(                                                                                                             \
@@ -114,151 +111,148 @@ namespace alpaka
         && ((!defined(ALPAKA_DEBUG_OFFLOAD_ASSUME_HOST))                                                              \
             && (defined(TEST_UNIT_MATH) /* 21.7: nvc++ fmod no acc device info */                                     \
                 )))
-            template<typename TDim, typename TIdx>
-            using AccOaccIfAvailableElseInt = alpaka::AccOacc<TDim, TIdx>;
+        template<typename TDim, typename TIdx>
+        using AccOaccIfAvailableElseInt = AccOacc<TDim, TIdx>;
 #else
-            template<typename TDim, typename TIdx>
-            using AccOaccIfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccOaccIfAvailableElseInt = int;
 #endif
 #if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && (BOOST_LANG_CUDA || defined(ALPAKA_HOST_ONLY)))                           \
     || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && (BOOST_LANG_HIP || defined(ALPAKA_HOST_ONLY)))
-            template<typename TDim, typename TIdx>
-            using AccGpuUniformCudaHipRtIfAvailableElseInt = alpaka::AccGpuUniformCudaHipRt<TDim, TIdx>;
+        template<typename TDim, typename TIdx>
+        using AccGpuUniformCudaHipRtIfAvailableElseInt = AccGpuUniformCudaHipRt<TDim, TIdx>;
 #else
-            template<typename TDim, typename TIdx>
-            using AccGpuUniformCudaHipRtIfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccGpuUniformCudaHipRtIfAvailableElseInt = int;
 #endif
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && (BOOST_LANG_CUDA || defined(ALPAKA_HOST_ONLY))
-            template<typename TDim, typename TIdx>
-            using AccGpuCudaRtIfAvailableElseInt = alpaka::AccGpuCudaRt<TDim, TIdx>;
+        template<typename TDim, typename TIdx>
+        using AccGpuCudaRtIfAvailableElseInt = AccGpuCudaRt<TDim, TIdx>;
 #else
-            template<typename TDim, typename TIdx>
-            using AccGpuCudaRtIfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccGpuCudaRtIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && (BOOST_LANG_HIP || defined(ALPAKA_HOST_ONLY))
-            template<typename TDim, typename TIdx>
-            using AccGpuHipRtIfAvailableElseInt = typename std::conditional<
-                std::is_same_v<TDim, alpaka::DimInt<3u>> == false,
-                alpaka::AccGpuHipRt<TDim, TIdx>,
-                int>::type;
+        template<typename TDim, typename TIdx>
+        using AccGpuHipRtIfAvailableElseInt =
+            typename std::conditional<std::is_same_v<TDim, DimInt<3u>> == false, AccGpuHipRt<TDim, TIdx>, int>::type;
 #else
-            template<typename TDim, typename TIdx>
-            using AccGpuHipRtIfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccGpuHipRtIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_BACKEND_ONEAPI) && defined(ALPAKA_SYCL_TARGET_CPU)
-            template<typename TDim, typename TIdx>
-            using AccCpuSyclIntelIfAvailableElseInt = alpaka::experimental::AccCpuSyclIntel<TDim, TIdx>;
+        template<typename TDim, typename TIdx>
+        using AccCpuSyclIntelIfAvailableElseInt = alpaka::experimental::AccCpuSyclIntel<TDim, TIdx>;
 #else
-            template<typename TDim, typename TIdx>
-            using AccCpuSyclIntelIfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccCpuSyclIntelIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_BACKEND_ONEAPI) && defined(ALPAKA_SYCL_TARGET_FPGA)
-            template<typename TDim, typename TIdx>
-            using AccFpgaSyclIntelIfAvailableElseInt = alpaka::experimental::AccFpgaSyclIntel<TDim, TIdx>;
+        template<typename TDim, typename TIdx>
+        using AccFpgaSyclIntelIfAvailableElseInt = alpaka::experimental::AccFpgaSyclIntel<TDim, TIdx>;
 #else
-            template<typename TDim, typename TIdx>
-            using AccFpgaSyclIntelIfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccFpgaSyclIntelIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_BACKEND_XILINX)
-            template<typename TDim, typename TIdx>
-            using AccFpgaSyclXilinxIfAvailableElseInt = alpaka::experimental::AccFpgaSyclXilinx<TDim, TIdx>;
+        template<typename TDim, typename TIdx>
+        using AccFpgaSyclXilinxIfAvailableElseInt = alpaka::experimental::AccFpgaSyclXilinx<TDim, TIdx>;
 #else
-            template<typename TDim, typename TIdx>
-            using AccFpgaSyclXilinxIfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccFpgaSyclXilinxIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_BACKEND_ONEAPI) && defined(ALPAKA_SYCL_TARGET_GPU)
-            template<typename TDim, typename TIdx>
-            using AccGpuSyclIntelIfAvailableElseInt = alpaka::experimental::AccGpuSyclIntel<TDim, TIdx>;
+        template<typename TDim, typename TIdx>
+        using AccGpuSyclIntelIfAvailableElseInt = alpaka::experimental::AccGpuSyclIntel<TDim, TIdx>;
 #else
-            template<typename TDim, typename TIdx>
-            using AccGpuSyclIntelIfAvailableElseInt = int;
+        template<typename TDim, typename TIdx>
+        using AccGpuSyclIntelIfAvailableElseInt = int;
 #endif
 
-            //! A vector containing all available accelerators and void's.
-            template<typename TDim, typename TIdx>
-            using EnabledAccsElseInt = std::tuple<
-                AccCpuSerialIfAvailableElseInt<TDim, TIdx>,
-                AccCpuThreadsIfAvailableElseInt<TDim, TIdx>,
-                AccCpuFibersIfAvailableElseInt<TDim, TIdx>,
-                AccCpuTbbIfAvailableElseInt<TDim, TIdx>,
-                AccCpuOmp2BlocksIfAvailableElseInt<TDim, TIdx>,
-                AccCpuOmp2ThreadsIfAvailableElseInt<TDim, TIdx>,
-                AccOmp5IfAvailableElseInt<TDim, TIdx>,
-                AccOaccIfAvailableElseInt<TDim, TIdx>,
-                AccGpuUniformCudaHipRtIfAvailableElseInt<TDim, TIdx>,
-                AccGpuCudaRtIfAvailableElseInt<TDim, TIdx>,
-                AccGpuHipRtIfAvailableElseInt<TDim, TIdx>,
-                AccCpuSyclIntelIfAvailableElseInt<TDim, TIdx>,
-                AccFpgaSyclIntelIfAvailableElseInt<TDim, TIdx>,
-                AccFpgaSyclXilinxIfAvailableElseInt<TDim, TIdx>,
-                AccGpuSyclIntelIfAvailableElseInt<TDim, TIdx>>;
-        } // namespace detail
-
-        //! A vector containing all available accelerators.
+        //! A vector containing all available accelerators and void's.
         template<typename TDim, typename TIdx>
-        using EnabledAccs = typename alpaka::meta::Filter<detail::EnabledAccsElseInt<TDim, TIdx>, std::is_class>;
+        using EnabledAccsElseInt = std::tuple<
+            AccCpuSerialIfAvailableElseInt<TDim, TIdx>,
+            AccCpuThreadsIfAvailableElseInt<TDim, TIdx>,
+            AccCpuFibersIfAvailableElseInt<TDim, TIdx>,
+            AccCpuTbbIfAvailableElseInt<TDim, TIdx>,
+            AccCpuOmp2BlocksIfAvailableElseInt<TDim, TIdx>,
+            AccCpuOmp2ThreadsIfAvailableElseInt<TDim, TIdx>,
+            AccOmp5IfAvailableElseInt<TDim, TIdx>,
+            AccOaccIfAvailableElseInt<TDim, TIdx>,
+            AccGpuUniformCudaHipRtIfAvailableElseInt<TDim, TIdx>,
+            AccGpuCudaRtIfAvailableElseInt<TDim, TIdx>,
+            AccGpuHipRtIfAvailableElseInt<TDim, TIdx>,
+            AccCpuSyclIntelIfAvailableElseInt<TDim, TIdx>,
+            AccFpgaSyclIntelIfAvailableElseInt<TDim, TIdx>,
+            AccFpgaSyclXilinxIfAvailableElseInt<TDim, TIdx>,
+            AccGpuSyclIntelIfAvailableElseInt<TDim, TIdx>>;
+    } // namespace detail
 
-        namespace detail
+    //! A vector containing all available accelerators.
+    template<typename TDim, typename TIdx>
+    using EnabledAccs = typename meta::Filter<detail::EnabledAccsElseInt<TDim, TIdx>, std::is_class>;
+
+    namespace detail
+    {
+        //! The accelerator name write wrapper.
+        struct StreamOutAccName
         {
-            //! The accelerator name write wrapper.
-            struct StreamOutAccName
+            template<typename TAcc>
+            ALPAKA_FN_HOST auto operator()(std::ostream& os) -> void
             {
-                template<typename TAcc>
-                ALPAKA_FN_HOST auto operator()(std::ostream& os) -> void
-                {
-                    os << alpaka::getAccName<TAcc>();
-                    os << " ";
-                }
-            };
-        } // namespace detail
+                os << getAccName<TAcc>();
+                os << " ";
+            }
+        };
+    } // namespace detail
 
-        //! Writes the enabled accelerators to the given stream.
-        template<typename TDim, typename TIdx>
-        ALPAKA_FN_HOST auto writeEnabledAccs(std::ostream& os) -> void
-        {
-            os << "Accelerators enabled: ";
+    //! Writes the enabled accelerators to the given stream.
+    template<typename TDim, typename TIdx>
+    ALPAKA_FN_HOST auto writeEnabledAccs(std::ostream& os) -> void
+    {
+        os << "Accelerators enabled: ";
 
-            alpaka::meta::forEachType<EnabledAccs<TDim, TIdx>>(detail::StreamOutAccName(), std::ref(os));
+        meta::forEachType<EnabledAccs<TDim, TIdx>>(detail::StreamOutAccName(), std::ref(os));
 
-            os << std::endl;
-        }
+        os << std::endl;
+    }
 
-        namespace detail
-        {
-            //! A std::tuple holding multiple std::tuple consisting of a dimension and a idx type.
-            //!
-            //! TestDimIdxTuples =
-            //!     tuple<
-            //!         tuple<Dim1,Idx1>,
-            //!         tuple<Dim2,Idx1>,
-            //!         tuple<Dim3,Idx1>,
-            //!         ...,
-            //!         tuple<DimN,IdxN>>
-            using TestDimIdxTuples = alpaka::meta::CartesianProduct<std::tuple, TestDims, TestIdxs>;
-
-            template<typename TList>
-            using ApplyEnabledAccs = alpaka::meta::Apply<TList, EnabledAccs>;
-
-            //! A std::tuple containing std::tuple with fully instantiated accelerators.
-            //!
-            //! TestEnabledAccs =
-            //!     tuple<
-            //!         tuple<Acc1<Dim1,Idx1>, ..., AccN<Dim1,Idx1>>,
-            //!         tuple<Acc1<Dim2,Idx1>, ..., AccN<Dim2,Idx1>>,
-            //!         ...,
-            //!         tuple<Acc1<DimN,IdxN>, ..., AccN<DimN,IdxN>>>
-            using InstantiatedEnabledAccs = alpaka::meta::Transform<TestDimIdxTuples, ApplyEnabledAccs>;
-        } // namespace detail
-
-        //! A std::tuple containing fully instantiated accelerators.
+    namespace detail
+    {
+        //! A std::tuple holding multiple std::tuple consisting of a dimension and a idx type.
         //!
-        //! TestAccs =
+        //! TestDimIdxTuples =
         //!     tuple<
-        //!         Acc1<Dim1,Idx1>, ..., AccN<Dim1,Idx1>,
-        //!         Acc1<Dim2,Idx1>, ..., AccN<Dim2,Idx1>,
+        //!         tuple<Dim1,Idx1>,
+        //!         tuple<Dim2,Idx1>,
+        //!         tuple<Dim3,Idx1>,
         //!         ...,
-        //!         Acc1<DimN,IdxN>, ..., AccN<DimN,IdxN>>
-        using TestAccs = alpaka::meta::Apply<detail::InstantiatedEnabledAccs, alpaka::meta::Concatenate>;
-    } // namespace test
-} // namespace alpaka
+        //!         tuple<DimN,IdxN>>
+        using TestDimIdxTuples = meta::CartesianProduct<std::tuple, TestDims, TestIdxs>;
+
+        template<typename TList>
+        using ApplyEnabledAccs = meta::Apply<TList, EnabledAccs>;
+
+        //! A std::tuple containing std::tuple with fully instantiated accelerators.
+        //!
+        //! TestEnabledAccs =
+        //!     tuple<
+        //!         tuple<Acc1<Dim1,Idx1>, ..., AccN<Dim1,Idx1>>,
+        //!         tuple<Acc1<Dim2,Idx1>, ..., AccN<Dim2,Idx1>>,
+        //!         ...,
+        //!         tuple<Acc1<DimN,IdxN>, ..., AccN<DimN,IdxN>>>
+        using InstantiatedEnabledAccs = meta::Transform<TestDimIdxTuples, ApplyEnabledAccs>;
+    } // namespace detail
+
+    //! A std::tuple containing fully instantiated accelerators.
+    //!
+    //! TestAccs =
+    //!     tuple<
+    //!         Acc1<Dim1,Idx1>, ..., AccN<Dim1,Idx1>,
+    //!         Acc1<Dim2,Idx1>, ..., AccN<Dim2,Idx1>,
+    //!         ...,
+    //!         Acc1<DimN,IdxN>, ..., AccN<DimN,IdxN>>
+    using TestAccs = meta::Apply<detail::InstantiatedEnabledAccs, meta::Concatenate>;
+} // namespace alpaka::test

--- a/include/alpaka/test/dim/TestDims.hpp
+++ b/include/alpaka/test/dim/TestDims.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Andrea Bocci, Jan Stephan
+/* Copyright 2022 Benjamin Worpitz, Andrea Bocci, Jan Stephan, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -18,13 +18,13 @@ namespace alpaka::test
 {
     //! A std::tuple holding dimensions.
     using TestDims = std::tuple<
-        alpaka::DimInt<1u>,
-        alpaka::DimInt<2u>,
-        alpaka::DimInt<3u>
+        DimInt<1u>,
+        DimInt<2u>,
+        DimInt<3u>
     // The CUDA & HIP accelerators do not currently support 4D buffers and 4D acceleration.
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !defined(ALPAKA_ACC_SYCL_ENABLED)
         ,
-        alpaka::DimInt<4u>
+        DimInt<4u>
 #endif
         >;
 } // namespace alpaka::test

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -16,267 +16,260 @@
 #include <mutex>
 #include <utility>
 
-namespace alpaka
+namespace alpaka::test
 {
-    //! The test specifics.
-    namespace test
+    namespace traits
     {
-        namespace traits
-        {
-            template<typename TDev>
-            struct EventHostManualTriggerType;
-
-            template<typename TDev>
-            struct IsEventHostManualTriggerSupported;
-        } // namespace traits
-
-        //! The event host manual trigger type trait alias template to remove the ::type.
         template<typename TDev>
-        using EventHostManualTrigger = typename traits::EventHostManualTriggerType<TDev>::type;
+        struct EventHostManualTriggerType;
 
         template<typename TDev>
-        ALPAKA_FN_HOST auto isEventHostManualTriggerSupported(TDev const& dev) -> bool
-        {
-            return traits::IsEventHostManualTriggerSupported<TDev>::isSupported(dev);
-        }
+        struct IsEventHostManualTriggerSupported;
+    } // namespace traits
 
-        namespace cpu
-        {
-            namespace detail
-            {
-                //! Event that can be enqueued into a queue and can be triggered by the Host.
-                template<class TDev = DevCpu>
-                class EventHostManualTriggerCpuImpl
-                {
-                public:
-                    //! Constructor.
-                    ALPAKA_FN_HOST EventHostManualTriggerCpuImpl(TDev dev) noexcept
-                        : m_dev(std::move(dev))
-                        , m_mutex()
-                        , m_enqueueCount(0u)
-                        , m_bIsReady(true)
-                    {
-                    }
-                    EventHostManualTriggerCpuImpl(EventHostManualTriggerCpuImpl const& other) = delete;
-                    auto operator=(EventHostManualTriggerCpuImpl const&) -> EventHostManualTriggerCpuImpl& = delete;
+    //! The event host manual trigger type trait alias template to remove the ::type.
+    template<typename TDev>
+    using EventHostManualTrigger = typename traits::EventHostManualTriggerType<TDev>::type;
 
-                    void trigger()
-                    {
-                        {
-                            std::unique_lock<std::mutex> lock(m_mutex);
-                            m_bIsReady = true;
-                        }
-                        m_conditionVariable.notify_one();
-                    }
+    template<typename TDev>
+    ALPAKA_FN_HOST auto isEventHostManualTriggerSupported(TDev const& dev) -> bool
+    {
+        return traits::IsEventHostManualTriggerSupported<TDev>::isSupported(dev);
+    }
 
-                public:
-                    TDev const m_dev; //!< The device this event is bound to.
-
-                    mutable std::mutex m_mutex; //!< The mutex used to synchronize access to the event.
-
-                    mutable std::condition_variable
-                        m_conditionVariable; //!< The condition signaling the event completion.
-                    std::size_t m_enqueueCount; //!< The number of times this event has been enqueued.
-
-                    bool m_bIsReady; //!< If the event is not waiting within a queue (not enqueued or already
-                                     //!< completed).
-                };
-            } // namespace detail
-        } // namespace cpu
-
+    namespace cpu::detail
+    {
         //! Event that can be enqueued into a queue and can be triggered by the Host.
         template<class TDev = DevCpu>
-        class EventHostManualTriggerCpu
+        class EventHostManualTriggerCpuImpl
         {
         public:
             //! Constructor.
-            ALPAKA_FN_HOST EventHostManualTriggerCpu(TDev const& dev)
-                : m_spEventImpl(std::make_shared<cpu::detail::EventHostManualTriggerCpuImpl<TDev>>(dev))
+            ALPAKA_FN_HOST EventHostManualTriggerCpuImpl(TDev dev) noexcept
+                : m_dev(std::move(dev))
+                , m_mutex()
+                , m_enqueueCount(0u)
+                , m_bIsReady(true)
             {
             }
-            //! Equality comparison operator.
-            ALPAKA_FN_HOST auto operator==(EventHostManualTriggerCpu const& rhs) const -> bool
-            {
-                return (m_spEventImpl == rhs.m_spEventImpl);
-            }
-            //! Inequality comparison operator.
-            ALPAKA_FN_HOST auto operator!=(EventHostManualTriggerCpu const& rhs) const -> bool
-            {
-                return !((*this) == rhs);
-            }
+            EventHostManualTriggerCpuImpl(EventHostManualTriggerCpuImpl const& other) = delete;
+            auto operator=(EventHostManualTriggerCpuImpl const&) -> EventHostManualTriggerCpuImpl& = delete;
 
             void trigger()
             {
-                m_spEventImpl->trigger();
+                {
+                    std::unique_lock<std::mutex> lock(m_mutex);
+                    m_bIsReady = true;
+                }
+                m_conditionVariable.notify_one();
             }
 
         public:
-            std::shared_ptr<cpu::detail::EventHostManualTriggerCpuImpl<TDev>> m_spEventImpl;
-        };
+            TDev const m_dev; //!< The device this event is bound to.
 
-        namespace traits
+            mutable std::mutex m_mutex; //!< The mutex used to synchronize access to the event.
+
+            mutable std::condition_variable m_conditionVariable; //!< The condition signaling the event completion.
+            std::size_t m_enqueueCount; //!< The number of times this event has been enqueued.
+
+            bool m_bIsReady; //!< If the event is not waiting within a queue (not enqueued or already
+                             //!< completed).
+        };
+    } // namespace cpu::detail
+
+    //! Event that can be enqueued into a queue and can be triggered by the Host.
+    template<class TDev = DevCpu>
+    class EventHostManualTriggerCpu
+    {
+    public:
+        //! Constructor.
+        ALPAKA_FN_HOST EventHostManualTriggerCpu(TDev const& dev)
+            : m_spEventImpl(std::make_shared<cpu::detail::EventHostManualTriggerCpuImpl<TDev>>(dev))
         {
-            template<>
-            struct EventHostManualTriggerType<alpaka::DevCpu>
-            {
-                using type = alpaka::test::EventHostManualTriggerCpu<DevCpu>;
-            };
-#ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-            template<>
-            struct EventHostManualTriggerType<alpaka::DevOmp5>
-            {
-                using type = alpaka::test::EventHostManualTriggerCpu<alpaka::DevOmp5>;
-            };
-#elif defined(ALPAKA_ACC_ANY_BT_OACC_ENABLED)
-            template<>
-            struct EventHostManualTriggerType<alpaka::DevOacc>
-            {
-                using type = alpaka::test::EventHostManualTriggerCpu<alpaka::DevOacc>;
-            };
-#endif
-            //! The CPU event host manual trigger support get trait specialization.
-            template<>
-            struct IsEventHostManualTriggerSupported<alpaka::DevCpu>
-            {
-                ALPAKA_FN_HOST static auto isSupported(alpaka::DevCpu const&) -> bool
-                {
-                    return true;
-                }
-            };
-#ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-            //! The Omp5 event host manual trigger support get trait specialization.
-            template<>
-            struct IsEventHostManualTriggerSupported<alpaka::DevOmp5>
-            {
-                ALPAKA_FN_HOST static auto isSupported(alpaka::DevOmp5 const&) -> bool
-                {
-                    return true;
-                }
-            };
-#elif defined(ALPAKA_ACC_ANY_BT_OACC_ENABLED)
-            //! The OpenACC event host manual trigger support get trait specialization.
-            template<>
-            struct IsEventHostManualTriggerSupported<alpaka::DevOacc>
-            {
-                ALPAKA_FN_HOST static auto isSupported(alpaka::DevOacc const&) -> bool
-                {
-                    return true;
-                }
-            };
-#endif
-        } // namespace traits
-    } // namespace test
+        }
+        //! Equality comparison operator.
+        ALPAKA_FN_HOST auto operator==(EventHostManualTriggerCpu const& rhs) const -> bool
+        {
+            return (m_spEventImpl == rhs.m_spEventImpl);
+        }
+        //! Inequality comparison operator.
+        ALPAKA_FN_HOST auto operator!=(EventHostManualTriggerCpu const& rhs) const -> bool
+        {
+            return !((*this) == rhs);
+        }
+
+        void trigger()
+        {
+            m_spEventImpl->trigger();
+        }
+
+    public:
+        std::shared_ptr<cpu::detail::EventHostManualTriggerCpuImpl<TDev>> m_spEventImpl;
+    };
+
     namespace traits
     {
-        //! The CPU device event device get trait specialization.
-        template<typename TDev>
-        struct GetDev<test::EventHostManualTriggerCpu<TDev>>
+        template<>
+        struct EventHostManualTriggerType<DevCpu>
         {
-            //
-            ALPAKA_FN_HOST static auto getDev(test::EventHostManualTriggerCpu<TDev> const& event) -> TDev
-            {
-                return event.m_spEventImpl->m_dev;
-            }
+            using type = test::EventHostManualTriggerCpu<DevCpu>;
         };
-
-        //! The CPU device event test trait specialization.
-        template<typename TDev>
-        struct IsComplete<test::EventHostManualTriggerCpu<TDev>>
+#ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
+        template<>
+        struct EventHostManualTriggerType<DevOmp5>
         {
-            //! \return If the event is not waiting within a queue (not enqueued or already handled).
-            ALPAKA_FN_HOST static auto isComplete(test::EventHostManualTriggerCpu<TDev> const& event) -> bool
-            {
-                std::lock_guard<std::mutex> lk(event.m_spEventImpl->m_mutex);
-
-                return event.m_spEventImpl->m_bIsReady;
-            }
+            using type = test::EventHostManualTriggerCpu<DevOmp5>;
         };
-
-        template<typename TDev>
-        struct Enqueue<QueueGenericThreadsNonBlocking<TDev>, test::EventHostManualTriggerCpu<TDev>>
+#elif defined(ALPAKA_ACC_ANY_BT_OACC_ENABLED)
+        template<>
+        struct EventHostManualTriggerType<DevOacc>
         {
-            //
-            ALPAKA_FN_HOST static auto enqueue(
-#if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_PTX)
-                QueueGenericThreadsNonBlocking<TDev>& queue,
-#else
-                QueueGenericThreadsNonBlocking<TDev>&,
+            using type = test::EventHostManualTriggerCpu<DevOacc>;
+        };
 #endif
-                test::EventHostManualTriggerCpu<TDev>& event) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // Copy the shared pointer to ensure that the event implementation is alive as long as it is enqueued.
-                auto spEventImpl = event.m_spEventImpl;
-
-                // Setting the event state and enqueuing it has to be atomic.
-                std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
-
-                // The event should not yet be enqueued.
-                ALPAKA_ASSERT(spEventImpl->m_bIsReady);
-
-                // Set its state to enqueued.
-                spEventImpl->m_bIsReady = false;
-
-                // Increment the enqueue counter. This is used to skip waits for events that had already been finished
-                // and re-enqueued which would lead to deadlocks.
-                ++spEventImpl->m_enqueueCount;
-
-                // Workaround: Clang can not support this when natively compiling device code. See
-                // ConcurrentExecPool.hpp.
-#if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_PTX)
-                auto const enqueueCount = spEventImpl->m_enqueueCount;
-
-                // Enqueue a task that only resets the events flag if it is completed.
-                queue.m_spQueueImpl->m_workerThread.enqueueTask(
-                    [spEventImpl, enqueueCount]()
-                    {
-                        std::unique_lock<std::mutex> lk2(spEventImpl->m_mutex);
-                        spEventImpl->m_conditionVariable.wait(
-                            lk2,
-                            [spEventImpl, enqueueCount]
-                            { return (enqueueCount != spEventImpl->m_enqueueCount) || spEventImpl->m_bIsReady; });
-                    });
-#endif
-            }
-        };
-
-        template<typename TDev>
-        struct Enqueue<QueueGenericThreadsBlocking<TDev>, test::EventHostManualTriggerCpu<TDev>>
+        //! The CPU event host manual trigger support get trait specialization.
+        template<>
+        struct IsEventHostManualTriggerSupported<DevCpu>
         {
-            //
-            ALPAKA_FN_HOST static auto enqueue(
-                QueueGenericThreadsBlocking<TDev>&,
-                test::EventHostManualTriggerCpu<TDev>& event) -> void
+            ALPAKA_FN_HOST static auto isSupported(DevCpu const&) -> bool
             {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // Copy the shared pointer to ensure that the event implementation is alive as long as it is enqueued.
-                auto spEventImpl = event.m_spEventImpl;
-
-                // Setting the event state and enqueuing it has to be atomic.
-                std::unique_lock<std::mutex> lk(spEventImpl->m_mutex);
-
-                // The event should not yet be enqueued.
-                ALPAKA_ASSERT(spEventImpl->m_bIsReady);
-
-                // Set its state to enqueued.
-                spEventImpl->m_bIsReady = false;
-
-                // Increment the enqueue counter. This is used to skip waits for events that had already been finished
-                // and re-enqueued which would lead to deadlocks.
-                ++spEventImpl->m_enqueueCount;
-
-                auto const enqueueCount = spEventImpl->m_enqueueCount;
-
-                spEventImpl->m_conditionVariable.wait(
-                    lk,
-                    [spEventImpl, enqueueCount]
-                    { return (enqueueCount != spEventImpl->m_enqueueCount) || spEventImpl->m_bIsReady; });
+                return true;
             }
         };
+#ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
+        //! The Omp5 event host manual trigger support get trait specialization.
+        template<>
+        struct IsEventHostManualTriggerSupported<DevOmp5>
+        {
+            ALPAKA_FN_HOST static auto isSupported(DevOmp5 const&) -> bool
+            {
+                return true;
+            }
+        };
+#elif defined(ALPAKA_ACC_ANY_BT_OACC_ENABLED)
+        //! The OpenACC event host manual trigger support get trait specialization.
+        template<>
+        struct IsEventHostManualTriggerSupported<DevOacc>
+        {
+            ALPAKA_FN_HOST static auto isSupported(DevOacc const&) -> bool
+            {
+                return true;
+            }
+        };
+#endif
     } // namespace traits
-} // namespace alpaka
+} // namespace alpaka::test
+
+namespace alpaka::traits
+{
+    //! The CPU device event device get trait specialization.
+    template<typename TDev>
+    struct GetDev<test::EventHostManualTriggerCpu<TDev>>
+    {
+        //
+        ALPAKA_FN_HOST static auto getDev(test::EventHostManualTriggerCpu<TDev> const& event) -> TDev
+        {
+            return event.m_spEventImpl->m_dev;
+        }
+    };
+
+    //! The CPU device event test trait specialization.
+    template<typename TDev>
+    struct IsComplete<test::EventHostManualTriggerCpu<TDev>>
+    {
+        //! \return If the event is not waiting within a queue (not enqueued or already handled).
+        ALPAKA_FN_HOST static auto isComplete(test::EventHostManualTriggerCpu<TDev> const& event) -> bool
+        {
+            std::lock_guard<std::mutex> lk(event.m_spEventImpl->m_mutex);
+
+            return event.m_spEventImpl->m_bIsReady;
+        }
+    };
+
+    template<typename TDev>
+    struct Enqueue<QueueGenericThreadsNonBlocking<TDev>, test::EventHostManualTriggerCpu<TDev>>
+    {
+        //
+        ALPAKA_FN_HOST static auto enqueue(
+#if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_PTX)
+            QueueGenericThreadsNonBlocking<TDev>& queue,
+#else
+            QueueGenericThreadsNonBlocking<TDev>&,
+#endif
+            test::EventHostManualTriggerCpu<TDev>& event) -> void
+        {
+            ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+            // Copy the shared pointer to ensure that the event implementation is alive as long as it is enqueued.
+            auto spEventImpl = event.m_spEventImpl;
+
+            // Setting the event state and enqueuing it has to be atomic.
+            std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
+
+            // The event should not yet be enqueued.
+            ALPAKA_ASSERT(spEventImpl->m_bIsReady);
+
+            // Set its state to enqueued.
+            spEventImpl->m_bIsReady = false;
+
+            // Increment the enqueue counter. This is used to skip waits for events that had already been finished
+            // and re-enqueued which would lead to deadlocks.
+            ++spEventImpl->m_enqueueCount;
+
+            // Workaround: Clang can not support this when natively compiling device code. See
+            // ConcurrentExecPool.hpp.
+#if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_PTX)
+            auto const enqueueCount = spEventImpl->m_enqueueCount;
+
+            // Enqueue a task that only resets the events flag if it is completed.
+            queue.m_spQueueImpl->m_workerThread.enqueueTask(
+                [spEventImpl, enqueueCount]()
+                {
+                    std::unique_lock<std::mutex> lk2(spEventImpl->m_mutex);
+                    spEventImpl->m_conditionVariable.wait(
+                        lk2,
+                        [spEventImpl, enqueueCount]
+                        { return (enqueueCount != spEventImpl->m_enqueueCount) || spEventImpl->m_bIsReady; });
+                });
+#endif
+        }
+    };
+
+    template<typename TDev>
+    struct Enqueue<QueueGenericThreadsBlocking<TDev>, test::EventHostManualTriggerCpu<TDev>>
+    {
+        //
+        ALPAKA_FN_HOST static auto enqueue(
+            QueueGenericThreadsBlocking<TDev>&,
+            test::EventHostManualTriggerCpu<TDev>& event) -> void
+        {
+            ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+            // Copy the shared pointer to ensure that the event implementation is alive as long as it is enqueued.
+            auto spEventImpl = event.m_spEventImpl;
+
+            // Setting the event state and enqueuing it has to be atomic.
+            std::unique_lock<std::mutex> lk(spEventImpl->m_mutex);
+
+            // The event should not yet be enqueued.
+            ALPAKA_ASSERT(spEventImpl->m_bIsReady);
+
+            // Set its state to enqueued.
+            spEventImpl->m_bIsReady = false;
+
+            // Increment the enqueue counter. This is used to skip waits for events that had already been finished
+            // and re-enqueued which would lead to deadlocks.
+            ++spEventImpl->m_enqueueCount;
+
+            auto const enqueueCount = spEventImpl->m_enqueueCount;
+
+            spEventImpl->m_conditionVariable.wait(
+                lk,
+                [spEventImpl, enqueueCount]
+                { return (enqueueCount != spEventImpl->m_enqueueCount) || spEventImpl->m_bIsReady; });
+        }
+    };
+} // namespace alpaka::traits
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
@@ -290,207 +283,203 @@ namespace alpaka
 
 #    include <alpaka/core/Cuda.hpp>
 
-namespace alpaka
+
+namespace alpaka::test
 {
-    namespace test
+    namespace uniform_cuda_hip::detail
     {
-        namespace uniform_cuda_hip
-        {
-            namespace detail
-            {
-                class EventHostManualTriggerCudaImpl final
-                {
-                public:
-                    ALPAKA_FN_HOST EventHostManualTriggerCudaImpl(DevUniformCudaHipRt const& dev)
-                        : m_dev(dev)
-                        , m_mutex()
-                        , m_bIsReady(true)
-                    {
-                        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                        // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.getNativeHandle()));
-                        // Allocate the buffer on this device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaMalloc(&m_devMem, static_cast<size_t>(sizeof(int32_t))));
-                        // Initiate the memory set.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            cudaMemset(m_devMem, static_cast<int>(0u), static_cast<size_t>(sizeof(int32_t))));
-                    }
-                    EventHostManualTriggerCudaImpl(EventHostManualTriggerCudaImpl const&) = delete;
-                    auto operator=(EventHostManualTriggerCudaImpl const&) -> EventHostManualTriggerCudaImpl& = delete;
-                    ALPAKA_FN_HOST ~EventHostManualTriggerCudaImpl()
-                    {
-                        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                        // Free the buffer.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaFree(m_devMem));
-                    }
-
-                    void trigger()
-                    {
-                        std::unique_lock<std::mutex> lock(m_mutex);
-                        m_bIsReady = true;
-
-                        // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.getNativeHandle()));
-                        // Initiate the memory set.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            cudaMemset(m_devMem, static_cast<int>(1u), static_cast<size_t>(sizeof(int32_t))));
-                    }
-
-                public:
-                    DevUniformCudaHipRt const m_dev; //!< The device this event is bound to.
-
-                    mutable std::mutex m_mutex; //!< The mutex used to synchronize access to the event.
-                    void* m_devMem;
-
-                    bool m_bIsReady; //!< If the event is not waiting within a queue (not enqueued or already
-                                     //!< completed).
-                };
-            } // namespace detail
-        } // namespace uniform_cuda_hip
-
-        class EventHostManualTriggerCuda final
+        class EventHostManualTriggerCudaImpl final
         {
         public:
-            ALPAKA_FN_HOST EventHostManualTriggerCuda(DevUniformCudaHipRt const& dev)
-                : m_spEventImpl(std::make_shared<uniform_cuda_hip::detail::EventHostManualTriggerCudaImpl>(dev))
+            ALPAKA_FN_HOST EventHostManualTriggerCudaImpl(DevUniformCudaHipRt const& dev)
+                : m_dev(dev)
+                , m_mutex()
+                , m_bIsReady(true)
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                // Set the current device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.getNativeHandle()));
+                // Allocate the buffer on this device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaMalloc(&m_devMem, static_cast<size_t>(sizeof(int32_t))));
+                // Initiate the memory set.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    cudaMemset(m_devMem, static_cast<int>(0u), static_cast<size_t>(sizeof(int32_t))));
             }
-            ALPAKA_FN_HOST auto operator==(EventHostManualTriggerCuda const& rhs) const -> bool
+            EventHostManualTriggerCudaImpl(EventHostManualTriggerCudaImpl const&) = delete;
+            auto operator=(EventHostManualTriggerCudaImpl const&) -> EventHostManualTriggerCudaImpl& = delete;
+            ALPAKA_FN_HOST ~EventHostManualTriggerCudaImpl()
             {
-                return (m_spEventImpl == rhs.m_spEventImpl);
-            }
-            ALPAKA_FN_HOST auto operator!=(EventHostManualTriggerCuda const& rhs) const -> bool
-            {
-                return !((*this) == rhs);
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                // Free the buffer.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaFree(m_devMem));
             }
 
             void trigger()
             {
-                m_spEventImpl->trigger();
+                std::unique_lock<std::mutex> lock(m_mutex);
+                m_bIsReady = true;
+
+                // Set the current device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaSetDevice(m_dev.getNativeHandle()));
+                // Initiate the memory set.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    cudaMemset(m_devMem, static_cast<int>(1u), static_cast<size_t>(sizeof(int32_t))));
             }
 
         public:
-            std::shared_ptr<uniform_cuda_hip::detail::EventHostManualTriggerCudaImpl> m_spEventImpl;
-        };
+            DevUniformCudaHipRt const m_dev; //!< The device this event is bound to.
 
-        namespace traits
+            mutable std::mutex m_mutex; //!< The mutex used to synchronize access to the event.
+            void* m_devMem;
+
+            bool m_bIsReady; //!< If the event is not waiting within a queue (not enqueued or already
+                             //!< completed).
+        };
+    } // namespace uniform_cuda_hip::detail
+
+    class EventHostManualTriggerCuda final
+    {
+    public:
+        ALPAKA_FN_HOST EventHostManualTriggerCuda(DevUniformCudaHipRt const& dev)
+            : m_spEventImpl(std::make_shared<uniform_cuda_hip::detail::EventHostManualTriggerCudaImpl>(dev))
         {
-            template<>
-            struct EventHostManualTriggerType<alpaka::DevUniformCudaHipRt>
-            {
-                using type = alpaka::test::EventHostManualTriggerCuda;
-            };
-            //! The CPU event host manual trigger support get trait specialization.
-            template<>
-            struct IsEventHostManualTriggerSupported<alpaka::DevUniformCudaHipRt>
-            {
-                ALPAKA_FN_HOST static auto isSupported(alpaka::DevCudaRt const& dev) -> bool
-                {
-                    int result = 0;
-                    cuDeviceGetAttribute(&result, CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS, dev.getNativeHandle());
-                    return result != 0;
-                }
-            };
-        } // namespace traits
-    } // namespace test
+            ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+        }
+        ALPAKA_FN_HOST auto operator==(EventHostManualTriggerCuda const& rhs) const -> bool
+        {
+            return (m_spEventImpl == rhs.m_spEventImpl);
+        }
+        ALPAKA_FN_HOST auto operator!=(EventHostManualTriggerCuda const& rhs) const -> bool
+        {
+            return !((*this) == rhs);
+        }
+
+        void trigger()
+        {
+            m_spEventImpl->trigger();
+        }
+
+    public:
+        std::shared_ptr<uniform_cuda_hip::detail::EventHostManualTriggerCudaImpl> m_spEventImpl;
+    };
+
     namespace traits
     {
-        //! The CPU device event device get trait specialization.
         template<>
-        struct GetDev<test::EventHostManualTriggerCuda>
+        struct EventHostManualTriggerType<DevUniformCudaHipRt>
         {
-            ALPAKA_FN_HOST static auto getDev(test::EventHostManualTriggerCuda const& event) -> DevUniformCudaHipRt
-            {
-                return event.m_spEventImpl->m_dev;
-            }
+            using type = test::EventHostManualTriggerCuda;
         };
-
-        //! The CPU device event test trait specialization.
+        //! The CPU event host manual trigger support get trait specialization.
         template<>
-        struct IsComplete<test::EventHostManualTriggerCuda>
+        struct IsEventHostManualTriggerSupported<DevUniformCudaHipRt>
         {
-            //! \return If the event is not waiting within a queue (not enqueued or already handled).
-            ALPAKA_FN_HOST static auto isComplete(test::EventHostManualTriggerCuda const& event) -> bool
+            ALPAKA_FN_HOST static auto isSupported(DevCudaRt const& dev) -> bool
             {
-                std::lock_guard<std::mutex> lk(event.m_spEventImpl->m_mutex);
-
-                return event.m_spEventImpl->m_bIsReady;
-            }
-        };
-
-        template<>
-        struct Enqueue<QueueUniformCudaHipRtNonBlocking, test::EventHostManualTriggerCuda>
-        {
-            ALPAKA_FN_HOST static auto enqueue(
-                QueueUniformCudaHipRtNonBlocking& queue,
-                test::EventHostManualTriggerCuda& event) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // Copy the shared pointer to ensure that the event implementation is alive as long as it is enqueued.
-                auto spEventImpl(event.m_spEventImpl);
-
-                // Setting the event state and enqueuing it has to be atomic.
-                std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
-
-                // The event should not yet be enqueued.
-                ALPAKA_ASSERT(spEventImpl->m_bIsReady);
-
-                // Set its state to enqueued.
-                spEventImpl->m_bIsReady = false;
-
-                // PGI Profiler`s User Guide:
-                // The following are known issues related to Events and Metrics:
-                // * In event or metric profiling, kernel launches are blocking. Thus kernels waiting
-                //   on host updates may hang. This includes synchronization between the host and
-                //   the device build upon value-based CUDA queue synchronization APIs such as
-                //   cuStreamWaitValue32() and cuStreamWriteValue32().
-                ALPAKA_CUDA_DRV_CHECK(cuStreamWaitValue32(
-                    static_cast<CUstream>(queue.m_spQueueImpl->m_UniformCudaHipQueue),
-                    reinterpret_cast<CUdeviceptr>(event.m_spEventImpl->m_devMem),
-                    0x01010101u,
-                    CU_STREAM_WAIT_VALUE_GEQ));
-            }
-        };
-        template<>
-        struct Enqueue<QueueUniformCudaHipRtBlocking, test::EventHostManualTriggerCuda>
-        {
-            ALPAKA_FN_HOST static auto enqueue(
-                QueueUniformCudaHipRtBlocking& queue,
-                test::EventHostManualTriggerCuda& event) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // Copy the shared pointer to ensure that the event implementation is alive as long as it is enqueued.
-                auto spEventImpl(event.m_spEventImpl);
-
-                // Setting the event state and enqueuing it has to be atomic.
-                std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
-
-                // The event should not yet be enqueued.
-                ALPAKA_ASSERT(spEventImpl->m_bIsReady);
-
-                // Set its state to enqueued.
-                spEventImpl->m_bIsReady = false;
-
-                // PGI Profiler`s User Guide:
-                // The following are known issues related to Events and Metrics:
-                // * In event or metric profiling, kernel launches are blocking. Thus kernels waiting
-                //   on host updates may hang. This includes synchronization between the host and
-                //   the device build upon value-based CUDA queue synchronization APIs such as
-                //   cuStreamWaitValue32() and cuStreamWriteValue32().
-                ALPAKA_CUDA_DRV_CHECK(cuStreamWaitValue32(
-                    static_cast<CUstream>(queue.m_spQueueImpl->m_UniformCudaHipQueue),
-                    reinterpret_cast<CUdeviceptr>(event.m_spEventImpl->m_devMem),
-                    0x01010101u,
-                    CU_STREAM_WAIT_VALUE_GEQ));
+                int result = 0;
+                cuDeviceGetAttribute(&result, CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS, dev.getNativeHandle());
+                return result != 0;
             }
         };
     } // namespace traits
-} // namespace alpaka
+} // namespace alpaka::test
+
+namespace alpaka::traits
+{
+    //! The CPU device event device get trait specialization.
+    template<>
+    struct GetDev<test::EventHostManualTriggerCuda>
+    {
+        ALPAKA_FN_HOST static auto getDev(test::EventHostManualTriggerCuda const& event) -> DevUniformCudaHipRt
+        {
+            return event.m_spEventImpl->m_dev;
+        }
+    };
+
+    //! The CPU device event test trait specialization.
+    template<>
+    struct IsComplete<test::EventHostManualTriggerCuda>
+    {
+        //! \return If the event is not waiting within a queue (not enqueued or already handled).
+        ALPAKA_FN_HOST static auto isComplete(test::EventHostManualTriggerCuda const& event) -> bool
+        {
+            std::lock_guard<std::mutex> lk(event.m_spEventImpl->m_mutex);
+
+            return event.m_spEventImpl->m_bIsReady;
+        }
+    };
+
+    template<>
+    struct Enqueue<QueueUniformCudaHipRtNonBlocking, test::EventHostManualTriggerCuda>
+    {
+        ALPAKA_FN_HOST static auto enqueue(
+            QueueUniformCudaHipRtNonBlocking& queue,
+            test::EventHostManualTriggerCuda& event) -> void
+        {
+            ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+            // Copy the shared pointer to ensure that the event implementation is alive as long as it is enqueued.
+            auto spEventImpl(event.m_spEventImpl);
+
+            // Setting the event state and enqueuing it has to be atomic.
+            std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
+
+            // The event should not yet be enqueued.
+            ALPAKA_ASSERT(spEventImpl->m_bIsReady);
+
+            // Set its state to enqueued.
+            spEventImpl->m_bIsReady = false;
+
+            // PGI Profiler`s User Guide:
+            // The following are known issues related to Events and Metrics:
+            // * In event or metric profiling, kernel launches are blocking. Thus kernels waiting
+            //   on host updates may hang. This includes synchronization between the host and
+            //   the device build upon value-based CUDA queue synchronization APIs such as
+            //   cuStreamWaitValue32() and cuStreamWriteValue32().
+            ALPAKA_CUDA_DRV_CHECK(cuStreamWaitValue32(
+                static_cast<CUstream>(queue.m_spQueueImpl->m_UniformCudaHipQueue),
+                reinterpret_cast<CUdeviceptr>(event.m_spEventImpl->m_devMem),
+                0x01010101u,
+                CU_STREAM_WAIT_VALUE_GEQ));
+        }
+    };
+    template<>
+    struct Enqueue<QueueUniformCudaHipRtBlocking, test::EventHostManualTriggerCuda>
+    {
+        ALPAKA_FN_HOST static auto enqueue(
+            QueueUniformCudaHipRtBlocking& queue,
+            test::EventHostManualTriggerCuda& event) -> void
+        {
+            ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+            // Copy the shared pointer to ensure that the event implementation is alive as long as it is enqueued.
+            auto spEventImpl(event.m_spEventImpl);
+
+            // Setting the event state and enqueuing it has to be atomic.
+            std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
+
+            // The event should not yet be enqueued.
+            ALPAKA_ASSERT(spEventImpl->m_bIsReady);
+
+            // Set its state to enqueued.
+            spEventImpl->m_bIsReady = false;
+
+            // PGI Profiler`s User Guide:
+            // The following are known issues related to Events and Metrics:
+            // * In event or metric profiling, kernel launches are blocking. Thus kernels waiting
+            //   on host updates may hang. This includes synchronization between the host and
+            //   the device build upon value-based CUDA queue synchronization APIs such as
+            //   cuStreamWaitValue32() and cuStreamWriteValue32().
+            ALPAKA_CUDA_DRV_CHECK(cuStreamWaitValue32(
+                static_cast<CUstream>(queue.m_spQueueImpl->m_UniformCudaHipQueue),
+                reinterpret_cast<CUdeviceptr>(event.m_spEventImpl->m_devMem),
+                0x01010101u,
+                CU_STREAM_WAIT_VALUE_GEQ));
+        }
+    };
+} // namespace alpaka::traits
 #endif
 
 
@@ -504,229 +493,221 @@ namespace alpaka
 
 #    include <alpaka/core/Hip.hpp>
 
-namespace alpaka
+namespace alpaka::test
 {
-    namespace test
+    namespace hip::detail
     {
-        namespace hip
-        {
-            namespace detail
-            {
-                class EventHostManualTriggerHipImpl final
-                {
-                public:
-                    ALPAKA_FN_HOST EventHostManualTriggerHipImpl(DevHipRt const& dev)
-                        : m_dev(dev)
-                        , m_mutex()
-                        , m_bIsReady(true)
-                    {
-                        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                        // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.getNativeHandle()));
-                        // Allocate the buffer on this device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipMalloc(&m_devMem, static_cast<size_t>(sizeof(int32_t))));
-                        // Initiate the memory set.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            hipMemset(m_devMem, static_cast<int>(0u), static_cast<size_t>(sizeof(int32_t))));
-                    }
-                    EventHostManualTriggerHipImpl(EventHostManualTriggerHipImpl const&) = delete;
-                    auto operator=(EventHostManualTriggerHipImpl const&) -> EventHostManualTriggerHipImpl& = delete;
-                    ALPAKA_FN_HOST ~EventHostManualTriggerHipImpl()
-                    {
-                        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                        // Free the buffer.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipFree(m_devMem));
-                    }
-
-                    void trigger()
-                    {
-                        std::unique_lock<std::mutex> lock(m_mutex);
-                        m_bIsReady = true;
-
-                        // Set the current device.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.getNativeHandle()));
-                        // Initiate the memory set.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            hipMemset(m_devMem, static_cast<int>(1u), static_cast<size_t>(sizeof(int32_t))));
-                    }
-
-                public:
-                    DevHipRt const m_dev; //!< The device this event is bound to.
-
-                    mutable std::mutex m_mutex; //!< The mutex used to synchronize access to the event.
-                    void* m_devMem;
-
-                    bool m_bIsReady; //!< If the event is not waiting within a queue (not enqueued or already
-                                     //!< completed).
-                };
-            } // namespace detail
-        } // namespace hip
-
-        class EventHostManualTriggerHip final
+        class EventHostManualTriggerHipImpl final
         {
         public:
-            ALPAKA_FN_HOST EventHostManualTriggerHip(DevHipRt const& dev)
-                : m_spEventImpl(std::make_shared<hip::detail::EventHostManualTriggerHipImpl>(dev))
+            ALPAKA_FN_HOST EventHostManualTriggerHipImpl(DevHipRt const& dev) : m_dev(dev), m_mutex(), m_bIsReady(true)
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                // Set the current device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.getNativeHandle()));
+                // Allocate the buffer on this device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipMalloc(&m_devMem, static_cast<size_t>(sizeof(int32_t))));
+                // Initiate the memory set.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    hipMemset(m_devMem, static_cast<int>(0u), static_cast<size_t>(sizeof(int32_t))));
             }
-            ALPAKA_FN_HOST auto operator==(EventHostManualTriggerHip const& rhs) const -> bool
+            EventHostManualTriggerHipImpl(EventHostManualTriggerHipImpl const&) = delete;
+            auto operator=(EventHostManualTriggerHipImpl const&) -> EventHostManualTriggerHipImpl& = delete;
+            ALPAKA_FN_HOST ~EventHostManualTriggerHipImpl()
             {
-                return (m_spEventImpl == rhs.m_spEventImpl);
-            }
-            ALPAKA_FN_HOST auto operator!=(EventHostManualTriggerHip const& rhs) const -> bool
-            {
-                return !((*this) == rhs);
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                // Free the buffer.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipFree(m_devMem));
             }
 
             void trigger()
             {
-                m_spEventImpl->trigger();
+                std::unique_lock<std::mutex> lock(m_mutex);
+                m_bIsReady = true;
+
+                // Set the current device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipSetDevice(m_dev.getNativeHandle()));
+                // Initiate the memory set.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    hipMemset(m_devMem, static_cast<int>(1u), static_cast<size_t>(sizeof(int32_t))));
             }
 
         public:
-            std::shared_ptr<hip::detail::EventHostManualTriggerHipImpl> m_spEventImpl;
+            DevHipRt const m_dev; //!< The device this event is bound to.
+
+            mutable std::mutex m_mutex; //!< The mutex used to synchronize access to the event.
+            void* m_devMem;
+
+            bool m_bIsReady; //!< If the event is not waiting within a queue (not enqueued or already
+                             //!< completed).
         };
+    } // namespace hip::detail
 
-        namespace traits
+    class EventHostManualTriggerHip final
+    {
+    public:
+        ALPAKA_FN_HOST EventHostManualTriggerHip(DevHipRt const& dev)
+            : m_spEventImpl(std::make_shared<hip::detail::EventHostManualTriggerHipImpl>(dev))
         {
-            template<>
-            struct EventHostManualTriggerType<alpaka::DevHipRt>
-            {
-                using type = alpaka::test::EventHostManualTriggerHip;
-            };
+            ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+        }
+        ALPAKA_FN_HOST auto operator==(EventHostManualTriggerHip const& rhs) const -> bool
+        {
+            return (m_spEventImpl == rhs.m_spEventImpl);
+        }
+        ALPAKA_FN_HOST auto operator!=(EventHostManualTriggerHip const& rhs) const -> bool
+        {
+            return !((*this) == rhs);
+        }
 
-            //! The HIP event host manual trigger support get trait specialization.
-            template<>
-            struct IsEventHostManualTriggerSupported<alpaka::DevHipRt>
-            {
-                // TODO: there is no CUDA_VERSION in the HIP compiler path.
-                // TODO: there is a hipDeviceGetAttribute, but there is no pendant for
-                // CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS.
-                ALPAKA_FN_HOST static auto isSupported(alpaka::DevHipRt const&) -> bool
-                {
-                    return false;
-                }
-            };
-        } // namespace traits
-    } // namespace test
+        void trigger()
+        {
+            m_spEventImpl->trigger();
+        }
+
+    public:
+        std::shared_ptr<hip::detail::EventHostManualTriggerHipImpl> m_spEventImpl;
+    };
+
     namespace traits
     {
-        //! The CPU device event device get trait specialization.
         template<>
-        struct GetDev<test::EventHostManualTriggerHip>
+        struct EventHostManualTriggerType<DevHipRt>
         {
-            ALPAKA_FN_HOST static auto getDev(test::EventHostManualTriggerHip const& event) -> DevHipRt
-            {
-                return event.m_spEventImpl->m_dev;
-            }
+            using type = test::EventHostManualTriggerHip;
         };
 
-        //! The CPU device event test trait specialization.
+        //! The HIP event host manual trigger support get trait specialization.
         template<>
-        struct IsComplete<test::EventHostManualTriggerHip>
+        struct IsEventHostManualTriggerSupported<DevHipRt>
         {
-            //! \return If the event is not waiting within a queue (not enqueued or already handled).
-            ALPAKA_FN_HOST static auto isComplete(test::EventHostManualTriggerHip const& event) -> bool
+            // TODO: there is no CUDA_VERSION in the HIP compiler path.
+            // TODO: there is a hipDeviceGetAttribute, but there is no pendant for
+            // CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS.
+            ALPAKA_FN_HOST static auto isSupported(DevHipRt const&) -> bool
             {
-                std::lock_guard<std::mutex> lk(event.m_spEventImpl->m_mutex);
-
-                return event.m_spEventImpl->m_bIsReady;
-            }
-        };
-
-        template<>
-        struct Enqueue<QueueHipRtNonBlocking, test::EventHostManualTriggerHip>
-        {
-            ALPAKA_FN_HOST static auto enqueue(QueueHipRtNonBlocking& queue, test::EventHostManualTriggerHip& event)
-                -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // Copy the shared pointer to ensure that the event implementation is alive as long as it is enqueued.
-                auto spEventImpl(event.m_spEventImpl);
-
-                // Setting the event state and enqueuing it has to be atomic.
-                std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
-
-                // The event should not yet be enqueued.
-                ALPAKA_ASSERT(spEventImpl->m_bIsReady);
-
-                // Set its state to enqueued.
-                spEventImpl->m_bIsReady = false;
-
-                // PGI Profiler`s User Guide:
-                // The following are known issues related to Events and Metrics:
-                // * In event or metric profiling, kernel launches are blocking. Thus kernels waiting
-                //   on host updates may hang. This includes synchronization between the host and
-                //   the device build upon value-based CUDA queue synchronization APIs such as
-                //   cuStreamWaitValue32() and cuStreamWriteValue32().
-                int32_t hostMem = 0;
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
-                std::cerr << "[Workaround] polling of device-located value in stream, as hipStreamWaitValue32 is not "
-                             "available.\n";
-#    endif
-                while(hostMem < 0x01010101)
-                {
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipMemcpyDtoHAsync(
-                        &hostMem,
-                        reinterpret_cast<hipDeviceptr_t>(event.m_spEventImpl->m_devMem),
-                        sizeof(int32_t),
-                        queue.m_spQueueImpl->m_UniformCudaHipQueue));
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipStreamSynchronize(queue.m_spQueueImpl->m_UniformCudaHipQueue));
-                }
-            }
-        };
-        template<>
-        struct Enqueue<QueueHipRtBlocking, test::EventHostManualTriggerHip>
-        {
-            ALPAKA_FN_HOST static auto enqueue(
-                [[maybe_unused]] QueueHipRtBlocking& queue,
-                test::EventHostManualTriggerHip& event) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // Copy the shared pointer to ensure that the event implementation is alive as long as it is enqueued.
-                auto spEventImpl(event.m_spEventImpl);
-
-                // Setting the event state and enqueuing it has to be atomic.
-                std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
-
-                // The event should not yet be enqueued.
-                ALPAKA_ASSERT(spEventImpl->m_bIsReady);
-
-                // Set its state to enqueued.
-                spEventImpl->m_bIsReady = false;
-
-                // PGI Profiler`s User Guide:
-                // The following are known issues related to Events and Metrics:
-                // * In event or metric profiling, kernel launches are blocking. Thus kernels waiting
-                //   on host updates may hang. This includes synchronization between the host and
-                //   the device build upon value-based HIP queue synchronization APIs such as
-                //   cuStreamWaitValue32() and cuStreamWriteValue32().
-#    if BOOST_COMP_NVCC
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipCUResultTohipError(cuStreamWaitValue32(
-                    static_cast<CUstream>(queue.m_spQueueImpl->m_UniformCudaHipQueue),
-                    reinterpret_cast<CUdeviceptr>(event.m_spEventImpl->m_devMem),
-                    0x01010101u,
-                    CU_STREAM_WAIT_VALUE_GEQ)));
-#    else
-                // workaround for missing cuStreamWaitValue32 in HIP
-                std::uint32_t hmem = 0;
-                do
-                {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(10u));
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        hipMemcpy(&hmem, event.m_spEventImpl->m_devMem, sizeof(std::uint32_t), hipMemcpyDefault));
-                } while(hmem < 0x01010101u);
-
-#    endif
+                return false;
             }
         };
     } // namespace traits
-} // namespace alpaka
+} // namespace alpaka::test
+
+namespace alpaka::traits
+{
+    //! The CPU device event device get trait specialization.
+    template<>
+    struct GetDev<test::EventHostManualTriggerHip>
+    {
+        ALPAKA_FN_HOST static auto getDev(test::EventHostManualTriggerHip const& event) -> DevHipRt
+        {
+            return event.m_spEventImpl->m_dev;
+        }
+    };
+
+    //! The CPU device event test trait specialization.
+    template<>
+    struct IsComplete<test::EventHostManualTriggerHip>
+    {
+        //! \return If the event is not waiting within a queue (not enqueued or already handled).
+        ALPAKA_FN_HOST static auto isComplete(test::EventHostManualTriggerHip const& event) -> bool
+        {
+            std::lock_guard<std::mutex> lk(event.m_spEventImpl->m_mutex);
+
+            return event.m_spEventImpl->m_bIsReady;
+        }
+    };
+
+    template<>
+    struct Enqueue<QueueHipRtNonBlocking, test::EventHostManualTriggerHip>
+    {
+        ALPAKA_FN_HOST static auto enqueue(QueueHipRtNonBlocking& queue, test::EventHostManualTriggerHip& event)
+            -> void
+        {
+            ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+            // Copy the shared pointer to ensure that the event implementation is alive as long as it is enqueued.
+            auto spEventImpl(event.m_spEventImpl);
+
+            // Setting the event state and enqueuing it has to be atomic.
+            std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
+
+            // The event should not yet be enqueued.
+            ALPAKA_ASSERT(spEventImpl->m_bIsReady);
+
+            // Set its state to enqueued.
+            spEventImpl->m_bIsReady = false;
+
+            // PGI Profiler`s User Guide:
+            // The following are known issues related to Events and Metrics:
+            // * In event or metric profiling, kernel launches are blocking. Thus kernels waiting
+            //   on host updates may hang. This includes synchronization between the host and
+            //   the device build upon value-based CUDA queue synchronization APIs such as
+            //   cuStreamWaitValue32() and cuStreamWriteValue32().
+            int32_t hostMem = 0;
+#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
+            std::cerr << "[Workaround] polling of device-located value in stream, as hipStreamWaitValue32 is not "
+                         "available.\n";
+#    endif
+            while(hostMem < 0x01010101)
+            {
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipMemcpyDtoHAsync(
+                    &hostMem,
+                    reinterpret_cast<hipDeviceptr_t>(event.m_spEventImpl->m_devMem),
+                    sizeof(int32_t),
+                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipStreamSynchronize(queue.m_spQueueImpl->m_UniformCudaHipQueue));
+            }
+        }
+    };
+    template<>
+    struct Enqueue<QueueHipRtBlocking, test::EventHostManualTriggerHip>
+    {
+        ALPAKA_FN_HOST static auto enqueue(
+            [[maybe_unused]] QueueHipRtBlocking& queue,
+            test::EventHostManualTriggerHip& event) -> void
+        {
+            ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+            // Copy the shared pointer to ensure that the event implementation is alive as long as it is enqueued.
+            auto spEventImpl(event.m_spEventImpl);
+
+            // Setting the event state and enqueuing it has to be atomic.
+            std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
+
+            // The event should not yet be enqueued.
+            ALPAKA_ASSERT(spEventImpl->m_bIsReady);
+
+            // Set its state to enqueued.
+            spEventImpl->m_bIsReady = false;
+
+            // PGI Profiler`s User Guide:
+            // The following are known issues related to Events and Metrics:
+            // * In event or metric profiling, kernel launches are blocking. Thus kernels waiting
+            //   on host updates may hang. This includes synchronization between the host and
+            //   the device build upon value-based HIP queue synchronization APIs such as
+            //   cuStreamWaitValue32() and cuStreamWriteValue32().
+#    if BOOST_COMP_NVCC
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipCUResultTohipError(cuStreamWaitValue32(
+                static_cast<CUstream>(queue.m_spQueueImpl->m_UniformCudaHipQueue),
+                reinterpret_cast<CUdeviceptr>(event.m_spEventImpl->m_devMem),
+                0x01010101u,
+                CU_STREAM_WAIT_VALUE_GEQ)));
+#    else
+            // workaround for missing cuStreamWaitValue32 in HIP
+            std::uint32_t hmem = 0;
+            do
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10u));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    hipMemcpy(&hmem, event.m_spEventImpl->m_devMem, sizeof(std::uint32_t), hipMemcpyDefault));
+            } while(hmem < 0x01010101u);
+
+#    endif
+        }
+    };
+} // namespace alpaka::traits
 #endif
 
 #ifdef ALPAKA_ACC_SYCL_ENABLED

--- a/include/alpaka/test/idx/TestIdxs.hpp
+++ b/include/alpaka/test/idx/TestIdxs.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, Erik Zenker, Matthias Werner
+/* Copyright 2022 Benjamin Worpitz, Erik Zenker, Matthias Werner, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -12,26 +12,22 @@
 #include <cstdint>
 #include <tuple>
 
-namespace alpaka
+namespace alpaka::test
 {
-    //! The test specifics.
-    namespace test
-    {
-        //! A std::tuple holding idx types.
-        using TestIdxs = std::tuple<
-        // size_t is most probably identical to either std::uint64_t or std::uint32_t.
-        // This would lead to duplicate tests (especially test names) which is not allowed.
-        // std::size_t,
+    //! A std::tuple holding idx types.
+    using TestIdxs = std::tuple<
+    // size_t is most probably identical to either std::uint64_t or std::uint32_t.
+    // This would lead to duplicate tests (especially test names) which is not allowed.
+    // std::size_t,
 #if !defined(ALPAKA_CI)
-            std::int64_t,
+        std::int64_t,
 #endif
-            std::uint64_t,
-            std::int32_t
+        std::uint64_t,
+        std::int32_t
 #if !defined(ALPAKA_CI)
-            ,
-            std::uint32_t
+        ,
+        std::uint32_t
 #endif
-            // index type must be >=32bit
-            >;
-    } // namespace test
-} // namespace alpaka
+        // index type must be >=32bit
+        >;
+} // namespace alpaka::test

--- a/include/alpaka/test/mem/view/Iterator.hpp
+++ b/include/alpaka/test/mem/view/Iterator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, Erik Zenker
+/* Copyright 2022 Benjamin Worpitz, Erik Zenker, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -13,104 +13,100 @@
 
 #include <type_traits>
 
-namespace alpaka
+namespace alpaka::test
 {
-    //! The test specifics.
-    namespace test
+    namespace traits
     {
-        namespace traits
-        {
-            // \tparam T Type to conditionally make const.
-            // \tparam TSource Type to mimic the constness of.
-            template<typename T, typename TSource>
-            using MimicConst
-                = std::conditional_t<std::is_const_v<TSource>, std::add_const_t<T>, std::remove_const_t<T>>;
+        // \tparam T Type to conditionally make const.
+        // \tparam TSource Type to mimic the constness of.
+        template<typename T, typename TSource>
+        using MimicConst = std::conditional_t<std::is_const_v<TSource>, std::add_const_t<T>, std::remove_const_t<T>>;
 
 #if BOOST_COMP_GNUC
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored                                                                                    \
         "-Wcast-align" // "cast from 'Byte*' to 'Elem*' increases required alignment of target type"
 #endif
-            template<typename TView, typename TSfinae = void>
-            class IteratorView
+        template<typename TView, typename TSfinae = void>
+        class IteratorView
+        {
+            using TViewDecayed = std::decay_t<TView>;
+            using Dim = alpaka::Dim<TViewDecayed>;
+            using Idx = alpaka::Idx<TViewDecayed>;
+            using Elem = MimicConst<alpaka::Elem<TViewDecayed>, TView>;
+
+        public:
+            ALPAKA_FN_HOST IteratorView(TView& view, Idx const idx)
+                : m_nativePtr(getPtrNative(view))
+                , m_currentIdx(idx)
+                , m_extents(getExtentVec(view))
+                , m_pitchBytes(getPitchBytesVec(view))
             {
-                using TViewDecayed = std::decay_t<TView>;
-                using Dim = alpaka::Dim<TViewDecayed>;
-                using Idx = alpaka::Idx<TViewDecayed>;
-                using Elem = MimicConst<alpaka::Elem<TViewDecayed>, TView>;
+            }
 
-            public:
-                ALPAKA_FN_HOST IteratorView(TView& view, Idx const idx)
-                    : m_nativePtr(alpaka::getPtrNative(view))
-                    , m_currentIdx(idx)
-                    , m_extents(alpaka::getExtentVec(view))
-                    , m_pitchBytes(alpaka::getPitchBytesVec(view))
-                {
-                }
+            ALPAKA_FN_HOST IteratorView(TView& view) : IteratorView(view, 0)
+            {
+            }
 
-                ALPAKA_FN_HOST IteratorView(TView& view) : IteratorView(view, 0)
-                {
-                }
+            ALPAKA_FN_HOST_ACC auto operator++() -> IteratorView&
+            {
+                ++m_currentIdx;
+                return *this;
+            }
 
-                ALPAKA_FN_HOST_ACC auto operator++() -> IteratorView&
-                {
-                    ++m_currentIdx;
-                    return *this;
-                }
+            ALPAKA_FN_HOST_ACC auto operator--() -> IteratorView&
+            {
+                --m_currentIdx;
+                return *this;
+            }
 
-                ALPAKA_FN_HOST_ACC auto operator--() -> IteratorView&
-                {
-                    --m_currentIdx;
-                    return *this;
-                }
+            ALPAKA_FN_HOST_ACC auto operator++(int) -> IteratorView
+            {
+                IteratorView iterCopy = *this;
+                m_currentIdx++;
+                return iterCopy;
+            }
 
-                ALPAKA_FN_HOST_ACC auto operator++(int) -> IteratorView
-                {
-                    IteratorView iterCopy = *this;
-                    m_currentIdx++;
-                    return iterCopy;
-                }
+            ALPAKA_FN_HOST_ACC auto operator--(int) -> IteratorView
+            {
+                IteratorView iterCopy = *this;
+                m_currentIdx--;
+                return iterCopy;
+            }
 
-                ALPAKA_FN_HOST_ACC auto operator--(int) -> IteratorView
-                {
-                    IteratorView iterCopy = *this;
-                    m_currentIdx--;
-                    return iterCopy;
-                }
+            template<typename TIter>
+            ALPAKA_FN_HOST_ACC auto operator==(TIter& other) const -> bool
+            {
+                return m_currentIdx == other.m_currentIdx;
+            }
 
-                template<typename TIter>
-                ALPAKA_FN_HOST_ACC auto operator==(TIter& other) const -> bool
-                {
-                    return m_currentIdx == other.m_currentIdx;
-                }
+            template<typename TIter>
+            ALPAKA_FN_HOST_ACC auto operator!=(TIter& other) const -> bool
+            {
+                return m_currentIdx != other.m_currentIdx;
+            }
 
-                template<typename TIter>
-                ALPAKA_FN_HOST_ACC auto operator!=(TIter& other) const -> bool
-                {
-                    return m_currentIdx != other.m_currentIdx;
-                }
+            ALPAKA_FN_HOST_ACC auto operator*() const -> Elem&
+            {
+                using Dim1 = DimInt<1>;
+                using DimMin1 = DimInt<Dim::value - 1u>;
 
-                ALPAKA_FN_HOST_ACC auto operator*() const -> Elem&
-                {
-                    using Dim1 = alpaka::DimInt<1>;
-                    using DimMin1 = alpaka::DimInt<Dim::value - 1u>;
+                Vec<Dim1, Idx> const currentIdxDim1{m_currentIdx};
+                Vec<Dim, Idx> const currentIdxDimx(mapIdx<Dim::value>(currentIdxDim1, m_extents));
 
-                    Vec<Dim1, Idx> const currentIdxDim1{m_currentIdx};
-                    Vec<Dim, Idx> const currentIdxDimx(alpaka::mapIdx<Dim::value>(currentIdxDim1, m_extents));
+                // [pz, py, px] -> [py, px]
+                auto const pitchWithoutOutermost = subVecEnd<DimMin1>(m_pitchBytes);
+                // [ElemSize]
+                Vec<Dim1, Idx> const elementSizeVec = static_cast<Idx>(sizeof(Elem));
+                // [py, px] ++ [ElemSize] -> [py, px, ElemSize]
+                Vec<Dim, Idx> const dstPitchBytes = concatVec(pitchWithoutOutermost, elementSizeVec);
+                // [py, px, ElemSize] [z, y, x] -> [py*z, px*y, ElemSize*x]
+                auto const dimensionalOffsetsInByte = currentIdxDimx * dstPitchBytes;
+                // sum{[py*z, px*y, ElemSize*x]} -> offset in byte
+                auto const offsetInByte = dimensionalOffsetsInByte.foldrAll(std::plus<Idx>());
 
-                    // [pz, py, px] -> [py, px]
-                    auto const pitchWithoutOutermost = subVecEnd<DimMin1>(m_pitchBytes);
-                    // [ElemSize]
-                    Vec<Dim1, Idx> const elementSizeVec = static_cast<Idx>(sizeof(Elem));
-                    // [py, px] ++ [ElemSize] -> [py, px, ElemSize]
-                    Vec<Dim, Idx> const dstPitchBytes = concatVec(pitchWithoutOutermost, elementSizeVec);
-                    // [py, px, ElemSize] [z, y, x] -> [py*z, px*y, ElemSize*x]
-                    auto const dimensionalOffsetsInByte = currentIdxDimx * dstPitchBytes;
-                    // sum{[py*z, px*y, ElemSize*x]} -> offset in byte
-                    auto const offsetInByte = dimensionalOffsetsInByte.foldrAll(std::plus<Idx>());
-
-                    using Byte = MimicConst<std::uint8_t, Elem>;
-                    Byte* ptr(reinterpret_cast<Byte*>(m_nativePtr) + offsetInByte);
+                using Byte = MimicConst<std::uint8_t, Elem>;
+                Byte* ptr(reinterpret_cast<Byte*>(m_nativePtr) + offsetInByte);
 
 #if 0
                     std::cout
@@ -122,52 +118,51 @@ namespace alpaka
                         << " v: " << *reinterpret_cast<Elem *>(ptr)
                         << std::endl;
 #endif
-                    return *reinterpret_cast<Elem*>(ptr);
-                }
+                return *reinterpret_cast<Elem*>(ptr);
+            }
 
-            private:
-                Elem* const m_nativePtr;
-                Idx m_currentIdx;
-                Vec<Dim, Idx> const m_extents;
-                Vec<Dim, Idx> const m_pitchBytes;
-            };
+        private:
+            Elem* const m_nativePtr;
+            Idx m_currentIdx;
+            Vec<Dim, Idx> const m_extents;
+            Vec<Dim, Idx> const m_pitchBytes;
+        };
 #if BOOST_COMP_GNUC
 #    pragma GCC diagnostic pop
 #endif
 
-            template<typename TView, typename TSfinae = void>
-            struct Begin
-            {
-                ALPAKA_FN_HOST static auto begin(TView& view) -> IteratorView<TView>
-                {
-                    return IteratorView<TView>(view);
-                }
-            };
-
-            template<typename TView, typename TSfinae = void>
-            struct End
-            {
-                ALPAKA_FN_HOST static auto end(TView& view) -> IteratorView<TView>
-                {
-                    auto extents = alpaka::getExtentVec(view);
-                    return IteratorView<TView>(view, extents.prod());
-                }
-            };
-        } // namespace traits
-
-        template<typename TView>
-        using Iterator = traits::IteratorView<TView>;
-
-        template<typename TView>
-        ALPAKA_FN_HOST auto begin(TView& view) -> Iterator<TView>
+        template<typename TView, typename TSfinae = void>
+        struct Begin
         {
-            return traits::Begin<TView>::begin(view);
-        }
+            ALPAKA_FN_HOST static auto begin(TView& view) -> IteratorView<TView>
+            {
+                return IteratorView<TView>(view);
+            }
+        };
 
-        template<typename TView>
-        ALPAKA_FN_HOST auto end(TView& view) -> Iterator<TView>
+        template<typename TView, typename TSfinae = void>
+        struct End
         {
-            return traits::End<TView>::end(view);
-        }
-    } // namespace test
-} // namespace alpaka
+            ALPAKA_FN_HOST static auto end(TView& view) -> IteratorView<TView>
+            {
+                auto extents = getExtentVec(view);
+                return IteratorView<TView>(view, extents.prod());
+            }
+        };
+    } // namespace traits
+
+    template<typename TView>
+    using Iterator = traits::IteratorView<TView>;
+
+    template<typename TView>
+    ALPAKA_FN_HOST auto begin(TView& view) -> Iterator<TView>
+    {
+        return traits::Begin<TView>::begin(view);
+    }
+
+    template<typename TView>
+    ALPAKA_FN_HOST auto end(TView& view) -> Iterator<TView>
+    {
+        return traits::End<TView>::end(view);
+    }
+} // namespace alpaka::test

--- a/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/include/alpaka/test/mem/view/ViewTest.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Jan Stephan
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Jan Stephan, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -18,266 +18,258 @@
 #include <numeric>
 #include <type_traits>
 
-
-namespace alpaka
+//! The test specifics.
+namespace alpaka::test
 {
-    //! The test specifics.
-    namespace test
+    template<typename TElem, typename TDim, typename TIdx, typename TDev, typename TView>
+    ALPAKA_FN_HOST auto testViewImmutable(
+        TView const& view,
+        TDev const& dev,
+        Vec<TDim, TIdx> const& extent,
+        Vec<TDim, TIdx> const& offset) -> void
     {
-        template<typename TElem, typename TDim, typename TIdx, typename TDev, typename TView>
-        ALPAKA_FN_HOST auto testViewImmutable(
-            TView const& view,
-            TDev const& dev,
-            alpaka::Vec<TDim, TIdx> const& extent,
-            alpaka::Vec<TDim, TIdx> const& offset) -> void
+        // traits::DevType
         {
-            // alpaka::traits::DevType
+            static_assert(
+                std::is_same_v<Dev<TView>, TDev>,
+                "The device type of the view has to be equal to the specified one.");
+        }
+
+        // traits::GetDev
+        {
+            REQUIRE(dev == getDev(view));
+        }
+
+        // traits::DimType
+        {
+            static_assert(
+                Dim<TView>::value == TDim::value,
+                "The dimensionality of the view has to be equal to the specified one.");
+        }
+
+        // traits::ElemType
+        {
+            static_assert(
+                std::is_same_v<Elem<TView>, TElem>,
+                "The element type of the view has to be equal to the specified one.");
+        }
+
+        // traits::GetExtent
+        {
+            REQUIRE(extent == getExtentVec(view));
+        }
+
+        // traits::GetPitchBytes
+        {
+            // The pitches have to be at least as large as the values we calculate here.
+            auto pitchMinimum = Vec<DimInt<TDim::value + 1u>, TIdx>::ones();
+            // Initialize the pitch between two elements of the X dimension ...
+            pitchMinimum[TDim::value] = sizeof(TElem);
+            // ... and fill all the other dimensions.
+            for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
             {
-                static_assert(
-                    std::is_same_v<alpaka::Dev<TView>, TDev>,
-                    "The device type of the view has to be equal to the specified one.");
+                pitchMinimum[i - 1] = extent[i - 1] * pitchMinimum[i];
             }
 
-            // alpaka::traits::GetDev
+            auto const pitchView = getPitchBytesVec(view);
+
+            for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
             {
-                REQUIRE(dev == alpaka::getDev(view));
-            }
-
-            // alpaka::traits::DimType
-            {
-                static_assert(
-                    alpaka::Dim<TView>::value == TDim::value,
-                    "The dimensionality of the view has to be equal to the specified one.");
-            }
-
-            // alpaka::traits::ElemType
-            {
-                static_assert(
-                    std::is_same_v<alpaka::Elem<TView>, TElem>,
-                    "The element type of the view has to be equal to the specified one.");
-            }
-
-            // alpaka::traits::GetExtent
-            {
-                REQUIRE(extent == alpaka::getExtentVec(view));
-            }
-
-            // alpaka::traits::GetPitchBytes
-            {
-                // The pitches have to be at least as large as the values we calculate here.
-                auto pitchMinimum = alpaka::Vec<alpaka::DimInt<TDim::value + 1u>, TIdx>::ones();
-                // Initialize the pitch between two elements of the X dimension ...
-                pitchMinimum[TDim::value] = sizeof(TElem);
-                // ... and fill all the other dimensions.
-                for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
-                {
-                    pitchMinimum[i - 1] = extent[i - 1] * pitchMinimum[i];
-                }
-
-                auto const pitchView = alpaka::getPitchBytesVec(view);
-
-                for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
-                {
-                    REQUIRE(pitchView[i - 1] >= pitchMinimum[i - 1]);
-                }
-            }
-
-            // alpaka::traits::GetPtrNative
-            {
-                // The view is a const& so the pointer has to point to a const value.
-                using NativePtr = decltype(alpaka::getPtrNative(view));
-                static_assert(std::is_pointer_v<NativePtr>, "The value returned by getPtrNative has to be a pointer.");
-                static_assert(
-                    std::is_const_v<std::remove_pointer_t<NativePtr>>,
-                    "The value returned by getPtrNative has to be const when the view is const.");
-
-                if(alpaka::getExtentProduct(view) != static_cast<TIdx>(0u))
-                {
-                    // The pointer is only required to be non-null when the extent is > 0.
-                    TElem const* const invalidPtr(nullptr);
-                    REQUIRE(invalidPtr != alpaka::getPtrNative(view));
-                }
-                else
-                {
-                    // When the extent is 0, the pointer is undefined but it should still be possible get it.
-                    alpaka::getPtrNative(view);
-                }
-            }
-
-            // alpaka::traits::GetOffset
-            {
-                REQUIRE(offset == alpaka::getOffsetVec(view));
-            }
-
-            // alpaka::traits::IdxType
-            {
-                static_assert(
-                    std::is_same_v<alpaka::Idx<TView>, TIdx>,
-                    "The idx type of the view has to be equal to the specified one.");
+                REQUIRE(pitchView[i - 1] >= pitchMinimum[i - 1]);
             }
         }
 
-        //! Compares element-wise that all bytes are set to the same value.
-        struct VerifyBytesSetKernel
+        // traits::GetPtrNative
         {
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<typename TAcc, typename TIter>
-            ALPAKA_FN_ACC void operator()(
-                TAcc const& acc [[maybe_unused]], // used by SYCL back-end
-                bool* success,
-                TIter const& begin,
-                TIter const& end,
-                std::uint8_t const& byte) const
+            // The view is a const& so the pointer has to point to a const value.
+            using NativePtr = decltype(getPtrNative(view));
+            static_assert(std::is_pointer_v<NativePtr>, "The value returned by getPtrNative has to be a pointer.");
+            static_assert(
+                std::is_const_v<std::remove_pointer_t<NativePtr>>,
+                "The value returned by getPtrNative has to be const when the view is const.");
+
+            if(getExtentProduct(view) != static_cast<TIdx>(0u))
             {
-                constexpr auto elemSizeInByte = sizeof(decltype(*begin));
-                for(auto it = begin; it != end; ++it)
-                {
-                    auto const& elem = *it;
-                    auto const pBytes = reinterpret_cast<std::uint8_t const*>(&elem);
-                    for(std::size_t i = 0u; i < elemSizeInByte; ++i)
-                    {
-                        ALPAKA_CHECK(*success, pBytes[i] == byte);
-                    }
-                }
+                // The pointer is only required to be non-null when the extent is > 0.
+                TElem const* const invalidPtr(nullptr);
+                REQUIRE(invalidPtr != getPtrNative(view));
             }
-        };
-        template<typename TAcc, typename TView>
-        ALPAKA_FN_HOST auto verifyBytesSet(TView const& view, std::uint8_t const& byte) -> void
-        {
-            using Dim = alpaka::Dim<TView>;
-            using Idx = alpaka::Idx<TView>;
-
-            alpaka::test::KernelExecutionFixture<TAcc> fixture(alpaka::Vec<Dim, Idx>::ones());
-
-            VerifyBytesSetKernel verifyBytesSet;
-
-            REQUIRE(fixture(verifyBytesSet, alpaka::test::begin(view), alpaka::test::end(view), byte));
+            else
+            {
+                // When the extent is 0, the pointer is undefined but it should still be possible get it.
+                getPtrNative(view);
+            }
         }
 
-        //! Compares iterators element-wise
+        // traits::GetOffset
+        {
+            REQUIRE(offset == getOffsetVec(view));
+        }
+
+        // traits::IdxType
+        {
+            static_assert(
+                std::is_same_v<Idx<TView>, TIdx>,
+                "The idx type of the view has to be equal to the specified one.");
+        }
+    }
+
+    //! Compares element-wise that all bytes are set to the same value.
+    struct VerifyBytesSetKernel
+    {
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<typename TAcc, typename TIter>
+        ALPAKA_FN_ACC void operator()(
+            TAcc const& acc [[maybe_unused]], // used by SYCL back-end
+            bool* success,
+            TIter const& begin,
+            TIter const& end,
+            std::uint8_t const& byte) const
+        {
+            constexpr auto elemSizeInByte = sizeof(decltype(*begin));
+            for(auto it = begin; it != end; ++it)
+            {
+                auto const& elem = *it;
+                auto const pBytes = reinterpret_cast<std::uint8_t const*>(&elem);
+                for(std::size_t i = 0u; i < elemSizeInByte; ++i)
+                {
+                    ALPAKA_CHECK(*success, pBytes[i] == byte);
+                }
+            }
+        }
+    };
+    template<typename TAcc, typename TView>
+    ALPAKA_FN_HOST auto verifyBytesSet(TView const& view, std::uint8_t const& byte) -> void
+    {
+        using Dim = Dim<TView>;
+        using Idx = Idx<TView>;
+
+        test::KernelExecutionFixture<TAcc> fixture(Vec<Dim, Idx>::ones());
+
+        VerifyBytesSetKernel verifyBytesSet;
+
+        REQUIRE(fixture(verifyBytesSet, test::begin(view), test::end(view), byte));
+    }
+
+    //! Compares iterators element-wise
 #if BOOST_COMP_GNUC
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wfloat-equal" // "comparing floating point with == or != is unsafe"
 #endif
-        struct VerifyViewsEqualKernel
+    struct VerifyViewsEqualKernel
+    {
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<typename TAcc, typename TIterA, typename TIterB>
+        ALPAKA_FN_ACC void operator()(
+            TAcc const& acc [[maybe_unused]], // used by SYCL back-end
+            bool* success,
+            TIterA beginA,
+            TIterA const& endA,
+            TIterB beginB) const
         {
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<typename TAcc, typename TIterA, typename TIterB>
-            ALPAKA_FN_ACC void operator()(
-                TAcc const& acc [[maybe_unused]], // used by SYCL back-end
-                bool* success,
-                TIterA beginA,
-                TIterA const& endA,
-                TIterB beginB) const
+            for(; beginA != endA; ++beginA, ++beginB)
             {
-                for(; beginA != endA; ++beginA, ++beginB)
-                {
 #if BOOST_COMP_CLANG
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wfloat-equal" // "comparing floating point with == or != is unsafe"
 #endif
-                    ALPAKA_CHECK(*success, *beginA == *beginB);
+                ALPAKA_CHECK(*success, *beginA == *beginB);
 #if BOOST_COMP_CLANG
 #    pragma clang diagnostic pop
 #endif
-                }
             }
-        };
+        }
+    };
 #if BOOST_COMP_GNUC
 #    pragma GCC diagnostic pop
 #endif
 
-        template<typename TAcc, typename TViewB, typename TViewA>
-        ALPAKA_FN_HOST auto verifyViewsEqual(TViewA const& viewA, TViewB const& viewB) -> void
+    template<typename TAcc, typename TViewB, typename TViewA>
+    ALPAKA_FN_HOST auto verifyViewsEqual(TViewA const& viewA, TViewB const& viewB) -> void
+    {
+        using DimA = Dim<TViewA>;
+        using DimB = Dim<TViewB>;
+        static_assert(DimA::value == DimB::value, "viewA and viewB are required to have identical Dim");
+        using IdxA = Idx<TViewA>;
+        using IdxB = Idx<TViewB>;
+        static_assert(std::is_same_v<IdxA, IdxB>, "viewA and viewB are required to have identical Idx");
+
+        test::KernelExecutionFixture<TAcc> fixture(Vec<DimA, IdxA>::ones());
+
+        VerifyViewsEqualKernel verifyViewsEqualKernel;
+
+        REQUIRE(fixture(verifyViewsEqualKernel, test::begin(viewA), test::end(viewA), test::begin(viewB)));
+    }
+
+    //! Fills the given view with increasing values starting at 0.
+    template<typename TView, typename TQueue>
+    ALPAKA_FN_HOST auto iotaFillView(TQueue& queue, TView& view) -> void
+    {
+        using DevHost = DevCpu;
+        using PltfHost = Pltf<DevHost>;
+
+        using Elem = Elem<TView>;
+
+        DevHost const devHost = getDevByIdx<PltfHost>(0);
+
+        auto const extent = getExtentVec(view);
+
+        // Init buf with increasing values
+        std::vector<Elem> v(static_cast<std::size_t>(extent.prod()), static_cast<Elem>(0));
+        std::iota(std::begin(v), std::end(v), static_cast<Elem>(0));
+        auto plainBuf = createView(devHost, v, extent);
+
+        // Copy the generated content into the given view.
+        memcpy(queue, view, plainBuf);
+
+        wait(queue);
+    }
+
+    template<typename TAcc, typename TView, typename TQueue>
+    ALPAKA_FN_HOST auto testViewMutable(TQueue& queue, TView& view) -> void
+    {
+        // traits::GetPtrNative
         {
-            using DimA = alpaka::Dim<TViewA>;
-            using DimB = alpaka::Dim<TViewB>;
-            static_assert(DimA::value == DimB::value, "viewA and viewB are required to have identical Dim");
-            using IdxA = alpaka::Idx<TViewA>;
-            using IdxB = alpaka::Idx<TViewB>;
-            static_assert(std::is_same_v<IdxA, IdxB>, "viewA and viewB are required to have identical Idx");
-
-            alpaka::test::KernelExecutionFixture<TAcc> fixture(alpaka::Vec<DimA, IdxA>::ones());
-
-            VerifyViewsEqualKernel verifyViewsEqualKernel;
-
-            REQUIRE(fixture(
-                verifyViewsEqualKernel,
-                alpaka::test::begin(viewA),
-                alpaka::test::end(viewA),
-                alpaka::test::begin(viewB)));
+            // The view is a non-const so the pointer has to point to a non-const value.
+            using NativePtr = decltype(getPtrNative(view));
+            static_assert(std::is_pointer_v<NativePtr>, "The value returned by getPtrNative has to be a pointer.");
+            static_assert(
+                !std::is_const_v<std::remove_pointer_t<NativePtr>>,
+                "The value returned by getPtrNative has to be non-const when the view is non-const.");
         }
 
-        //! Fills the given view with increasing values starting at 0.
-        template<typename TView, typename TQueue>
-        ALPAKA_FN_HOST auto iotaFillView(TQueue& queue, TView& view) -> void
+        // set
         {
-            using DevHost = alpaka::DevCpu;
-            using PltfHost = alpaka::Pltf<DevHost>;
-
-            using Elem = alpaka::Elem<TView>;
-
-            DevHost const devHost = alpaka::getDevByIdx<PltfHost>(0);
-
-            auto const extent = alpaka::getExtentVec(view);
-
-            // Init buf with increasing values
-            std::vector<Elem> v(static_cast<std::size_t>(extent.prod()), static_cast<Elem>(0));
-            std::iota(std::begin(v), std::end(v), static_cast<Elem>(0));
-            auto plainBuf = alpaka::createView(devHost, v, extent);
-
-            // Copy the generated content into the given view.
-            alpaka::memcpy(queue, view, plainBuf);
-
-            alpaka::wait(queue);
+            auto const byte(static_cast<uint8_t>(42u));
+            memset(queue, view, byte);
+            wait(queue);
+            verifyBytesSet<TAcc>(view, byte);
         }
 
-        template<typename TAcc, typename TView, typename TQueue>
-        ALPAKA_FN_HOST auto testViewMutable(TQueue& queue, TView& view) -> void
+        // copy
         {
-            // alpaka::traits::GetPtrNative
+            using Elem = Elem<TView>;
+            using Idx = Idx<TView>;
+
+            auto const devAcc = getDev(view);
+            auto const extent = getExtentVec(view);
+
+            // copy into given view
             {
-                // The view is a non-const so the pointer has to point to a non-const value.
-                using NativePtr = decltype(alpaka::getPtrNative(view));
-                static_assert(std::is_pointer_v<NativePtr>, "The value returned by getPtrNative has to be a pointer.");
-                static_assert(
-                    !std::is_const_v<std::remove_pointer_t<NativePtr>>,
-                    "The value returned by getPtrNative has to be non-const when the view is non-const.");
+                auto srcBufAcc = allocBuf<Elem, Idx>(devAcc, extent);
+                iotaFillView(queue, srcBufAcc);
+                memcpy(queue, view, srcBufAcc);
+                wait(queue);
+                verifyViewsEqual<TAcc>(view, srcBufAcc);
             }
 
-            // alpaka::set
+            // copy from given view
             {
-                auto const byte(static_cast<uint8_t>(42u));
-                alpaka::memset(queue, view, byte);
-                alpaka::wait(queue);
-                verifyBytesSet<TAcc>(view, byte);
-            }
-
-            // alpaka::copy
-            {
-                using Elem = alpaka::Elem<TView>;
-                using Idx = alpaka::Idx<TView>;
-
-                auto const devAcc = alpaka::getDev(view);
-                auto const extent = alpaka::getExtentVec(view);
-
-                // alpaka::copy into given view
-                {
-                    auto srcBufAcc = alpaka::allocBuf<Elem, Idx>(devAcc, extent);
-                    iotaFillView(queue, srcBufAcc);
-                    alpaka::memcpy(queue, view, srcBufAcc);
-                    alpaka::wait(queue);
-                    verifyViewsEqual<TAcc>(view, srcBufAcc);
-                }
-
-                // alpaka::copy from given view
-                {
-                    auto dstBufAcc = alpaka::allocBuf<Elem, Idx>(devAcc, extent);
-                    alpaka::memcpy(queue, dstBufAcc, view);
-                    alpaka::wait(queue);
-                    verifyViewsEqual<TAcc>(dstBufAcc, view);
-                }
+                auto dstBufAcc = allocBuf<Elem, Idx>(devAcc, extent);
+                memcpy(queue, dstBufAcc, view);
+                wait(queue);
+                verifyViewsEqual<TAcc>(dstBufAcc, view);
             }
         }
-    } // namespace test
-} // namespace alpaka
+    }
+} // namespace alpaka::test

--- a/include/alpaka/test/queue/Queue.hpp
+++ b/include/alpaka/test/queue/Queue.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, Matthias Werner
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -11,257 +11,253 @@
 
 #include <alpaka/alpaka.hpp>
 
-namespace alpaka
+namespace alpaka::test
 {
-    //! The test specifics.
-    namespace test
+    namespace traits
     {
-        namespace traits
-        {
-            //! The default queue type trait for devices.
-            template<typename TDev, typename TSfinae = void>
-            struct DefaultQueueType;
+        //! The default queue type trait for devices.
+        template<typename TDev, typename TSfinae = void>
+        struct DefaultQueueType;
 
-            //! The default queue type trait specialization for the CPU device.
-            template<>
-            struct DefaultQueueType<alpaka::DevCpu>
-            {
+        //! The default queue type trait specialization for the CPU device.
+        template<>
+        struct DefaultQueueType<DevCpu>
+        {
 #if(ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-                using type = alpaka::QueueCpuBlocking;
+            using type = QueueCpuBlocking;
 #else
-                using type = alpaka::QueueCpuNonBlocking;
+            using type = QueueCpuNonBlocking;
 #endif
-            };
+        };
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-            //! The default queue type trait specialization for the CUDA/HIP device.
-            template<>
-            struct DefaultQueueType<alpaka::DevUniformCudaHipRt>
-            {
-#    if(ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-                using type = alpaka::QueueUniformCudaHipRtBlocking;
-#    else
-                using type = alpaka::QueueUniformCudaHipRtNonBlocking;
-#    endif
-            };
-#endif
-        } // namespace traits
-        //! The queue type that should be used for the given accelerator.
-        template<typename TAcc>
-        using DefaultQueue = typename traits::DefaultQueueType<TAcc>::type;
-
-        namespace traits
+        //! The default queue type trait specialization for the CUDA/HIP device.
+        template<>
+        struct DefaultQueueType<DevUniformCudaHipRt>
         {
-            //! The blocking queue trait.
-            template<typename TQueue, typename TSfinae = void>
-            struct IsBlockingQueue;
+#    if(ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
+            using type = QueueUniformCudaHipRtBlocking;
+#    else
+            using type = QueueUniformCudaHipRtNonBlocking;
+#    endif
+        };
+#endif
+    } // namespace traits
+    //! The queue type that should be used for the given accelerator.
+    template<typename TAcc>
+    using DefaultQueue = typename traits::DefaultQueueType<TAcc>::type;
 
-            //! The blocking queue trait specialization for a blocking CPU queue.
-            template<typename TDev>
-            struct IsBlockingQueue<alpaka::QueueGenericThreadsBlocking<TDev>>
-            {
-                static constexpr bool value = true;
-            };
+    namespace traits
+    {
+        //! The blocking queue trait.
+        template<typename TQueue, typename TSfinae = void>
+        struct IsBlockingQueue;
 
-            //! The blocking queue trait specialization for a non-blocking CPU queue.
-            template<typename TDev>
-            struct IsBlockingQueue<alpaka::QueueGenericThreadsNonBlocking<TDev>>
-            {
-                static constexpr bool value = false;
-            };
+        //! The blocking queue trait specialization for a blocking CPU queue.
+        template<typename TDev>
+        struct IsBlockingQueue<QueueGenericThreadsBlocking<TDev>>
+        {
+            static constexpr bool value = true;
+        };
+
+        //! The blocking queue trait specialization for a non-blocking CPU queue.
+        template<typename TDev>
+        struct IsBlockingQueue<QueueGenericThreadsNonBlocking<TDev>>
+        {
+            static constexpr bool value = false;
+        };
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-            //! The blocking queue trait specialization for a blocking CUDA/HIP RT queue.
-            template<>
-            struct IsBlockingQueue<alpaka::QueueUniformCudaHipRtBlocking>
-            {
-                static constexpr bool value = true;
-            };
+        //! The blocking queue trait specialization for a blocking CUDA/HIP RT queue.
+        template<>
+        struct IsBlockingQueue<QueueUniformCudaHipRtBlocking>
+        {
+            static constexpr bool value = true;
+        };
 
-            //! The blocking queue trait specialization for a non-blocking CUDA/HIP RT queue.
-            template<>
-            struct IsBlockingQueue<alpaka::QueueUniformCudaHipRtNonBlocking>
-            {
-                static constexpr bool value = false;
-            };
+        //! The blocking queue trait specialization for a non-blocking CUDA/HIP RT queue.
+        template<>
+        struct IsBlockingQueue<QueueUniformCudaHipRtNonBlocking>
+        {
+            static constexpr bool value = false;
+        };
 #endif
 
 #ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
 
-            //! The default queue type trait specialization for the Omp5 device.
-            template<>
-            struct DefaultQueueType<alpaka::DevOmp5>
-            {
+        //! The default queue type trait specialization for the Omp5 device.
+        template<>
+        struct DefaultQueueType<DevOmp5>
+        {
 #    if(ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-                using type = alpaka::QueueOmp5Blocking;
+            using type = QueueOmp5Blocking;
 #    else
-                using type = alpaka::QueueOmp5Blocking;
+            using type = QueueOmp5Blocking;
 #    endif
-            };
+        };
 #elif defined ALPAKA_ACC_ANY_BT_OACC_ENABLED
 
-            //! The default queue type trait specialization for the OMP4 device.
-            template<>
-            struct DefaultQueueType<alpaka::DevOacc>
-            {
-                using type = alpaka::QueueOaccBlocking;
-            };
+        //! The default queue type trait specialization for the OMP4 device.
+        template<>
+        struct DefaultQueueType<DevOacc>
+        {
+            using type = QueueOaccBlocking;
+        };
 #endif
 
 #ifdef ALPAKA_ACC_SYCL_ENABLED
 #    ifdef ALPAKA_SYCL_BACKEND_ONEAPI
 #        ifdef ALPAKA_SYCL_ONEAPI_CPU
-            //! The default queue type trait specialization for the Intel CPU device.
-            template<>
-            struct DefaultQueueType<alpaka::experimental::DevCpuSyclIntel>
-            {
+        //! The default queue type trait specialization for the Intel CPU device.
+        template<>
+        struct DefaultQueueType<alpaka::experimental::DevCpuSyclIntel>
+        {
 #            if(ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-                using type = alpaka::experimental::QueueCpuSyclIntelBlocking;
+            using type = alpaka::experimental::QueueCpuSyclIntelBlocking;
 #            else
-                using type = alpaka::experimental::QueueCpuSyclIntelNonBlocking;
+            using type = alpaka::experimental::QueueCpuSyclIntelNonBlocking;
 #            endif
-            };
+        };
 
-            template<>
-            struct IsBlockingQueue<alpaka::experimental::QueueCpuSyclIntelBlocking>
-            {
-                static constexpr auto value = true;
-            };
+        template<>
+        struct IsBlockingQueue<alpaka::experimental::QueueCpuSyclIntelBlocking>
+        {
+            static constexpr auto value = true;
+        };
 
-            template<>
-            struct IsBlockingQueue<alpaka::experimental::QueueCpuSyclIntelNonBlocking>
-            {
-                static constexpr auto value = false;
-            };
+        template<>
+        struct IsBlockingQueue<alpaka::experimental::QueueCpuSyclIntelNonBlocking>
+        {
+            static constexpr auto value = false;
+        };
 #        endif
 #        ifdef ALPAKA_SYCL_ONEAPI_FPGA
-            //! The default queue type trait specialization for the Intel SYCL device.
-            template<>
-            struct DefaultQueueType<alpaka::experimental::DevFpgaSyclIntel>
-            {
+        //! The default queue type trait specialization for the Intel SYCL device.
+        template<>
+        struct DefaultQueueType<alpaka::experimental::DevFpgaSyclIntel>
+        {
 #            if(ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-                using type = alpaka::experimental::QueueFpgaSyclIntelBlocking;
+            using type = alpaka::experimental::QueueFpgaSyclIntelBlocking;
 #            else
-                using type = alpaka::experimental::QueueFpgaSyclIntelNonBlocking;
+            using type = alpaka::experimental::QueueFpgaSyclIntelNonBlocking;
 #            endif
-            };
+        };
 
-            template<>
-            struct IsBlockingQueue<alpaka::experimental::QueueFpgaSyclIntelBlocking>
-            {
-                static constexpr auto value = true;
-            };
+        template<>
+        struct IsBlockingQueue<alpaka::experimental::QueueFpgaSyclIntelBlocking>
+        {
+            static constexpr auto value = true;
+        };
 
-            template<>
-            struct IsBlockingQueue<alpaka::experimental::QueueFpgaSyclIntelNonBlocking>
-            {
-                static constexpr auto value = false;
-            };
+        template<>
+        struct IsBlockingQueue<alpaka::experimental::QueueFpgaSyclIntelNonBlocking>
+        {
+            static constexpr auto value = false;
+        };
 #        endif
 #        ifdef ALPAKA_SYCL_ONEAPI_GPU
-            //! The default queue type trait specialization for the Intel CPU device.
-            template<>
-            struct DefaultQueueType<alpaka::experimental::DevGpuSyclIntel>
-            {
+        //! The default queue type trait specialization for the Intel CPU device.
+        template<>
+        struct DefaultQueueType<alpaka::experimental::DevGpuSyclIntel>
+        {
 #            if(ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-                using type = alpaka::experimental::QueueGpuSyclIntelBlocking;
+            using type = alpaka::experimental::QueueGpuSyclIntelBlocking;
 #            else
-                using type = alpaka::experimental::QueueGpuSyclIntelNonBlocking;
+            using type = alpaka::experimental::QueueGpuSyclIntelNonBlocking;
 #            endif
-            };
+        };
 
-            template<>
-            struct IsBlockingQueue<alpaka::experimental::QueueGpuSyclIntelBlocking>
-            {
-                static constexpr auto value = true;
-            };
+        template<>
+        struct IsBlockingQueue<alpaka::experimental::QueueGpuSyclIntelBlocking>
+        {
+            static constexpr auto value = true;
+        };
 
-            template<>
-            struct IsBlockingQueue<alpaka::experimental::QueueGpuSyclIntelNonBlocking>
-            {
-                static constexpr auto value = false;
-            };
+        template<>
+        struct IsBlockingQueue<alpaka::experimental::QueueGpuSyclIntelNonBlocking>
+        {
+            static constexpr auto value = false;
+        };
 #        endif
 #    endif
 #    ifdef ALPAKA_SYCL_BACKEND_XILINX
-            //! The default queue type trait specialization for the Xilinx SYCL device.
-            template<>
-            struct DefaultQueueType<alpaka::experimental::DevFpgaSyclXilinx>
-            {
+        //! The default queue type trait specialization for the Xilinx SYCL device.
+        template<>
+        struct DefaultQueueType<alpaka::experimental::DevFpgaSyclXilinx>
+        {
 #        if(ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-                using type = alpaka::experimental::QueueFpgaSyclXilinxBlocking;
+            using type = alpaka::experimental::QueueFpgaSyclXilinxBlocking;
 #        else
-                using type = alpaka::experimental::QueueFpgaSyclXilinxNonBlocking;
+            using type = alpaka::experimental::QueueFpgaSyclXilinxNonBlocking;
 #        endif
-            };
+        };
 
-            template<>
-            struct IsBlockingQueue<alpaka::experimental::QueueFpgaSyclXilinxBlocking>
-            {
-                static constexpr auto value = true;
-            };
+        template<>
+        struct IsBlockingQueue<alpaka::experimental::QueueFpgaSyclXilinxBlocking>
+        {
+            static constexpr auto value = true;
+        };
 
-            template<>
-            struct IsBlockingQueue<alpaka::experimental::QueueFpgaSyclXilinxNonBlocking>
-            {
-                static constexpr auto value = false;
-            };
+        template<>
+        struct IsBlockingQueue<alpaka::experimental::QueueFpgaSyclXilinxNonBlocking>
+        {
+            static constexpr auto value = false;
+        };
 #    endif
 #endif
-        } // namespace traits
-        //! The queue type that should be used for the given accelerator.
-        template<typename TQueue>
-        using IsBlockingQueue = traits::IsBlockingQueue<TQueue>;
+    } // namespace traits
+    //! The queue type that should be used for the given accelerator.
+    template<typename TQueue>
+    using IsBlockingQueue = traits::IsBlockingQueue<TQueue>;
 
-        //! A std::tuple holding tuples of devices and corresponding queue types.
-        using TestQueues = std::tuple<
-            std::tuple<alpaka::DevCpu, alpaka::QueueCpuBlocking>,
-            std::tuple<alpaka::DevCpu, alpaka::QueueCpuNonBlocking>
+    //! A std::tuple holding tuples of devices and corresponding queue types.
+    using TestQueues = std::tuple<
+        std::tuple<DevCpu, QueueCpuBlocking>,
+        std::tuple<DevCpu, QueueCpuNonBlocking>
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-            ,
-            std::tuple<alpaka::DevUniformCudaHipRt, alpaka::QueueUniformCudaHipRtBlocking>,
-            std::tuple<alpaka::DevUniformCudaHipRt, alpaka::QueueUniformCudaHipRtNonBlocking>
+        ,
+        std::tuple<DevUniformCudaHipRt, QueueUniformCudaHipRtBlocking>,
+        std::tuple<DevUniformCudaHipRt, QueueUniformCudaHipRtNonBlocking>
 #endif
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-            ,
-            std::tuple<alpaka::DevHipRt, alpaka::QueueHipRtBlocking>,
-            std::tuple<alpaka::DevHipRt, alpaka::QueueHipRtNonBlocking>
+        ,
+        std::tuple<DevHipRt, QueueHipRtBlocking>,
+        std::tuple<DevHipRt, QueueHipRtNonBlocking>
 #endif
 #ifdef ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-            ,
-            std::tuple<alpaka::DevOmp5, alpaka::QueueOmp5Blocking>,
-            std::tuple<alpaka::DevOmp5, alpaka::QueueOmp5NonBlocking>
+        ,
+        std::tuple<DevOmp5, QueueOmp5Blocking>,
+        std::tuple<DevOmp5, QueueOmp5NonBlocking>
 #elif defined(ALPAKA_ACC_ANY_BT_OACC_ENABLED)
-            ,
-            std::tuple<alpaka::DevOacc, alpaka::QueueOaccBlocking>,
-            std::tuple<alpaka::DevOacc, alpaka::QueueOaccNonBlocking>
+        ,
+        std::tuple<DevOacc, QueueOaccBlocking>,
+        std::tuple<DevOacc, QueueOaccNonBlocking>
 #endif
 #ifdef ALPAKA_ACC_SYCL_ENABLED
 #    ifdef ALPAKA_SYCL_BACKEND_ONEAPI
 #        ifdef ALPAKA_SYCL_ONEAPI_CPU
-            ,
-            std::tuple<alpaka::experimental::DevCpuSyclIntel, alpaka::experimental::QueueCpuSyclIntelBlocking>,
-            std::tuple<alpaka::experimental::DevCpuSyclIntel, alpaka::experimental::QueueCpuSyclIntelNonBlocking>
+        ,
+        std::tuple<alpaka::experimental::DevCpuSyclIntel, alpaka::experimental::QueueCpuSyclIntelBlocking>,
+        std::tuple<alpaka::experimental::DevCpuSyclIntel, alpaka::experimental::QueueCpuSyclIntelNonBlocking>
 #        endif
 #        ifdef ALPAKA_SYCL_ONEAPI_FPGA
-            ,
-            std::tuple<alpaka::experimental::DevFpgaSyclIntel, alpaka::experimental::QueueFpgaSyclIntelBlocking>,
-            std::tuple<alpaka::experimental::DevFpgaSyclIntel, alpaka::experimental::QueueFpgaSyclIntelNonBlocking>
+        ,
+        std::tuple<alpaka::experimental::DevFpgaSyclIntel, alpaka::experimental::QueueFpgaSyclIntelBlocking>,
+        std::tuple<alpaka::experimental::DevFpgaSyclIntel, alpaka::experimental::QueueFpgaSyclIntelNonBlocking>
 #        endif
 #        ifdef ALPAKA_SYCL_ONEAPI_GPU
-            ,
-            std::tuple<alpaka::experimental::DevGpuSyclIntel, alpaka::experimental::QueueGpuSyclIntelBlocking>,
-            std::tuple<alpaka::experimental::DevGpuSyclIntel, alpaka::experimental::QueueGpuSyclIntelNonBlocking>
+        ,
+        std::tuple<alpaka::experimental::DevGpuSyclIntel, alpaka::experimental::QueueGpuSyclIntelBlocking>,
+        std::tuple<alpaka::experimental::DevGpuSyclIntel, alpaka::experimental::QueueGpuSyclIntelNonBlocking>
 #        endif
 #    endif
 #    if defined(ALPAKA_SYCL_BACKEND_XILINX)
-            ,
-            std::tuple<alpaka::experimental::DevFpgaSyclXilinx, alpaka::experimental::QueueFpgaSyclXilinxBlocking>,
-            std::tuple<alpaka::experimental::DevFpgaSyclXilinx, alpaka::experimental::QueueFpgaSyclXilinxNonBlocking>
+        ,
+        std::tuple<alpaka::experimental::DevFpgaSyclXilinx, alpaka::experimental::QueueFpgaSyclXilinxBlocking>,
+        std::tuple<alpaka::experimental::DevFpgaSyclXilinx, alpaka::experimental::QueueFpgaSyclXilinxNonBlocking>
 #    endif
 #endif
-            >;
-    } // namespace test
-} // namespace alpaka
+        >;
+} // namespace alpaka::test

--- a/include/alpaka/test/queue/QueueTestFixture.hpp
+++ b/include/alpaka/test/queue/QueueTestFixture.hpp
@@ -12,24 +12,21 @@
 
 #include <tuple>
 
-namespace alpaka
+namespace alpaka::test
 {
-    namespace test
+    template<typename TDevQueue>
+    struct QueueTestFixture
     {
-        template<typename TDevQueue>
-        struct QueueTestFixture
+        using Dev = std::tuple_element_t<0, TDevQueue>;
+        using Queue = std::tuple_element_t<1, TDevQueue>;
+
+        using Pltf = alpaka::Pltf<Dev>;
+
+        QueueTestFixture() : m_dev(getDevByIdx<Pltf>(0u)), m_queue(m_dev)
         {
-            using Dev = std::tuple_element_t<0, TDevQueue>;
-            using Queue = std::tuple_element_t<1, TDevQueue>;
+        }
 
-            using Pltf = alpaka::Pltf<Dev>;
-
-            QueueTestFixture() : m_dev(alpaka::getDevByIdx<Pltf>(0u)), m_queue(m_dev)
-            {
-            }
-
-            Dev m_dev;
-            Queue m_queue;
-        };
-    } // namespace test
-} // namespace alpaka
+        Dev m_dev;
+        Queue m_queue;
+    };
+} // namespace alpaka::test


### PR DESCRIPTION
This PR uses nested namespace specifier in the headers around `alpaka/test`. Furthermore, redundant `alpaka::` qualifications are removed. `KernelExecutionFixture` is similified using a delegated ctor.

- [x] Merge #1594 first.