### PR TITLE
Do not throw in destructors

### DIFF
--- a/include/alpaka/core/UniformCudaHip.hpp
+++ b/include/alpaka/core/UniformCudaHip.hpp
@@ -34,35 +34,44 @@ namespace alpaka::uniform_cuda_hip::detail
 #    else
     using Error_t = hipError_t;
 #    endif
+
     //! CUDA/HIP runtime API error checking with log and exception, ignoring specific error values
-    ALPAKA_FN_HOST inline auto rtCheck(Error_t const& error, char const* desc, char const* file, int const& line)
-        -> void
+    template<bool TThrow>
+    ALPAKA_FN_HOST inline void rtCheck(
+        Error_t const& error,
+        char const* desc,
+        char const* file,
+        int const& line) noexcept(!TThrow)
     {
         if(error != ALPAKA_API_PREFIX(Success))
         {
-            std::string const sError(
+            auto const sError = std::string{
                 std::string(file) + "(" + std::to_string(line) + ") " + std::string(desc) + " : '"
                 + ALPAKA_API_PREFIX(GetErrorName)(error) + "': '"
-                + std::string(ALPAKA_API_PREFIX(GetErrorString)(error)) + "'!");
-#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
-            std::cerr << sError << std::endl;
-#    endif
+                + std::string(ALPAKA_API_PREFIX(GetErrorString)(error)) + "'!"};
+
+            if constexpr(!TThrow || ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL)
+                std::cerr << sError << std::endl;
+
             ALPAKA_DEBUG_BREAK;
             // reset the last error to allow user side error handling. Using std::ignore to discard unneeded
             // return values is suggested by the C++ core guidelines.
             std::ignore = ALPAKA_API_PREFIX(GetLastError)();
-            throw std::runtime_error(sError);
+
+            if constexpr(TThrow)
+                throw std::runtime_error(sError);
         }
     }
-    //! CUDA/Hip runtime API error checking with log and exception, ignoring specific error values
+
+    //! CUDA/HIP runtime API error checking with log and exception, ignoring specific error values
     // NOTE: All ignored errors have to be convertible to Error_t.
-    template<typename... TErrors>
-    ALPAKA_FN_HOST auto rtCheckIgnore(
+    template<bool TThrow, typename... TErrors>
+    ALPAKA_FN_HOST inline void rtCheckIgnore(
         Error_t const& error,
         char const* cmd,
         char const* file,
         int const& line,
-        TErrors&&... ignoredErrorCodes) -> void
+        TErrors&&... ignoredErrorCodes) noexcept(!TThrow)
     {
         if(error != ALPAKA_API_PREFIX(Success))
         {
@@ -72,7 +81,7 @@ namespace alpaka::uniform_cuda_hip::detail
             if(std::find(std::cbegin(aIgnoredErrorCodes), std::cend(aIgnoredErrorCodes), error)
                == std::cend(aIgnoredErrorCodes))
             {
-                rtCheck(error, ("'" + std::string(cmd) + "' returned error ").c_str(), file, line);
+                rtCheck<TThrow>(error, ("'" + std::string(cmd) + "' returned error ").c_str(), file, line);
             }
             else
             {
@@ -82,40 +91,69 @@ namespace alpaka::uniform_cuda_hip::detail
             }
         }
     }
-    //! CUDA runtime API last error checking with log and exception.
-    ALPAKA_FN_HOST inline auto rtCheckLastError(char const* desc, char const* file, int const& line) -> void
+
+    //! CUDA/HIP runtime API last error checking with log and exception.
+    template<bool TThrow>
+    ALPAKA_FN_HOST inline void rtCheckLastError(char const* desc, char const* file, int const& line) noexcept(!TThrow)
     {
         Error_t const error(ALPAKA_API_PREFIX(GetLastError)());
-        rtCheck(error, desc, file, line);
+        rtCheck<TThrow>(error, desc, file, line);
     }
 } // namespace alpaka::uniform_cuda_hip::detail
 
 #    if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
