### PR TITLE
Fix include path for Intel FPGA extensions

### DIFF
--- a/include/alpaka/pltf/PltfFpgaSyclIntel.hpp
+++ b/include/alpaka/pltf/PltfFpgaSyclIntel.hpp
@@ -16,7 +16,7 @@
 #    include <alpaka/pltf/PltfGenericSycl.hpp>
 
 #    include <CL/sycl.hpp>
-#    include <CL/sycl/INTEL/fpga_extensions.hpp>
+#    include <sycl/ext/intel/fpga_extensions.hpp>
 
 #    include <string>
 


### PR DESCRIPTION
These changed in the latest oneAPI release.