### PR TITLE
Enforce trivially copyable kernel arguments

### DIFF
--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -223,6 +223,9 @@ namespace alpaka
         detail::CheckFnReturnType<TAcc>{}(kernelFnObj, args...);
 
         static_assert(
+            (std::is_trivially_copyable_v<std::decay_t<TArgs>> && ...),
+            "Kernel arguments must be trivially copyable!");
+        static_assert(
             Dim<std::decay_t<TWorkDiv>>::value == Dim<TAcc>::value,
             "The dimensions of TAcc and TWorkDiv have to be identical!");
         static_assert(

--- a/include/alpaka/test/mem/view/Iterator.hpp
+++ b/include/alpaka/test/mem/view/Iterator.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Erik Zenker, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Erik Zenker, Bernhard Manfred Gruber, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -122,10 +122,10 @@ namespace alpaka::test
             }
 
         private:
-            Elem* const m_nativePtr;
+            Elem* m_nativePtr;
             Idx m_currentIdx;
-            Vec<Dim, Idx> const m_extents;
-            Vec<Dim, Idx> const m_pitchBytes;
+            Vec<Dim, Idx> m_extents;
+            Vec<Dim, Idx> m_pitchBytes;
         };
 #if BOOST_COMP_GNUC
 #    pragma GCC diagnostic pop

--- a/test/unit/math/src/Functor.hpp
+++ b/test/unit/math/src/Functor.hpp
@@ -36,7 +36,7 @@ namespace alpaka
         /* ranges is not a constexpr, so that it's accessible via for loop*/                                          \
         static constexpr Arity arity = ARITY;                                                                         \
         static constexpr size_t arity_nr = static_cast<size_t>(ARITY);                                                \
-        const Range ranges[arity_nr] = {__VA_ARGS__};                                                                 \
+        Range ranges[arity_nr] = {__VA_ARGS__};                                                                       \
                                                                                                                       \
         ALPAKA_NO_HOST_ACC_WARNING                                                                                    \
         template<                                                                                                     \


### PR DESCRIPTION
Fixes #1384. This PR enforces all kernel arguments to be trivially copyable.

The check for the kernel function object being trivially copyable is deliberately left out until a consensus on #1634 has been reached. 