-//! CUDA runtime error checking with log and exception, ignoring specific error values
+//! CUDA/HIP runtime error checking with log and exception, ignoring specific error values
 #        define ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(cmd, ...)                                                     \
-            ::alpaka::uniform_cuda_hip::detail::rtCheckLastError(                                                     \
+            ::alpaka::uniform_cuda_hip::detail::rtCheckLastError<true>(                                               \
                 "'" #cmd "' A previous API call (not this one) set the error ",                                       \
                 __FILE__,                                                                                             \
                 __LINE__);                                                                                            \
-            ::alpaka::uniform_cuda_hip::detail::rtCheckIgnore(cmd, #cmd, __FILE__, __LINE__, __VA_ARGS__)
+            ::alpaka::uniform_cuda_hip::detail::rtCheckIgnore<true>(cmd, #cmd, __FILE__, __LINE__, __VA_ARGS__)
 #    else
 #        if BOOST_COMP_CLANG
 #            pragma clang diagnostic push
 #            pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #        endif
-//! CUDA runtime error checking with log and exception, ignoring specific error values
+//! CUDA/HIP runtime error checking with log and exception, ignoring specific error values
 #        define ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(cmd, ...)                                                     \
-            ::alpaka::uniform_cuda_hip::detail::rtCheckLastError(                                                     \
+            ::alpaka::uniform_cuda_hip::detail::rtCheckLastError<true>(                                               \
                 "'" #cmd "' A previous API call (not this one) set the error ",                                       \
                 __FILE__,                                                                                             \
                 __LINE__);                                                                                            \
-            ::alpaka::uniform_cuda_hip::detail::rtCheckIgnore(cmd, #cmd, __FILE__, __LINE__, ##__VA_ARGS__)
+            ::alpaka::uniform_cuda_hip::detail::rtCheckIgnore<true>(cmd, #cmd, __FILE__, __LINE__, ##__VA_ARGS__)
 #        if BOOST_COMP_CLANG
 #            pragma clang diagnostic pop
 #        endif
 #    endif
 
-//! CUDA runtime error checking with log and exception.
+//! CUDA/HIP runtime error checking with log and exception.
 #    define ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cmd) ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(cmd)
 
+#    if BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
+//! CUDA/HIP runtime error checking with log, ignoring specific error values
+#        define ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE_NOEXCEPT(cmd, ...)                                            \
+            ::alpaka::uniform_cuda_hip::detail::rtCheckLastError<false>(                                              \
+                "'" #cmd "' A previous API call (not this one) set the error ",                                       \
+                __FILE__,                                                                                             \
+                __LINE__);                                                                                            \
+            ::alpaka::uniform_cuda_hip::detail::rtCheckIgnore<false>(cmd, #cmd, __FILE__, __LINE__, __VA_ARGS__)
+#    else
+#        if BOOST_COMP_CLANG
+#            pragma clang diagnostic push
+#            pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#        endif
+//! CUDA/HIP runtime error checking with log and exception, ignoring specific error values
+#        define ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE_NOEXCEPT(cmd, ...)                                            \
+            ::alpaka::uniform_cuda_hip::detail::rtCheckLastError<false>(                                              \
+                "'" #cmd "' A previous API call (not this one) set the error ",                                       \
+                __FILE__,                                                                                             \
+                __LINE__);                                                                                            \
+            ::alpaka::uniform_cuda_hip::detail::rtCheckIgnore<false>(cmd, #cmd, __FILE__, __LINE__, ##__VA_ARGS__)
+#        if BOOST_COMP_CLANG
+#            pragma clang diagnostic pop
+#        endif
+#    endif
+
+//! CUDA/HIP runtime error checking with log.
+#    define ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(cmd) ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE_NOEXCEPT(cmd)
 #endif

--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -72,7 +72,7 @@ namespace alpaka
                 // called, the function will return immediately and the resources associated with event will be
                 // released automatically once the device has completed event.
                 // -> No need to synchronize here.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(EventDestroy)(m_UniformCudaHipEvent));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ALPAKA_API_PREFIX(EventDestroy)(m_UniformCudaHipEvent));
             }
 
             [[nodiscard]] auto getNativeHandle() const noexcept

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -292,15 +292,16 @@ namespace alpaka
                     },
                     task.m_args);
 
-#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
-                // Wait for the kernel execution to finish but do not check error return of this call.
-                // Do not use the alpaka::wait method because it checks the error itself but we want to give a custom
-                // error message.
-                ALPAKA_API_PREFIX(StreamSynchronize)(queue.getNativeHandle());
-                std::string const msg(
-                    "'execution of kernel: '" + std::string(typeid(TKernelFnObj).name()) + "' failed with");
-                ::alpaka::uniform_cuda_hip::detail::rtCheckLastError(msg.c_str(), __FILE__, __LINE__);
-#        endif
+                if constexpr(ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL)
+                {
+                    // Wait for the kernel execution to finish but do not check error return of this call.
+                    // Do not use the alpaka::wait method because it checks the error itself but we want to give a
+                    // custom error message.
+                    std::ignore = ALPAKA_API_PREFIX(StreamSynchronize)(queue.getNativeHandle());
+                    auto const msg = std::string{
+                        "'execution of kernel: '" + std::string{typeid(TKernelFnObj).name()} + "' failed with"};
+                    ::alpaka::uniform_cuda_hip::detail::rtCheckLastError<true>(msg.c_str(), __FILE__, __LINE__);
+                }
             }
         };
         //! The CUDA/HIP synchronous kernel enqueue trait specialization.
@@ -422,11 +423,12 @@ namespace alpaka
                 // Do not use the alpaka::wait method because it checks the error itself but we want to give a custom
                 // error message.
                 std::ignore = ALPAKA_API_PREFIX(StreamSynchronize)(queue.getNativeHandle());
-#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
-                std::string const msg(
-                    "'execution of kernel: '" + std::string(typeid(TKernelFnObj).name()) + "' failed with");
-                ::alpaka::uniform_cuda_hip::detail::rtCheckLastError(msg.c_str(), __FILE__, __LINE__);
-#        endif
+                if constexpr(ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL)
+                {
+                    auto const msg = std::string{
+                        "'execution of kernel: '" + std::string{typeid(TKernelFnObj).name()} + "' failed with"};
+                    ::alpaka::uniform_cuda_hip::detail::rtCheckLastError<true>(msg.c_str(), __FILE__, __LINE__);
+                }
             }
         };
     } // namespace traits

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -81,7 +81,18 @@ namespace alpaka
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
                 // Unpin this memory if it is currently pinned.
