### PR TITLE
Unit test move ctor/assign of Buf

### DIFF
--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -73,8 +73,8 @@ namespace alpaka
                           << std::endl;
 #endif
             }
-            BufCpuImpl(BufCpuImpl&&) = default;
-            auto operator=(BufCpuImpl&&) -> BufCpuImpl& = default;
+            BufCpuImpl(BufCpuImpl&&) = delete;
+            auto operator=(BufCpuImpl&&) -> BufCpuImpl& = delete;
             ALPAKA_FN_HOST ~BufCpuImpl()
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;

--- a/include/alpaka/mem/buf/BufOacc.hpp
+++ b/include/alpaka/mem/buf/BufOacc.hpp
@@ -72,8 +72,8 @@ namespace alpaka
             Vec<TDim, TIdx> m_extentElements;
             TElem* m_pMem;
 
-            BufOaccImpl(BufOaccImpl&&) = default;
-            BufOaccImpl& operator=(BufOaccImpl&&) = default;
+            BufOaccImpl(BufOaccImpl&&) = delete;
+            BufOaccImpl& operator=(BufOaccImpl&&) = delete;
             ~BufOaccImpl()
             {
                 m_dev.makeCurrent();

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -72,8 +72,8 @@ namespace alpaka
             Vec<TDim, TIdx> m_extentElements;
             TElem* m_pMem;
 
-            BufOmp5Impl(BufOmp5Impl&&) = default;
-            auto operator=(BufOmp5Impl&&) -> BufOmp5Impl& = default;
+            BufOmp5Impl(BufOmp5Impl&&) = delete;
+            auto operator=(BufOmp5Impl&&) -> BufOmp5Impl& = delete;
             ~BufOmp5Impl()
             {
                 omp_target_free(m_pMem, m_dev.m_spDevOmp5Impl->getNativeHandle());

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -331,10 +331,10 @@ namespace alpaka
         struct CreatePitchBytes
         {
             ALPAKA_NO_HOST_ACC_WARNING
-            template<typename TPitch>
-            ALPAKA_FN_HOST_ACC static auto create(TPitch const& pitch) -> Idx<TPitch>
+            template<typename TView>
+            ALPAKA_FN_HOST_ACC static auto create(TView const& view) -> Idx<TView>
             {
-                return getPitchBytes<Tidx>(pitch);
+                return getPitchBytes<Tidx>(view);
             }
         };
 
@@ -352,19 +352,20 @@ namespace alpaka
         }
     } // namespace detail
     //! \return The pitch vector.
-    template<typename TPitch>
-    auto getPitchBytesVec(TPitch const& pitch = TPitch()) -> Vec<Dim<TPitch>, Idx<TPitch>>
+    template<typename TView>
+    auto getPitchBytesVec(TView const& view = TView()) -> Vec<Dim<TView>, Idx<TView>>
     {
-        return createVecFromIndexedFn<Dim<TPitch>, detail::CreatePitchBytes>(pitch);
+        return createVecFromIndexedFn<Dim<TView>, detail::CreatePitchBytes>(view);
     }
+
     //! \return The pitch but only the last N elements.
-    template<typename TDim, typename TPitch>
-    ALPAKA_FN_HOST auto getPitchBytesVecEnd(TPitch const& pitch = TPitch()) -> Vec<TDim, Idx<TPitch>>
+    template<typename TDim, typename TView>
+    ALPAKA_FN_HOST auto getPitchBytesVecEnd(TView const& view = TView()) -> Vec<TDim, Idx<TView>>
     {
         using IdxOffset = std::integral_constant<
             std::intmax_t,
-            static_cast<std::intmax_t>(Dim<TPitch>::value) - static_cast<std::intmax_t>(TDim::value)>;
-        return createVecFromIndexedFnOffset<TDim, detail::CreatePitchBytes, IdxOffset>(pitch);
+            static_cast<std::intmax_t>(Dim<TView>::value) - static_cast<std::intmax_t>(TDim::value)>;
+        return createVecFromIndexedFnOffset<TDim, detail::CreatePitchBytes, IdxOffset>(view);
     }
 
     //! \return A view to static device memory.

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -343,10 +343,13 @@ namespace alpaka
         ALPAKA_FN_HOST inline auto calculatePitchesFromExtents(Vec<TDim, TIdx> const& extent)
         {
             Vec<TDim, TIdx> pitchBytes(Vec<TDim, TIdx>::all(0));
-            pitchBytes[TDim::value - 1u] = extent[TDim::value - 1u] * static_cast<TIdx>(sizeof(TElem));
-            for(TIdx i = TDim::value - 1u; i > static_cast<TIdx>(0u); --i)
+            if constexpr(TDim::value > 0)
             {
-                pitchBytes[i - 1] = extent[i - 1] * pitchBytes[i];
+                pitchBytes[TDim::value - 1u] = extent[TDim::value - 1u] * static_cast<TIdx>(sizeof(TElem));
+                for(TIdx i = TDim::value - 1u; i > static_cast<TIdx>(0u); --i)
+                {
+                    pitchBytes[i - 1] = extent[i - 1] * pitchBytes[i];
+                }
             }
             return pitchBytes;
         }


### PR DESCRIPTION
This PR adds a unit test for the move ctor/assign operator of buffers. It additionally deletes move operations on buffer implementations, since those are not necessary and may even cause bugs. It also renames a few template and function parameter names to be more meaningful.

- [x] Merge #1614 first