### PR TITLE
Refactor Vec

### DIFF
--- a/include/alpaka/core/Assert.hpp
+++ b/include/alpaka/core/Assert.hpp
@@ -39,7 +39,7 @@ namespace alpaka::core
         template<typename TArg>
         struct AssertValueUnsigned
         {
-            ALPAKA_NO_HOST_ACC_WARNING ALPAKA_FN_HOST_ACC static auto assertValueUnsigned(
+            ALPAKA_NO_HOST_ACC_WARNING ALPAKA_FN_HOST_ACC static constexpr auto assertValueUnsigned(
                 [[maybe_unused]] TArg const& arg)
             {
                 if constexpr(std::is_signed_v<TArg>)
@@ -54,7 +54,7 @@ namespace alpaka::core
     //! The implementation prevents warnings for checking this for unsigned types.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TArg>
-    ALPAKA_FN_HOST_ACC auto assertValueUnsigned(TArg const& arg) -> void
+    ALPAKA_FN_HOST_ACC constexpr auto assertValueUnsigned(TArg const& arg) -> void
     {
         detail::AssertValueUnsigned<TArg>::assertValueUnsigned(arg);
     }
@@ -64,7 +64,7 @@ namespace alpaka::core
         template<typename TLhs, typename TRhs>
         struct AssertGreaterThan
         {
-            ALPAKA_NO_HOST_ACC_WARNING ALPAKA_FN_HOST_ACC static auto assertGreaterThan(
+            ALPAKA_NO_HOST_ACC_WARNING ALPAKA_FN_HOST_ACC static constexpr auto assertGreaterThan(
                 [[maybe_unused]] TRhs const& rhs)
             {
                 if constexpr(std::is_signed_v<TRhs> || (TLhs::value != 0u))
@@ -78,7 +78,7 @@ namespace alpaka::core
     //! This function asserts that the integral value TLhs is greater than TRhs.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TLhs, typename TRhs>
-    ALPAKA_FN_HOST_ACC auto assertGreaterThan(TRhs const& rhs) -> void
+    ALPAKA_FN_HOST_ACC constexpr auto assertGreaterThan(TRhs const& rhs) -> void
     {
         detail::AssertGreaterThan<TLhs, TRhs>::assertGreaterThan(rhs);
     }

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unreachable.hpp>
 #include <alpaka/dev/Traits.hpp>
 #include <alpaka/dim/Traits.hpp>
 #include <alpaka/elem/Traits.hpp>
@@ -63,6 +64,7 @@ namespace alpaka
                     return getExtent<viewDim - 1>(view) * static_cast<ViewIdx>(sizeof(Elem<TView>));
                 else
                     return static_cast<ViewIdx>(sizeof(Elem<TView>));
+                ALPAKA_UNREACHABLE({});
             }
         };
 

--- a/include/alpaka/meta/Fold.hpp
+++ b/include/alpaka/meta/Fold.hpp
@@ -15,13 +15,13 @@ namespace alpaka::meta
 {
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TFnObj, typename T>
-    ALPAKA_FN_HOST_ACC auto foldr(TFnObj const& /* f */, T const& t) -> T
+    ALPAKA_FN_HOST_ACC constexpr auto foldr(TFnObj const& /* f */, T const& t) -> T
     {
         return t;
     }
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TFnObj, typename T0, typename T1, typename... Ts>
-    ALPAKA_FN_HOST_ACC auto foldr(TFnObj const& f, T0 const& t0, T1 const& t1, Ts const&... ts)
+    ALPAKA_FN_HOST_ACC constexpr auto foldr(TFnObj const& f, T0 const& t0, T1 const& t1, Ts const&... ts)
     {
         return f(t0, foldr(f, t1, ts...));
     }

--- a/include/alpaka/vec/Traits.hpp
+++ b/include/alpaka/vec/Traits.hpp
@@ -45,7 +45,7 @@ namespace alpaka
     //! \return The sub-vector consisting of the elements specified by the indices.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TIndexSequence, typename TVec>
-    ALPAKA_FN_HOST_ACC auto subVecFromIndices(TVec const& vec)
+    ALPAKA_FN_HOST_ACC constexpr auto subVecFromIndices(TVec const& vec)
     {
         return traits::SubVecFromIndices<TVec, TIndexSequence>::subVecFromIndices(vec);
     }
@@ -53,7 +53,7 @@ namespace alpaka
     //! \return The sub-vector consisting of the first N elements of the source vector.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TSubDim, typename TVec>
-    ALPAKA_FN_HOST_ACC auto subVecBegin(TVec const& vec)
+    ALPAKA_FN_HOST_ACC constexpr auto subVecBegin(TVec const& vec)
     {
         static_assert(
             TSubDim::value <= Dim<TVec>::value,
@@ -67,7 +67,7 @@ namespace alpaka
     //! \return The sub-vector consisting of the last N elements of the source vector.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TSubDim, typename TVec>
-    ALPAKA_FN_HOST_ACC auto subVecEnd(TVec const& vec)
+    ALPAKA_FN_HOST_ACC constexpr auto subVecEnd(TVec const& vec)
     {
         static_assert(
             TSubDim::value <= Dim<TVec>::value,
@@ -83,7 +83,7 @@ namespace alpaka
     //! \return The casted vector.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TVal, typename TVec>
-    ALPAKA_FN_HOST_ACC auto castVec(TVec const& vec)
+    ALPAKA_FN_HOST_ACC constexpr auto castVec(TVec const& vec)
     {
         return traits::CastVec<TVal, TVec>::castVec(vec);
     }
@@ -91,7 +91,7 @@ namespace alpaka
     //! \return The reverseVec vector.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TVec>
-    ALPAKA_FN_HOST_ACC auto reverseVec(TVec const& vec)
+    ALPAKA_FN_HOST_ACC constexpr auto reverseVec(TVec const& vec)
     {
         return traits::ReverseVec<TVec>::reverseVec(vec);
     }
@@ -99,7 +99,7 @@ namespace alpaka
     //! \return The concatenated vector.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TVecL, typename TVecR>
-    ALPAKA_FN_HOST_ACC auto concatVec(TVecL const& vecL, TVecR const& vecR)
+    ALPAKA_FN_HOST_ACC constexpr auto concatVec(TVecL const& vecL, TVecR const& vecR)
     {
         return traits::ConcatVec<TVecL, TVecR>::concatVec(vecL, vecR);
     }

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -98,13 +98,10 @@ namespace alpaka
         //! This constructor is only available if the number of parameters matches the vector idx.
         ALPAKA_NO_HOST_ACC_WARNING
         template<
-            typename TArg0,
             typename... TArgs,
             typename = std::enable_if_t<
-                // There have to be dim arguments.
-                (sizeof...(TArgs) + 1 == TDim::value) && (std::is_same_v<TVal, std::decay_t<TArg0>>)>>
-        ALPAKA_FN_HOST_ACC constexpr Vec(TArg0&& arg0, TArgs&&... args)
-            : m_data{std::forward<TArg0>(arg0), std::forward<TArgs>(args)...}
+                sizeof...(TArgs) == TDim::value && (std::is_convertible_v<std::decay_t<TArgs>, TVal> && ...)>>
+        ALPAKA_FN_HOST_ACC constexpr Vec(TArgs&&... args) : m_data{static_cast<TVal>(std::forward<TArgs>(args))...}
         {
         }
 

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -532,18 +532,19 @@ namespace alpaka
     //! \return The extent vector.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TExtent>
-    ALPAKA_FN_HOST_ACC auto constexpr getExtentVec(TExtent const& extent = TExtent())
-        -> Vec<Dim<TExtent>, Idx<TExtent>>
+    ALPAKA_FN_HOST_ACC auto constexpr getExtentVec(TExtent const& extent = {}) -> Vec<Dim<TExtent>, Idx<TExtent>>
     {
         return createVecFromIndexedFn<Dim<TExtent>, detail::CreateExtent>(extent);
     }
 
     //! \tparam TExtent has to specialize GetExtent.
-    //! \return The extent but only the last N elements.
+    //! \return The extent but only the last TDim elements.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TExtent>
-    ALPAKA_FN_HOST_ACC auto constexpr getExtentVecEnd(TExtent const& extent = TExtent()) -> Vec<TDim, Idx<TExtent>>
+    ALPAKA_FN_HOST_ACC auto constexpr getExtentVecEnd(TExtent const& extent = {}) -> Vec<TDim, Idx<TExtent>>
     {
+        static_assert(TDim::value <= Dim<TExtent>::value, "Cannot get more items than the extent holds");
+
         using IdxOffset = std::integral_constant<
             std::intmax_t,
             static_cast<std::intmax_t>(Dim<TExtent>::value) - static_cast<std::intmax_t>(TDim::value)>;
@@ -569,18 +570,19 @@ namespace alpaka
     //! \return The offset vector.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TOffsets>
-    ALPAKA_FN_HOST_ACC constexpr auto getOffsetVec(TOffsets const& offsets = TOffsets())
-        -> Vec<Dim<TOffsets>, Idx<TOffsets>>
+    ALPAKA_FN_HOST_ACC constexpr auto getOffsetVec(TOffsets const& offsets = {}) -> Vec<Dim<TOffsets>, Idx<TOffsets>>
     {
         return createVecFromIndexedFn<Dim<TOffsets>, detail::CreateOffset>(offsets);
     }
 
     //! \tparam TOffsets has to specialize GetOffset.
-    //! \return The offset vector but only the last N elements.
+    //! \return The offset vector but only the last TDim elements.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TOffsets>
-    ALPAKA_FN_HOST_ACC constexpr auto getOffsetVecEnd(TOffsets const& offsets = TOffsets()) -> Vec<TDim, Idx<TOffsets>>
+    ALPAKA_FN_HOST_ACC constexpr auto getOffsetVecEnd(TOffsets const& offsets = {}) -> Vec<TDim, Idx<TOffsets>>
     {
+        static_assert(TDim::value <= Dim<TOffsets>::value, "Cannot get more items than the offsets hold");
+
         using IdxOffset = std::integral_constant<
             std::size_t,
             static_cast<std::size_t>(

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -62,6 +62,7 @@ namespace alpaka
         using IdxSequence = std::make_integer_sequence<typename TDim::value_type, TDim::value>;
         return createVecFromIndexedFnArbitrary<TDim, TTFnObj>(IdxSequence(), std::forward<TArgs>(args)...);
     }
+
     //! Creator using func<idx>(args...) to initialize all values of the vector.
     //! The idx is in the range [TIdxOffset, TIdxOffset + TDim].
     ALPAKA_NO_HOST_ACC_WARNING
@@ -89,13 +90,9 @@ namespace alpaka
         using IdxSequence = std::make_integer_sequence<std::size_t, TDim::value>;
 
     public:
-        // The default constructor is only available when the vector is zero-dimensional.
-        ALPAKA_NO_HOST_ACC_WARNING
-        template<bool B = (TDim::value == 0u), typename = std::enable_if_t<B>>
-        ALPAKA_FN_HOST_ACC Vec() : m_data{static_cast<TVal>(0u)}
+        ALPAKA_FN_HOST_ACC constexpr Vec() : m_data{}
         {
         }
-
 
         //! Value constructor.
         //! This constructor is only available if the number of parameters matches the vector idx.
@@ -106,51 +103,63 @@ namespace alpaka
             typename = std::enable_if_t<
                 // There have to be dim arguments.
                 (sizeof...(TArgs) + 1 == TDim::value) && (std::is_same_v<TVal, std::decay_t<TArg0>>)>>
-        ALPAKA_FN_HOST_ACC Vec(TArg0&& arg0, TArgs&&... args)
+        ALPAKA_FN_HOST_ACC constexpr Vec(TArg0&& arg0, TArgs&&... args)
             : m_data{std::forward<TArg0>(arg0), std::forward<TArgs>(args)...}
         {
         }
 
-    private:
-        //! A function object that returns the given value for each index.
-        template<std::size_t Tidx>
-        struct CreateSingleVal
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto create(TVal const& val) -> TVal
-            {
-                return val;
-            }
-        };
-
-    public:
         //! \brief Single value constructor.
         //!
         //! Creates a vector with all values set to val.
         //! \param val The initial value.
         ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC static auto all(TVal const& val) -> Vec<TDim, TVal>
+        ALPAKA_FN_HOST_ACC static constexpr auto all(TVal const& val) -> Vec<TDim, TVal>
         {
-            return createVecFromIndexedFn<TDim, CreateSingleVal>(val);
+            Vec<TDim, TVal> v;
+            for(auto& e : v)
+                e = val;
+            return v;
         }
+
         //! Zero value constructor.
         ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC static auto zeros() -> Vec<TDim, TVal>
+        ALPAKA_FN_HOST_ACC static constexpr auto zeros() -> Vec<TDim, TVal>
         {
             return all(static_cast<TVal>(0));
         }
+
         //! One value constructor.
         ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC static auto ones() -> Vec<TDim, TVal>
+        ALPAKA_FN_HOST_ACC static constexpr auto ones() -> Vec<TDim, TVal>
         {
             return all(static_cast<TVal>(1));
+        }
+
+        ALPAKA_FN_HOST_ACC constexpr auto begin() -> TVal*
+        {
+            return m_data;
+        }
+
+        ALPAKA_FN_HOST_ACC constexpr auto begin() const -> const TVal*
+        {
+            return m_data;
+        }
+
+        ALPAKA_FN_HOST_ACC constexpr auto end() -> TVal*
+        {
+            return m_data + TDim::value;
+        }
+
+        ALPAKA_FN_HOST_ACC constexpr auto end() const -> const TVal*
+        {
+            return m_data + TDim::value;
         }
 
         //! Value reference accessor at the given non-unsigned integer index.
         //! \return A reference to the value at the given index.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TIdx, typename = std::enable_if_t<std::is_integral_v<TIdx>>>
-        ALPAKA_FN_HOST_ACC auto operator[](TIdx const iIdx) -> TVal&
+        ALPAKA_FN_HOST_ACC constexpr auto operator[](TIdx const iIdx) -> TVal&
         {
             core::assertValueUnsigned(iIdx);
             auto const idx = static_cast<typename TDim::value_type>(iIdx);
@@ -162,7 +171,7 @@ namespace alpaka
         //! \return The value at the given index.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TIdx, typename = std::enable_if_t<std::is_integral_v<TIdx>>>
-        ALPAKA_FN_HOST_ACC auto operator[](TIdx const iIdx) const -> TVal
+        ALPAKA_FN_HOST_ACC constexpr auto operator[](TIdx const iIdx) const -> TVal
         {
             core::assertValueUnsigned(iIdx);
             auto const idx = static_cast<typename TDim::value_type>(iIdx);
@@ -171,60 +180,38 @@ namespace alpaka
         }
 
         ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC auto operator==(Vec const& rhs) const -> bool
-        {
-            if constexpr(TDim::value == 0)
-            {
-                // all zero-dimensional vectors are equivalent
-                return true;
-            }
-            else
-            {
-                for(typename TDim::value_type i(0); i < TDim::value; ++i)
-                {
-                    if((*this)[i] != rhs[i])
-                    {
-                        return false;
-                    }
-                }
-                return true;
-            }
-            ALPAKA_UNREACHABLE(bool{});
-        }
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC auto operator!=(Vec const& rhs) const -> bool
-        {
-            return !((*this) == rhs);
-        }
-        ALPAKA_NO_HOST_ACC_WARNING
         template<typename TFnObj, std::size_t... TIndices>
-        [[nodiscard]] ALPAKA_FN_HOST_ACC auto foldrByIndices(
+        [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto foldrByIndices(
             TFnObj const& f,
             std::integer_sequence<std::size_t, TIndices...> const& /* indices */) const
         {
             return meta::foldr(f, ((*this)[TIndices])...);
         }
+
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TFnObj, std::size_t... TIndices>
-        [[nodiscard]] ALPAKA_FN_HOST_ACC auto foldrByIndices(
+        [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto foldrByIndices(
             TFnObj const& f,
             std::integer_sequence<std::size_t, TIndices...> const& /* indices */,
             TVal initial) const
         {
             return meta::foldr(f, ((*this)[TIndices])..., initial);
         }
+
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TFnObj>
-        [[nodiscard]] ALPAKA_FN_HOST_ACC auto foldrAll(TFnObj const& f) const
+        [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto foldrAll(TFnObj const& f) const
         {
             return foldrByIndices(f, IdxSequence());
         }
+
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TFnObj>
-        [[nodiscard]] ALPAKA_FN_HOST_ACC auto foldrAll(TFnObj const& f, TVal initial) const
+        [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto foldrAll(TFnObj const& f, TVal initial) const
         {
             return foldrByIndices(f, IdxSequence(), initial);
         }
+
 // suppress strange warning produced by nvcc+MSVC in release mode
 #if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
 #    pragma warning(push)
@@ -232,7 +219,7 @@ namespace alpaka
 #endif
         //! \return The product of all values.
         ALPAKA_NO_HOST_ACC_WARNING
-        [[nodiscard]] ALPAKA_FN_HOST_ACC auto prod() const -> TVal
+        [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto prod() const -> TVal
         {
             return foldrAll(std::multiplies<TVal>(), TVal(1));
         }
@@ -241,192 +228,174 @@ namespace alpaka
 #endif
         //! \return The sum of all values.
         ALPAKA_NO_HOST_ACC_WARNING
-        [[nodiscard]] ALPAKA_FN_HOST_ACC auto sum() const -> TVal
+        [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto sum() const -> TVal
         {
             return foldrAll(std::plus<TVal>(), TVal(0));
         }
+
         //! \return The min of all values.
         ALPAKA_NO_HOST_ACC_WARNING
-        [[nodiscard]] ALPAKA_FN_HOST_ACC auto min() const -> TVal
+        [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto min() const -> TVal
         {
             return foldrAll(meta::min<TVal>());
         }
+
         //! \return The max of all values.
         ALPAKA_NO_HOST_ACC_WARNING
-        [[nodiscard]] ALPAKA_FN_HOST_ACC auto max() const -> TVal
+        [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto max() const -> TVal
         {
             return foldrAll(meta::max<TVal>());
         }
+
         //! \return The index of the minimal element.
-        [[nodiscard]] ALPAKA_FN_HOST auto minElem() const -> typename TDim::value_type
+        [[nodiscard]] ALPAKA_FN_HOST constexpr auto minElem() const -> typename TDim::value_type
         {
             return static_cast<typename TDim::value_type>(
                 std::distance(std::begin(m_data), std::min_element(std::begin(m_data), std::end(m_data))));
         }
+
         //! \return The index of the maximal element.
-        [[nodiscard]] ALPAKA_FN_HOST auto maxElem() const -> typename TDim::value_type
+        [[nodiscard]] ALPAKA_FN_HOST constexpr auto maxElem() const -> typename TDim::value_type
         {
             return static_cast<typename TDim::value_type>(
                 std::distance(std::begin(m_data), std::max_element(std::begin(m_data), std::end(m_data))));
         }
 
         template<size_t I>
-        ALPAKA_FN_HOST_ACC auto get() -> TVal&
+        ALPAKA_FN_HOST_ACC constexpr auto get() -> TVal&
         {
             return (*this)[I];
         }
 
         template<size_t I>
-        [[nodiscard]] ALPAKA_FN_HOST_ACC auto get() const -> TVal
+        [[nodiscard]] ALPAKA_FN_HOST_ACC constexpr auto get() const -> TVal
         {
             return (*this)[I];
+        }
+
+        //! \return The element-wise sum of two vectors.
+        ALPAKA_NO_HOST_ACC_WARNING
+        ALPAKA_FN_HOST_ACC friend constexpr auto operator+(Vec const& p, Vec const& q) -> Vec
+        {
+            Vec r;
+            for(typename TDim::value_type i = 0; i < TDim::value; ++i)
+                r[i] = p[i] + q[i];
+            return r;
+        }
+
+        //! \return The element-wise difference of two vectors.
+        ALPAKA_NO_HOST_ACC_WARNING
+        ALPAKA_FN_HOST_ACC friend constexpr auto operator-(Vec const& p, Vec const& q) -> Vec
+        {
+            Vec r;
+            for(typename TDim::value_type i = 0; i < TDim::value; ++i)
+                r[i] = p[i] - q[i];
+            return r;
+        }
+
+        //! \return The element-wise product of two vectors.
+        ALPAKA_NO_HOST_ACC_WARNING
+        ALPAKA_FN_HOST_ACC friend constexpr auto operator*(Vec const& p, Vec const& q) -> Vec
+        {
+            Vec r;
+            for(typename TDim::value_type i = 0; i < TDim::value; ++i)
+                r[i] = p[i] * q[i];
+            return r;
+        }
+
+        ALPAKA_NO_HOST_ACC_WARNING
+        ALPAKA_FN_HOST_ACC friend constexpr auto operator==(Vec const& a, Vec const& b) -> bool
+        {
+#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
+            if(TDim::value == 0)
+#else
+            if constexpr(TDim::value == 0)
+#endif
+                return true; // all zero-dimensional vectors are equivalent
+            else
+            {
+                for(typename TDim::value_type i(0); i < TDim::value; ++i)
+                    if(a[i] != b[i])
+                        return false;
+                return true;
+            }
+        }
+
+        ALPAKA_NO_HOST_ACC_WARNING
+        ALPAKA_FN_HOST_ACC friend constexpr auto operator!=(Vec const& a, Vec const& b) -> bool
+        {
+            return !(a == b);
+        }
+
+        //! \return The element-wise less than relation of two vectors.
+        ALPAKA_NO_HOST_ACC_WARNING
+        ALPAKA_FN_HOST_ACC friend constexpr auto operator<(Vec const& p, Vec const& q) -> Vec<TDim, bool>
+        {
+            Vec<TDim, bool> r;
+            for(typename TDim::value_type i = 0; i < TDim::value; ++i)
+                r[i] = p[i] < q[i];
+            return r;
+        }
+
+        //! \return The element-wise less than relation of two vectors.
+        ALPAKA_NO_HOST_ACC_WARNING
+        ALPAKA_FN_HOST_ACC friend constexpr auto operator<=(Vec const& p, Vec const& q) -> Vec<TDim, bool>
+        {
+            Vec<TDim, bool> r;
+            for(typename TDim::value_type i = 0; i < TDim::value; ++i)
+                r[i] = p[i] <= q[i];
+            return r;
+        }
+
+        //! \return The element-wise greater than relation of two vectors.
+        ALPAKA_NO_HOST_ACC_WARNING
+        ALPAKA_FN_HOST_ACC friend constexpr auto operator>(Vec const& p, Vec const& q) -> Vec<TDim, bool>
+        {
+            Vec<TDim, bool> r;
+            for(typename TDim::value_type i = 0; i < TDim::value; ++i)
+                r[i] = p[i] > q[i];
+            return r;
+        }
+
+        //! \return The element-wise greater equal than relation of two vectors.
+        ALPAKA_NO_HOST_ACC_WARNING
+        ALPAKA_FN_HOST_ACC friend constexpr auto operator>=(Vec const& p, Vec const& q) -> Vec<TDim, bool>
+        {
+            Vec<TDim, bool> r;
+            for(typename TDim::value_type i = 0; i < TDim::value; ++i)
+                r[i] = p[i] >= q[i];
+            return r;
+        }
+
+        ALPAKA_FN_HOST friend constexpr auto operator<<(std::ostream& os, Vec const& v) -> std::ostream&
+        {
+            os << "(";
+#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
+            if(TDim::value > 0)
+#else
+            if constexpr(TDim::value > 0)
+#endif
+            {
+                for(typename TDim::value_type i = 0; i < TDim::value; ++i)
+                {
+                    os << v[i];
+                    if(i != TDim::value - 1)
+                    {
+                        os << ", ";
+                    }
+                }
+            }
+            else
+                os << ".";
+            os << ")";
+
+            return os;
         }
 
     private:
         // Zero sized arrays are not allowed, therefore zero-dimensional vectors have one member.
         TVal m_data[TDim::value == 0u ? 1u : TDim::value];
     };
-
-    namespace detail
-    {
-        //! This is used to create a Vec by applying a binary operation onto the corresponding elements of two input
-        //! vectors.
-        template<template<typename> class TFnObj, std::size_t Tidx>
-        struct CreateVecByApplyingBinaryFnToTwoIndexedVecs
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<typename TDim, typename TVal>
-            ALPAKA_FN_HOST_ACC static auto create(Vec<TDim, TVal> const& p, Vec<TDim, TVal> const& q)
-            {
-                return TFnObj<TVal>()(p[Tidx], q[Tidx]);
-            }
-        };
-    } // namespace detail
-
-    namespace detail
-    {
-        template<std::size_t Tidx>
-        using CreateVecFromTwoIndexedVecsPlus = CreateVecByApplyingBinaryFnToTwoIndexedVecs<std::plus, Tidx>;
-    }
-
-    //! \return The element-wise sum of two vectors.
-    ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TDim, typename TVal>
-    ALPAKA_FN_HOST_ACC auto operator+(Vec<TDim, TVal> const& p, Vec<TDim, TVal> const& q) -> Vec<TDim, TVal>
-    {
-        return createVecFromIndexedFn<TDim, detail::CreateVecFromTwoIndexedVecsPlus>(p, q);
-    }
-
-    namespace detail
-    {
-        template<std::size_t Tidx>
-        using CreateVecFromTwoIndexedVecsMinus = CreateVecByApplyingBinaryFnToTwoIndexedVecs<std::minus, Tidx>;
-    }
-
-    //! \return The element-wise difference of two vectors.
-    ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TDim, typename TVal>
-    ALPAKA_FN_HOST_ACC auto operator-(Vec<TDim, TVal> const& p, Vec<TDim, TVal> const& q) -> Vec<TDim, TVal>
-    {
-        return createVecFromIndexedFn<TDim, detail::CreateVecFromTwoIndexedVecsMinus>(p, q);
-    }
-
-    namespace detail
-    {
-        template<std::size_t Tidx>
-        using CreateVecFromTwoIndexedVecsMul = CreateVecByApplyingBinaryFnToTwoIndexedVecs<std::multiplies, Tidx>;
-    }
-
-    //! \return The element-wise product of two vectors.
-    ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TDim, typename TVal>
-    ALPAKA_FN_HOST_ACC auto operator*(Vec<TDim, TVal> const& p, Vec<TDim, TVal> const& q) -> Vec<TDim, TVal>
-    {
-        return createVecFromIndexedFn<TDim, detail::CreateVecFromTwoIndexedVecsMul>(p, q);
-    }
-
-    namespace detail
-    {
-        template<std::size_t Tidx>
-        using CreateVecFromTwoIndexedVecsLess = CreateVecByApplyingBinaryFnToTwoIndexedVecs<std::less, Tidx>;
-    }
-
-    //! \return The element-wise less than relation of two vectors.
-    ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TDim, typename TVal>
-    ALPAKA_FN_HOST_ACC auto operator<(Vec<TDim, TVal> const& p, Vec<TDim, TVal> const& q) -> Vec<TDim, bool>
-    {
-        return createVecFromIndexedFn<TDim, detail::CreateVecFromTwoIndexedVecsLess>(p, q);
-    }
-
-    namespace detail
-    {
-        template<std::size_t Tidx>
-        using CreateVecFromTwoIndexedVecsLessEqual
-            = CreateVecByApplyingBinaryFnToTwoIndexedVecs<std::less_equal, Tidx>;
-    }
-
-    //! \return The element-wise less than or equal relation of two vectors.
-    ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TDim, typename TVal>
-    ALPAKA_FN_HOST_ACC auto operator<=(Vec<TDim, TVal> const& p, Vec<TDim, TVal> const& q) -> Vec<TDim, bool>
-    {
-        return createVecFromIndexedFn<TDim, detail::CreateVecFromTwoIndexedVecsLessEqual>(p, q);
-    }
-
-    namespace detail
-    {
-        template<std::size_t Tidx>
-        using CreateVecFromTwoIndexedVecsGreaterEqual
-            = CreateVecByApplyingBinaryFnToTwoIndexedVecs<std::greater_equal, Tidx>;
-    }
-
-    //! \return The element-wise greater than or equal relation of two vectors.
-    ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TDim, typename TVal>
-    ALPAKA_FN_HOST_ACC auto operator>=(Vec<TDim, TVal> const& p, Vec<TDim, TVal> const& q) -> Vec<TDim, bool>
-    {
-        return createVecFromIndexedFn<TDim, detail::CreateVecFromTwoIndexedVecsGreaterEqual>(p, q);
-    }
-
-    namespace detail
-    {
-        template<std::size_t Tidx>
-        using CreateVecFromTwoIndexedVecsGreater = CreateVecByApplyingBinaryFnToTwoIndexedVecs<std::greater, Tidx>;
-    }
-
-    //! \return The element-wise greater than relation of two vectors.
-    ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TDim, typename TVal>
-    ALPAKA_FN_HOST_ACC auto operator>(Vec<TDim, TVal> const& p, Vec<TDim, TVal> const& q) -> Vec<TDim, bool>
-    {
-        return createVecFromIndexedFn<TDim, detail::CreateVecFromTwoIndexedVecsGreater>(p, q);
-    }
-
-    //! Stream out operator.
-    template<typename TDim, typename TVal>
-    ALPAKA_FN_HOST auto operator<<(std::ostream& os, Vec<TDim, TVal> const& v) -> std::ostream&
-    {
-        os << "(";
-        if constexpr(TDim::value > typename TDim::value_type(0))
-        {
-            for(typename TDim::value_type i(0); i < TDim::value; ++i)
-            {
-                os << v[i];
-                if(i != TDim::value - 1)
-                {
-                    os << ", ";
-                }
-            }
-        }
-        else
-        {
-            os << ".";
-        }
-        os << ")";
-
-        return os;
-    }
 
     namespace traits
     {
@@ -446,87 +415,48 @@ namespace alpaka
 
         //! Specialization for selecting a sub-vector.
         template<typename TDim, typename TVal, std::size_t... TIndices>
-        struct SubVecFromIndices<Vec<TDim, TVal>, std::integer_sequence<std::size_t, TIndices...>>
+        struct SubVecFromIndices<Vec<TDim, TVal>, std::index_sequence<TIndices...>>
         {
-            ALPAKA_NO_HOST_ACC_WARNING ALPAKA_FN_HOST_ACC static auto subVecFromIndices(
-                [[maybe_unused]] Vec<TDim, TVal> const& vec)
+            ALPAKA_NO_HOST_ACC_WARNING ALPAKA_FN_HOST_ACC static constexpr auto subVecFromIndices(
+                Vec<TDim, TVal> const& vec) -> Vec<DimInt<sizeof...(TIndices)>, TVal>
             {
-                static_assert(
-                    sizeof...(TIndices) <= TDim::value,
-                    "The sub-vector's dimensionality must be smaller than or equal to the original dimensionality.");
-
-                if constexpr(!std::is_same_v<
-                                 std::integer_sequence<std::size_t, TIndices...>,
-                                 std::make_integer_sequence<std::size_t, TDim::value>>)
-                    return Vec<DimInt<sizeof...(TIndices)>, TVal>(vec[TIndices]...); // Return sub-vector.
-                else
+                if constexpr(std::is_same_v<std::index_sequence<TIndices...>, std::make_index_sequence<TDim::value>>)
+                {
                     return vec; // Return whole vector.
+                }
+                else
+                {
+                    static_assert(
+                        sizeof...(TIndices) <= TDim::value,
+                        "The sub-vector's dimensionality must be smaller than or equal to the original "
+                        "dimensionality.");
+                    return {vec[TIndices]...}; // Return sub-vector.
+                }
+                ALPAKA_UNREACHABLE({});
+            }
+        };
 
-                using Ret [[maybe_unused]] = std::conditional_t<
-                    !std::is_same_v<
-                        std::integer_sequence<std::size_t, TIndices...>,
-                        std::make_integer_sequence<std::size_t, TDim::value>>,
-                    Vec<DimInt<sizeof...(TIndices)>, TVal>,
-                    Vec<TDim, TVal>>;
-                ALPAKA_UNREACHABLE(Ret{vec[TIndices]...});
+        template<typename TValNew, typename TDim, typename TVal>
+        struct CastVec<TValNew, Vec<TDim, TVal>>
+        {
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_HOST_ACC static constexpr auto castVec(Vec<TDim, TVal> const& vec) -> Vec<TDim, TValNew>
+            {
+                if constexpr(std::is_same_v<TValNew, TVal>)
+                {
+                    return vec;
+                }
+                else
+                {
+                    Vec<TDim, TValNew> r;
+                    for(typename TDim::value_type i = 0; i < TDim::value; ++i)
+                        r[i] = static_cast<TValNew>(vec[i]);
+                    return r;
+                }
+                ALPAKA_UNREACHABLE({});
             }
         };
     } // namespace traits
-
-    namespace detail
-    {
-        //! A function object that returns the given value for each index.
-        template<std::size_t Tidx>
-        struct CreateCast
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<typename TSizeNew, typename TDim, typename TVal>
-            ALPAKA_FN_HOST_ACC static auto create(TSizeNew const& /* valNew*/, Vec<TDim, TVal> const& vec) -> TSizeNew
-            {
-                return static_cast<TSizeNew>(vec[Tidx]);
-            }
-        };
-    } // namespace detail
-
-    namespace traits
-    {
-        //! CastVec specialization for Vec.
-        template<typename TSizeNew, typename TDim, typename TVal>
-        struct CastVec<TSizeNew, Vec<TDim, TVal>>
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto castVec(Vec<TDim, TVal> const& vec) -> Vec<TDim, TSizeNew>
-            {
-                return createVecFromIndexedFn<TDim, alpaka::detail::CreateCast>(TSizeNew(), vec);
-            }
-        };
-
-        //! (Non-)CastVec specialization for Vec when src and dst types are identical.
-        template<typename TDim, typename TVal>
-        struct CastVec<TVal, Vec<TDim, TVal>>
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto castVec(Vec<TDim, TVal> const& vec) -> Vec<TDim, TVal>
-            {
-                return vec;
-            }
-        };
-    } // namespace traits
-
-    namespace detail
-    {
-        //! A function object that returns the value at the index from the back of the vector.
-        template<std::size_t Tidx>
-        struct CreateReverse
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<typename TDim, typename TVal>
-            ALPAKA_FN_HOST_ACC static auto create(Vec<TDim, TVal> const& vec) -> TVal
-            {
-                return vec[TDim::value - 1u - Tidx];
-            }
-        };
-    } // namespace detail
 
     namespace traits
     {
@@ -535,52 +465,53 @@ namespace alpaka
         struct ReverseVec<Vec<TDim, TVal>>
         {
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto reverseVec(Vec<TDim, TVal> const& vec) -> Vec<TDim, TVal>
+            ALPAKA_FN_HOST_ACC static constexpr auto reverseVec(Vec<TDim, TVal> const& vec) -> Vec<TDim, TVal>
             {
-                return createVecFromIndexedFn<TDim, alpaka::detail::CreateReverse>(vec);
+                if constexpr(TDim::value <= 1)
+                {
+                    return vec;
+                }
+                else
+                {
+                    Vec<TDim, TVal> r;
+                    for(typename TDim::value_type i = 0; i < TDim::value; ++i)
+                        r[i] = vec[TDim::value - 1u - i];
+                    return r;
+                }
+                ALPAKA_UNREACHABLE({});
             }
         };
 
-        //! (Non-)ReverseVec specialization for 1D Vec.
-        template<typename TVal>
-        struct ReverseVec<Vec<DimInt<1u>, TVal>>
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto reverseVec(Vec<DimInt<1u>, TVal> const& vec) -> Vec<DimInt<1u>, TVal>
-            {
-                return vec;
-            }
-        };
-    } // namespace traits
-
-    namespace detail
-    {
-        //! A function object that returns the value at the index from the back of the vector.
-        template<std::size_t Tidx>
-        struct CreateConcat
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            template<typename TDimL, typename TDimR, typename TVal>
-            ALPAKA_FN_HOST_ACC static auto create(Vec<TDimL, TVal> const& vecL, Vec<TDimR, TVal> const& vecR) -> TVal
-            {
-                return Tidx < TDimL::value ? vecL[Tidx] : vecR[Tidx - TDimL::value];
-            }
-        };
-    } // namespace detail
-
-    namespace traits
-    {
         //! Concatenation specialization for Vec.
         template<typename TDimL, typename TDimR, typename TVal>
         struct ConcatVec<Vec<TDimL, TVal>, Vec<TDimR, TVal>>
         {
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto concatVec(Vec<TDimL, TVal> const& vecL, Vec<TDimR, TVal> const& vecR)
-                -> Vec<DimInt<TDimL::value + TDimR::value>, TVal>
+            ALPAKA_FN_HOST_ACC static constexpr auto concatVec(
+                Vec<TDimL, TVal> const& vecL,
+                Vec<TDimR, TVal> const& vecR) -> Vec<DimInt<TDimL::value + TDimR::value>, TVal>
             {
-                return createVecFromIndexedFn<DimInt<TDimL::value + TDimR::value>, alpaka::detail::CreateConcat>(
-                    vecL,
-                    vecR);
+                Vec<DimInt<TDimL::value + TDimR::value>, TVal> r;
+#if BOOST_COMP_NVCC
+#    ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#        pragma nv_diagnostic push
+#        pragma nv_diag_suppress = unsigned_compare_with_zero
+#    else
+#        pragma diag_suppress = unsigned_compare_with_zero
+#    endif
+#endif
+                for(typename TDimL::value_type i = 0; i < TDimL::value; ++i)
+                    r[i] = vecL[i];
+                for(typename TDimR::value_type i = 0; i < TDimR::value; ++i)
+                    r[TDimL::value + i] = vecR[i];
+#if BOOST_COMP_NVCC
+#    ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#        pragma nv_diagnostic pop
+#    else
+#        pragma diag_default = unsigned_compare_with_zero
+#    endif
+#endif
+                return r;
             }
         };
     } // namespace traits
@@ -593,7 +524,7 @@ namespace alpaka
         {
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename TExtent>
-            ALPAKA_FN_HOST_ACC static auto create(TExtent const& extent) -> Idx<TExtent>
+            ALPAKA_FN_HOST_ACC static constexpr auto create(TExtent const& extent) -> Idx<TExtent>
             {
                 return getExtent<Tidx>(extent);
             }
@@ -604,7 +535,8 @@ namespace alpaka
     //! \return The extent vector.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TExtent>
-    ALPAKA_FN_HOST_ACC auto getExtentVec(TExtent const& extent = TExtent()) -> Vec<Dim<TExtent>, Idx<TExtent>>
+    ALPAKA_FN_HOST_ACC auto constexpr getExtentVec(TExtent const& extent = TExtent())
+        -> Vec<Dim<TExtent>, Idx<TExtent>>
     {
         return createVecFromIndexedFn<Dim<TExtent>, detail::CreateExtent>(extent);
     }
@@ -613,7 +545,7 @@ namespace alpaka
     //! \return The extent but only the last N elements.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TExtent>
-    ALPAKA_FN_HOST_ACC auto getExtentVecEnd(TExtent const& extent = TExtent()) -> Vec<TDim, Idx<TExtent>>
+    ALPAKA_FN_HOST_ACC auto constexpr getExtentVecEnd(TExtent const& extent = TExtent()) -> Vec<TDim, Idx<TExtent>>
     {
         using IdxOffset = std::integral_constant<
             std::intmax_t,
@@ -629,7 +561,7 @@ namespace alpaka
         {
             ALPAKA_NO_HOST_ACC_WARNING
             template<typename TOffsets>
-            ALPAKA_FN_HOST_ACC static auto create(TOffsets const& offsets) -> Idx<TOffsets>
+            ALPAKA_FN_HOST_ACC static constexpr auto create(TOffsets const& offsets) -> Idx<TOffsets>
             {
                 return getOffset<Tidx>(offsets);
             }
@@ -640,7 +572,8 @@ namespace alpaka
     //! \return The offset vector.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TOffsets>
-    ALPAKA_FN_HOST_ACC auto getOffsetVec(TOffsets const& offsets = TOffsets()) -> Vec<Dim<TOffsets>, Idx<TOffsets>>
+    ALPAKA_FN_HOST_ACC constexpr auto getOffsetVec(TOffsets const& offsets = TOffsets())
+        -> Vec<Dim<TOffsets>, Idx<TOffsets>>
     {
         return createVecFromIndexedFn<Dim<TOffsets>, detail::CreateOffset>(offsets);
     }
@@ -649,7 +582,7 @@ namespace alpaka
     //! \return The offset vector but only the last N elements.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TOffsets>
-    ALPAKA_FN_HOST_ACC auto getOffsetVecEnd(TOffsets const& offsets = TOffsets()) -> Vec<TDim, Idx<TOffsets>>
+    ALPAKA_FN_HOST_ACC constexpr auto getOffsetVecEnd(TOffsets const& offsets = TOffsets()) -> Vec<TDim, Idx<TOffsets>>
     {
         using IdxOffset = std::integral_constant<
             std::size_t,
@@ -668,7 +601,7 @@ namespace alpaka
             std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
         {
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto getExtent(Vec<TDim, TVal> const& extent) -> TVal
+            ALPAKA_FN_HOST_ACC static constexpr auto getExtent(Vec<TDim, TVal> const& extent) -> TVal
             {
                 return extent[TIdxIntegralConst::value];
             }
@@ -682,7 +615,8 @@ namespace alpaka
             std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
         {
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto setExtent(Vec<TDim, TVal>& extent, TExtentVal const& extentVal) -> void
+            ALPAKA_FN_HOST_ACC static constexpr auto setExtent(Vec<TDim, TVal>& extent, TExtentVal const& extentVal)
+                -> void
             {
                 extent[TIdxIntegralConst::value] = extentVal;
             }
@@ -696,7 +630,7 @@ namespace alpaka
             std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
         {
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto getOffset(Vec<TDim, TVal> const& offsets) -> TVal
+            ALPAKA_FN_HOST_ACC static constexpr auto getOffset(Vec<TDim, TVal> const& offsets) -> TVal
             {
                 return offsets[TIdxIntegralConst::value];
             }
@@ -710,7 +644,7 @@ namespace alpaka
             std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
         {
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto setOffset(Vec<TDim, TVal>& offsets, TOffset const& offset) -> void
+            ALPAKA_FN_HOST_ACC static constexpr auto setOffset(Vec<TDim, TVal>& offsets, TOffset const& offset) -> void
             {
                 offsets[TIdxIntegralConst::value] = offset;
             }

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -40,8 +40,27 @@ TEST_CASE("basicVecTraits", "[vec]")
     using Idx = std::size_t;
     using Vec = alpaka::Vec<Dim, Idx>;
 
+    // constructor from Idx
     static constexpr Vec vec(static_cast<Idx>(0u), static_cast<Idx>(8u), static_cast<Idx>(15u));
 
+    // constructor from convertible integral
+    {
+        [[maybe_unused]] constexpr Vec v(0, 0, 0);
+    }
+
+    // constructor from convertible type
+    {
+        constexpr struct S
+        {
+            constexpr operator Idx() const
+            {
+                return 5;
+            }
+        } s;
+        STATIC_REQUIRE(std::is_convertible_v<S, Idx>);
+
+        [[maybe_unused]] constexpr Vec v(s, s, s);
+    }
 
     // alpaka::Vec<0> default ctor
     {

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -13,7 +13,26 @@
 
 #include <catch2/catch.hpp>
 
+#include <numeric>
 #include <utility>
+
+namespace
+{
+    namespace detail
+    {
+        template<typename F, std::size_t... Is>
+        constexpr void foreachImpl(F&& f, std::index_sequence<Is...>)
+        {
+            (std::forward<F>(f)(std::integral_constant<std::size_t, Is>{}), ...);
+        }
+    } // namespace detail
+
+    template<std::size_t I, typename F>
+    constexpr void foreach(F&& f)
+    {
+        detail::foreachImpl(std::forward<F>(f), std::make_index_sequence<I>{});
+    }
+} // namespace
 
 TEST_CASE("basicVecTraits", "[vec]")
 {
@@ -21,228 +40,225 @@ TEST_CASE("basicVecTraits", "[vec]")
     using Idx = std::size_t;
     using Vec = alpaka::Vec<Dim, Idx>;
 
-    Vec const vec(static_cast<Idx>(0u), static_cast<Idx>(8u), static_cast<Idx>(15u));
+    static constexpr Vec vec(static_cast<Idx>(0u), static_cast<Idx>(8u), static_cast<Idx>(15u));
 
 
-    // alpaka::Vec zero elements
+    // alpaka::Vec<0> default ctor
     {
         using Dim0 = alpaka::DimInt<0u>;
-        alpaka::Vec<Dim0, Idx> const vec0{};
+        [[maybe_unused]] alpaka::Vec<Dim0, Idx> const v1;
+        [[maybe_unused]] constexpr alpaka::Vec<Dim0, Idx> v2{};
+    }
+
+    // default ctor
+    {
+        [[maybe_unused]] alpaka::Vec<Dim, Idx> const v1;
+        [[maybe_unused]] constexpr alpaka::Vec<Dim, Idx> v2{};
     }
 
     // alpaka::subVecFromIndices
     {
         using IdxSequence = std::integer_sequence<std::size_t, 0u, Dim::value - 1u, 0u>;
-        auto const vecSubIndices(alpaka::subVecFromIndices<IdxSequence>(vec));
+        constexpr auto vecSubIndices(alpaka::subVecFromIndices<IdxSequence>(vec));
 
-        REQUIRE(vecSubIndices[0u] == vec[0u]);
-        REQUIRE(vecSubIndices[1u] == vec[Dim::value - 1u]);
-        REQUIRE(vecSubIndices[2u] == vec[0u]);
+        STATIC_REQUIRE(vecSubIndices[0u] == vec[0u]);
+        STATIC_REQUIRE(vecSubIndices[1u] == vec[Dim::value - 1u]);
+        STATIC_REQUIRE(vecSubIndices[2u] == vec[0u]);
     }
 
     // alpaka::subVecBegin
     {
         using DimSubVecEnd = alpaka::DimInt<2u>;
-        auto const vecSubBegin(alpaka::subVecBegin<DimSubVecEnd>(vec));
+        static constexpr auto vecSubBegin(alpaka::subVecBegin<DimSubVecEnd>(vec));
 
-        for(typename Dim::value_type i(0); i < DimSubVecEnd::value; ++i)
-        {
-            REQUIRE(vecSubBegin[i] == vec[i]);
-        }
+        foreach
+            <DimSubVecEnd::value>(
+                [&](auto ic)
+                {
+                    constexpr auto i = decltype(ic)::value;
+                    STATIC_REQUIRE(vecSubBegin[i] == vec[i]);
+                });
     }
 
     // alpaka::subVecEnd
     {
         using DimSubVecEnd = alpaka::DimInt<2u>;
-        auto const vecSubEnd(alpaka::subVecEnd<DimSubVecEnd>(vec));
+        static constexpr auto vecSubEnd(alpaka::subVecEnd<DimSubVecEnd>(vec));
 
-        for(typename Dim::value_type i(0); i < DimSubVecEnd::value; ++i)
-        {
-            REQUIRE(vecSubEnd[i] == vec[Dim::value - DimSubVecEnd::value + i]);
-        }
+        foreach
+            <DimSubVecEnd::value>(
+                [&](auto ic)
+                {
+                    constexpr auto i = decltype(ic)::value;
+                    STATIC_REQUIRE(vecSubEnd[i] == vec[Dim::value - DimSubVecEnd::value + i]);
+                });
     }
 
     // alpaka::castVec
     {
         using SizeCast = std::uint16_t;
-        auto const vecCast(alpaka::castVec<SizeCast>(vec));
+        static constexpr auto vecCast(alpaka::castVec<SizeCast>(vec));
 
         /*using VecCastConst = decltype(vecCast);
         using VecCast = std::decay_t<VecCastConst>;
-        static_assert(
-            std::is_same<
+        STATIC_REQUIRE(
+            std::is_same_v<
                 alpaka::Idx<VecCast>,
                 SizeCast
-            >::value,
-            "The idx type of the casted vec is wrong");*/
+            >);*/
 
-        for(typename Dim::value_type i(0); i < Dim::value; ++i)
-        {
-            REQUIRE(vecCast[i] == static_cast<SizeCast>(vec[i]));
-        }
+        foreach
+            <Dim::value>(
+                [&](auto ic)
+                {
+                    constexpr auto i = decltype(ic)::value;
+                    STATIC_REQUIRE(vecCast[i] == static_cast<SizeCast>(vec[i]));
+                });
     }
 
     // alpaka::reverseVec
     {
-        auto const vecReverse(alpaka::reverseVec(vec));
+        static constexpr auto vecReverse(alpaka::reverseVec(vec));
 
-        for(typename Dim::value_type i(0); i < Dim::value; ++i)
-        {
-            REQUIRE(vecReverse[i] == vec[Dim::value - 1u - i]);
-        }
+        foreach
+            <Dim::value>(
+                [&](auto ic)
+                {
+                    constexpr auto i = decltype(ic)::value;
+                    STATIC_REQUIRE(vecReverse[i] == vec[Dim::value - 1u - i]);
+                });
     }
 
     // alpaka::concatVec
     {
         using Dim2 = alpaka::DimInt<2u>;
-        alpaka::Vec<Dim2, Idx> const vec2(static_cast<Idx>(47u), static_cast<Idx>(11u));
+        static constexpr alpaka::Vec<Dim2, Idx> vec2(static_cast<Idx>(47u), static_cast<Idx>(11u));
 
-        auto const vecConcat(alpaka::concatVec(vec, vec2));
+        static constexpr auto vecConcat(alpaka::concatVec(vec, vec2));
+        STATIC_REQUIRE(std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecConcat)>>, alpaka::DimInt<5u>>);
 
-        static_assert(
-            std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecConcat)>>, alpaka::DimInt<5u>>,
-            "Result dimension type of concatenation incorrect!");
-
-        for(typename Dim::value_type i(0); i < Dim::value; ++i)
-        {
-            REQUIRE(vecConcat[i] == vec[i]);
-        }
-        for(typename Dim2::value_type i(0); i < Dim2::value; ++i)
-        {
-            REQUIRE(vecConcat[Dim::value + i] == vec2[i]);
-        }
+        foreach
+            <Dim::value>(
+                [&](auto ic)
+                {
+                    constexpr auto i = decltype(ic)::value;
+                    STATIC_REQUIRE(vecConcat[i] == vec[i]);
+                });
+        foreach
+            <Dim2::value>(
+                [&](auto ic)
+                {
+                    constexpr auto i = decltype(ic)::value;
+                    STATIC_REQUIRE(vecConcat[Dim::value + i] == vec2[i]);
+                });
     }
 
     {
-        alpaka::Vec<Dim, Idx> const vec3(static_cast<Idx>(47u), static_cast<Idx>(8u), static_cast<Idx>(3u));
+        constexpr alpaka::Vec<Dim, Idx> vec3(static_cast<Idx>(47u), static_cast<Idx>(8u), static_cast<Idx>(3u));
 
         // alpaka::Vec operator +
         {
-            auto const vecLessEqual(vec + vec3);
+            constexpr auto vecLessEqual(vec + vec3);
+            STATIC_REQUIRE(std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecLessEqual)>>, Dim>);
+            STATIC_REQUIRE(std::is_same_v<alpaka::Idx<std::decay_t<decltype(vecLessEqual)>>, Idx>);
 
-            static_assert(
-                std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecLessEqual)>>, Dim>,
-                "Result dimension type of operator <= incorrect!");
-
-            static_assert(
-                std::is_same_v<alpaka::Idx<std::decay_t<decltype(vecLessEqual)>>, Idx>,
-                "Result idx type of operator <= incorrect!");
-
-            alpaka::Vec<Dim, Idx> const referenceVec(
+            constexpr alpaka::Vec<Dim, Idx> referenceVec(
                 static_cast<Idx>(47u),
                 static_cast<Idx>(16u),
                 static_cast<Idx>(18u));
-
-            REQUIRE(referenceVec == vecLessEqual);
+            STATIC_REQUIRE(referenceVec == vecLessEqual);
         }
 
         // alpaka::Vec operator -
         {
-            auto const vecLessEqual(vec - vec3);
+            constexpr auto vecLessEqual(vec - vec3);
+            STATIC_REQUIRE(std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecLessEqual)>>, Dim>);
+            STATIC_REQUIRE(std::is_same_v<alpaka::Idx<std::decay_t<decltype(vecLessEqual)>>, Idx>);
 
-            static_assert(
-                std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecLessEqual)>>, Dim>,
-                "Result dimension type of operator <= incorrect!");
-
-            static_assert(
-                std::is_same_v<alpaka::Idx<std::decay_t<decltype(vecLessEqual)>>, Idx>,
-                "Result idx type of operator <= incorrect!");
-
-            alpaka::Vec<Dim, Idx> const referenceVec(
+            constexpr alpaka::Vec<Dim, Idx> referenceVec(
                 static_cast<Idx>(-47),
                 static_cast<Idx>(0u),
                 static_cast<Idx>(12u));
-
-            REQUIRE(referenceVec == vecLessEqual);
+            STATIC_REQUIRE(referenceVec == vecLessEqual);
         }
 
         // alpaka::Vec operator *
         {
-            auto const vecLessEqual(vec * vec3);
+            constexpr auto vecLessEqual(vec * vec3);
+            STATIC_REQUIRE(std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecLessEqual)>>, Dim>);
+            STATIC_REQUIRE(std::is_same_v<alpaka::Idx<std::decay_t<decltype(vecLessEqual)>>, Idx>);
 
-            static_assert(
-                std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecLessEqual)>>, Dim>,
-                "Result dimension type of operator <= incorrect!");
-
-            static_assert(
-                std::is_same_v<alpaka::Idx<std::decay_t<decltype(vecLessEqual)>>, Idx>,
-                "Result idx type of operator <= incorrect!");
-
-            alpaka::Vec<Dim, Idx> const referenceVec(
+            constexpr alpaka::Vec<Dim, Idx> referenceVec(
                 static_cast<Idx>(0u),
                 static_cast<Idx>(64u),
                 static_cast<Idx>(45u));
-
-            REQUIRE(referenceVec == vecLessEqual);
+            STATIC_REQUIRE(referenceVec == vecLessEqual);
         }
 
         // alpaka::Vec operator <
         {
-            auto const vecLessEqual(vec < vec3);
+            constexpr auto vecLessEqual(vec < vec3);
+            STATIC_REQUIRE(std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecLessEqual)>>, Dim>);
+            STATIC_REQUIRE(std::is_same_v<alpaka::Idx<std::decay_t<decltype(vecLessEqual)>>, bool>);
 
-            static_assert(
-                std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecLessEqual)>>, Dim>,
-                "Result dimension type of operator <= incorrect!");
-
-            static_assert(
-                std::is_same_v<alpaka::Idx<std::decay_t<decltype(vecLessEqual)>>, bool>,
-                "Result idx type of operator <= incorrect!");
-
-            alpaka::Vec<Dim, bool> const referenceVec(true, false, false);
-
-            REQUIRE(referenceVec == vecLessEqual);
+            constexpr alpaka::Vec<Dim, bool> referenceVec(true, false, false);
+            STATIC_REQUIRE(referenceVec == vecLessEqual);
         }
 
         // alpaka::Vec operator <=
         {
-            auto const vecLessEqual(vec <= vec3);
+            constexpr auto vecLessEqual(vec <= vec3);
+            STATIC_REQUIRE(std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecLessEqual)>>, Dim>);
+            STATIC_REQUIRE(std::is_same_v<alpaka::Idx<std::decay_t<decltype(vecLessEqual)>>, bool>);
 
-            static_assert(
-                std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecLessEqual)>>, Dim>,
-                "Result dimension type of operator <= incorrect!");
-
-            static_assert(
-                std::is_same_v<alpaka::Idx<std::decay_t<decltype(vecLessEqual)>>, bool>,
-                "Result idx type of operator <= incorrect!");
-
-            alpaka::Vec<Dim, bool> const referenceVec(true, true, false);
-
-            REQUIRE(referenceVec == vecLessEqual);
+            constexpr alpaka::Vec<Dim, bool> referenceVec(true, true, false);
+            STATIC_REQUIRE(referenceVec == vecLessEqual);
         }
 
         // alpaka::Vec operator >=
         {
-            auto const vecLessEqual(vec >= vec3);
+            constexpr auto vecLessEqual(vec >= vec3);
+            STATIC_REQUIRE(std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecLessEqual)>>, Dim>);
+            STATIC_REQUIRE(std::is_same_v<alpaka::Idx<std::decay_t<decltype(vecLessEqual)>>, bool>);
 
-            static_assert(
-                std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecLessEqual)>>, Dim>,
-                "Result dimension type of operator <= incorrect!");
+            constexpr alpaka::Vec<Dim, bool> referenceVec(false, true, true);
 
-            static_assert(
-                std::is_same_v<alpaka::Idx<std::decay_t<decltype(vecLessEqual)>>, bool>,
-                "Result idx type of operator <= incorrect!");
-
-            alpaka::Vec<Dim, bool> const referenceVec(false, true, true);
-
-            REQUIRE(referenceVec == vecLessEqual);
+            STATIC_REQUIRE(referenceVec == vecLessEqual);
         }
 
         // alpaka::Vec operator >
         {
-            auto const vecLessEqual(vec > vec3);
+            constexpr auto vecLessEqual(vec > vec3);
+            STATIC_REQUIRE(std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecLessEqual)>>, Dim>);
+            STATIC_REQUIRE(std::is_same_v<alpaka::Idx<std::decay_t<decltype(vecLessEqual)>>, bool>);
 
-            static_assert(
-                std::is_same_v<alpaka::Dim<std::decay_t<decltype(vecLessEqual)>>, Dim>,
-                "Result dimension type of operator <= incorrect!");
-
-            static_assert(
-                std::is_same_v<alpaka::Idx<std::decay_t<decltype(vecLessEqual)>>, bool>,
-                "Result idx type of operator <= incorrect!");
-
-            alpaka::Vec<Dim, bool> const referenceVec(false, false, true);
-
-            REQUIRE(referenceVec == vecLessEqual);
+            constexpr alpaka::Vec<Dim, bool> referenceVec(false, false, true);
+            STATIC_REQUIRE(referenceVec == vecLessEqual);
         }
+
+        // alpaka::Vec begin/end
+        STATIC_REQUIRE(
+            []
+            {
+                auto v = alpaka::Vec<Dim, int>::ones();
+                for(auto& e : v)
+                {
+                    int i = e; // read
+                    e += i; // write
+                }
+                return v == alpaka::Vec<Dim, int>::all(2);
+            }());
+
+        // const alpaka::Vec begin/end
+        STATIC_REQUIRE(
+            []
+            {
+                const auto v = alpaka::Vec<Dim, int>::ones();
+                int sum = 0;
+                for(const auto& e : v)
+                    sum += e; // read
+                return sum == Dim::value;
+            }());
     }
 }
 


### PR DESCRIPTION
I had to debug around `Vec` and here is a quick simplification.

The big change is that `Vec` is now default constructible, which simplifies other implementations a lot. Furthermore, all functions are now `constexpr`. And I added `begin/end`.

Also fixes #1015 and #1389.