### PR TITLE
Deprecate `alpaka::clock()`

### DIFF
--- a/include/alpaka/time/Traits.hpp
+++ b/include/alpaka/time/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -32,9 +32,9 @@ namespace alpaka
     //!
     //! \tparam TTime The time implementation type.
     //! \param time The time implementation.
-    ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TTime>
-    ALPAKA_FN_HOST_ACC auto clock(TTime const& time) -> std::uint64_t
+    ALPAKA_NO_HOST_ACC_WARNING template<typename TTime>
+    [[deprecated("clock() is deprecated and will be removed in the next release")]] ALPAKA_FN_HOST_ACC auto clock(
+        TTime const& time) -> std::uint64_t
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptTime, TTime>;
         return traits::Clock<ImplementationBase>::clock(time);

--- a/test/unit/time/CMakeLists.txt
+++ b/test/unit/time/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2020 Benjamin Worpitz, Axel Huebl, Jan Stephan
+# Copyright 2022 Benjamin Worpitz, Axel Huebl, Jan Stephan
 #
 # This file is part of alpaka.
 #
@@ -21,5 +21,11 @@ target_link_libraries(
 
 set_target_properties(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 target_compile_definitions(${_TARGET_NAME} PRIVATE "-DTEST_UNIT_TIME")
+target_compile_options(${_TARGET_NAME} PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CUDA_COMPILER_ID:Clang,NVIDIA>>:-Wno-deprecated-declarations>
+                                               $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:AppleClang,Clang,GNU>>:-Wno-deprecated-declarations>
+                                               $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:Intel>,$<PLATFORM_ID:Linux>>:-diag-disable=1786>
+                                               $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:Intel>,$<PLATFORM_ID:Windows>>:/Qdiag-disable:1786>
+                                               $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/wd4996>
+                                               $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:PGI>>:--diag_suppress 1361>)
 
 add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME} ${_ALPAKA_TEST_OPTIONS})


### PR DESCRIPTION
In today's developer meeting we decided to deprecate `alpaka::clock()` and remove it in the release after 0.9.