### PR TITLE
Native handles for queues and events (CUDA & SYCL)

### DIFF
--- a/include/alpaka/acc/AccGenericSycl.hpp
+++ b/include/alpaka/acc/AccGenericSycl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Jan Stephan
+/* Copyright 2022 Jan Stephan, Antonio Di Pilato
  *
  * This file is part of Alpaka.
  *
@@ -134,7 +134,7 @@ namespace alpaka::traits
     {
         static auto getAccDevProps(typename DevType<TAcc<TDim, TIdx>>::type const& dev) -> AccDevProps<TDim, TIdx>
         {
-            auto const device = dev.m_impl->get_device();
+            auto const device = dev.getNativeHandle().first;
             auto max_threads_dim = device.template get_info<sycl::info::device::max_work_item_sizes>();
             return {// m_multiProcessorCount
                     alpaka::core::clipCast<TIdx>(device.template get_info<sycl::info::device::max_compute_units>()),

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -122,7 +122,7 @@ namespace alpaka
             m_spDevCpuImpl->registerQueue(spQueue);
         }
 
-        auto getNativeHandle() const noexcept
+        [[nodiscard]] auto getNativeHandle() const noexcept
         {
             return 0;
         }
@@ -188,7 +188,7 @@ namespace alpaka
         template<>
         struct NativeHandle<DevCpu>
         {
-            static auto getNativeHandle(DevCpu const& dev)
+            [[nodiscard]] static auto getNativeHandle(DevCpu const& dev)
             {
                 return dev.getNativeHandle();
             }

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -88,7 +88,7 @@ namespace alpaka
                 m_queues.push_back(std::move(spQueue));
             }
 
-            int getNativeHandle() const noexcept
+            [[nodiscard]] auto getNativeHandle() const noexcept -> int
             {
                 return m_iDevice;
             }
@@ -177,11 +177,13 @@ namespace alpaka
         {
             return getNativeHandle() == rhs.getNativeHandle();
         }
+
         ALPAKA_FN_HOST auto operator!=(DevOacc const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        auto getNativeHandle() const noexcept -> int
+
+        [[nodiscard]] auto getNativeHandle() const noexcept -> int
         {
             return m_devOaccImpl->getNativeHandle();
         }
@@ -278,7 +280,7 @@ namespace alpaka
         template<>
         struct NativeHandle<DevOacc>
         {
-            static auto getNativeHandle(DevOacc const& dev)
+            [[nodiscard]] static auto getNativeHandle(DevOacc const& dev)
             {
                 return dev.getNativeHandle();
             }

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -175,13 +175,13 @@ namespace alpaka
     public:
         ALPAKA_FN_HOST auto operator==(DevOacc const& rhs) const -> bool
         {
-            return m_devOaccImpl->getNativeHandle() == rhs.m_devOaccImpl->getNativeHandle();
+            return getNativeHandle() == rhs.getNativeHandle();
         }
         ALPAKA_FN_HOST auto operator!=(DevOacc const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
-        auto getNativeHandle() const noexcept
+        auto getNativeHandle() const noexcept -> int
         {
             return m_devOaccImpl->getNativeHandle();
         }

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -90,7 +90,7 @@ namespace alpaka
                 m_queues.push_back(spQueue);
             }
 
-            auto getNativeHandle() const noexcept -> int
+            [[nodiscard]] auto getNativeHandle() const noexcept -> int
             {
                 return m_iDevice;
             }
@@ -244,7 +244,7 @@ namespace alpaka
         template<>
         struct NativeHandle<DevOmp5>
         {
-            static auto getNativeHandle(DevOmp5 const& dev)
+            [[nodiscard]] static auto getNativeHandle(DevOmp5 const& dev)
             {
                 return dev.getNativeHandle();
             }

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -147,14 +147,14 @@ namespace alpaka
     public:
         ALPAKA_FN_HOST auto operator==(DevOmp5 const& rhs) const -> bool
         {
-            return m_spDevOmp5Impl->getNativeHandle() == rhs.m_spDevOmp5Impl->getNativeHandle();
+            return getNativeHandle() == rhs.getNativeHandle();
         }
         ALPAKA_FN_HOST auto operator!=(DevOmp5 const& rhs) const -> bool
         {
             return !((*this) == rhs);
         }
 
-        [[nodiscard]] auto getNativeHandle() const noexcept
+        [[nodiscard]] auto getNativeHandle() const noexcept -> int
         {
             return m_spDevOmp5Impl->getNativeHandle();
         }

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -57,7 +57,8 @@ namespace alpaka
         {
             return !((*this) == rhs);
         }
-        auto getNativeHandle() const noexcept
+
+        [[nodiscard]] auto getNativeHandle() const noexcept -> int
         {
             return m_iDevice;
         }
@@ -170,7 +171,7 @@ namespace alpaka
         template<>
         struct NativeHandle<DevUniformCudaHipRt>
         {
-            static auto getNativeHandle(DevUniformCudaHipRt const& dev)
+            [[nodiscard]] static auto getNativeHandle(DevUniformCudaHipRt const& dev)
             {
                 return dev.getNativeHandle();
             }

--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -74,9 +74,15 @@ namespace alpaka
                 // -> No need to synchronize here.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(EventDestroy)(m_UniformCudaHipEvent));
             }
+            auto getNativeHandle() const noexcept
+            {
+                return m_UniformCudaHipEvent;
+            }
 
         public:
             DevUniformCudaHipRt const m_dev; //!< The device this event is bound to.
+
+        private:
             ALPAKA_API_PREFIX(Event_t) m_UniformCudaHipEvent;
         };
     } // namespace uniform_cuda_hip::detail
@@ -99,6 +105,10 @@ namespace alpaka
         ALPAKA_FN_HOST auto operator!=(EventUniformCudaHipRt const& rhs) const -> bool
         {
             return !((*this) == rhs);
+        }
+        auto getNativeHandle() const noexcept
+        {
+            return m_spEventImpl->getNativeHandle();
         }
 
     public:
@@ -133,7 +143,7 @@ namespace alpaka
                 // Query is allowed even for events on non current device.
                 ALPAKA_API_PREFIX(Error_t) ret = ALPAKA_API_PREFIX(Success);
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
-                    ret = ALPAKA_API_PREFIX(EventQuery)(event.m_spEventImpl->m_UniformCudaHipEvent),
+                    ret = ALPAKA_API_PREFIX(EventQuery)(event.getNativeHandle()),
                     ALPAKA_API_PREFIX(ErrorNotReady));
                 return (ret == ALPAKA_API_PREFIX(Success));
             }
@@ -148,8 +158,8 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
-                    EventRecord)(event.m_spEventImpl->m_UniformCudaHipEvent, queue.m_spQueueImpl->getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(EventRecord)(event.getNativeHandle(), queue.getNativeHandle()));
             }
         };
         //! The CUDA/HIP RT queue enqueue trait specialization.
@@ -161,8 +171,8 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
-                    EventRecord)(event.m_spEventImpl->m_UniformCudaHipEvent, queue.m_spQueueImpl->getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(EventRecord)(event.getNativeHandle(), queue.getNativeHandle()));
             }
         };
 
@@ -178,8 +188,7 @@ namespace alpaka
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                 // Sync is allowed even for events on non current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(EventSynchronize)(event.m_spEventImpl->m_UniformCudaHipEvent));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(EventSynchronize)(event.getNativeHandle()));
             }
         };
         //! The CUDA/HIP RT queue event wait trait specialization.
@@ -192,10 +201,8 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamWaitEvent)(
-                    queue.m_spQueueImpl->getNativeHandle(),
-                    event.m_spEventImpl->m_UniformCudaHipEvent,
-                    0));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(StreamWaitEvent)(queue.getNativeHandle(), event.getNativeHandle(), 0));
             }
         };
         //! The CUDA/HIP RT queue event wait trait specialization.
@@ -208,10 +215,8 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamWaitEvent)(
-                    queue.m_spQueueImpl->getNativeHandle(),
-                    event.m_spEventImpl->m_UniformCudaHipEvent,
-                    0));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(StreamWaitEvent)(queue.getNativeHandle(), event.getNativeHandle(), 0));
             }
         };
         //! The CUDA/HIP RT device event wait trait specialization.
@@ -230,9 +235,19 @@ namespace alpaka
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(StreamWaitEvent)(nullptr, event.m_spEventImpl->m_UniformCudaHipEvent, 0));
+                    ALPAKA_API_PREFIX(StreamWaitEvent)(nullptr, event.getNativeHandle(), 0));
             }
         };
+        //! The CUDA/HIP RT event native handle trait specialization.
+        template<>
+        struct NativeHandle<EventUniformCudaHipRt>
+        {
+            static auto getNativeHandle(EventUniformCudaHipRt const& event)
+            {
+                return event.getNativeHandle();
+            }
+        };
+
     } // namespace traits
 } // namespace alpaka
 

--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -77,7 +77,6 @@ namespace alpaka
 
         public:
             DevUniformCudaHipRt const m_dev; //!< The device this event is bound to.
-
             ALPAKA_API_PREFIX(Event_t) m_UniformCudaHipEvent;
         };
     } // namespace uniform_cuda_hip::detail
@@ -149,9 +148,8 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(EventRecord)(
-                    event.m_spEventImpl->m_UniformCudaHipEvent,
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
+                    EventRecord)(event.m_spEventImpl->m_UniformCudaHipEvent, queue.m_spQueueImpl->getNativeHandle()));
             }
         };
         //! The CUDA/HIP RT queue enqueue trait specialization.
@@ -163,9 +161,8 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(EventRecord)(
-                    event.m_spEventImpl->m_UniformCudaHipEvent,
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
+                    EventRecord)(event.m_spEventImpl->m_UniformCudaHipEvent, queue.m_spQueueImpl->getNativeHandle()));
             }
         };
 
@@ -196,7 +193,7 @@ namespace alpaka
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamWaitEvent)(
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue,
+                    queue.m_spQueueImpl->getNativeHandle(),
                     event.m_spEventImpl->m_UniformCudaHipEvent,
                     0));
             }
@@ -212,7 +209,7 @@ namespace alpaka
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamWaitEvent)(
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue,
+                    queue.m_spQueueImpl->getNativeHandle(),
                     event.m_spEventImpl->m_UniformCudaHipEvent,
                     0));
             }

--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -74,7 +74,8 @@ namespace alpaka
                 // -> No need to synchronize here.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(EventDestroy)(m_UniformCudaHipEvent));
             }
-            auto getNativeHandle() const noexcept
+
+            [[nodiscard]] auto getNativeHandle() const noexcept
             {
                 return m_UniformCudaHipEvent;
             }
@@ -106,7 +107,8 @@ namespace alpaka
         {
             return !((*this) == rhs);
         }
-        auto getNativeHandle() const noexcept
+
+        [[nodiscard]] auto getNativeHandle() const noexcept
         {
             return m_spEventImpl->getNativeHandle();
         }
@@ -242,12 +244,11 @@ namespace alpaka
         template<>
         struct NativeHandle<EventUniformCudaHipRt>
         {
-            static auto getNativeHandle(EventUniformCudaHipRt const& event)
+            [[nodiscard]] static auto getNativeHandle(EventUniformCudaHipRt const& event)
             {
                 return event.getNativeHandle();
             }
         };
-
     } // namespace traits
 } // namespace alpaka
 

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -277,14 +277,14 @@ namespace alpaka
                             gridDim,
                             blockDim,
                             static_cast<std::size_t>(blockSharedMemDynSizeBytes),
-                            queue.m_spQueueImpl->getNativeHandle()>>>(threadElemExtent, task.m_kernelFnObj, args...);
+                            queue.getNativeHandle()>>>(threadElemExtent, task.m_kernelFnObj, args...);
 #        else
                         hipLaunchKernelGGL(
                             HIP_KERNEL_NAME(kernelName),
                             gridDim,
                             blockDim,
                             static_cast<std::uint32_t>(blockSharedMemDynSizeBytes),
-                            queue.m_spQueueImpl->getNativeHandle(),
+                            queue.getNativeHandle(),
                             threadElemExtent,
                             task.m_kernelFnObj,
                             args...);
@@ -296,7 +296,7 @@ namespace alpaka
                 // Wait for the kernel execution to finish but do not check error return of this call.
                 // Do not use the alpaka::wait method because it checks the error itself but we want to give a custom
                 // error message.
-                ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->getNativeHandle());
+                ALPAKA_API_PREFIX(StreamSynchronize)(queue.getNativeHandle());
                 std::string const msg(
                     "'execution of kernel: '" + std::string(typeid(TKernelFnObj).name()) + "' failed with");
                 ::alpaka::uniform_cuda_hip::detail::rtCheckLastError(msg.c_str(), __FILE__, __LINE__);
@@ -403,14 +403,14 @@ namespace alpaka
                             gridDim,
                             blockDim,
                             static_cast<std::size_t>(blockSharedMemDynSizeBytes),
-                            queue.m_spQueueImpl->getNativeHandle()>>>(threadElemExtent, task.m_kernelFnObj, args...);
+                            queue.getNativeHandle()>>>(threadElemExtent, task.m_kernelFnObj, args...);
 #        else
                         hipLaunchKernelGGL(
                             HIP_KERNEL_NAME(kernelName),
                             gridDim,
                             blockDim,
                             static_cast<std::uint32_t>(blockSharedMemDynSizeBytes),
-                            queue.m_spQueueImpl->getNativeHandle(),
+                            queue.getNativeHandle(),
                             threadElemExtent,
                             task.m_kernelFnObj,
                             args...);
@@ -421,7 +421,7 @@ namespace alpaka
                 // Wait for the kernel execution to finish but do not check error return of this call.
                 // Do not use the alpaka::wait method because it checks the error itself but we want to give a custom
                 // error message.
-                std::ignore = ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->getNativeHandle());
+                std::ignore = ALPAKA_API_PREFIX(StreamSynchronize)(queue.getNativeHandle());
 #        if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                 std::string const msg(
                     "'execution of kernel: '" + std::string(typeid(TKernelFnObj).name()) + "' failed with");

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -277,17 +277,14 @@ namespace alpaka
                             gridDim,
                             blockDim,
                             static_cast<std::size_t>(blockSharedMemDynSizeBytes),
-                            queue.m_spQueueImpl->m_UniformCudaHipQueue>>>(
-                            threadElemExtent,
-                            task.m_kernelFnObj,
-                            args...);
+                            queue.m_spQueueImpl->getNativeHandle()>>>(threadElemExtent, task.m_kernelFnObj, args...);
 #        else
                         hipLaunchKernelGGL(
                             HIP_KERNEL_NAME(kernelName),
                             gridDim,
                             blockDim,
                             static_cast<std::uint32_t>(blockSharedMemDynSizeBytes),
-                            queue.m_spQueueImpl->m_UniformCudaHipQueue,
+                            queue.m_spQueueImpl->getNativeHandle(),
                             threadElemExtent,
                             task.m_kernelFnObj,
                             args...);
@@ -299,7 +296,7 @@ namespace alpaka
                 // Wait for the kernel execution to finish but do not check error return of this call.
                 // Do not use the alpaka::wait method because it checks the error itself but we want to give a custom
                 // error message.
-                ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->m_UniformCudaHipQueue);
+                ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->getNativeHandle());
                 std::string const msg(
                     "'execution of kernel: '" + std::string(typeid(TKernelFnObj).name()) + "' failed with");
                 ::alpaka::uniform_cuda_hip::detail::rtCheckLastError(msg.c_str(), __FILE__, __LINE__);
@@ -406,17 +403,14 @@ namespace alpaka
                             gridDim,
                             blockDim,
                             static_cast<std::size_t>(blockSharedMemDynSizeBytes),
-                            queue.m_spQueueImpl->m_UniformCudaHipQueue>>>(
-                            threadElemExtent,
-                            task.m_kernelFnObj,
-                            args...);
+                            queue.m_spQueueImpl->getNativeHandle()>>>(threadElemExtent, task.m_kernelFnObj, args...);
 #        else
                         hipLaunchKernelGGL(
                             HIP_KERNEL_NAME(kernelName),
                             gridDim,
                             blockDim,
                             static_cast<std::uint32_t>(blockSharedMemDynSizeBytes),
-                            queue.m_spQueueImpl->m_UniformCudaHipQueue,
+                            queue.m_spQueueImpl->getNativeHandle(),
                             threadElemExtent,
                             task.m_kernelFnObj,
                             args...);
@@ -427,7 +421,7 @@ namespace alpaka
                 // Wait for the kernel execution to finish but do not check error return of this call.
                 // Do not use the alpaka::wait method because it checks the error itself but we want to give a custom
                 // error message.
-                std::ignore = ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->m_UniformCudaHipQueue);
+                std::ignore = ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->getNativeHandle());
 #        if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                 std::string const msg(
                     "'execution of kernel: '" + std::string(typeid(TKernelFnObj).name()) + "' failed with");

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -76,7 +76,7 @@ namespace alpaka
             auto operator=(BufOmp5Impl&&) -> BufOmp5Impl& = delete;
             ~BufOmp5Impl()
             {
-                omp_target_free(m_pMem, m_dev.m_spDevOmp5Impl->getNativeHandle());
+                omp_target_free(m_pMem, m_dev.getNativeHandle());
             }
         };
     } // namespace detail
@@ -210,12 +210,11 @@ namespace alpaka
                 auto const width(getWidth(extent));
                 auto const widthBytes(width * static_cast<TIdx>(sizeof(TElem)));
 
-                void* memPtr
-                    = omp_target_alloc(static_cast<std::size_t>(widthBytes), dev.m_spDevOmp5Impl->getNativeHandle());
+                void* memPtr = omp_target_alloc(static_cast<std::size_t>(widthBytes), dev.getNativeHandle());
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " ew: " << width << " ewb: " << widthBytes << " ptr: " << memPtr
-                          << " device: " << dev.m_spDevOmp5Impl->getNativeHandle() << std::endl;
+                          << " device: " << dev.getNativeHandle() << std::endl;
 #    endif
                 return BufOmp5<TElem, DimInt<1u>, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), extent);
             }
@@ -233,11 +232,11 @@ namespace alpaka
 
                 const std::size_t size = static_cast<std::size_t>(getExtentVec(extent).prod()) * sizeof(TElem);
 
-                void* memPtr = omp_target_alloc(size, dev.m_spDevOmp5Impl->getNativeHandle());
+                void* memPtr = omp_target_alloc(size, dev.getNativeHandle());
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " dim: " << TDim::value << " extent: " << getExtentVec(extent)
-                          << " ewb: " << size << " ptr: " << memPtr
-                          << " device: " << dev.m_spDevOmp5Impl->getNativeHandle() << std::endl;
+                          << " ewb: " << size << " ptr: " << memPtr << " device: " << dev.getNativeHandle()
+                          << std::endl;
 #    endif
                 return BufOmp5<TElem, TDim, TIdx>(dev, reinterpret_cast<TElem*>(memPtr), extent);
             }

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -274,10 +274,8 @@ namespace alpaka
                 auto const& dev = getDev(queue);
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(dev.getNativeHandle()));
                 void* memPtr;
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(MallocAsync)(
-                    &memPtr,
-                    static_cast<std::size_t>(width) * sizeof(TElem),
-                    queue.getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
+                    MallocAsync)(&memPtr, static_cast<std::size_t>(width) * sizeof(TElem), queue.getNativeHandle()));
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " ew: " << width << " ptr: " << memPtr << std::endl;
@@ -285,10 +283,8 @@ namespace alpaka
                 return BufUniformCudaHipRt<TElem, TDim, TIdx>(
                     dev,
                     reinterpret_cast<TElem*>(memPtr),
-                    [queue = std::move(queue)](TElem* ptr) {
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            ALPAKA_API_PREFIX(FreeAsync)(ptr, queue.getNativeHandle()));
-                    },
+                    [queue = std::move(queue)](TElem* ptr)
+                    { ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(FreeAsync)(ptr, queue.getNativeHandle())); },
                     width * static_cast<TIdx>(sizeof(TElem)),
                     extent);
             }

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -277,7 +277,7 @@ namespace alpaka
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(MallocAsync)(
                     &memPtr,
                     static_cast<std::size_t>(width) * sizeof(TElem),
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    queue.getNativeHandle()));
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << __func__ << " ew: " << width << " ptr: " << memPtr << std::endl;
@@ -287,7 +287,7 @@ namespace alpaka
                     reinterpret_cast<TElem*>(memPtr),
                     [queue = std::move(queue)](TElem* ptr) {
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            ALPAKA_API_PREFIX(FreeAsync)(ptr, queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                            ALPAKA_API_PREFIX(FreeAsync)(ptr, queue.getNativeHandle()));
                     },
                     width * static_cast<TIdx>(sizeof(TElem)),
                     extent);

--- a/include/alpaka/mem/buf/oacc/Copy.hpp
+++ b/include/alpaka/mem/buf/oacc/Copy.hpp
@@ -338,8 +338,7 @@ namespace alpaka
 
 #    if _OPENACC >= 201510 && (!defined __GNUC__)
                 // acc_memcpy_device is only available since OpenACC2.5, but we want the tests to compile anyway
-                if(getDev(viewDst).m_spDevOaccImpl->getNativeHandle()
-                   == getDev(viewSrc).m_spDevOaccImpl->getNativeHandle())
+                if(getDev(viewDst).getNativeHandle() == getDev(viewSrc).getNativeHandle())
                 {
                     return alpaka::oacc::detail::
                         makeTaskCopyOacc<alpaka::oacc::detail::TaskCopyOacc, TDim, TViewDst, TViewSrc, TExtent>(

--- a/include/alpaka/mem/buf/omp5/Copy.hpp
+++ b/include/alpaka/mem/buf/omp5/Copy.hpp
@@ -338,7 +338,7 @@ namespace alpaka
                     viewDst,
                     viewSrc,
                     extent,
-                    getDev(viewDst).m_spDevOmp5Impl->getNativeHandle(),
+                    getDev(viewDst).getNativeHandle(),
                     omp_get_initial_device());
             }
         };
@@ -360,7 +360,7 @@ namespace alpaka
                     viewSrc,
                     extent,
                     omp_get_initial_device(),
-                    getDev(viewSrc).m_spDevOmp5Impl->getNativeHandle());
+                    getDev(viewSrc).getNativeHandle());
             }
         };
 
@@ -380,8 +380,8 @@ namespace alpaka
                     viewDst,
                     viewSrc,
                     extent,
-                    getDev(viewDst).m_spDevOmp5Impl->getNativeHandle(),
-                    getDev(viewSrc).m_spDevOmp5Impl->getNativeHandle());
+                    getDev(viewDst).getNativeHandle(),
+                    getDev(viewSrc).getNativeHandle());
             }
         };
     } // namespace traits

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -96,7 +96,7 @@ namespace alpaka
                     m_srcMemNative,
                     sizeof(Elem<TViewDst>),
                     m_uniformMemCpyKind,
-                    queue.m_spQueueImpl->getNativeHandle()));
+                    queue.getNativeHandle()));
             }
 
         private:
@@ -185,7 +185,7 @@ namespace alpaka
                     m_srcMemNative,
                     static_cast<std::size_t>(m_extentWidthBytes),
                     m_uniformMemCpyKind,
-                    queue.m_spQueueImpl->getNativeHandle()));
+                    queue.getNativeHandle()));
             }
 
         private:
@@ -295,7 +295,7 @@ namespace alpaka
                     static_cast<std::size_t>(m_extentWidthBytes),
                     static_cast<std::size_t>(m_extentHeight),
                     m_uniformMemCpyKind,
-                    queue.m_spQueueImpl->getNativeHandle()));
+                    queue.getNativeHandle()));
             }
 
         private:
@@ -416,8 +416,8 @@ namespace alpaka
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_iDstDevice));
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
-                    Memcpy3DAsync)(&uniformCudaHipMemCpy3DParms, queue.m_spQueueImpl->getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    ALPAKA_API_PREFIX(Memcpy3DAsync)(&uniformCudaHipMemCpy3DParms, queue.getNativeHandle()));
             }
 
         private:
@@ -597,8 +597,7 @@ namespace alpaka
 
                 task.enqueue(queue);
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamSynchronize)(queue.getNativeHandle()));
             }
         };
 
@@ -632,8 +631,7 @@ namespace alpaka
 
                 task.enqueue(queue);
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamSynchronize)(queue.getNativeHandle()));
             }
         };
 
@@ -667,8 +665,7 @@ namespace alpaka
 
                 task.enqueue(queue);
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamSynchronize)(queue.getNativeHandle()));
             }
         };
 
@@ -702,8 +699,7 @@ namespace alpaka
 
                 task.enqueue(queue);
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamSynchronize)(queue.getNativeHandle()));
             }
         };
     } // namespace traits

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -96,7 +96,7 @@ namespace alpaka
                     m_srcMemNative,
                     sizeof(Elem<TViewDst>),
                     m_uniformMemCpyKind,
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    queue.m_spQueueImpl->getNativeHandle()));
             }
 
         private:
@@ -185,7 +185,7 @@ namespace alpaka
                     m_srcMemNative,
                     static_cast<std::size_t>(m_extentWidthBytes),
                     m_uniformMemCpyKind,
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    queue.m_spQueueImpl->getNativeHandle()));
             }
 
         private:
@@ -295,7 +295,7 @@ namespace alpaka
                     static_cast<std::size_t>(m_extentWidthBytes),
                     static_cast<std::size_t>(m_extentHeight),
                     m_uniformMemCpyKind,
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    queue.m_spQueueImpl->getNativeHandle()));
             }
 
         private:
@@ -417,7 +417,7 @@ namespace alpaka
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(SetDevice)(m_iDstDevice));
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
-                    Memcpy3DAsync)(&uniformCudaHipMemCpy3DParms, queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    Memcpy3DAsync)(&uniformCudaHipMemCpy3DParms, queue.m_spQueueImpl->getNativeHandle()));
             }
 
         private:
@@ -598,7 +598,7 @@ namespace alpaka
                 task.enqueue(queue);
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->getNativeHandle()));
             }
         };
 
@@ -633,7 +633,7 @@ namespace alpaka
                 task.enqueue(queue);
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->getNativeHandle()));
             }
         };
 
@@ -668,7 +668,7 @@ namespace alpaka
                 task.enqueue(queue);
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->getNativeHandle()));
             }
         };
 
@@ -703,7 +703,7 @@ namespace alpaka
                 task.enqueue(queue);
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->getNativeHandle()));
             }
         };
     } // namespace traits

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -96,7 +96,7 @@ namespace alpaka
                     dstNativePtr,
                     static_cast<int>(this->m_byte),
                     sizeof(Elem<TView>),
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    queue.m_spQueueImpl->getNativeHandle()));
             }
         };
         //! The 1D CUDA/HIP memory set task.
@@ -143,7 +143,7 @@ namespace alpaka
                     dstNativePtr,
                     static_cast<int>(this->m_byte),
                     static_cast<size_t>(extentWidthBytes),
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    queue.m_spQueueImpl->getNativeHandle()));
             }
         };
         //! The 2D CUDA/HIP memory set task.
@@ -197,7 +197,7 @@ namespace alpaka
                     static_cast<int>(this->m_byte),
                     static_cast<size_t>(extentWidthBytes),
                     static_cast<size_t>(extentHeight),
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    queue.m_spQueueImpl->getNativeHandle()));
             }
         };
         //! The 3D CUDA/HIP memory set task.
@@ -267,7 +267,7 @@ namespace alpaka
                     pitchedPtrVal,
                     static_cast<int>(this->m_byte),
                     extentVal,
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    queue.m_spQueueImpl->getNativeHandle()));
             }
         };
     } // namespace detail

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -96,7 +96,7 @@ namespace alpaka
                     dstNativePtr,
                     static_cast<int>(this->m_byte),
                     sizeof(Elem<TView>),
-                    queue.m_spQueueImpl->getNativeHandle()));
+                    queue.getNativeHandle()));
             }
         };
         //! The 1D CUDA/HIP memory set task.
@@ -143,7 +143,7 @@ namespace alpaka
                     dstNativePtr,
                     static_cast<int>(this->m_byte),
                     static_cast<size_t>(extentWidthBytes),
-                    queue.m_spQueueImpl->getNativeHandle()));
+                    queue.getNativeHandle()));
             }
         };
         //! The 2D CUDA/HIP memory set task.
@@ -197,7 +197,7 @@ namespace alpaka
                     static_cast<int>(this->m_byte),
                     static_cast<size_t>(extentWidthBytes),
                     static_cast<size_t>(extentHeight),
-                    queue.m_spQueueImpl->getNativeHandle()));
+                    queue.getNativeHandle()));
             }
         };
         //! The 3D CUDA/HIP memory set task.
@@ -263,11 +263,8 @@ namespace alpaka
                     static_cast<size_t>(extentDepth));
 
                 // Initiate the memory set.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(Memset3DAsync)(
-                    pitchedPtrVal,
-                    static_cast<int>(this->m_byte),
-                    extentVal,
-                    queue.m_spQueueImpl->getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(
+                    Memset3DAsync)(pitchedPtrVal, static_cast<int>(this->m_byte), extentVal, queue.getNativeHandle()));
             }
         };
     } // namespace detail

--- a/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
@@ -133,7 +133,7 @@ namespace alpaka
                 auto pCallbackSynchronizationData = std::make_shared<CallbackSynchronizationData>();
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamAddCallback)(
-                    queue.m_spQueueImpl->getNativeHandle(),
+                    queue.getNativeHandle(),
                     uniformCudaHipRtCallback,
                     pCallbackSynchronizationData.get(),
                     0u));
@@ -174,7 +174,7 @@ namespace alpaka
         {
             static auto getNativeHandle(QueueUniformCudaHipRtBlocking const& queue)
             {
-                return queue.m_spQueueImpl->getNativeHandle();
+                return queue.getNativeHandle();
             }
         };
     } // namespace traits

--- a/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
@@ -133,7 +133,7 @@ namespace alpaka
                 auto pCallbackSynchronizationData = std::make_shared<CallbackSynchronizationData>();
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamAddCallback)(
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue,
+                    queue.m_spQueueImpl->getNativeHandle(),
                     uniformCudaHipRtCallback,
                     pCallbackSynchronizationData.get(),
                     0u));
@@ -166,6 +166,15 @@ namespace alpaka
                     });
 
                 t.join();
+            }
+        };
+        //! The CUDA/HIP RT blocking queue native handle trait specialization.
+        template<>
+        struct NativeHandle<QueueUniformCudaHipRtBlocking>
+        {
+            static auto getNativeHandle(QueueUniformCudaHipRtBlocking const& queue)
+            {
+                return queue.m_spQueueImpl->getNativeHandle();
             }
         };
     } // namespace traits

--- a/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, René Widera, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, René Widera, Andrea Bocci, Bernhard Manfred Gruber, Antonio Di Pilato
  *
  * This file is part of alpaka.
  *
@@ -168,11 +168,12 @@ namespace alpaka
                 t.join();
             }
         };
+
         //! The CUDA/HIP RT blocking queue native handle trait specialization.
         template<>
         struct NativeHandle<QueueUniformCudaHipRtBlocking>
         {
-            static auto getNativeHandle(QueueUniformCudaHipRtBlocking const& queue)
+            [[nodiscard]] static auto getNativeHandle(QueueUniformCudaHipRtBlocking const& queue)
             {
                 return queue.getNativeHandle();
             }

--- a/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
@@ -132,7 +132,7 @@ namespace alpaka
             {
                 auto pCallbackSynchronizationData = std::make_shared<CallbackSynchronizationData>();
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamAddCallback)(
-                    queue.m_spQueueImpl->getNativeHandle(),
+                    queue.getNativeHandle(),
                     uniformCudaHipRtCallback,
                     pCallbackSynchronizationData.get(),
                     0u));
@@ -173,7 +173,7 @@ namespace alpaka
         {
             static auto getNativeHandle(QueueUniformCudaHipRtNonBlocking const& queue)
             {
-                return queue.m_spQueueImpl->getNativeHandle();
+                return queue.getNativeHandle();
             }
         };
     } // namespace traits

--- a/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
@@ -132,7 +132,7 @@ namespace alpaka
             {
                 auto pCallbackSynchronizationData = std::make_shared<CallbackSynchronizationData>();
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamAddCallback)(
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue,
+                    queue.m_spQueueImpl->getNativeHandle(),
                     uniformCudaHipRtCallback,
                     pCallbackSynchronizationData.get(),
                     0u));
@@ -165,6 +165,15 @@ namespace alpaka
                     });
 
                 t.detach();
+            }
+        };
+        //! The CUDA/HIP RT blocking queue native handle trait specialization.
+        template<>
+        struct NativeHandle<QueueUniformCudaHipRtNonBlocking>
+        {
+            static auto getNativeHandle(QueueUniformCudaHipRtNonBlocking const& queue)
+            {
+                return queue.m_spQueueImpl->getNativeHandle();
             }
         };
     } // namespace traits

--- a/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2022 Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci, Bernhard Manfred Gruber,
+ * Antonio Di Pilato
  *
  * This file is part of alpaka.
  *
@@ -167,11 +168,12 @@ namespace alpaka
                 t.detach();
             }
         };
-        //! The CUDA/HIP RT blocking queue native handle trait specialization.
+
+        //! The CUDA/HIP RT non-blocking queue native handle trait specialization.
         template<>
         struct NativeHandle<QueueUniformCudaHipRtNonBlocking>
         {
-            static auto getNativeHandle(QueueUniformCudaHipRtNonBlocking const& queue)
+            [[nodiscard]] static auto getNativeHandle(QueueUniformCudaHipRtNonBlocking const& queue)
             {
                 return queue.getNativeHandle();
             }

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -69,7 +69,8 @@ namespace alpaka
                     // -> No need to synchronize here.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamDestroy)(m_UniformCudaHipQueue));
                 }
-                auto getNativeHandle() const noexcept
+
+                [[nodiscard]] auto getNativeHandle() const noexcept
                 {
                     return m_UniformCudaHipQueue;
                 }
@@ -99,7 +100,8 @@ namespace alpaka
                 {
                     return !((*this) == rhs);
                 }
-                auto getNativeHandle() const noexcept
+
+                [[nodiscard]] auto getNativeHandle() const noexcept
                 {
                     return m_spQueueImpl->getNativeHandle();
                 }

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -134,7 +134,7 @@ namespace alpaka
                 // Query is allowed even for queues on non current device.
                 ALPAKA_API_PREFIX(Error_t) ret = ALPAKA_API_PREFIX(Success);
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
-                    ret = ALPAKA_API_PREFIX(StreamQuery)(queue.m_spQueueImpl->getNativeHandle()),
+                    ret = ALPAKA_API_PREFIX(StreamQuery)(queue.getNativeHandle()),
                     ALPAKA_API_PREFIX(ErrorNotReady));
                 return (ret == ALPAKA_API_PREFIX(Success));
             }
@@ -153,8 +153,7 @@ namespace alpaka
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                 // Sync is allowed even for queues on non current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamSynchronize)(queue.getNativeHandle()));
             }
         };
     } // namespace traits

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -69,9 +69,14 @@ namespace alpaka
                     // -> No need to synchronize here.
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamDestroy)(m_UniformCudaHipQueue));
                 }
+                auto getNativeHandle() const noexcept
+                {
+                    return m_UniformCudaHipQueue;
+                }
 
             public:
                 DevUniformCudaHipRt const m_dev; //!< The device this queue is bound to.
+            private:
                 ALPAKA_API_PREFIX(Stream_t) m_UniformCudaHipQueue;
             };
 
@@ -93,6 +98,10 @@ namespace alpaka
                 ALPAKA_FN_HOST auto operator!=(QueueUniformCudaHipRtBase const& rhs) const -> bool
                 {
                     return !((*this) == rhs);
+                }
+                auto getNativeHandle() const noexcept
+                {
+                    return m_spQueueImpl->getNativeHandle();
                 }
 
             public:
@@ -125,7 +134,7 @@ namespace alpaka
                 // Query is allowed even for queues on non current device.
                 ALPAKA_API_PREFIX(Error_t) ret = ALPAKA_API_PREFIX(Success);
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
-                    ret = ALPAKA_API_PREFIX(StreamQuery)(queue.m_spQueueImpl->m_UniformCudaHipQueue),
+                    ret = ALPAKA_API_PREFIX(StreamQuery)(queue.m_spQueueImpl->getNativeHandle()),
                     ALPAKA_API_PREFIX(ErrorNotReady));
                 return (ret == ALPAKA_API_PREFIX(Success));
             }
@@ -145,7 +154,7 @@ namespace alpaka
 
                 // Sync is allowed even for queues on non current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    ALPAKA_API_PREFIX(StreamSynchronize)(queue.m_spQueueImpl->getNativeHandle()));
             }
         };
     } // namespace traits

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -439,7 +439,7 @@ namespace alpaka::traits
             //   the device build upon value-based CUDA queue synchronization APIs such as
             //   cuStreamWaitValue32() and cuStreamWriteValue32().
             ALPAKA_CUDA_DRV_CHECK(cuStreamWaitValue32(
-                static_cast<CUstream>(queue.m_spQueueImpl->m_UniformCudaHipQueue),
+                static_cast<CUstream>(queue.m_spQueueImpl->getNativeHandle()),
                 reinterpret_cast<CUdeviceptr>(event.m_spEventImpl->m_devMem),
                 0x01010101u,
                 CU_STREAM_WAIT_VALUE_GEQ));
@@ -473,7 +473,7 @@ namespace alpaka::traits
             //   the device build upon value-based CUDA queue synchronization APIs such as
             //   cuStreamWaitValue32() and cuStreamWriteValue32().
             ALPAKA_CUDA_DRV_CHECK(cuStreamWaitValue32(
-                static_cast<CUstream>(queue.m_spQueueImpl->m_UniformCudaHipQueue),
+                static_cast<CUstream>(queue.m_spQueueImpl->getNativeHandle()),
                 reinterpret_cast<CUdeviceptr>(event.m_spEventImpl->m_devMem),
                 0x01010101u,
                 CU_STREAM_WAIT_VALUE_GEQ));
@@ -656,8 +656,8 @@ namespace alpaka::traits
                     &hostMem,
                     reinterpret_cast<hipDeviceptr_t>(event.m_spEventImpl->m_devMem),
                     sizeof(int32_t),
-                    queue.m_spQueueImpl->m_UniformCudaHipQueue));
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipStreamSynchronize(queue.m_spQueueImpl->m_UniformCudaHipQueue));
+                    queue.m_spQueueImpl->getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipStreamSynchronize(queue.m_spQueueImpl->getNativeHandle()));
             }
         }
     };
@@ -690,7 +690,7 @@ namespace alpaka::traits
             //   cuStreamWaitValue32() and cuStreamWriteValue32().
 #    if BOOST_COMP_NVCC
             ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipCUResultTohipError(cuStreamWaitValue32(
-                static_cast<CUstream>(queue.m_spQueueImpl->m_UniformCudaHipQueue),
+                static_cast<CUstream>(queue.m_spQueueImpl->getNativeHandle()),
                 reinterpret_cast<CUdeviceptr>(event.m_spEventImpl->m_devMem),
                 0x01010101u,
                 CU_STREAM_WAIT_VALUE_GEQ)));

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -439,7 +439,7 @@ namespace alpaka::traits
             //   the device build upon value-based CUDA queue synchronization APIs such as
             //   cuStreamWaitValue32() and cuStreamWriteValue32().
             ALPAKA_CUDA_DRV_CHECK(cuStreamWaitValue32(
-                static_cast<CUstream>(queue.m_spQueueImpl->getNativeHandle()),
+                static_cast<CUstream>(queue.getNativeHandle()),
                 reinterpret_cast<CUdeviceptr>(event.m_spEventImpl->m_devMem),
                 0x01010101u,
                 CU_STREAM_WAIT_VALUE_GEQ));
@@ -473,7 +473,7 @@ namespace alpaka::traits
             //   the device build upon value-based CUDA queue synchronization APIs such as
             //   cuStreamWaitValue32() and cuStreamWriteValue32().
             ALPAKA_CUDA_DRV_CHECK(cuStreamWaitValue32(
-                static_cast<CUstream>(queue.m_spQueueImpl->getNativeHandle()),
+                static_cast<CUstream>(queue.getNativeHandle()),
                 reinterpret_cast<CUdeviceptr>(event.m_spEventImpl->m_devMem),
                 0x01010101u,
                 CU_STREAM_WAIT_VALUE_GEQ));
@@ -656,8 +656,8 @@ namespace alpaka::traits
                     &hostMem,
                     reinterpret_cast<hipDeviceptr_t>(event.m_spEventImpl->m_devMem),
                     sizeof(int32_t),
-                    queue.m_spQueueImpl->getNativeHandle()));
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipStreamSynchronize(queue.m_spQueueImpl->getNativeHandle()));
+                    queue.getNativeHandle()));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipStreamSynchronize(queue.getNativeHandle()));
             }
         }
     };
@@ -690,7 +690,7 @@ namespace alpaka::traits
             //   cuStreamWaitValue32() and cuStreamWriteValue32().
 #    if BOOST_COMP_NVCC
             ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipCUResultTohipError(cuStreamWaitValue32(
-                static_cast<CUstream>(queue.m_spQueueImpl->getNativeHandle()),
+                static_cast<CUstream>(queue.getNativeHandle()),
                 reinterpret_cast<CUdeviceptr>(event.m_spEventImpl->m_devMem),
                 0x01010101u,
                 CU_STREAM_WAIT_VALUE_GEQ)));


### PR DESCRIPTION
This PR introduces the native handle support for queues and events, for UniformCudaHipRt and SYCL backends.