### PR TITLE
Refactor `getWarpSize` to `getWarpSizes` and return `std::vector<std::size_t>`

### DIFF
--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -23,9 +23,11 @@
 #include <alpaka/wait/Traits.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <vector>
 
 namespace alpaka
@@ -127,7 +129,7 @@ namespace alpaka
             return 0;
         }
 
-    public:
+    private:
         std::shared_ptr<cpu::detail::DevCpuImpl> m_spDevCpuImpl;
     };
 
@@ -165,11 +167,11 @@ namespace alpaka
 
         //! The CPU device warp size get trait specialization.
         template<>
-        struct GetWarpSize<DevCpu>
+        struct GetWarpSizes<DevCpu>
         {
-            ALPAKA_FN_HOST static auto getWarpSize(DevCpu const& /* dev */) -> std::size_t
+            ALPAKA_FN_HOST static auto getWarpSizes(DevCpu const& /* dev */) -> std::vector<std::size_t>
             {
-                return 1u;
+                return {1u};
             }
         };
 

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -26,9 +26,11 @@
 #    include <CL/sycl.hpp>
 
 #    include <algorithm>
+#    include <cstddef>
 #    include <memory>
 #    include <mutex>
 #    include <shared_mutex>
+#    include <string>
 #    include <utility>
 #    include <vector>
 
@@ -174,15 +176,12 @@ namespace alpaka::traits
 
     //! The SYCL device warp size get trait specialization.
     template<typename TPltf>
-    struct GetWarpSize<experimental::DevGenericSycl<TPltf>>
+    struct GetWarpSizes<experimental::DevGenericSycl<TPltf>>
     {
-        static auto getWarpSize(experimental::DevGenericSycl<TPltf> const& dev) -> std::size_t
+        static auto getWarpSizes(experimental::DevGenericSycl<TPltf> const& dev) -> std::vector<std::size_t>
         {
-            // TODO: This trait should return a vector instead. Not everything is a NVIDIA GPU. For now we report
-            // the smallest possible size.
             const auto device = dev.getNativeHandle().first;
-            const auto sizes = device.template get_info<sycl::info::device::sub_group_sizes>();
-            return *(std::min_element(std::begin(sizes), std::end(sizes)));
+            return device.template get_info<sycl::info::device::sub_group_sizes>();
         }
     };
 

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -29,9 +29,11 @@
 
 #    include <openacc.h>
 
+#    include <cstddef>
 #    include <memory>
 #    include <mutex>
 #    include <sstream>
+#    include <string>
 #    include <vector>
 
 namespace alpaka
@@ -258,11 +260,11 @@ namespace alpaka
 
         //! The OpenACC device warp size get trait specialization.
         template<>
-        struct GetWarpSize<DevOacc>
+        struct GetWarpSizes<DevOacc>
         {
-            ALPAKA_FN_HOST static auto getWarpSize(DevOacc const& /* dev */) -> std::size_t
+            ALPAKA_FN_HOST static auto getWarpSizes(DevOacc const& /* dev */) -> std::vector<std::size_t>
             {
-                return 1u;
+                return {1u};
             }
         };
 

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -27,9 +27,12 @@
 #    include <alpaka/traits/Traits.hpp>
 #    include <alpaka/wait/Traits.hpp>
 
+#    include <cstddef>
 #    include <map>
 #    include <sstream>
 #    include <stdexcept>
