### PR TITLE
Add a test for the device-wise fence

### DIFF
--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -282,10 +282,11 @@ Atomic operations
          AtomicAdd, AtomicSub, AtomicMin, AtomicMax, AtomicExch,
          AtomicInc, AtomicDec, AtomicAnd, AtomicOr, AtomicXor, AtomicCas
 
-Memory fences on block- or device level (guarantees LoadLoad and StoreStore ordering)
+Memory fences on block-, grid- or device level (guarantees LoadLoad and StoreStore ordering)
   .. code-block:: c++
 
      mem_fence(acc, memory_scope::Block{});
+     mem_fence(acc, memory_scope::Grid{});
      mem_fence(acc, memory_scope::Device{});
 
 Warp-level operations

--- a/docs/source/basic/library.rst
+++ b/docs/source/basic/library.rst
@@ -161,9 +161,10 @@ guarantees the following **for the local thread**  and regardless of global or s
 **Note**: ``alpaka::mem_fence`` does not guarantee that there will be no *LoadStore* reordering. Depending on the
 back-end, loads occurring before the fence may still be reordered with stores occurring after the fence.
 
-Memory fences can be issued on the block level (``alpaka::memory_scope::Block``) and the device level
-(``alpaka::memory_scope::Device``). Depending on the memory scope, the *StoreStore* order will be visible to other
-threads in the same block or the whole device.
+Memory fences can be issued on the block level (``alpaka::memory_scope::Block``), grid level
+(``alpaka::memory_scope::Grid``) and the device level (``alpaka::memory_scope::Device``).
+Depending on the memory scope, the *StoreStore* order will be visible to other threads in the same block, in the same grid
+(_i.e._ within the same kernel launch), or on the whole device (_i.e._ across concurrent kernel launches).
 
 Some accelerators (like GPUs) follow weaker cache coherency rules than x86 CPUs. In order to avoid storing to (or loading
 from) a cache or register it is necessary to prefix all observed buffers with `ALPAKA_DEVICE_VOLATILE`. This enforces

--- a/include/alpaka/mem/fence/MemFenceCpuSerial.hpp
+++ b/include/alpaka/mem/fence/MemFenceCpuSerial.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Jan Stephan
+/* Copyright 2022 Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -29,6 +29,15 @@ namespace alpaka
             static auto mem_fence(MemFenceCpuSerial const&, memory_scope::Block const&)
             {
                 /* Nothing to be done on the block level for the serial case. */
+            }
+        };
+
+        template<>
+        struct MemFence<MemFenceCpuSerial, memory_scope::Grid>
+        {
+            static auto mem_fence(MemFenceCpuSerial const&, memory_scope::Grid const&)
+            {
+                /* Nothing to be done on the grid level for the serial case. */
             }
         };
 

--- a/include/alpaka/mem/fence/MemFenceOmp2Blocks.hpp
+++ b/include/alpaka/mem/fence/MemFenceOmp2Blocks.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2022 Jan Stephan, Bernhard Manfred Gruber, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -33,6 +33,15 @@ namespace alpaka
             static auto mem_fence(MemFenceOmp2Blocks const&, memory_scope::Block const&)
             {
                 // Only one thread per block allowed -> no memory fence required on block level
+            }
+        };
+
+        template<>
+        struct MemFence<MemFenceOmp2Blocks, memory_scope::Grid>
+        {
+            static auto mem_fence(MemFenceOmp2Blocks const&, memory_scope::Grid const&)
+            {
+#    pragma omp flush
             }
         };
 

--- a/include/alpaka/mem/fence/MemFenceUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/mem/fence/MemFenceUniformCudaHipBuiltIn.hpp
@@ -44,6 +44,16 @@ namespace alpaka
         };
 
         template<>
+        struct MemFence<MemFenceUniformCudaHipBuiltIn, memory_scope::Grid>
+        {
+            __device__ static auto mem_fence(MemFenceUniformCudaHipBuiltIn const&, memory_scope::Grid const&)
+            {
+                // CUDA and HIP do not have a per-grid memory fence, so a device-level fence is used
+                __threadfence();
+            }
+        };
+
+        template<>
         struct MemFence<MemFenceUniformCudaHipBuiltIn, memory_scope::Device>
         {
             __device__ static auto mem_fence(MemFenceUniformCudaHipBuiltIn const&, memory_scope::Device const&)

--- a/include/alpaka/mem/fence/Traits.hpp
+++ b/include/alpaka/mem/fence/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Jan Stephan
+/* Copyright 2022 Jan Stephan, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -22,6 +22,11 @@ namespace alpaka
     {
         //! Memory fences are observed by all threads in the same block.
         struct Block
+        {
+        };
+
+        //! Memory fences are observed by all threads in the same grid.
+        struct Grid
         {
         };
 


### PR DESCRIPTION
Since the original device-wise fence test using a single kernel has been repurposed as a test for the grid-wise fences, this PR adds a new test for the device-wise fences using two concurrent kernels.