### PR TITLE
Remove several GetPitchBytes specializations 

### DIFF
--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -202,16 +202,6 @@ namespace alpaka
                 }
             }
         };
-        //! The BufCpu pitch get trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct GetPitchBytes<DimInt<TDim::value - 1u>, BufCpu<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto getPitchBytes(BufCpu<TElem, TDim, TIdx> const& pitch) -> TIdx
-            {
-                return static_cast<TIdx>(getWidth(pitch.m_spBufCpuImpl->m_extentElements))
-                    * static_cast<TIdx>(sizeof(TElem));
-            }
-        };
 
         //! The BufCpu memory allocation trait specialization.
         template<typename TElem, typename TDim, typename TIdx>

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -48,29 +48,12 @@ namespace alpaka
                 "elements!");
             static_assert(!std::is_const_v<TIdx>, "The idx type of the buffer can not be const!");
 
-        private:
-            using Elem = TElem;
-            using Dim = TDim;
-            //! Calculate the pitches purely from the extents.
-            template<typename TExtent>
-            ALPAKA_FN_HOST static auto calculatePitchesFromExtents(TExtent const& extent) -> Vec<TDim, TIdx>
-            {
-                Vec<TDim, TIdx> pitchBytes(Vec<TDim, TIdx>::all(0));
-                pitchBytes[TDim::value - 1u] = extent[TDim::value - 1u] * static_cast<TIdx>(sizeof(TElem));
-                for(TIdx i = TDim::value - 1u; i > static_cast<TIdx>(0u); --i)
-                {
-                    pitchBytes[i - 1] = extent[i - 1] * pitchBytes[i];
-                }
-                return pitchBytes;
-            }
-
         public:
             //! Constructor
             template<typename TExtent>
             ALPAKA_FN_HOST BufOmp5Impl(DevOmp5 const& dev, TElem* const pMem, TExtent const& extent)
                 : m_dev(dev)
                 , m_extentElements(getExtentVecEnd<TDim>(extent))
-                , m_pitchBytes(calculatePitchesFromExtents(m_extentElements))
                 , m_pMem(pMem)
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -87,7 +70,6 @@ namespace alpaka
         public:
             DevOmp5 m_dev;
             Vec<TDim, TIdx> m_extentElements;
-            Vec<TDim, TIdx> m_pitchBytes;
             TElem* m_pMem;
 
             BufOmp5Impl(BufOmp5Impl&&) = default;
@@ -212,15 +194,6 @@ namespace alpaka
                 {
                     throw std::runtime_error("The buffer is not accessible from the given device!");
                 }
-            }
-        };
-        //! The BufOmp5 pitch get trait specialization.
-        template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
-        struct GetPitchBytes<TIdxIntegralConst, BufOmp5<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto getPitchBytes(BufOmp5<TElem, TDim, TIdx> const& pitch) -> TIdx
-            {
-                return (*pitch).m_pitchBytes[TIdxIntegralConst::value];
             }
         };
 

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -176,7 +176,9 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getPitchBytes(BufUniformCudaHipRt<TElem, TDim, TIdx> const& buf) -> TIdx
             {
-                return buf.m_pitchBytes;
+                return buf.m_pitchBytes; // TODO(bgruber): is this even correct? This reports the pitch for the TDim -
+                                         // 1 dimension, but CUDA's pitch is always the row pitch, independently of the
+                                         // buffer's dimensions.
             }
         };
 

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -61,7 +61,7 @@ namespace alpaka
         {
             template<typename TIdx, typename TView>
                 struct GetPitchBytesDefault < TIdx,
-                TView, std::enable_if_t<TIdx::value<(Dim<TView>::value - 1)>>
+                TView, std::enable_if_t<TIdx::value<Dim<TView>::value - 1>>
             {
                 ALPAKA_FN_HOST static auto getPitchBytesDefault(TView const& view) -> Idx<TView>
                 {
@@ -74,7 +74,7 @@ namespace alpaka
             {
                 ALPAKA_FN_HOST static auto getPitchBytesDefault(TView const& view) -> Idx<TView>
                 {
-                    return getExtent<Dim<TView>::value - 1u>(view) * sizeof(Elem<TView>);
+                    return getExtent<Dim<TView>::value - 1u>(view) * static_cast<Idx<TView>>(sizeof(Elem<TView>));
                 }
             };
             template<typename TView>

--- a/include/alpaka/mem/view/ViewStdArray.hpp
+++ b/include/alpaka/mem/view/ViewStdArray.hpp
@@ -77,17 +77,6 @@ namespace alpaka::traits
         }
     };
 
-    //! The std::array pitch get trait specialization.
-    template<typename TElem, std::size_t Tsize>
-    struct GetPitchBytes<DimInt<0u>, std::array<TElem, Tsize>>
-    {
-        ALPAKA_FN_HOST static auto getPitchBytes(std::array<TElem, Tsize> const& pitch)
-            -> Idx<std::array<TElem, Tsize>>
-        {
-            return sizeof(TElem) * std::size(pitch);
-        }
-    };
-
     //! The std::array offset get trait specialization.
     template<typename TIdx, typename TElem, std::size_t Tsize>
     struct GetOffset<TIdx, std::array<TElem, Tsize>>

--- a/include/alpaka/mem/view/ViewStdVector.hpp
+++ b/include/alpaka/mem/view/ViewStdVector.hpp
@@ -77,17 +77,6 @@ namespace alpaka::traits
         }
     };
 
-    //! The std::vector pitch get trait specialization.
-    template<typename TElem, typename TAllocator>
-    struct GetPitchBytes<DimInt<0u>, std::vector<TElem, TAllocator>>
-    {
-        ALPAKA_FN_HOST static auto getPitchBytes(std::vector<TElem, TAllocator> const& pitch)
-            -> Idx<std::vector<TElem, TAllocator>>
-        {
-            return sizeof(TElem) * std::size(pitch);
-        }
-    };
-
     //! The std::vector offset get trait specialization.
     template<typename TIdx, typename TElem, typename TAllocator>
     struct GetOffset<TIdx, std::vector<TElem, TAllocator>>


### PR DESCRIPTION
The pitch calculation for most buffers/views should just fallback to the default implementation of `GetPitchBytes`.

This also fixes a bug in the manual pitch calculations in `BufOmp5` and `BufOmpOacc` when the buffer is zero-dimensional.