+#    include <string>
+#    include <vector>
 
 namespace alpaka
 {
@@ -222,11 +225,11 @@ namespace alpaka
 
         //! The OpenMP 5.0 device warp size get trait specialization.
         template<>
-        struct GetWarpSize<DevOmp5>
+        struct GetWarpSizes<DevOmp5>
         {
-            ALPAKA_FN_HOST static auto getWarpSize(DevOmp5 const& /* dev */) -> std::size_t
+            ALPAKA_FN_HOST static auto getWarpSizes(DevOmp5 const& /* dev */) -> std::vector<std::size_t>
             {
-                return 1u;
+                return {1u};
             }
         };
 

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Andrea Bocci, Bernhard Manfred Gruber, Antonio Di Pilato
+/* Copyright 2022 Benjamin Worpitz, Andrea Bocci, Bernhard Manfred Gruber, Antonio Di Pilato, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -26,6 +26,10 @@
 #    else
 #        include <alpaka/core/Hip.hpp>
 #    endif
+
+#    include <cstddef>
+#    include <string>
+#    include <vector>
 
 namespace alpaka
 {
@@ -137,9 +141,9 @@ namespace alpaka
 
         //! The CUDA/HIP RT device warp size get trait specialization.
         template<>
-        struct GetWarpSize<DevUniformCudaHipRt>
+        struct GetWarpSizes<DevUniformCudaHipRt>
         {
-            ALPAKA_FN_HOST static auto getWarpSize(DevUniformCudaHipRt const& dev) -> std::size_t
+            ALPAKA_FN_HOST static auto getWarpSizes(DevUniformCudaHipRt const& dev) -> std::vector<std::size_t>
             {
 #    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                 cudaDeviceProp devProp;
@@ -149,7 +153,7 @@ namespace alpaka
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     ALPAKA_API_PREFIX(GetDeviceProperties)(&devProp, dev.getNativeHandle()));
 
-                return static_cast<std::size_t>(devProp.warpSize);
+                return {static_cast<std::size_t>(devProp.warpSize)};
             }
         };
 

--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,10 @@
 
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+
+#include <cstddef>
+#include <string>
+#include <vector>
 
 namespace alpaka
 {
@@ -39,7 +43,7 @@ namespace alpaka
 
         //! The device warp size get trait.
         template<typename T, typename TSfinae = void>
-        struct GetWarpSize;
+        struct GetWarpSizes;
 
         //! The device reset trait.
         template<typename T, typename TSfinae = void>
@@ -86,11 +90,11 @@ namespace alpaka
         return traits::GetFreeMemBytes<TDev>::getFreeMemBytes(dev);
     }
 
-    //! \return The warp size on the device in number of threads.
+    //! \return The supported warp sizes on the device in number of threads.
     template<typename TDev>
-    ALPAKA_FN_HOST auto getWarpSize(TDev const& dev) -> std::size_t
+    ALPAKA_FN_HOST auto getWarpSizes(TDev const& dev) -> std::vector<std::size_t>
     {
-        return traits::GetWarpSize<TDev>::getWarpSize(dev);
+        return traits::GetWarpSizes<TDev>::getWarpSizes(dev);
     }
 
     //! Resets the device.

--- a/test/unit/dev/src/DevWarpSizeTest.cpp
+++ b/test/unit/dev/src/DevWarpSizeTest.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Sergei Bastrakov, Bernhard Manfred Gruber
+/* Copyright 2022 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan
  *
  * This file is part of Alpaka.
  *
@@ -12,11 +12,17 @@
 
 #include <catch2/catch.hpp>
 
-TEMPLATE_LIST_TEST_CASE("getWarpSize", "[dev]", alpaka::test::TestAccs)
+#include <algorithm>
+#include <cstddef>
+
+TEMPLATE_LIST_TEST_CASE("getWarpSizes", "[dev]", alpaka::test::TestAccs)
 {
     using Dev = alpaka::Dev<TestType>;
     using Pltf = alpaka::Pltf<Dev>;
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::getWarpSize(dev);
-    REQUIRE(warpExtent > 0);
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    REQUIRE(std::all_of(
+        std::cbegin(warpExtents),
+        std::cend(warpExtents),
+        [](std::size_t warpExtent) { return warpExtent > 0; }));
 }

--- a/test/unit/warp/src/Activemask.cpp
+++ b/test/unit/warp/src/Activemask.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Sergei Bastrakov, Bernhard Manfred Gruber
+/* Copyright 2022 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan
  *
  * This file is part of Alpaka.
  *
@@ -69,31 +69,34 @@ TEMPLATE_LIST_TEST_CASE("activemask", "[warp]", alpaka::test::TestAccs)
     using Idx = alpaka::Idx<Acc>;
 
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::getWarpSize(dev);
-    if(warpExtent == 1)
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
     {
-        Idx const gridThreadExtentPerDim = 4;
-        alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(gridThreadExtentPerDim));
-        ActivemaskSingleThreadWarpTestKernel kernel;
-        REQUIRE(fixture(kernel));
-    }
-    else
-    {
-        // Work around gcc 7.5 trying and failing to offload for OpenMP 4.0
+        if(warpExtent == 1)
+        {
+            Idx const gridThreadExtentPerDim = 4;
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(gridThreadExtentPerDim));
+            ActivemaskSingleThreadWarpTestKernel kernel;
+            REQUIRE(fixture(kernel));
+        }
+        else
+        {
+            // Work around gcc 7.5 trying and failing to offload for OpenMP 4.0
 #if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 5, 0)) && defined ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-        return;
+            return;
 #else
-        using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-        auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-        // Enforce one warp per thread block
-        auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-        blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-        auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-        auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-        auto fixture = ExecutionFixture{workDiv};
-        ActivemaskMultipleThreadWarpTestKernel kernel;
-        for(auto inactiveThreadIdx = 0u; inactiveThreadIdx < warpExtent; inactiveThreadIdx++)
-            REQUIRE(fixture(kernel, inactiveThreadIdx));
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            ActivemaskMultipleThreadWarpTestKernel kernel;
+            for(auto inactiveThreadIdx = 0u; inactiveThreadIdx < warpExtent; inactiveThreadIdx++)
+                REQUIRE(fixture(kernel, inactiveThreadIdx));
 #endif
+        }
     }
 }

--- a/test/unit/warp/src/Any.cpp
+++ b/test/unit/warp/src/Any.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Sergei Bastrakov, Bernhard Manfred Gruber
+/* Copyright 2022 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan
  *
  * This file is part of Alpaka.
  *
@@ -73,30 +73,33 @@ TEMPLATE_LIST_TEST_CASE("any", "[warp]", alpaka::test::TestAccs)
     using Idx = alpaka::Idx<Acc>;
 
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::getWarpSize(dev);
-    if(warpExtent == 1)
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
     {
-        Idx const gridThreadExtentPerDim = 4;
-        alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(gridThreadExtentPerDim));
-        AnySingleThreadWarpTestKernel kernel;
-        REQUIRE(fixture(kernel));
-    }
-    else
-    {
-        // Work around gcc 7.5 trying and failing to offload for OpenMP 4.0
+        if(warpExtent == 1)
+        {
+            Idx const gridThreadExtentPerDim = 4;
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(gridThreadExtentPerDim));
+            AnySingleThreadWarpTestKernel kernel;
+            REQUIRE(fixture(kernel));
+        }
+        else
+        {
+            // Work around gcc 7.5 trying and failing to offload for OpenMP 4.0
 #if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 5, 0)) && defined ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-        return;
+            return;
 #else
-        using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-        auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-        // Enforce one warp per thread block
-        auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-        blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-        auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-        auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-        auto fixture = ExecutionFixture{workDiv};
-        AnyMultipleThreadWarpTestKernel kernel;
-        REQUIRE(fixture(kernel));
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            AnyMultipleThreadWarpTestKernel kernel;
+            REQUIRE(fixture(kernel));
 #endif
+        }
     }
 }

--- a/test/unit/warp/src/Ballot.cpp
+++ b/test/unit/warp/src/Ballot.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Sergei Bastrakov, Bernhard Manfred Gruber
+/* Copyright 2022 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan
  *
  * This file is part of Alpaka.
  *
@@ -81,30 +81,33 @@ TEMPLATE_LIST_TEST_CASE("ballot", "[warp]", alpaka::test::TestAccs)
     using Idx = alpaka::Idx<Acc>;
 
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::getWarpSize(dev);
-    if(warpExtent == 1)
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
     {
-        Idx const gridThreadExtentPerDim = 4;
-        alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(gridThreadExtentPerDim));
-        BallotSingleThreadWarpTestKernel kernel;
-        REQUIRE(fixture(kernel));
-    }
-    else
-    {
-        // Work around gcc 7.5 trying and failing to offload for OpenMP 4.0
+        if(warpExtent == 1)
+        {
+            Idx const gridThreadExtentPerDim = 4;
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(gridThreadExtentPerDim));
+            BallotSingleThreadWarpTestKernel kernel;
+            REQUIRE(fixture(kernel));
+        }
+        else
+        {
+            // Work around gcc 7.5 trying and failing to offload for OpenMP 4.0
 #if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 5, 0)) && defined ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-        return;
+            return;
 #else
-        using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-        auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-        // Enforce one warp per thread block
-        auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-        blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-        auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-        auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-        auto fixture = ExecutionFixture{workDiv};
-        BallotMultipleThreadWarpTestKernel kernel;
-        REQUIRE(fixture(kernel));
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            BallotMultipleThreadWarpTestKernel kernel;
+            REQUIRE(fixture(kernel));
 #endif
+        }
     }
 }

--- a/test/unit/warp/src/GetSize.cpp
+++ b/test/unit/warp/src/GetSize.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Sergei Bastrakov, Bernhard Manfred Gruber
+/* Copyright 2022 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan
  *
  * This file is part of Alpaka.
  *
@@ -37,9 +37,17 @@ TEMPLATE_LIST_TEST_CASE("getSize", "[warp]", alpaka::test::TestAccs)
     using Idx = alpaka::Idx<Acc>;
 
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto const expectedWarpSize = static_cast<int>(alpaka::getWarpSize(dev));
+    auto const warpSizes = alpaka::getWarpSizes(dev);
     Idx const gridThreadExtentPerDim = 8;
     alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(gridThreadExtentPerDim));
     GetSizeTestKernel kernel;
-    REQUIRE(fixture(kernel, expectedWarpSize));
+    auto success = false;
+    for(auto const expectedWarpSize : warpSizes)
+    {
+        // ensure that at least one of the supported warp sizes is used in the kernel
+        success = success || fixture(kernel, static_cast<std::int32_t>(expectedWarpSize));
+        if(success)
+            break; // don't do more work than necessary
+    }
+    REQUIRE(success);
 }

--- a/test/unit/warp/src/Shfl.cpp
+++ b/test/unit/warp/src/Shfl.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 David M. Rogers
+/* Copyright 2022 David M. Rogers, Jan Stephan
  *
  * This file is part of Alpaka.
  *
@@ -96,30 +96,33 @@ TEMPLATE_LIST_TEST_CASE("shfl", "[warp]", alpaka::test::TestAccs)
     using Idx = alpaka::Idx<Acc>;
 
     Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto const warpExtent = alpaka::getWarpSize(dev);
-    if(warpExtent == 1)
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
     {
-        Idx const gridThreadExtentPerDim = 4;
-        alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(gridThreadExtentPerDim));
-        ShflSingleThreadWarpTestKernel kernel;
-        REQUIRE(fixture(kernel));
-    }
-    else
-    {
-        // Work around gcc 7.5 trying and failing to offload for OpenMP 4.0
+        if(warpExtent == 1)
+        {
+            Idx const gridThreadExtentPerDim = 4;
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(gridThreadExtentPerDim));
+            ShflSingleThreadWarpTestKernel kernel;
+            REQUIRE(fixture(kernel));
+        }
+        else
+        {
+            // Work around gcc 7.5 trying and failing to offload for OpenMP 4.0
 #if BOOST_COMP_GNUC && (BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(7, 5, 0)) && defined ALPAKA_ACC_ANY_BT_OMP5_ENABLED
-        return;
+            return;
 #else
-        using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-        auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-        // Enforce one warp per thread block
-        auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-        blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-        auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-        auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-        auto fixture = ExecutionFixture{workDiv};
-        ShflMultipleThreadWarpTestKernel kernel;
-        REQUIRE(fixture(kernel));
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            ShflMultipleThreadWarpTestKernel kernel;
+            REQUIRE(fixture(kernel));
 #endif
+        }
     }
 }


### PR DESCRIPTION
Fixes #1595. This PR renames all instances of `getWarpSize` to `getWarpSizes` and always returns a `std::vector<std::size_t>` instead of a single `std::size_t`.