-                unpin(*this);
+                if(m_bPinned)
+                {
+                    try
+                    {
+                        unpin(*this); // May throw std::runtime_error
+                    }
+                    catch(std::runtime_error const& err)
+                    {
+                        std::cerr << "Caught runtime error while unpinning in ~BufCpuImpl(): " << err.what()
+                                  << std::endl;
+                    }
+                }
 #endif
                 // NOTE: m_pMem is allowed to be a nullptr here.
                 m_deleter(m_pMem);

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -67,7 +67,7 @@ namespace alpaka
                     // function will return immediately and the resources associated with queue will be released
                     // automatically once the device has completed all work in queue.
                     // -> No need to synchronize here.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamDestroy)(m_UniformCudaHipQueue));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(ALPAKA_API_PREFIX(StreamDestroy)(m_UniformCudaHipQueue));
                 }
 
                 [[nodiscard]] auto getNativeHandle() const noexcept

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -313,7 +313,7 @@ namespace alpaka::test
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                 // Free the buffer.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(cudaFree(m_devMem));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(cudaFree(m_devMem));
             }
 
             void trigger()
@@ -519,7 +519,7 @@ namespace alpaka::test
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                 // Free the buffer.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(hipFree(m_devMem));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(hipFree(m_devMem));
             }
 
             void trigger()


### PR DESCRIPTION
Fixes #468.

This PR adds a new CUDA/HIP error checking macro which just prints the error message instead of throwing a `std::runtime_error` (which is useful in destructors).