### PR TITLE
Renamed "traits" namespace to "trait"

### DIFF
--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -263,7 +263,7 @@ Allocate static shared memory variable
 Get dynamic shared memory pool, requires the kernel to specialize
   .. code-block:: c++
 
-     traits::BlockSharedMemDynSizeBytes
+     trait::BlockSharedMemDynSizeBytes
        Type * dynamicSharedMemoryPool = getDynSharedMem<Type>(acc);
 
 Synchronize threads of the same block

--- a/docs/source/dev/details.rst
+++ b/docs/source/dev/details.rst
@@ -251,10 +251,10 @@ These functions are dispatched in two ways to support user defined overloads of 
 
 Let's take `alpaka::math::abs` as an example:
 When `alpaka::math::abs(acc, value)` is called, a concrete implementation of `abs` is picked via template specialization.
-Concretely, something similar to `alpaka::math::traits::Abs<decltype(acc), decltype(value)>{}(acc, value)` is called.
-This allows alpaka (and the user) to specialize the template `alpaka::math::traits::Abs` for various backends and various argument types.
+Concretely, something similar to `alpaka::math::trait::Abs<decltype(acc), decltype(value)>{}(acc, value)` is called.
+This allows alpaka (and the user) to specialize the template `alpaka::math::trait::Abs` for various backends and various argument types.
 E.g. alpaka contains specializations for `float` and `double`.
-If there is no specialization within alpaka (or by the user), the default implementation of `alpaka::math::traits::Abs<....>{}(acc, value)` will just call `abs(value)`.
+If there is no specialization within alpaka (or by the user), the default implementation of `alpaka::math::trait::Abs<....>{}(acc, value)` will just call `abs(value)`.
 This is called an unqualified call and C++ will try to find a function called `abs` in the namespace where the type of `value` is defined.
 This feature is called Argument Dependent Lookup (ADL).
 Using ADL for types which are not covered by specializations in alpaka allows a user to bring their own implementation for which `abs` is meaningful, e.g. a custom implementation of complex numbers or a fixed precision type.

--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -70,7 +70,7 @@ struct OpenMPScheduleTraitKernel : public OpenMPScheduleDefaultKernel
 {
 };
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! Schedule trait specialization for OpenMPScheduleTraitKernel.
     //! This is the most general way to define a schedule.
@@ -90,7 +90,7 @@ namespace alpaka::traits
             return alpaka::omp::Schedule{alpaka::omp::Schedule::Dynamic, 2};
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 auto main() -> int
 {

--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -124,7 +124,7 @@ namespace alpaka
         boost::fibers::fiber::id mutable m_masterFiberId; //!< The id of the master fiber.
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU fibers accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
@@ -218,7 +218,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -116,7 +116,7 @@ namespace alpaka
         Vec<TDim, TIdx> mutable m_gridBlockIdx; //!< The index of the currently executed block.
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU OpenMP 2.0 block accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
@@ -201,7 +201,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -121,7 +121,7 @@ namespace alpaka
         Vec<TDim, TIdx> mutable m_gridBlockIdx; //!< The index of the currently executed block.
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU OpenMP 2.0 thread accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
@@ -211,7 +211,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -110,7 +110,7 @@ namespace alpaka
         Vec<TDim, TIdx> mutable m_gridBlockIdx; //!< The index of the currently executed block.
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU serial accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
@@ -195,7 +195,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/acc/AccCpuSyclIntel.hpp
+++ b/include/alpaka/acc/AccCpuSyclIntel.hpp
@@ -43,7 +43,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The Intel CPU SYCL accelerator name trait specialization.
     template<typename TDim, typename TIdx>
@@ -81,6 +81,6 @@ namespace alpaka::traits
     {
         using type = experimental::PltfCpuSyclIntel;
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -107,7 +107,7 @@ namespace alpaka
         Vec<TDim, TIdx> mutable m_gridBlockIdx; //!< The index of the currently executed block.
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU TBB block accelerator type trait specialization.
         template<typename TDim, typename TIdx>
@@ -192,7 +192,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -122,7 +122,7 @@ namespace alpaka
         std::thread::id mutable m_idMasterThread; //!< The id of the master thread.
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU threads accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
@@ -217,7 +217,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/acc/AccFpgaSyclIntel.hpp
+++ b/include/alpaka/acc/AccFpgaSyclIntel.hpp
@@ -42,7 +42,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The Intel FPGA SYCL accelerator name trait specialization.
     template<typename TDim, typename TIdx>
@@ -80,6 +80,6 @@ namespace alpaka::traits
     {
         using type = experimental::PltfFpgaSyclIntel;
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/acc/AccFpgaSyclXilinx.hpp
+++ b/include/alpaka/acc/AccFpgaSyclXilinx.hpp
@@ -42,7 +42,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The Xilinx FPGA SYCL accelerator name trait specialization.
     template<typename TDim, typename TIdx>
@@ -80,6 +80,6 @@ namespace alpaka::traits
     {
         using type = experimental::PltfFpgaSyclXilinx;
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/acc/AccGenericSycl.hpp
+++ b/include/alpaka/acc/AccGenericSycl.hpp
@@ -115,7 +115,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL accelerator type trait specialization.
     template<template<typename, typename> typename TAcc, typename TDim, typename TIdx>
@@ -179,6 +179,6 @@ namespace alpaka::traits
     {
         using type = TIdx;
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/acc/AccGpuCudaRt.hpp
+++ b/include/alpaka/acc/AccGpuCudaRt.hpp
@@ -49,7 +49,7 @@ namespace alpaka
         }
     };
 
-    namespace traits
+    namespace trait
     {
         //! The GPU CUDA accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
@@ -83,7 +83,7 @@ namespace alpaka
                     std::forward<TArgs>(args)...);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/acc/AccGpuHipRt.hpp
+++ b/include/alpaka/acc/AccGpuHipRt.hpp
@@ -49,7 +49,7 @@ namespace alpaka
         }
     };
 
-    namespace traits
+    namespace trait
     {
         //! The GPU HIP accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
@@ -83,7 +83,7 @@ namespace alpaka
                     std::forward<TArgs>(args)...);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/acc/AccGpuSyclIntel.hpp
+++ b/include/alpaka/acc/AccGpuSyclIntel.hpp
@@ -42,7 +42,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The Intel GPU SYCL accelerator name trait specialization.
     template<typename TDim, typename TIdx>
@@ -80,6 +80,6 @@ namespace alpaka::traits
     {
         using type = experimental::PltfGpuSyclIntel;
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -98,7 +98,7 @@ namespace alpaka
         }
     };
 
-    namespace traits
+    namespace trait
     {
         //! The GPU CUDA accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
@@ -222,7 +222,7 @@ namespace alpaka
         {
             using type = TDim;
         };
-    } // namespace traits
+    } // namespace trait
     namespace detail
     {
         //! specialization of the TKernelFnObj return type evaluation
@@ -239,7 +239,7 @@ namespace alpaka
             }
         };
     } // namespace detail
-    namespace traits
+    namespace trait
     {
         //! The GPU CUDA accelerator execution task type trait specialization.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
@@ -272,7 +272,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/acc/AccOacc.hpp
+++ b/include/alpaka/acc/AccOacc.hpp
@@ -99,7 +99,7 @@ namespace alpaka
         CtxBlockOacc<TDim, TIdx>& m_blockShared;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The OpenACC accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
@@ -344,7 +344,7 @@ namespace alpaka
                     workDiv.m_blockShared);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/acc/AccOmp5.hpp
+++ b/include/alpaka/acc/AccOmp5.hpp
@@ -169,7 +169,7 @@ namespace alpaka
         }
     };
 
-    namespace traits
+    namespace trait
     {
         //! The OpenMP 5.0 accelerator accelerator type trait specialization.
         template<typename TDim, typename TIdx>
@@ -280,7 +280,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/acc/Traits.hpp
+++ b/include/alpaka/acc/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -33,7 +33,7 @@ namespace alpaka
     {
     };
     //! The accelerator traits.
-    namespace traits
+    namespace trait
     {
         //! The accelerator type trait.
         template<typename T, typename TSfinae = void>
@@ -59,25 +59,25 @@ namespace alpaka
         template<typename TAcc>
         struct GetAccDevProps<TAcc, std::enable_if_t<concepts::ImplementsConcept<ConceptUniformCudaHip, TAcc>::value>>
         {
-            ALPAKA_FN_HOST static auto getAccDevProps(typename alpaka::traits::DevType<TAcc>::type const& dev)
-                -> AccDevProps<typename traits::DimType<TAcc>::type, typename traits::IdxType<TAcc>::type>
+            ALPAKA_FN_HOST static auto getAccDevProps(typename alpaka::trait::DevType<TAcc>::type const& dev)
+                -> AccDevProps<typename trait::DimType<TAcc>::type, typename trait::IdxType<TAcc>::type>
             {
                 using ImplementationBase = typename concepts::ImplementationBase<ConceptUniformCudaHip, TAcc>;
                 return GetAccDevProps<ImplementationBase>::getAccDevProps(dev);
             }
         };
-    } // namespace traits
+    } // namespace trait
 
     //! The accelerator type trait alias template to remove the ::type.
     template<typename T>
-    using Acc = typename traits::AccType<T>::type;
+    using Acc = typename trait::AccType<T>::type;
 
     //! \return The acceleration properties on the given device.
     template<typename TAcc, typename TDev>
     ALPAKA_FN_HOST auto getAccDevProps(TDev const& dev) -> AccDevProps<Dim<TAcc>, Idx<TAcc>>
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptAcc, TAcc>;
-        return traits::GetAccDevProps<ImplementationBase>::getAccDevProps(dev);
+        return trait::GetAccDevProps<ImplementationBase>::getAccDevProps(dev);
     }
 
     //! \return The accelerator name
@@ -86,7 +86,7 @@ namespace alpaka
     template<typename TAcc>
     ALPAKA_FN_HOST auto getAccName() -> std::string
     {
-        return traits::GetAccName<TAcc>::getAccName();
+        return trait::GetAccName<TAcc>::getAccName();
     }
 
     namespace detail
@@ -105,7 +105,7 @@ namespace alpaka
         };
     } // namespace detail
 
-    namespace traits
+    namespace trait
     {
         //! The GPU HIP accelerator device type trait specialization.
         template<typename TAcc>
@@ -142,7 +142,7 @@ namespace alpaka
         template<typename TAcc, typename TProperty>
         struct QueueType<TAcc, TProperty, std::enable_if_t<concepts::ImplementsConcept<ConceptAcc, TAcc>::value>>
         {
-            using type = typename QueueType<typename alpaka::traits::PltfType<TAcc>::type, TProperty>::type;
+            using type = typename QueueType<typename alpaka::trait::PltfType<TAcc>::type, TProperty>::type;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/atomic/AtomicAtomicRef.hpp
+++ b/include/alpaka/atomic/AtomicAtomicRef.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Felice Pantaleo, Andrea Bocci
+/* Copyright 2022 Felice Pantaleo, Andrea Bocci
  *
  * This file is part of alpaka.
  *
@@ -37,7 +37,7 @@ namespace alpaka
             "ALPAKA_DISABLE_ATOMIC_ATOMICREF.");
     }
 
-    namespace traits
+    namespace trait
     {
         //! The CPU accelerators AtomicAdd.
         template<typename T, typename THierarchy>
@@ -214,5 +214,5 @@ namespace alpaka
                 return old;
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/atomic/AtomicGenericSycl.hpp
+++ b/include/alpaka/atomic/AtomicGenericSycl.hpp
@@ -101,7 +101,7 @@ namespace alpaka::experimental
     } // namespace detail
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     // Add.
     //! The SYCL accelerator atomic operation.
@@ -318,6 +318,6 @@ namespace alpaka::traits
             }
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/atomic/AtomicNoOp.hpp
+++ b/include/alpaka/atomic/AtomicNoOp.hpp
@@ -18,7 +18,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU fibers accelerator atomic operation.
         template<typename TOp, typename T, typename THierarchy>
@@ -38,5 +38,5 @@ namespace alpaka
                 return TOp()(addr, compare, value);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/atomic/AtomicOaccBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicOaccBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Jeffrey Kelling, Bernhard Manfred Gruber
+/* Copyright 2022 Jeffrey Kelling, Bernhard Manfred Gruber
  *
  * This file is part of Alpaka.
  *
@@ -28,7 +28,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         // "omp atomic update capture" is not supported before OpenACC 2.5 and by PGI
         // "omp atomic capture {}" works for PGI and GCC, using this even though non-standart
@@ -146,7 +146,7 @@ namespace alpaka
             }
         };
 
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/atomic/AtomicOaccExtended.hpp
+++ b/include/alpaka/atomic/AtomicOaccExtended.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Jeffrey Kelling, Bernhard Manfred Gruber
+/* Copyright 2022 Jeffrey Kelling, Bernhard Manfred Gruber
  *
  * This file is part of Alpaka.
  *
@@ -37,7 +37,7 @@ namespace alpaka
         mutable std::uint32_t mutex[2] = {0u, 0u};
     };
 
-    namespace traits
+    namespace trait
     {
         namespace detail
         {
@@ -213,7 +213,7 @@ namespace alpaka
             }
         };
 
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/atomic/AtomicOmpBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicOmpBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 René Widera, Bernhard Manfred Gruber
+/* Copyright 2022 René Widera, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -25,7 +25,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
 // check for OpenMP 3.1+
 // "omp atomic capture" is not supported before OpenMP 3.1
@@ -325,7 +325,7 @@ namespace alpaka
 
 #    endif // _OPENMP >= 202011
 
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/atomic/AtomicStdLibLock.hpp
+++ b/include/alpaka/atomic/AtomicStdLibLock.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -29,7 +29,7 @@ namespace alpaka
     {
     public:
         template<typename TAtomic, typename TOp, typename T, typename THierarchy, typename TSfinae>
-        friend struct traits::AtomicOp;
+        friend struct trait::AtomicOp;
 
         static constexpr auto nextPowerOf2(size_t const value, size_t const bit = 0u) -> size_t
         {
@@ -75,7 +75,7 @@ namespace alpaka
         }
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU threads accelerator atomic operation.
         template<typename TOp, typename T, typename THierarchy, size_t THashTableSize>
@@ -99,5 +99,5 @@ namespace alpaka
                 return TOp()(addr, compare, value);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/atomic/AtomicUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicUniformCudaHipBuiltIn.hpp
@@ -38,7 +38,7 @@ namespace alpaka
 #            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #        endif
 
-    namespace traits
+    namespace trait
     {
         //! The specializations to execute the requested atomic ops of the CUDA/HIP accelerator.
         // See: http://docs.nvidia.com/cuda/cuda-c-programming-guide/#atomic-functions how to implement everything with
@@ -800,7 +800,7 @@ namespace alpaka
                 return T();
             }
         };
-    } // namespace traits
+    } // namespace trait
 
 #    endif
 

--- a/include/alpaka/atomic/Traits.hpp
+++ b/include/alpaka/atomic/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, René Widera, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, René Widera, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -55,13 +55,13 @@ namespace alpaka
     template<typename THierarchy>
     using AtomicHierarchyConcept = typename detail::AtomicHierarchyConceptType<THierarchy>::type;
 
-    //! The atomic operation traits.
-    namespace traits
+    //! The atomic operation trait.
+    namespace trait
     {
         //! The atomic operation trait.
         template<typename TOp, typename TAtomic, typename T, typename THierarchy, typename TSfinae = void>
         struct AtomicOp;
-    } // namespace traits
+    } // namespace trait
 
     //! Executes the given operation atomically.
     //!
@@ -80,7 +80,7 @@ namespace alpaka
         THierarchy const& = THierarchy()) -> T
     {
         using ImplementationBase = typename concepts::ImplementationBase<AtomicHierarchyConcept<THierarchy>, TAtomic>;
-        return traits::AtomicOp<TOp, ImplementationBase, T, THierarchy>::atomicOp(atomic, addr, value);
+        return trait::AtomicOp<TOp, ImplementationBase, T, THierarchy>::atomicOp(atomic, addr, value);
     }
 
     //! Executes the given operation atomically.
@@ -102,7 +102,7 @@ namespace alpaka
         THierarchy const& = THierarchy()) -> T
     {
         using ImplementationBase = typename concepts::ImplementationBase<AtomicHierarchyConcept<THierarchy>, TAtomic>;
-        return traits::AtomicOp<TOp, ImplementationBase, T, THierarchy>::atomicOp(atomic, addr, compare, value);
+        return trait::AtomicOp<TOp, ImplementationBase, T, THierarchy>::atomicOp(atomic, addr, compare, value);
     }
 
     //! Executes an atomic add operation.

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynGenericSycl.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynGenericSycl.hpp
@@ -37,7 +37,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     template<typename T>
     struct GetDynSharedMem<T, experimental::BlockSharedMemDynGenericSycl>
@@ -49,6 +49,6 @@ namespace alpaka::traits
             return t_ptr.get();
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -92,7 +92,7 @@ namespace alpaka
 #    pragma warning(pop)
 #endif
 
-    namespace traits
+    namespace trait
     {
         template<typename T, std::size_t TStaticAllocKiB>
         struct GetDynSharedMem<T, BlockSharedMemDynMember<TStaticAllocKiB>>
@@ -114,5 +114,5 @@ namespace alpaka
 #    pragma GCC diagnostic pop
 #endif
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynOmp5BuiltIn.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynOmp5BuiltIn.hpp
@@ -98,7 +98,7 @@ namespace alpaka
 #        pragma warning(pop)
 #    endif
 
-    namespace traits
+    namespace trait
     {
         template<typename T>
         struct GetDynSharedMem<T, BlockSharedMemDynOmp5BuiltIn>
@@ -112,7 +112,7 @@ namespace alpaka
                 return reinterpret_cast<T*>(dyn.mem());
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynUniformCudaHipBuiltIn.hpp
@@ -35,7 +35,7 @@ namespace alpaka
 #            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #        endif
 
-    namespace traits
+    namespace trait
     {
         template<typename T>
         struct GetDynSharedMem<T, BlockSharedMemDynUniformCudaHipBuiltIn>
@@ -50,7 +50,7 @@ namespace alpaka
                 return reinterpret_cast<T*>(shMem);
             }
         };
-    } // namespace traits
+    } // namespace trait
 
 #    endif
 

--- a/include/alpaka/block/shared/dyn/Traits.hpp
+++ b/include/alpaka/block/shared/dyn/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -21,12 +21,12 @@ namespace alpaka
     };
 
     //! The block shared dynamic memory operation traits.
-    namespace traits
+    namespace trait
     {
         //! The block shared dynamic memory get trait.
         template<typename T, typename TBlockSharedMemDyn, typename TSfinae = void>
         struct GetDynSharedMem;
-    } // namespace traits
+    } // namespace trait
 
     //! Get block shared dynamic memory.
     //!
@@ -44,6 +44,6 @@ namespace alpaka
     ALPAKA_FN_ACC auto getDynSharedMem(TBlockSharedMemDyn const& blockSharedMemDyn) -> T*
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedDyn, TBlockSharedMemDyn>;
-        return traits::GetDynSharedMem<T, ImplementationBase>::getMem(blockSharedMemDyn);
+        return trait::GetDynSharedMem<T, ImplementationBase>::getMem(blockSharedMemDyn);
     }
 } // namespace alpaka

--- a/include/alpaka/block/shared/st/BlockSharedMemStGenericSycl.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStGenericSycl.hpp
@@ -41,7 +41,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     template<typename T, std::size_t TUniqueId>
     struct DeclareSharedVar<T, TUniqueId, experimental::BlockSharedMemStGenericSycl>
@@ -68,6 +68,6 @@ namespace alpaka::traits
             // shared memory block data will be reused
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMember.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Jeffrey Kelling, Rene Widera, Bernhard Manfred Gruber
+/* Copyright 2022 Jeffrey Kelling, Rene Widera, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -33,7 +33,7 @@ namespace alpaka
         using detail::BlockSharedMemStMemberImpl<TDataAlignBytes>::BlockSharedMemStMemberImpl;
     };
 
-    namespace traits
+    namespace trait
     {
         template<typename T, std::size_t TDataAlignBytes, std::size_t TuniqueId>
         struct DeclareSharedVar<T, TuniqueId, BlockSharedMemStMember<TDataAlignBytes>>
@@ -59,5 +59,5 @@ namespace alpaka
                 // shared memory block data will be reused
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/block/shared/st/BlockSharedMemStMemberMasterSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMemberMasterSync.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera
+/* Copyright 2022 Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera
  *
  * This file is part of alpaka.
  *
@@ -44,7 +44,7 @@ namespace alpaka
         std::function<bool()> m_isMasterThreadFn;
     };
 
-    namespace traits
+    namespace trait
     {
 #if BOOST_COMP_GNUC
 #    pragma GCC diagnostic push
@@ -88,5 +88,5 @@ namespace alpaka
                 // shared memory block data will be reused
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/block/shared/st/BlockSharedMemStOmp5.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStOmp5.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Erik Zenker, René Widera, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Erik Zenker, René Widera, Bernhard Manfred Gruber
  *
  * This file is part of Alpaka.
  *
@@ -34,7 +34,7 @@ namespace alpaka
         using BlockSharedMemStMemberImpl<4>::BlockSharedMemStMemberImpl;
     };
 
-    namespace traits
+    namespace trait
     {
         template<typename T, std::size_t TuniqueId>
         struct DeclareSharedVar<T, TuniqueId, BlockSharedMemStOmp5>
@@ -66,7 +66,7 @@ namespace alpaka
                 // shared memory block data will be reused
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/block/shared/st/BlockSharedMemStOmp5BuiltIn.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStOmp5BuiltIn.hpp
@@ -23,7 +23,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         template<typename T, std::size_t TuniqueId>
         struct DeclareSharedVar<T, TuniqueId, BlockSharedMemStOmp5BuiltIn>
@@ -43,7 +43,7 @@ namespace alpaka
                 // Nothing to do. OpenMP runtime frees block shared memory at the end of the parallel region.
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/block/shared/st/BlockSharedMemStUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStUniformCudaHipBuiltIn.hpp
@@ -36,7 +36,7 @@ namespace alpaka
 #            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #        endif
 
-    namespace traits
+    namespace trait
     {
         template<typename T, std::size_t TuniqueId>
         struct DeclareSharedVar<T, TuniqueId, BlockSharedMemStUniformCudaHipBuiltIn>
@@ -55,7 +55,7 @@ namespace alpaka
                 // Nothing to do. CUDA/HIP block shared memory is automatically freed when all threads left the block.
             }
         };
-    } // namespace traits
+    } // namespace trait
 
 #    endif
 

--- a/include/alpaka/block/shared/st/Traits.hpp
+++ b/include/alpaka/block/shared/st/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -20,8 +20,8 @@ namespace alpaka
     {
     };
 
-    //! The block shared static memory operation traits.
-    namespace traits
+    //! The block shared static memory operation trait.
+    namespace trait
     {
         //! The block shared static memory variable allocation operation trait.
         template<typename T, std::size_t TuniqueId, typename TBlockSharedMemSt, typename TSfinae = void>
@@ -29,7 +29,7 @@ namespace alpaka
         //! The block shared static memory free operation trait.
         template<typename TBlockSharedMemSt, typename TSfinae = void>
         struct FreeSharedVars;
-    } // namespace traits
+    } // namespace trait
 
     //! Declare a block shared variable.
     //!
@@ -47,7 +47,7 @@ namespace alpaka
     ALPAKA_FN_ACC auto declareSharedVar(TBlockSharedMemSt const& blockSharedMemSt) -> T&
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedSt, TBlockSharedMemSt>;
-        return traits::DeclareSharedVar<T, TuniqueId, ImplementationBase>::declareVar(blockSharedMemSt);
+        return trait::DeclareSharedVar<T, TuniqueId, ImplementationBase>::declareVar(blockSharedMemSt);
     }
 
     //! Frees all memory used by block shared variables.
@@ -59,6 +59,6 @@ namespace alpaka
     ALPAKA_FN_ACC auto freeSharedVars(TBlockSharedMemSt& blockSharedMemSt) -> void
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptBlockSharedSt, TBlockSharedMemSt>;
-        traits::FreeSharedVars<ImplementationBase>::freeVars(blockSharedMemSt);
+        trait::FreeSharedVars<ImplementationBase>::freeVars(blockSharedMemSt);
     }
 } // namespace alpaka

--- a/include/alpaka/block/sync/BlockSyncBarrierFiber.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierFiber.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -41,7 +41,7 @@ namespace alpaka
         int mutable m_result[2u];
     };
 
-    namespace traits
+    namespace trait
     {
         template<typename TIdx>
         struct SyncBlockThreads<BlockSyncBarrierFiber<TIdx>>
@@ -86,7 +86,7 @@ namespace alpaka
                 return blockSync.m_result[generationMod2];
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
@@ -24,7 +24,7 @@ namespace alpaka
         int mutable m_result[2];
     };
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct SyncBlockThreads<BlockSyncBarrierOmp>
@@ -102,7 +102,7 @@ namespace alpaka
                 return blockSync.m_result[generationMod2];
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/block/sync/BlockSyncBarrierThread.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierThread.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -39,7 +39,7 @@ namespace alpaka
         BarrierWithPredicate mutable m_barrierWithPredicate;
     };
 
-    namespace traits
+    namespace trait
     {
         template<typename TIdx>
         struct SyncBlockThreads<BlockSyncBarrierThread<TIdx>>
@@ -61,7 +61,7 @@ namespace alpaka
                 return blockSync.m_barrierWithPredicate.template wait<TOp>(predicate);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/block/sync/BlockSyncGenericSycl.hpp
+++ b/include/alpaka/block/sync/BlockSyncGenericSycl.hpp
@@ -32,7 +32,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     template<typename TDim>
     struct SyncBlockThreads<experimental::BlockSyncGenericSycl<TDim>>
@@ -82,6 +82,6 @@ namespace alpaka::traits
             return static_cast<int>(sycl::any_of_group(group, static_cast<bool>(predicate)));
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/block/sync/BlockSyncNoOp.hpp
+++ b/include/alpaka/block/sync/BlockSyncNoOp.hpp
@@ -19,7 +19,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct SyncBlockThreads<BlockSyncNoOp>
@@ -41,5 +41,5 @@ namespace alpaka
                 return predicate;
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/block/sync/BlockSyncUniformCudaHipBuiltIn.hpp
@@ -33,7 +33,7 @@ namespace alpaka
 #            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #        endif
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct SyncBlockThreads<BlockSyncUniformCudaHipBuiltIn>
@@ -118,7 +118,7 @@ namespace alpaka
 #        endif
             }
         };
-    } // namespace traits
+    } // namespace trait
 
 #    endif
 

--- a/include/alpaka/block/sync/Traits.hpp
+++ b/include/alpaka/block/sync/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -21,7 +21,7 @@ namespace alpaka
     };
 
     //! The block synchronization traits.
-    namespace traits
+    namespace trait
     {
         //! The block synchronization operation trait.
         template<typename TBlockSync, typename TSfinae = void>
@@ -30,7 +30,7 @@ namespace alpaka
         //! The block synchronization and predicate operation trait.
         template<typename TOp, typename TBlockSync, typename TSfinae = void>
         struct SyncBlockThreadsPredicate;
-    } // namespace traits
+    } // namespace trait
 
     //! Synchronizes all threads within the current block (independently for all blocks).
     //!
@@ -41,7 +41,7 @@ namespace alpaka
     ALPAKA_FN_ACC auto syncBlockThreads(TBlockSync const& blockSync) -> void
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptBlockSync, TBlockSync>;
-        traits::SyncBlockThreads<ImplementationBase>::syncBlockThreads(blockSync);
+        trait::SyncBlockThreads<ImplementationBase>::syncBlockThreads(blockSync);
     }
 
     //! The counting function object.
@@ -103,7 +103,7 @@ namespace alpaka
     ALPAKA_FN_ACC auto syncBlockThreadsPredicate(TBlockSync const& blockSync, int predicate) -> int
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptBlockSync, TBlockSync>;
-        return traits::SyncBlockThreadsPredicate<TOp, ImplementationBase>::syncBlockThreadsPredicate(
+        return trait::SyncBlockThreadsPredicate<TOp, ImplementationBase>::syncBlockThreadsPredicate(
             blockSync,
             predicate);
     }

--- a/include/alpaka/core/CudaHipCommon.hpp
+++ b/include/alpaka/core/CudaHipCommon.hpp
@@ -80,22 +80,22 @@ namespace alpaka
     } // namespace detail
 
 #    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-    namespace cuda::traits
+    namespace cuda::trait
     {
         template<typename T>
         inline constexpr auto isCudaBuiltInType = alpaka::detail::isCudaHipBuiltInType<T>;
-    } // namespace cuda::traits
+    } // namespace cuda::trait
 #    endif
 
 #    ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-    namespace hip::traits
+    namespace hip::trait
     {
         template<typename T>
         inline constexpr auto isHipBuiltInType = alpaka::detail::isCudaHipBuiltInType<T>;
-    } // namespace hip::traits
+    } // namespace hip::trait
 #    endif
 
-    namespace traits
+    namespace trait
     {
         //! The CUDA/HIP vectors 1D dimension get trait specialization.
         template<typename T>
@@ -353,7 +353,7 @@ namespace alpaka
         {
             using type = std::size_t;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/core/Sycl.hpp
+++ b/include/alpaka/core/Sycl.hpp
@@ -136,7 +136,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! SYCL's types get trait specialization.
     template<typename T>
@@ -151,9 +151,9 @@ namespace alpaka::traits
     {
         using type = std::conditional_t<std::is_scalar_v<T>, T, typename T::element_type>;
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL vectors' extent get trait specialization.
     template<typename TExtent>
@@ -243,6 +243,6 @@ namespace alpaka::traits
     {
         using type = std::size_t;
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/ctx/block/CtxBlockOacc.hpp
+++ b/include/alpaka/ctx/block/CtxBlockOacc.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Jeffrey Kelling, Bernhard Manfred Gruber
+/* Copyright 2022 Jeffrey Kelling, Bernhard Manfred Gruber
  *
  * This file is part of Alpaka.
  *
@@ -76,7 +76,7 @@ namespace alpaka
         }
     };
 
-    namespace traits
+    namespace trait
     {
         template<typename TDim, typename TIdx>
         struct SyncBlockThreads<CtxBlockOacc<TDim, TIdx>>
@@ -215,7 +215,7 @@ namespace alpaka
 
                 if(!data)
                 {
-                    traits::SyncBlockThreads<CtxBlockOacc<TDim, TIdx>>::masterOpBlockThreads(
+                    trait::SyncBlockThreads<CtxBlockOacc<TDim, TIdx>>::masterOpBlockThreads(
                         smem,
                         [&data, &smem]() { smem.template alloc<T>(TuniqueId); });
                     data = smem.template getLatestVarPtr<T>();
@@ -233,7 +233,7 @@ namespace alpaka
                 // Nothing to do. Block shared memory is automatically freed when all threads left the block.
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -37,7 +37,7 @@ namespace alpaka
     {
         using ICpuQueue = IGenericThreadsQueue<DevCpu>;
     }
-    namespace traits
+    namespace trait
     {
         template<typename TPltf, typename TSfinae>
         struct GetDevByIdx;
@@ -95,7 +95,7 @@ namespace alpaka
         : public concepts::Implements<ConceptCurrentThreadWaitFor, DevCpu>
         , public concepts::Implements<ConceptDev, DevCpu>
     {
-        friend struct traits::GetDevByIdx<PltfCpu>;
+        friend struct trait::GetDevByIdx<PltfCpu>;
 
     protected:
         DevCpu() : m_spDevCpuImpl(std::make_shared<cpu::detail::DevCpuImpl>())
@@ -133,7 +133,7 @@ namespace alpaka
         std::shared_ptr<cpu::detail::DevCpuImpl> m_spDevCpuImpl;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU device name get trait specialization.
         template<>
@@ -195,12 +195,12 @@ namespace alpaka
                 return dev.getNativeHandle();
             }
         };
-    } // namespace traits
+    } // namespace trait
 
     template<typename TElem, typename TDim, typename TIdx>
     class BufCpu;
 
-    namespace traits
+    namespace trait
     {
         //! The CPU device memory buffer type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
@@ -215,11 +215,11 @@ namespace alpaka
         {
             using type = PltfCpu;
         };
-    } // namespace traits
+    } // namespace trait
     using QueueCpuNonBlocking = QueueGenericThreadsNonBlocking<DevCpu>;
     using QueueCpuBlocking = QueueGenericThreadsBlocking<DevCpu>;
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct QueueType<DevCpu, Blocking>
@@ -232,5 +232,5 @@ namespace alpaka
         {
             using type = QueueCpuNonBlocking;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -139,7 +139,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL device name get trait specialization.
     template<typename TPltf>
@@ -242,6 +242,6 @@ namespace alpaka::traits
     {
         using type = experimental::detail::QueueGenericSyclBase<experimental::DevGenericSycl<TPltf>, false>;
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -141,7 +141,7 @@ namespace alpaka
         : public concepts::Implements<ConceptCurrentThreadWaitFor, DevOacc>
         , public concepts::Implements<ConceptDev, DevOacc>
     {
-        friend struct traits::GetDevByIdx<PltfOacc>;
+        friend struct trait::GetDevByIdx<PltfOacc>;
 
         template<typename T>
         class OnceInitialized
@@ -226,7 +226,7 @@ namespace alpaka
         oacc::detail::DevOaccImpl* m_devOaccImpl;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The OpenACC device name get trait specialization.
         template<>
@@ -287,12 +287,12 @@ namespace alpaka
                 return dev.getNativeHandle();
             }
         };
-    } // namespace traits
+    } // namespace trait
 
     template<typename TElem, typename TDim, typename TIdx>
     class BufOacc;
 
-    namespace traits
+    namespace trait
     {
         //! The OpenACC device memory buffer type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
@@ -307,12 +307,12 @@ namespace alpaka
         {
             using type = PltfOacc;
         };
-    } // namespace traits
+    } // namespace trait
 
     using QueueOaccNonBlocking = QueueGenericThreadsNonBlocking<DevOacc>;
     using QueueOaccBlocking = QueueGenericThreadsBlocking<DevOacc>;
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct QueueType<DevOacc, Blocking>
@@ -369,7 +369,7 @@ namespace alpaka
                 return {static_cast<int>(devIdx)};
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -37,7 +37,7 @@
 namespace alpaka
 {
     class DevOmp5;
-    namespace traits
+    namespace trait
     {
         template<typename TPltf, typename TSfinae>
         struct GetDevByIdx;
@@ -141,7 +141,7 @@ namespace alpaka
         : public concepts::Implements<ConceptCurrentThreadWaitFor, DevOmp5>
         , public concepts::Implements<ConceptDev, DevOmp5>
     {
-        friend struct traits::GetDevByIdx<PltfOmp5>;
+        friend struct trait::GetDevByIdx<PltfOmp5>;
 
         DevOmp5(int iDevice) : m_spDevOmp5Impl(std::make_shared<omp5::detail::DevOmp5Impl>(iDevice))
         {
@@ -186,7 +186,7 @@ namespace alpaka
         std::shared_ptr<omp5::detail::DevOmp5Impl> m_spDevOmp5Impl;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The OpenMP 5.0 device name get trait specialization.
         template<>
@@ -252,12 +252,12 @@ namespace alpaka
                 return dev.getNativeHandle();
             }
         };
-    } // namespace traits
+    } // namespace trait
 
     template<typename TElem, typename TDim, typename TIdx>
     class BufOmp5;
 
-    namespace traits
+    namespace trait
     {
         //! The OpenMP 5.0 device memory buffer type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
@@ -272,11 +272,11 @@ namespace alpaka
         {
             using type = PltfOmp5;
         };
-    } // namespace traits
+    } // namespace trait
     using QueueOmp5NonBlocking = QueueGenericThreadsNonBlocking<DevOmp5>;
     using QueueOmp5Blocking = QueueGenericThreadsBlocking<DevOmp5>;
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct QueueType<DevOmp5, Blocking>
@@ -304,7 +304,7 @@ namespace alpaka
                 generic::currentThreadWaitForDevice(dev);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -33,7 +33,7 @@
 
 namespace alpaka
 {
-    namespace traits
+    namespace trait
     {
         template<typename TPltf, typename TSfinae>
         struct GetDevByIdx;
@@ -47,7 +47,7 @@ namespace alpaka
         : public concepts::Implements<ConceptCurrentThreadWaitFor, DevUniformCudaHipRt>
         , public concepts::Implements<ConceptDev, DevUniformCudaHipRt>
     {
-        friend struct traits::GetDevByIdx<PltfUniformCudaHipRt>;
+        friend struct trait::GetDevByIdx<PltfUniformCudaHipRt>;
 
     protected:
         DevUniformCudaHipRt() = default;
@@ -81,7 +81,7 @@ namespace alpaka
 #    endif
 
 
-    namespace traits
+    namespace trait
     {
         //! The CUDA/HIP RT device name get trait specialization.
         template<>
@@ -180,12 +180,12 @@ namespace alpaka
                 return dev.getNativeHandle();
             }
         };
-    } // namespace traits
+    } // namespace trait
 
     template<typename TElem, typename TDim, typename TIdx>
     class BufUniformCudaHipRt;
 
-    namespace traits
+    namespace trait
     {
         //! The CUDA/HIP RT device memory buffer type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
@@ -229,7 +229,7 @@ namespace alpaka
         {
             using type = QueueUniformCudaHipRtNonBlocking;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -19,7 +19,7 @@
 namespace alpaka
 {
     //! The device traits.
-    namespace traits
+    namespace trait
     {
         //! The device type trait.
         template<typename T, typename TSfinae = void>
@@ -48,11 +48,11 @@ namespace alpaka
         //! The device reset trait.
         template<typename T, typename TSfinae = void>
         struct Reset;
-    } // namespace traits
+    } // namespace trait
 
     //! The device type trait alias template to remove the ::type.
     template<typename T>
-    using Dev = typename traits::DevType<T>::type;
+    using Dev = typename trait::DevType<T>::type;
 
     struct ConceptGetDev;
 
@@ -63,14 +63,14 @@ namespace alpaka
     ALPAKA_FN_HOST auto getDev(T const& t)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptGetDev, T>;
-        return traits::GetDev<ImplementationBase>::getDev(t);
+        return trait::GetDev<ImplementationBase>::getDev(t);
     }
 
     //! \return The device name.
     template<typename TDev>
     ALPAKA_FN_HOST auto getName(TDev const& dev) -> std::string
     {
-        return traits::GetName<TDev>::getName(dev);
+        return trait::GetName<TDev>::getName(dev);
     }
 
     //! \return The memory on the device in Bytes. Returns 0 if querying memory
@@ -78,7 +78,7 @@ namespace alpaka
     template<typename TDev>
     ALPAKA_FN_HOST auto getMemBytes(TDev const& dev) -> std::size_t
     {
-        return traits::GetMemBytes<TDev>::getMemBytes(dev);
+        return trait::GetMemBytes<TDev>::getMemBytes(dev);
     }
 
     //! \return The free memory on the device in Bytes.
@@ -87,14 +87,14 @@ namespace alpaka
     template<typename TDev>
     ALPAKA_FN_HOST auto getFreeMemBytes(TDev const& dev) -> std::size_t
     {
-        return traits::GetFreeMemBytes<TDev>::getFreeMemBytes(dev);
+        return trait::GetFreeMemBytes<TDev>::getFreeMemBytes(dev);
     }
 
     //! \return The supported warp sizes on the device in number of threads.
     template<typename TDev>
     ALPAKA_FN_HOST auto getWarpSizes(TDev const& dev) -> std::vector<std::size_t>
     {
-        return traits::GetWarpSizes<TDev>::getWarpSizes(dev);
+        return trait::GetWarpSizes<TDev>::getWarpSizes(dev);
     }
 
     //! Resets the device.
@@ -102,10 +102,10 @@ namespace alpaka
     template<typename TDev>
     ALPAKA_FN_HOST auto reset(TDev const& dev) -> void
     {
-        traits::Reset<TDev>::reset(dev);
+        trait::Reset<TDev>::reset(dev);
     }
 
-    namespace traits
+    namespace trait
     {
         //! Get device type
         template<typename TDev>
@@ -113,5 +113,5 @@ namespace alpaka
         {
             using type = typename concepts::ImplementationBase<ConceptDev, TDev>;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/dev/cpu/Wait.hpp
+++ b/include/alpaka/dev/cpu/Wait.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Rene Widera, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Rene Widera, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -15,7 +15,7 @@
 
 namespace alpaka
 {
-    namespace traits
+    namespace trait
     {
         //! The CPU device thread wait specialization.
         //!
@@ -31,5 +31,5 @@ namespace alpaka
                 generic::currentThreadWaitForDevice(dev);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/dim/DimArithmetic.hpp
+++ b/include/alpaka/dim/DimArithmetic.hpp
@@ -13,7 +13,7 @@
 
 #include <type_traits>
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The arithmetic type dimension getter trait specialization.
     template<typename T>
@@ -21,4 +21,4 @@ namespace alpaka::traits
     {
         using type = DimInt<1u>;
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait

--- a/include/alpaka/dim/Traits.hpp
+++ b/include/alpaka/dim/Traits.hpp
@@ -11,15 +11,15 @@
 
 namespace alpaka
 {
-    //! The dimension traits.
-    namespace traits
+    //! The dimension trait.
+    namespace trait
     {
         //! The dimension getter type trait.
         template<typename T, typename TSfinae = void>
         struct DimType;
-    } // namespace traits
+    } // namespace trait
 
     //! The dimension type trait alias template to remove the ::type.
     template<typename T>
-    using Dim = typename traits::DimType<T>::type;
+    using Dim = typename trait::DimType<T>::type;
 } // namespace alpaka

--- a/include/alpaka/elem/Traits.hpp
+++ b/include/alpaka/elem/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -13,20 +13,20 @@
 
 namespace alpaka
 {
-    //! The element traits.
-    namespace traits
+    //! The element trait.
+    namespace trait
     {
         //! The element type trait.
         template<typename TView, typename TSfinae = void>
         struct ElemType;
-    } // namespace traits
+    } // namespace trait
 
     //! The element type trait alias template to remove the ::type.
     template<typename TView>
-    using Elem = std::remove_volatile_t<typename traits::ElemType<TView>::type>;
+    using Elem = std::remove_volatile_t<typename trait::ElemType<TView>::type>;
 
     // Trait specializations for unsigned integral types.
-    namespace traits
+    namespace trait
     {
         //! The fundamental type elem type trait specialization.
         template<typename T>
@@ -34,5 +34,5 @@ namespace alpaka
         {
             using type = T;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/event/EventGenericSycl.hpp
+++ b/include/alpaka/event/EventGenericSycl.hpp
@@ -62,7 +62,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL device event device get trait specialization.
     template<typename TDev>
@@ -169,6 +169,6 @@ namespace alpaka::traits
             return event.getNativeHandle();
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/event/EventGenericThreads.hpp
+++ b/include/alpaka/event/EventGenericThreads.hpp
@@ -95,7 +95,7 @@ namespace alpaka
     public:
         std::shared_ptr<generic::detail::EventGenericThreadsImpl<TDev>> m_spEventImpl;
     };
-    namespace traits
+    namespace trait
     {
         //! The CPU device event device type trait specialization.
         template<typename TDev>
@@ -228,8 +228,8 @@ namespace alpaka
                 alpaka::enqueue(*queue.m_spQueueImpl, event);
             }
         };
-    } // namespace traits
-    namespace traits
+    } // namespace trait
+    namespace trait
     {
         namespace generic
         {
@@ -395,5 +395,5 @@ namespace alpaka
                 wait(event);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -116,7 +116,7 @@ namespace alpaka
     public:
         std::shared_ptr<uniform_cuda_hip::detail::EventUniformCudaHipImpl> m_spEventImpl;
     };
-    namespace traits
+    namespace trait
     {
         //! The CUDA/HIP RT device event device type trait specialization.
         template<>
@@ -249,7 +249,7 @@ namespace alpaka
                 return event.getNativeHandle();
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/event/Traits.hpp
+++ b/include/alpaka/event/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -15,7 +15,7 @@
 namespace alpaka
 {
     //! The event management traits.
-    namespace traits
+    namespace trait
     {
         //! The event type trait.
         template<typename T, typename TSfinae = void>
@@ -24,11 +24,11 @@ namespace alpaka
         //! The event tester trait.
         template<typename TEvent, typename TSfinae = void>
         struct IsComplete;
-    } // namespace traits
+    } // namespace trait
 
     //! The event type trait alias template to remove the ::type.
     template<typename T>
-    using Event = typename traits::EventType<T>::type;
+    using Event = typename trait::EventType<T>::type;
 
     //! Tests if the given event has already been completed.
     //!
@@ -38,6 +38,6 @@ namespace alpaka
     template<typename TEvent>
     ALPAKA_FN_HOST auto isComplete(TEvent const& event) -> bool
     {
-        return traits::IsComplete<TEvent>::isComplete(event);
+        return trait::IsComplete<TEvent>::isComplete(event);
     }
 } // namespace alpaka

--- a/include/alpaka/extent/Traits.hpp
+++ b/include/alpaka/extent/Traits.hpp
@@ -21,7 +21,7 @@
 namespace alpaka
 {
     //! The extent traits.
-    namespace traits
+    namespace trait
     {
         //! The extent get trait.
         //!
@@ -39,14 +39,14 @@ namespace alpaka
         //! The extent set trait.
         template<typename TIdxIntegralConst, typename TExtent, typename TExtentVal, typename TSfinae = void>
         struct SetExtent;
-    } // namespace traits
+    } // namespace trait
 
     //! \return The extent in the given dimension.
     ALPAKA_NO_HOST_ACC_WARNING
     template<std::size_t Tidx, typename TExtent>
     ALPAKA_FN_HOST_ACC auto getExtent(TExtent const& extent = TExtent()) -> Idx<TExtent>
     {
-        return traits::GetExtent<DimInt<Tidx>, TExtent>::getExtent(extent);
+        return trait::GetExtent<DimInt<Tidx>, TExtent>::getExtent(extent);
     }
     //! \return The width.
     ALPAKA_NO_HOST_ACC_WARNING
@@ -96,7 +96,7 @@ namespace alpaka
     template<std::size_t Tidx, typename TExtent, typename TExtentVal>
     ALPAKA_FN_HOST_ACC auto setExtent(TExtent& extent, TExtentVal const& extentVal) -> void
     {
-        traits::SetExtent<DimInt<Tidx>, TExtent, TExtentVal>::setExtent(extent, extentVal);
+        trait::SetExtent<DimInt<Tidx>, TExtent, TExtentVal>::setExtent(extent, extentVal);
     }
     //! Sets the width.
     ALPAKA_NO_HOST_ACC_WARNING
@@ -121,7 +121,7 @@ namespace alpaka
     }
 
     // Trait specializations for unsigned integral types.
-    namespace traits
+    namespace trait
     {
         //! The unsigned integral width get trait specialization.
         template<typename TExtent>
@@ -143,5 +143,5 @@ namespace alpaka
                 extent = extentVal;
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/idx/Accessors.hpp
+++ b/include/alpaka/idx/Accessors.hpp
@@ -27,17 +27,17 @@ namespace alpaka
     template<typename TOrigin, typename TUnit, typename TIdx, typename TWorkDiv>
     ALPAKA_FN_HOST_ACC auto getIdx(TIdx const& idx, TWorkDiv const& workDiv) -> Vec<Dim<TWorkDiv>, Idx<TIdx>>
     {
-        return traits::GetIdx<TIdx, TOrigin, TUnit>::getIdx(idx, workDiv);
+        return trait::GetIdx<TIdx, TOrigin, TUnit>::getIdx(idx, workDiv);
     }
     //! Get the indices requested.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TOrigin, typename TUnit, typename TIdxWorkDiv>
     ALPAKA_FN_HOST_ACC auto getIdx(TIdxWorkDiv const& idxWorkDiv) -> Vec<Dim<TIdxWorkDiv>, Idx<TIdxWorkDiv>>
     {
-        return traits::GetIdx<TIdxWorkDiv, TOrigin, TUnit>::getIdx(idxWorkDiv, idxWorkDiv);
+        return trait::GetIdx<TIdxWorkDiv, TOrigin, TUnit>::getIdx(idxWorkDiv, idxWorkDiv);
     }
 
-    namespace traits
+    namespace trait
     {
         //! The grid block index get trait specialization for classes with IdxGbBase member type.
         template<typename TIdxGb>
@@ -50,7 +50,7 @@ namespace alpaka
             ALPAKA_FN_HOST_ACC static auto getIdx(TIdxGb const& idx, TWorkDiv const& workDiv)
                 -> Vec<Dim<ImplementationBase>, Idx<ImplementationBase>>
             {
-                return traits::GetIdx<ImplementationBase, origin::Grid, unit::Blocks>::getIdx(idx, workDiv);
+                return trait::GetIdx<ImplementationBase, origin::Grid, unit::Blocks>::getIdx(idx, workDiv);
             }
         };
 
@@ -65,7 +65,7 @@ namespace alpaka
             ALPAKA_FN_HOST_ACC static auto getIdx(TIdxBt const& idx, TWorkDiv const& workDiv)
                 -> Vec<Dim<ImplementationBase>, Idx<ImplementationBase>>
             {
-                return traits::GetIdx<ImplementationBase, origin::Block, unit::Threads>::getIdx(idx, workDiv);
+                return trait::GetIdx<ImplementationBase, origin::Block, unit::Threads>::getIdx(idx, workDiv);
             }
         };
 
@@ -83,7 +83,7 @@ namespace alpaka
                     + alpaka::getIdx<origin::Block, unit::Threads>(idx, workDiv);
             }
         };
-    } // namespace traits
+    } // namespace trait
     //! Get the index of the first element this thread computes.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TIdxWorkDiv, typename TGridThreadIdx, typename TThreadElemExtent>

--- a/include/alpaka/idx/Traits.hpp
+++ b/include/alpaka/idx/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -21,18 +21,18 @@ namespace alpaka
     {
     };
 
-    //! The idx traits.
-    namespace traits
+    //! The idx trait.
+    namespace trait
     {
         //! The idx type trait.
         template<typename T, typename TSfinae = void>
         struct IdxType;
-    } // namespace traits
+    } // namespace trait
 
     template<typename T>
-    using Idx = typename traits::IdxType<T>::type;
+    using Idx = typename trait::IdxType<T>::type;
 
-    namespace traits
+    namespace trait
     {
         //! The arithmetic idx type trait specialization.
         template<typename T>
@@ -44,5 +44,5 @@ namespace alpaka
         //! The index get trait.
         template<typename TIdx, typename TOrigin, typename TUnit, typename TSfinae = void>
         struct GetIdx;
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/idx/bt/IdxBtGenericSycl.hpp
+++ b/include/alpaka/idx/bt/IdxBtGenericSycl.hpp
@@ -36,7 +36,7 @@ namespace alpaka::experimental::bt
     };
 } // namespace alpaka::experimental::bt
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL accelerator index dimension get trait specialization.
     template<typename TDim, typename TIdx>
@@ -78,6 +78,6 @@ namespace alpaka::traits
     {
         using type = TIdx;
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/idx/bt/IdxBtLinear.hpp
+++ b/include/alpaka/idx/bt/IdxBtLinear.hpp
@@ -33,7 +33,7 @@ namespace alpaka
         };
     } // namespace bt
 
-    namespace traits
+    namespace trait
     {
         //! The IdxBtLinear index dimension get trait specialization.
         template<typename TDim, typename TIdx>
@@ -73,5 +73,5 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/idx/bt/IdxBtOmp.hpp
+++ b/include/alpaka/idx/bt/IdxBtOmp.hpp
@@ -32,7 +32,7 @@ namespace alpaka
         };
     } // namespace bt
 
-    namespace traits
+    namespace trait
     {
         //! The OpenMP accelerator index dimension get trait specialization.
         template<typename TDim, typename TIdx>
@@ -76,7 +76,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
@@ -43,7 +43,7 @@ namespace alpaka
         };
     } // namespace bt
 
-    namespace traits
+    namespace trait
     {
         //! The CPU fibers accelerator index dimension get trait specialization.
         template<typename TDim, typename TIdx>
@@ -75,7 +75,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
@@ -43,7 +43,7 @@ namespace alpaka
         };
     } // namespace bt
 
-    namespace traits
+    namespace trait
     {
         //! The CPU threads accelerator index dimension get trait specialization.
         template<typename TDim, typename TIdx>
@@ -75,7 +75,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/idx/bt/IdxBtUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/idx/bt/IdxBtUniformCudaHipBuiltIn.hpp
@@ -47,7 +47,7 @@ namespace alpaka
 #            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #        endif
 
-    namespace traits
+    namespace trait
     {
         //! The GPU CUDA/HIP accelerator index dimension get trait specialization.
         template<typename TDim, typename TIdx>
@@ -82,7 +82,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 
 #    endif
 

--- a/include/alpaka/idx/bt/IdxBtZero.hpp
+++ b/include/alpaka/idx/bt/IdxBtZero.hpp
@@ -25,7 +25,7 @@ namespace alpaka
         };
     } // namespace bt
 
-    namespace traits
+    namespace trait
     {
         //! The zero block thread index provider dimension get trait specialization.
         template<typename TDim, typename TIdx>
@@ -54,5 +54,5 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/idx/gb/IdxGbGenericSycl.hpp
+++ b/include/alpaka/idx/gb/IdxGbGenericSycl.hpp
@@ -36,7 +36,7 @@ namespace alpaka::experimental::gb
     };
 } // namespace alpaka::experimental::gb
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL accelerator index dimension get trait specialization.
     template<typename TDim, typename TIdx>
@@ -77,6 +77,6 @@ namespace alpaka::traits
     {
         using type = TIdx;
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/idx/gb/IdxGbLinear.hpp
+++ b/include/alpaka/idx/gb/IdxGbLinear.hpp
@@ -33,7 +33,7 @@ namespace alpaka
         };
     } // namespace gb
 
-    namespace traits
+    namespace trait
     {
         //! The IdxGbLinear index dimension get trait specialization.
         template<typename TDim, typename TIdx>
@@ -74,5 +74,5 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/idx/gb/IdxGbRef.hpp
+++ b/include/alpaka/idx/gb/IdxGbRef.hpp
@@ -32,7 +32,7 @@ namespace alpaka
         };
     } // namespace gb
 
-    namespace traits
+    namespace trait
     {
         //! The IdxGbRef grid block index dimension get trait specialization.
         template<typename TDim, typename TIdx>
@@ -60,5 +60,5 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/idx/gb/IdxGbUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/idx/gb/IdxGbUniformCudaHipBuiltIn.hpp
@@ -47,7 +47,7 @@ namespace alpaka
 #            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #        endif
 
-    namespace traits
+    namespace trait
     {
         //! The GPU CUDA/HIP accelerator index dimension get trait specialization.
         template<typename TDim, typename TIdx>
@@ -82,7 +82,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 
 #    endif
 

--- a/include/alpaka/intrinsic/IntrinsicCpu.hpp
+++ b/include/alpaka/intrinsic/IntrinsicCpu.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov, Bernhard Manfred Gruber
+/* Copyright 2022 Sergei Bastrakov, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -26,7 +26,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct Popcount<IntrinsicCpu>
@@ -93,5 +93,5 @@ namespace alpaka
 #endif
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/intrinsic/IntrinsicFallback.hpp
+++ b/include/alpaka/intrinsic/IntrinsicFallback.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Sergei Bastrakov, Jeffrey Kelling, Bernhard Manfred Gruber
+/* Copyright 2022 Sergei Bastrakov, Jeffrey Kelling, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -49,7 +49,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct Popcount<IntrinsicFallback>
@@ -78,5 +78,5 @@ namespace alpaka
                 return alpaka::detail::ffsFallback(value);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/intrinsic/IntrinsicGenericSycl.hpp
+++ b/include/alpaka/intrinsic/IntrinsicGenericSycl.hpp
@@ -26,7 +26,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     template<>
     struct Popcount<experimental::IntrinsicGenericSycl>
@@ -57,6 +57,6 @@ namespace alpaka::traits
             return (value == 0l) ? 0 : static_cast<std::int32_t>(sycl::popcount(value ^ ~(-value)));
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/intrinsic/IntrinsicUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/intrinsic/IntrinsicUniformCudaHipBuiltIn.hpp
@@ -33,7 +33,7 @@ namespace alpaka
 #            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #        endif
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct Popcount<IntrinsicUniformCudaHipBuiltIn>
@@ -74,7 +74,7 @@ namespace alpaka
                 return static_cast<std::int32_t>(__ffsll(static_cast<long long>(value)));
             }
         };
-    } // namespace traits
+    } // namespace trait
 
 #    endif
 

--- a/include/alpaka/intrinsic/Traits.hpp
+++ b/include/alpaka/intrinsic/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Sergei Bastrakov, Bernhard Manfred Gruber
+/* Copyright 2022 Sergei Bastrakov, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -22,7 +22,7 @@ namespace alpaka
     };
 
     //! The intrinsics traits.
-    namespace traits
+    namespace trait
     {
         //! The popcount trait.
         template<typename TWarp, typename TSfinae = void>
@@ -31,7 +31,7 @@ namespace alpaka
         //! The ffs trait.
         template<typename TWarp, typename TSfinae = void>
         struct Ffs;
-    } // namespace traits
+    } // namespace trait
 
     //! Returns the number of 1 bits in the given 32-bit value.
     //!
@@ -43,7 +43,7 @@ namespace alpaka
     ALPAKA_FN_ACC auto popcount(TIntrinsic const& intrinsic, std::uint32_t value) -> std::int32_t
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptIntrinsic, TIntrinsic>;
-        return traits::Popcount<ImplementationBase>::popcount(intrinsic, value);
+        return trait::Popcount<ImplementationBase>::popcount(intrinsic, value);
     }
 
     //! Returns the number of 1 bits in the given 64-bit value.
@@ -56,7 +56,7 @@ namespace alpaka
     ALPAKA_FN_ACC auto popcount(TIntrinsic const& intrinsic, std::uint64_t value) -> std::int32_t
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptIntrinsic, TIntrinsic>;
-        return traits::Popcount<ImplementationBase>::popcount(intrinsic, value);
+        return trait::Popcount<ImplementationBase>::popcount(intrinsic, value);
     }
 
     //! Returns the 1-based position of the least significant bit set to 1
@@ -70,7 +70,7 @@ namespace alpaka
     ALPAKA_FN_ACC auto ffs(TIntrinsic const& intrinsic, std::int32_t value) -> std::int32_t
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptIntrinsic, TIntrinsic>;
-        return traits::Ffs<ImplementationBase>::ffs(intrinsic, value);
+        return trait::Ffs<ImplementationBase>::ffs(intrinsic, value);
     }
 
     //! Returns the 1-based position of the least significant bit set to 1
@@ -84,6 +84,6 @@ namespace alpaka
     ALPAKA_FN_ACC auto ffs(TIntrinsic const& intrinsic, std::int64_t value) -> std::int32_t
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptIntrinsic, TIntrinsic>;
-        return traits::Ffs<ImplementationBase>::ffs(intrinsic, value);
+        return trait::Ffs<ImplementationBase>::ffs(intrinsic, value);
     }
 } // namespace alpaka

--- a/include/alpaka/kernel/TaskKernelCpuFibers.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuFibers.hpp
@@ -239,7 +239,7 @@ namespace alpaka
         std::tuple<std::decay_t<TArgs>...> m_args;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU fibers execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
@@ -275,7 +275,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Benjamin Worpitz, Bert Wesarg, René Widera, Sergei Bastrakov, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bert Wesarg, René Widera, Sergei Bastrakov, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -915,7 +915,7 @@ namespace alpaka
         std::tuple<std::decay_t<TArgs>...> m_args;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU OpenMP 2.0 grid block execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
@@ -951,7 +951,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -161,7 +161,7 @@ namespace alpaka
         std::tuple<std::decay_t<TArgs>...> m_args;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU OpenMP 2.0 block thread execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
@@ -197,7 +197,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -106,7 +106,7 @@ namespace alpaka
         std::tuple<std::decay_t<TArgs>...> m_args;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU serial execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
@@ -142,7 +142,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Benjamin Worpitz, Erik Zenker, René Widera, Felice Pantaleo, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Erik Zenker, René Widera, Felice Pantaleo, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -118,7 +118,7 @@ namespace alpaka
         std::tuple<std::decay_t<TArgs>...> m_args;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU TBB block execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
@@ -154,7 +154,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -236,7 +236,7 @@ namespace alpaka
         std::tuple<std::decay_t<TArgs>...> m_args;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU threads execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
@@ -272,7 +272,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/kernel/TaskKernelGenericSycl.hpp
+++ b/include/alpaka/kernel/TaskKernelGenericSycl.hpp
@@ -220,7 +220,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL execution task accelerator type trait specialization.
     template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
@@ -256,6 +256,6 @@ namespace alpaka::traits
     {
         using type = TIdx;
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -145,7 +145,7 @@ namespace alpaka
         std::tuple<remove_restrict_t<std::decay_t<TArgs>>...> m_args;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The GPU CUDA/HIP execution task accelerator type trait specialization.
         template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
@@ -431,7 +431,7 @@ namespace alpaka
                 }
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #    endif

--- a/include/alpaka/kernel/TaskKernelOacc.hpp
+++ b/include/alpaka/kernel/TaskKernelOacc.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Benjamin Worpitz, René Widera, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, René Widera, Bernhard Manfred Gruber
  *
  * This file is part of Alpaka.
  *
@@ -165,7 +165,7 @@ namespace alpaka
         core::Tuple<std::decay_t<TArgs>...> m_args;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The OpenACC execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
@@ -230,7 +230,7 @@ namespace alpaka
                                                                 { task(queue.m_spQueueImpl->m_dev); });
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/kernel/TaskKernelOmp5.hpp
+++ b/include/alpaka/kernel/TaskKernelOmp5.hpp
@@ -200,7 +200,7 @@ namespace alpaka
         TKernelFnObj m_kernelFnObj;
         core::Tuple<std::decay_t<TArgs>...> m_args;
     };
-    namespace traits
+    namespace trait
     {
         //! The OpenMP 5.0 execution task accelerator type trait specialization.
         template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
@@ -265,7 +265,7 @@ namespace alpaka
                                                                 { task(queue.m_spQueueImpl->m_dev); });
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -27,7 +27,7 @@
 namespace alpaka
 {
     //! The kernel traits.
-    namespace traits
+    namespace trait
     {
         //! The kernel execution task creation trait.
         template<
@@ -125,7 +125,7 @@ namespace alpaka
                 return TraitNotSpecialized{};
             }
         };
-    } // namespace traits
+    } // namespace trait
 
 #if BOOST_COMP_CLANG
 #    pragma clang diagnostic push
@@ -150,7 +150,7 @@ namespace alpaka
         Vec<TDim, Idx<TAcc>> const& threadElemExtent,
         TArgs const&... args) -> std::size_t
     {
-        return traits::BlockSharedMemDynSizeBytes<TKernelFnObj, TAcc>::getBlockSharedMemDynSizeBytes(
+        return trait::BlockSharedMemDynSizeBytes<TKernelFnObj, TAcc>::getBlockSharedMemDynSizeBytes(
             kernelFnObj,
             blockThreadExtent,
             threadElemExtent,
@@ -179,7 +179,7 @@ namespace alpaka
         Vec<TDim, Idx<TAcc>> const& threadElemExtent,
         TArgs const&... args)
     {
-        return traits::OmpSchedule<TKernelFnObj, TAcc>::getOmpSchedule(
+        return trait::OmpSchedule<TKernelFnObj, TAcc>::getOmpSchedule(
             kernelFnObj,
             blockThreadExtent,
             threadElemExtent,
@@ -236,7 +236,7 @@ namespace alpaka
         std::cout << __func__ << " workDiv: " << workDiv << ", kernelFnObj: " << typeid(kernelFnObj).name()
                   << std::endl;
 #endif
-        return traits::CreateTaskKernel<TAcc, TWorkDiv, TKernelFnObj, TArgs...>::createTaskKernel(
+        return trait::CreateTaskKernel<TAcc, TWorkDiv, TKernelFnObj, TArgs...>::createTaskKernel(
             workDiv,
             kernelFnObj,
             std::forward<TArgs>(args)...);

--- a/include/alpaka/math/MathGenericSycl.hpp
+++ b/include/alpaka/math/MathGenericSycl.hpp
@@ -189,7 +189,7 @@ namespace alpaka::experimental::math
     };
 } // namespace alpaka::experimental::math
 
-namespace alpaka::math::traits
+namespace alpaka::math::trait
 {
     //! The SYCL abs trait specialization.
     template<typename TArg>
@@ -544,6 +544,6 @@ namespace alpaka::math::traits
             return sycl::trunc(arg);
         }
     };
-} // namespace alpaka::math::traits
+} // namespace alpaka::math::trait
 
 #endif

--- a/include/alpaka/math/MathStdLib.hpp
+++ b/include/alpaka/math/MathStdLib.hpp
@@ -182,7 +182,7 @@ namespace alpaka::math
     {
     };
 
-    namespace traits
+    namespace trait
     {
         //! The standard library max trait specialization.
         template<typename Tx, typename Ty>
@@ -229,6 +229,6 @@ namespace alpaka::math
                 ALPAKA_UNREACHABLE(std::common_type_t<Tx, Ty>{});
             }
         };
-    } // namespace traits
+    } // namespace trait
 
 } // namespace alpaka::math

--- a/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
@@ -202,7 +202,7 @@ namespace alpaka::math
 #            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #        endif
 
-    namespace traits
+    namespace trait
     {
         //! The CUDA built in abs trait specialization.
         template<typename TArg>
@@ -742,7 +742,7 @@ namespace alpaka::math
                 ALPAKA_UNREACHABLE(TArg{});
             }
         };
-    } // namespace traits
+    } // namespace trait
 #    endif
 } // namespace alpaka::math
 

--- a/include/alpaka/math/Traits.hpp
+++ b/include/alpaka/math/Traits.hpp
@@ -125,7 +125,7 @@ namespace alpaka::math
     };
 
     //! The math traits.
-    namespace traits
+    namespace trait
     {
         //! The abs trait.
         template<typename T, typename TArg, typename TSfinae = void>
@@ -528,7 +528,7 @@ namespace alpaka::math
                 return trunc(arg);
             }
         };
-    } // namespace traits
+    } // namespace trait
 
     //! Computes the absolute value.
     //!
@@ -541,7 +541,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto abs(T const& abs_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathAbs, T>;
-        return traits::Abs<ImplementationBase, TArg>{}(abs_ctx, arg);
+        return trait::Abs<ImplementationBase, TArg>{}(abs_ctx, arg);
     }
 
     //! Computes the principal value of the arc cosine.
@@ -558,7 +558,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto acos(T const& acos_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathAcos, T>;
-        return traits::Acos<ImplementationBase, TArg>{}(acos_ctx, arg);
+        return trait::Acos<ImplementationBase, TArg>{}(acos_ctx, arg);
     }
 
     //! Computes the principal value of the arc sine.
@@ -575,7 +575,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto asin(T const& asin_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathAsin, T>;
-        return traits::Asin<ImplementationBase, TArg>{}(asin_ctx, arg);
+        return trait::Asin<ImplementationBase, TArg>{}(asin_ctx, arg);
     }
 
     //! Computes the principal value of the arc tangent.
@@ -588,7 +588,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto atan(T const& atan_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathAtan, T>;
-        return traits::Atan<ImplementationBase, TArg>{}(atan_ctx, arg);
+        return trait::Atan<ImplementationBase, TArg>{}(atan_ctx, arg);
     }
 
     //! Computes the arc tangent of y/x using the signs of arguments to determine the correct quadrant.
@@ -604,7 +604,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto atan2(T const& atan2_ctx, Ty const& y, Tx const& x)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathAtan2, T>;
-        return traits::Atan2<ImplementationBase, Ty, Tx>{}(atan2_ctx, y, x);
+        return trait::Atan2<ImplementationBase, Ty, Tx>{}(atan2_ctx, y, x);
     }
 
     //! Computes the cbrt.
@@ -618,7 +618,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto cbrt(T const& cbrt_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathCbrt, T>;
-        return traits::Cbrt<ImplementationBase, TArg>{}(cbrt_ctx, arg);
+        return trait::Cbrt<ImplementationBase, TArg>{}(cbrt_ctx, arg);
     }
 
     //! Computes the smallest integer value not less than arg.
@@ -632,7 +632,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto ceil(T const& ceil_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathCeil, T>;
-        return traits::Ceil<ImplementationBase, TArg>{}(ceil_ctx, arg);
+        return trait::Ceil<ImplementationBase, TArg>{}(ceil_ctx, arg);
     }
 
     //! Computes the cosine (measured in radians).
@@ -646,7 +646,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto cos(T const& cos_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathCos, T>;
-        return traits::Cos<ImplementationBase, TArg>{}(cos_ctx, arg);
+        return trait::Cos<ImplementationBase, TArg>{}(cos_ctx, arg);
     }
 
     //! Computes the error function of arg.
@@ -660,7 +660,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto erf(T const& erf_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathErf, T>;
-        return traits::Erf<ImplementationBase, TArg>{}(erf_ctx, arg);
+        return trait::Erf<ImplementationBase, TArg>{}(erf_ctx, arg);
     }
 
     //! Computes the e (Euler's number, 2.7182818) raised to the given power arg.
@@ -674,7 +674,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto exp(T const& exp_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathExp, T>;
-        return traits::Exp<ImplementationBase, TArg>{}(exp_ctx, arg);
+        return trait::Exp<ImplementationBase, TArg>{}(exp_ctx, arg);
     }
 
     //! Computes the largest integer value not greater than arg.
@@ -688,7 +688,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto floor(T const& floor_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathFloor, T>;
-        return traits::Floor<ImplementationBase, TArg>{}(floor_ctx, arg);
+        return trait::Floor<ImplementationBase, TArg>{}(floor_ctx, arg);
     }
 
     //! Computes the floating-point remainder of the division operation x/y.
@@ -704,7 +704,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto fmod(T const& fmod_ctx, Tx const& x, Ty const& y)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathFmod, T>;
-        return traits::Fmod<ImplementationBase, Tx, Ty>{}(fmod_ctx, x, y);
+        return trait::Fmod<ImplementationBase, Tx, Ty>{}(fmod_ctx, x, y);
     }
 
     //! Checks if given value is finite.
@@ -718,7 +718,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto isfinite(T const& ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathIsfinite, T>;
-        return traits::Isfinite<ImplementationBase, TArg>{}(ctx, arg);
+        return trait::Isfinite<ImplementationBase, TArg>{}(ctx, arg);
     }
 
     //! Checks if given value is inf.
@@ -732,7 +732,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto isinf(T const& ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathIsinf, T>;
-        return traits::Isinf<ImplementationBase, TArg>{}(ctx, arg);
+        return trait::Isinf<ImplementationBase, TArg>{}(ctx, arg);
     }
 
     //! Checks if given value is NaN.
@@ -746,7 +746,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto isnan(T const& ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathIsnan, T>;
-        return traits::Isnan<ImplementationBase, TArg>{}(ctx, arg);
+        return trait::Isnan<ImplementationBase, TArg>{}(ctx, arg);
     }
 
     //! Computes the the natural (base e) logarithm of arg.
@@ -764,7 +764,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto log(T const& log_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathLog, T>;
-        return traits::Log<ImplementationBase, TArg>{}(log_ctx, arg);
+        return trait::Log<ImplementationBase, TArg>{}(log_ctx, arg);
     }
 
     //! Returns the larger of two arguments.
@@ -781,7 +781,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto max(T const& max_ctx, Tx const& x, Ty const& y)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathMax, T>;
-        return traits::Max<ImplementationBase, Tx, Ty>{}(max_ctx, x, y);
+        return trait::Max<ImplementationBase, Tx, Ty>{}(max_ctx, x, y);
     }
 
     //! Returns the smaller of two arguments.
@@ -798,7 +798,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto min(T const& min_ctx, Tx const& x, Ty const& y)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathMin, T>;
-        return traits::Min<ImplementationBase, Tx, Ty>{}(min_ctx, x, y);
+        return trait::Min<ImplementationBase, Tx, Ty>{}(min_ctx, x, y);
     }
 
     //! Computes the value of base raised to the power exp.
@@ -818,7 +818,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto pow(T const& pow_ctx, TBase const& base, TExp const& exp)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathPow, T>;
-        return traits::Pow<ImplementationBase, TBase, TExp>{}(pow_ctx, base, exp);
+        return trait::Pow<ImplementationBase, TBase, TExp>{}(pow_ctx, base, exp);
     }
 
     //! Computes the IEEE remainder of the floating point division operation x/y.
@@ -834,7 +834,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto remainder(T const& remainder_ctx, Tx const& x, Ty const& y)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathRemainder, T>;
-        return traits::Remainder<ImplementationBase, Tx, Ty>{}(remainder_ctx, x, y);
+        return trait::Remainder<ImplementationBase, Tx, Ty>{}(remainder_ctx, x, y);
     }
 
     //! Computes the nearest integer value to arg (in floating-point format), rounding halfway cases away from
@@ -849,7 +849,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto round(T const& round_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathRound, T>;
-        return traits::Round<ImplementationBase, TArg>{}(round_ctx, arg);
+        return trait::Round<ImplementationBase, TArg>{}(round_ctx, arg);
     }
     //! Computes the nearest integer value to arg (in integer format), rounding halfway cases away from zero,
     //! regardless of the current rounding mode.
@@ -863,7 +863,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto lround(T const& lround_ctx, TArg const& arg) -> long int
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathRound, T>;
-        return traits::Lround<ImplementationBase, TArg>{}(lround_ctx, arg);
+        return trait::Lround<ImplementationBase, TArg>{}(lround_ctx, arg);
     }
     //! Computes the nearest integer value to arg (in integer format), rounding halfway cases away from zero,
     //! regardless of the current rounding mode.
@@ -877,7 +877,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto llround(T const& llround_ctx, TArg const& arg) -> long long int
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathRound, T>;
-        return traits::Llround<ImplementationBase, TArg>{}(llround_ctx, arg);
+        return trait::Llround<ImplementationBase, TArg>{}(llround_ctx, arg);
     }
 
     //! Computes the rsqrt.
@@ -895,7 +895,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto rsqrt(T const& rsqrt_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathRsqrt, T>;
-        return traits::Rsqrt<ImplementationBase, TArg>{}(rsqrt_ctx, arg);
+        return trait::Rsqrt<ImplementationBase, TArg>{}(rsqrt_ctx, arg);
     }
 
     //! Computes the sine (measured in radians).
@@ -909,7 +909,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto sin(T const& sin_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathSin, T>;
-        return traits::Sin<ImplementationBase, TArg>{}(sin_ctx, arg);
+        return trait::Sin<ImplementationBase, TArg>{}(sin_ctx, arg);
     }
 
     //! Computes the sine and cosine (measured in radians).
@@ -925,7 +925,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto sincos(T const& sincos_ctx, TArg const& arg, TArg& result_sin, TArg& result_cos) -> void
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathSinCos, T>;
-        traits::SinCos<ImplementationBase, TArg>{}(sincos_ctx, arg, result_sin, result_cos);
+        trait::SinCos<ImplementationBase, TArg>{}(sincos_ctx, arg, result_sin, result_cos);
     }
 
 
@@ -944,7 +944,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto sqrt(T const& sqrt_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathSqrt, T>;
-        return traits::Sqrt<ImplementationBase, TArg>{}(sqrt_ctx, arg);
+        return trait::Sqrt<ImplementationBase, TArg>{}(sqrt_ctx, arg);
     }
 
     //! Computes the tangent (measured in radians).
@@ -958,7 +958,7 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto tan(T const& tan_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathTan, T>;
-        return traits::Tan<ImplementationBase, TArg>{}(tan_ctx, arg);
+        return trait::Tan<ImplementationBase, TArg>{}(tan_ctx, arg);
     }
 
     //! Computes the nearest integer not greater in magnitude than arg.
@@ -972,6 +972,6 @@ namespace alpaka::math
     ALPAKA_FN_HOST_ACC auto trunc(T const& trunc_ctx, TArg const& arg)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathTrunc, T>;
-        return traits::Trunc<ImplementationBase, TArg>{}(trunc_ctx, arg);
+        return trait::Trunc<ImplementationBase, TArg>{}(trunc_ctx, arg);
     }
 } // namespace alpaka::math

--- a/include/alpaka/mem/alloc/AllocCpuAligned.hpp
+++ b/include/alpaka/mem/alloc/AllocCpuAligned.hpp
@@ -26,7 +26,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU boost aligned allocator memory allocation trait specialization.
         template<typename T, typename TAlignment>
@@ -64,5 +64,5 @@ namespace alpaka
                 core::alignedFree(const_cast<void*>(reinterpret_cast<void const*>(ptr)));
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/mem/alloc/AllocCpuNew.hpp
+++ b/include/alpaka/mem/alloc/AllocCpuNew.hpp
@@ -19,7 +19,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU new allocator memory allocation trait specialization.
         template<typename T>
@@ -40,5 +40,5 @@ namespace alpaka
                 return delete[] ptr;
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/mem/alloc/Traits.hpp
+++ b/include/alpaka/mem/alloc/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Matthias Werner, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -22,7 +22,7 @@ namespace alpaka
     };
 
     //! The allocator traits.
-    namespace traits
+    namespace trait
     {
         //! The memory allocation trait.
         template<typename T, typename TAlloc, typename TSfinae = void>
@@ -31,14 +31,14 @@ namespace alpaka
         //! The memory free trait.
         template<typename T, typename TAlloc, typename TSfinae = void>
         struct Free;
-    } // namespace traits
+    } // namespace trait
 
     //! \return The pointer to the allocated memory.
     template<typename T, typename TAlloc>
     ALPAKA_FN_HOST auto malloc(TAlloc const& alloc, std::size_t const& sizeElems) -> T*
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMemAlloc, TAlloc>;
-        return traits::Malloc<T, ImplementationBase>::malloc(alloc, sizeElems);
+        return trait::Malloc<T, ImplementationBase>::malloc(alloc, sizeElems);
     }
 
     //! Frees the memory identified by the given pointer.
@@ -46,6 +46,6 @@ namespace alpaka
     ALPAKA_FN_HOST auto free(TAlloc const& alloc, T const* const ptr) -> void
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMemAlloc, TAlloc>;
-        traits::Free<T, ImplementationBase>::free(alloc, ptr);
+        trait::Free<T, ImplementationBase>::free(alloc, ptr);
     }
 } // namespace alpaka

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -123,7 +123,7 @@ namespace alpaka
         std::shared_ptr<detail::BufCpuImpl<TElem, TDim, TIdx>> m_spBufCpuImpl;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The BufCpu device type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
@@ -420,7 +420,7 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #include <alpaka/mem/buf/cpu/Copy.hpp>

--- a/include/alpaka/mem/buf/BufGenericSycl.hpp
+++ b/include/alpaka/mem/buf/BufGenericSycl.hpp
@@ -64,7 +64,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The BufGenericSycl device type trait specialization.
     template<typename TElem, typename TDim, typename TIdx, typename TDev>
@@ -333,7 +333,7 @@ namespace alpaka::traits
             return nullptr;
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #    include <alpaka/mem/buf/sycl/Accessor.hpp>
 #    include <alpaka/mem/buf/sycl/Copy.hpp>

--- a/include/alpaka/mem/buf/BufOacc.hpp
+++ b/include/alpaka/mem/buf/BufOacc.hpp
@@ -111,7 +111,7 @@ namespace alpaka
         std::shared_ptr<oacc::detail::BufOaccImpl<TElem, TDim, TIdx>> m_spBufImpl;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The BufOacc device type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
@@ -385,7 +385,7 @@ namespace alpaka
                 throw std::runtime_error("Mapping host memory to OpenACC device not implemented!");
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #    include <alpaka/mem/buf/oacc/Copy.hpp>

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -1,5 +1,4 @@
-/* Copyright 2022 Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred Gruber, Antonio
- * Di Pilato
+/* Copyright 2022 Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred Gruber
  *
  * This file is part of Alpaka.
  *
@@ -110,7 +109,7 @@ namespace alpaka
         std::shared_ptr<detail::BufOmp5Impl<TElem, TDim, TIdx>> m_spBufImpl;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The BufOmp5 device type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
@@ -383,7 +382,7 @@ namespace alpaka
                 throw std::runtime_error("Mapping host memory to OMP5 device not implemented!");
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #    include <alpaka/mem/buf/omp5/Copy.hpp>

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -81,7 +81,7 @@ namespace alpaka
         TIdx m_pitchBytes;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The BufUniformCudaHipRt device type trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
@@ -465,7 +465,7 @@ namespace alpaka
                 return pDev;
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #    include <alpaka/mem/buf/uniformCudaHip/Copy.hpp>

--- a/include/alpaka/mem/buf/SetKernel.hpp
+++ b/include/alpaka/mem/buf/SetKernel.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Jeffrey Kelling, Bernhard Manfred Gruber
+/* Copyright 2022 Jeffrey Kelling, Bernhard Manfred Gruber
  *
  * This file is part of Alpaka.
  *
@@ -40,7 +40,7 @@ namespace alpaka
             TExtent extent,
             TPitch pitch) const -> void
         {
-            using Idx = typename alpaka::traits::IdxType<TExtent>::type;
+            using Idx = typename alpaka::trait::IdxType<TExtent>::type;
             auto const gridThreadIdx(alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc));
             auto const threadElemExtent(alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc));
             auto const idxThreadFirstElem = getIdxThreadFirstElem(acc, gridThreadIdx, threadElemExtent);

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Alexander Matthes, Benjamin Worpitz, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2022 Alexander Matthes, Benjamin Worpitz, Andrea Bocci, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -15,7 +15,7 @@
 namespace alpaka
 {
     //! The buffer traits.
-    namespace traits
+    namespace trait
     {
         //! The memory buffer type trait.
         template<typename TDev, typename TElem, typename TDim, typename TIdx, typename TSfinae = void>
@@ -58,11 +58,11 @@ namespace alpaka
         //! The memory prepareForAsyncCopy trait.
         template<typename TBuf, typename TSfinae = void>
         struct PrepareForAsyncCopy;
-    } // namespace traits
+    } // namespace trait
 
     //! The memory buffer type trait alias template to remove the ::type.
     template<typename TDev, typename TElem, typename TDim, typename TIdx>
-    using Buf = typename traits::BufType<alpaka::Dev<TDev>, TElem, TDim, TIdx>::type;
+    using Buf = typename trait::BufType<alpaka::Dev<TDev>, TElem, TDim, TIdx>::type;
 
     //! Allocates memory on the given device.
     //!
@@ -76,7 +76,7 @@ namespace alpaka
     template<typename TElem, typename TIdx, typename TExtent, typename TDev>
     ALPAKA_FN_HOST auto allocBuf(TDev const& dev, TExtent const& extent = TExtent())
     {
-        return traits::BufAlloc<TElem, Dim<TExtent>, TIdx, TDev>::allocBuf(dev, extent);
+        return trait::BufAlloc<TElem, Dim<TExtent>, TIdx, TDev>::allocBuf(dev, extent);
     }
 
     //! Allocates stream-ordered memory on the given device.
@@ -91,7 +91,7 @@ namespace alpaka
     template<typename TElem, typename TIdx, typename TExtent, typename TQueue>
     ALPAKA_FN_HOST auto allocAsyncBuf(TQueue queue, TExtent const& extent = TExtent())
     {
-        return traits::AsyncBufAlloc<TElem, Dim<TExtent>, TIdx, alpaka::Dev<TQueue>>::allocAsyncBuf(queue, extent);
+        return trait::AsyncBufAlloc<TElem, Dim<TExtent>, TIdx, alpaka::Dev<TQueue>>::allocAsyncBuf(queue, extent);
     }
 
     //! Check if the given device can allocate a stream-ordered memory buffer of the given dimensionality.
@@ -105,7 +105,7 @@ namespace alpaka
 #    pragma clang diagnostic ignored "-Wmissing-variable-declarations"
 #endif
     template<typename TDev, typename TDim>
-    constexpr inline bool hasAsyncBufSupport = traits::HasAsyncBufSupport<TDim, TDev>::value;
+    constexpr inline bool hasAsyncBufSupport = trait::HasAsyncBufSupport<TDim, TDev>::value;
 #if BOOST_COMP_CLANG
 #    pragma clang diagnostic pop
 #endif
@@ -119,7 +119,7 @@ namespace alpaka
     template<typename TBuf, typename TDev>
     ALPAKA_FN_HOST auto map(TBuf& buf, TDev const& dev) -> void
     {
-        return traits::Map<TBuf, TDev>::map(buf, dev);
+        return trait::Map<TBuf, TDev>::map(buf, dev);
     }
 
     //! Unmaps the buffer from the memory of the given device.
@@ -131,7 +131,7 @@ namespace alpaka
     template<typename TBuf, typename TDev>
     ALPAKA_FN_HOST auto unmap(TBuf& buf, TDev const& dev) -> void
     {
-        return traits::Unmap<TBuf, TDev>::unmap(buf, dev);
+        return trait::Unmap<TBuf, TDev>::unmap(buf, dev);
     }
 
     //! Pins the buffer.
@@ -141,7 +141,7 @@ namespace alpaka
     template<typename TBuf>
     ALPAKA_FN_HOST auto pin(TBuf& buf) -> void
     {
-        return traits::Pin<TBuf>::pin(buf);
+        return trait::Pin<TBuf>::pin(buf);
     }
 
     //! Unpins the buffer.
@@ -151,7 +151,7 @@ namespace alpaka
     template<typename TBuf>
     ALPAKA_FN_HOST auto unpin(TBuf& buf) -> void
     {
-        return traits::Unpin<TBuf>::unpin(buf);
+        return trait::Unpin<TBuf>::unpin(buf);
     }
 
     //! The pin state of the buffer.
@@ -161,7 +161,7 @@ namespace alpaka
     template<typename TBuf>
     ALPAKA_FN_HOST auto isPinned(TBuf const& buf) -> bool
     {
-        return traits::IsPinned<TBuf>::isPinned(buf);
+        return trait::IsPinned<TBuf>::isPinned(buf);
     }
 
     //! Prepares the buffer for non-blocking copy operations, e.g. pinning if
@@ -172,6 +172,6 @@ namespace alpaka
     template<typename TBuf>
     ALPAKA_FN_HOST auto prepareForAsyncCopy(TBuf& buf) -> void
     {
-        return traits::PrepareForAsyncCopy<TBuf>::prepareForAsyncCopy(buf);
+        return trait::PrepareForAsyncCopy<TBuf>::prepareForAsyncCopy(buf);
     }
 } // namespace alpaka

--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -250,7 +250,7 @@ namespace alpaka
         };
     } // namespace detail
 
-    namespace traits
+    namespace trait
     {
         //! The CPU device memory copy trait specialization.
         //!
@@ -267,5 +267,5 @@ namespace alpaka
                 return alpaka::detail::TaskCopyCpu<TDim, TViewDst, TViewSrc, TExtent>(viewDst, viewSrc, extent);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -197,7 +197,7 @@ namespace alpaka
         };
     } // namespace detail
 
-    namespace traits
+    namespace trait
     {
         //! The CPU device memory set trait specialization.
         template<typename TDim>
@@ -210,5 +210,5 @@ namespace alpaka
                 return alpaka::detail::TaskSetCpu<TDim, TView, TExtent>(view, byte, extent);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/mem/buf/oacc/Copy.hpp
+++ b/include/alpaka/mem/buf/oacc/Copy.hpp
@@ -278,7 +278,7 @@ namespace alpaka
     } // namespace oacc
 
     // Trait specializations for CreateTaskCopy.
-    namespace traits
+    namespace trait
     {
         //! The CPU to OpenACC memory copy trait specialization.
         template<typename TDim>
@@ -371,7 +371,7 @@ namespace alpaka
                 }
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/mem/buf/oacc/Set.hpp
+++ b/include/alpaka/mem/buf/oacc/Set.hpp
@@ -38,7 +38,7 @@ namespace alpaka
 
 namespace alpaka
 {
-    namespace traits
+    namespace trait
     {
         //! The OpenACC device memory set trait specialization.
         template<typename TDim>
@@ -47,7 +47,7 @@ namespace alpaka
             template<typename TExtent, typename TView>
             ALPAKA_FN_HOST static auto createTaskMemset(TView& view, std::uint8_t const& byte, TExtent const& extent)
             {
-                using Idx = typename traits::IdxType<TExtent>::type;
+                using Idx = typename trait::IdxType<TExtent>::type;
                 auto pitch = getPitchBytesVec(view);
                 auto byteExtent = getExtentVec(extent);
                 byteExtent[TDim::value - 1] *= static_cast<Idx>(sizeof(Elem<TView>));
@@ -98,7 +98,7 @@ namespace alpaka
                 std::uint8_t const& byte,
                 TExtent const& /* extent */)
             {
-                using Idx = typename traits::IdxType<TExtent>::type;
+                using Idx = typename trait::IdxType<TExtent>::type;
                 using Dim1D = DimInt<1u>;
                 using Vec1D = Vec<Dim1D, Idx>;
 
@@ -114,7 +114,7 @@ namespace alpaka
                     Vec1D::zeros());
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/mem/buf/omp5/Copy.hpp
+++ b/include/alpaka/mem/buf/omp5/Copy.hpp
@@ -294,7 +294,7 @@ namespace alpaka
     } // namespace detail
 
     // Trait specializations for CreateTaskMemcpy.
-    namespace traits
+    namespace trait
     {
         namespace detail
         {
@@ -384,7 +384,7 @@ namespace alpaka
                     getDev(viewSrc).getNativeHandle());
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/mem/buf/omp5/Set.hpp
+++ b/include/alpaka/mem/buf/omp5/Set.hpp
@@ -35,7 +35,7 @@ namespace alpaka
 {
     class DevOmp5;
 
-    namespace traits
+    namespace trait
     {
         //! The OMP5 device memory set trait specialization.
         template<typename TDim>
@@ -44,7 +44,7 @@ namespace alpaka
             template<typename TExtent, typename TView>
             ALPAKA_FN_HOST static auto createTaskMemset(TView& view, std::uint8_t const& byte, TExtent const& extent)
             {
-                using Idx = typename alpaka::traits::IdxType<TExtent>::type;
+                using Idx = typename alpaka::trait::IdxType<TExtent>::type;
                 auto pitch = getPitchBytesVec(view);
                 auto byteExtent = getExtentVec(extent);
                 constexpr auto lastDim = TDim::value - 1;
@@ -96,7 +96,7 @@ namespace alpaka
                 std::uint8_t const& byte,
                 TExtent const& /* extent */)
             {
-                using Idx = typename alpaka::traits::IdxType<TExtent>::type;
+                using Idx = typename alpaka::trait::IdxType<TExtent>::type;
                 using Dim1D = DimInt<1u>;
                 using Vec1D = Vec<Dim1D, Idx>;
 
@@ -112,7 +112,7 @@ namespace alpaka
                     Vec1D::zeros());
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/mem/buf/sycl/Accessor.hpp
+++ b/include/alpaka/mem/buf/sycl/Accessor.hpp
@@ -116,7 +116,7 @@ namespace alpaka::experimental
         VecType extents;
     };
 
-    namespace traits
+    namespace trait
     {
         namespace internal
         {
@@ -138,7 +138,7 @@ namespace alpaka::experimental
                     buffer.m_extentElements};
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka::experimental
 
 #endif

--- a/include/alpaka/mem/buf/sycl/Copy.hpp
+++ b/include/alpaka/mem/buf/sycl/Copy.hpp
@@ -69,7 +69,7 @@ namespace alpaka::experimental::detail
 } // namespace alpaka::experimental::detail
 
 // Trait specializations for CreateTaskMemcpy.
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL host-to-device memory copy trait specialization.
     template<typename TDim, typename TPltf>
@@ -186,6 +186,6 @@ namespace alpaka::traits
                 DstType{viewDst.m_buffer, range, offset_dst}};
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/mem/buf/sycl/Set.hpp
+++ b/include/alpaka/mem/buf/sycl/Set.hpp
@@ -59,7 +59,7 @@ namespace alpaka
         } // namespace detail
     } // namespace experimental
 
-    namespace traits
+    namespace trait
     {
         //! The SYCL device memory set trait specialization.
         template<typename TDim, typename TPltf>
@@ -82,7 +82,7 @@ namespace alpaka
                 return experimental::detail::TaskSetSycl<DstType>{DstType{buf, range}, byte_val};
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -495,7 +495,7 @@ namespace alpaka
     } // namespace detail
 
     // Trait specializations for CreateTaskMemcpy.
-    namespace traits
+    namespace trait
     {
         //! The CUDA/HIP to CPU memory copy trait specialization.
         template<typename TDim>
@@ -702,7 +702,7 @@ namespace alpaka
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamSynchronize)(queue.getNativeHandle()));
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -269,7 +269,7 @@ namespace alpaka
         };
     } // namespace detail
 
-    namespace traits
+    namespace trait
     {
         //! The CUDA device memory set trait specialization.
         template<typename TDim>
@@ -411,7 +411,7 @@ namespace alpaka
                 wait(queue);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/mem/fence/MemFenceCpu.hpp
+++ b/include/alpaka/mem/fence/MemFenceCpu.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2022 Jan Stephan, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -21,7 +21,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         template<typename TMemScope>
         struct MemFence<MemFenceCpu, TMemScope>
@@ -68,5 +68,5 @@ namespace alpaka
                 dummy.store(x, std::memory_order_relaxed);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/mem/fence/MemFenceCpuSerial.hpp
+++ b/include/alpaka/mem/fence/MemFenceCpuSerial.hpp
@@ -21,7 +21,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct MemFence<MemFenceCpuSerial, memory_scope::Block>
@@ -57,5 +57,5 @@ namespace alpaka
                 dummy.store(x, std::memory_order_relaxed);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/mem/fence/MemFenceGenericSycl.hpp
+++ b/include/alpaka/mem/fence/MemFenceGenericSycl.hpp
@@ -56,7 +56,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     template<typename TMemScope>
     struct MemFence<experimental::MemFenceGenericSycl, TMemScope>
@@ -77,6 +77,6 @@ namespace alpaka::traits
             dummy.store(dummy_val);
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/mem/fence/MemFenceOacc.hpp
+++ b/include/alpaka/mem/fence/MemFenceOacc.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2022 Jan Stephan, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -25,7 +25,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         template<typename TMemScope>
         struct MemFence<MemFenceOacc, TMemScope>
@@ -52,7 +52,7 @@ namespace alpaka
                 static_assert(!sizeof(TMemScope), "Memory fences are not available in the OpenACC back-end");
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/mem/fence/MemFenceOmp2Blocks.hpp
+++ b/include/alpaka/mem/fence/MemFenceOmp2Blocks.hpp
@@ -25,7 +25,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct MemFence<MemFenceOmp2Blocks, memory_scope::Block>
@@ -53,7 +53,7 @@ namespace alpaka
 #    pragma omp flush
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/mem/fence/MemFenceOmp2Threads.hpp
+++ b/include/alpaka/mem/fence/MemFenceOmp2Threads.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2022 Jan Stephan, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -25,7 +25,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         template<typename TMemScope>
         struct MemFence<MemFenceOmp2Threads, TMemScope>
@@ -65,6 +65,6 @@ namespace alpaka
 #    pragma omp flush
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 #endif

--- a/include/alpaka/mem/fence/MemFenceOmp5.hpp
+++ b/include/alpaka/mem/fence/MemFenceOmp5.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2022 Jan Stephan, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -25,7 +25,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         template<typename TMemScope>
         struct MemFence<MemFenceOmp5, TMemScope>
@@ -36,7 +36,7 @@ namespace alpaka
 #    pragma omp flush acq_rel
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/mem/fence/MemFenceUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/mem/fence/MemFenceUniformCudaHipBuiltIn.hpp
@@ -32,7 +32,7 @@ namespace alpaka
 #            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #        endif
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct MemFence<MemFenceUniformCudaHipBuiltIn, memory_scope::Block>
@@ -61,7 +61,7 @@ namespace alpaka
                 __threadfence();
             }
         };
-    } // namespace traits
+    } // namespace trait
 
 #    endif
 

--- a/include/alpaka/mem/fence/Traits.hpp
+++ b/include/alpaka/mem/fence/Traits.hpp
@@ -36,13 +36,13 @@ namespace alpaka
         };
     } // namespace memory_scope
 
-    //! The memory fence traits.
-    namespace traits
+    //! The memory fence trait.
+    namespace trait
     {
         //! The mem_fence trait.
         template<typename TMemFence, typename TMemScope, typename TSfinae = void>
         struct MemFence;
-    } // namespace traits
+    } // namespace trait
 
     //! Issues memory fence instructions.
     //
@@ -66,6 +66,6 @@ namespace alpaka
     ALPAKA_FN_ACC auto mem_fence(TMemFence const& fence, TMemScope const& scope) -> void
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMemFence, TMemFence>;
-        traits::MemFence<ImplementationBase, TMemScope>::mem_fence(fence, scope);
+        trait::MemFence<ImplementationBase, TMemScope>::mem_fence(fence, scope);
     }
 } // namespace alpaka

--- a/include/alpaka/mem/view/Accessor.hpp
+++ b/include/alpaka/mem/view/Accessor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Bernhard Manfred Gruber
+/* Copyright 2022 Bernhard Manfred Gruber
 
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -51,7 +51,7 @@ namespace alpaka::experimental
     template<typename TMemoryHandle, typename TElem, typename TBufferIdx, std::size_t TDim, typename TAccessModes>
     struct Accessor;
 
-    namespace traits
+    namespace trait
     {
         //! The customization point for how to build an accessor for a given memory object.
         template<typename TMemoryObject, typename SFINAE = void>
@@ -65,7 +65,7 @@ namespace alpaka::experimental
                     "BuildAccessor<TMemoryObject> is not specialized for your TMemoryObject.");
             }
         };
-    } // namespace traits
+    } // namespace trait
 
     namespace internal
     {
@@ -106,7 +106,7 @@ namespace alpaka::experimental
         typename = std::enable_if_t<!internal::IsAccessor<std::decay_t<TMemoryObject>>::value>>
     ALPAKA_FN_HOST_ACC auto accessWith(TMemoryObject&& memoryObject)
     {
-        return traits::BuildAccessor<std::decay_t<TMemoryObject>>::template buildAccessor<TAccessModes...>(
+        return trait::BuildAccessor<std::decay_t<TMemoryObject>>::template buildAccessor<TAccessModes...>(
             memoryObject);
     }
 

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -28,7 +28,7 @@
 namespace alpaka
 {
     //! The view traits.
-    namespace traits
+    namespace trait
     {
         //! The native pointer get trait.
         template<typename TView, typename TSfinae = void>
@@ -91,7 +91,7 @@ namespace alpaka
         //! The sub view creation trait.
         template<typename TDev, typename TSfinae = void>
         struct CreateSubView;
-    } // namespace traits
+    } // namespace trait
 
     //! Gets the native pointer of the memory view.
     //!
@@ -100,7 +100,7 @@ namespace alpaka
     template<typename TView>
     ALPAKA_FN_HOST auto getPtrNative(TView const& view) -> Elem<TView> const*
     {
-        return traits::GetPtrNative<TView>::getPtrNative(view);
+        return trait::GetPtrNative<TView>::getPtrNative(view);
     }
 
     //! Gets the native pointer of the memory view.
@@ -110,7 +110,7 @@ namespace alpaka
     template<typename TView>
     ALPAKA_FN_HOST auto getPtrNative(TView& view) -> Elem<TView>*
     {
-        return traits::GetPtrNative<TView>::getPtrNative(view);
+        return trait::GetPtrNative<TView>::getPtrNative(view);
     }
 
     //! Gets the pointer to the view on the given device.
@@ -121,7 +121,7 @@ namespace alpaka
     template<typename TView, typename TDev>
     ALPAKA_FN_HOST auto getPtrDev(TView const& view, TDev const& dev) -> Elem<TView> const*
     {
-        return traits::GetPtrDev<TView, TDev>::getPtrDev(view, dev);
+        return trait::GetPtrDev<TView, TDev>::getPtrDev(view, dev);
     }
 
     //! Gets the pointer to the view on the given device.
@@ -132,7 +132,7 @@ namespace alpaka
     template<typename TView, typename TDev>
     ALPAKA_FN_HOST auto getPtrDev(TView& view, TDev const& dev) -> Elem<TView>*
     {
-        return traits::GetPtrDev<TView, TDev>::getPtrDev(view, dev);
+        return trait::GetPtrDev<TView, TDev>::getPtrDev(view, dev);
     }
 
     //! \return The pitch in bytes. This is the distance in bytes between two consecutive elements in the given
@@ -141,7 +141,7 @@ namespace alpaka
     template<std::size_t Tidx, typename TView>
     ALPAKA_FN_HOST_ACC auto getPitchBytes(TView const& view) -> Idx<TView>
     {
-        return traits::GetPitchBytes<DimInt<Tidx>, TView>::getPitchBytes(view);
+        return trait::GetPitchBytes<DimInt<Tidx>, TView>::getPitchBytes(view);
     }
 
     //! Create a memory set task.
@@ -156,7 +156,7 @@ namespace alpaka
             Dim<TView>::value == Dim<TExtent>::value,
             "The view and the extent are required to have the same dimensionality!");
 
-        return traits::CreateTaskMemset<Dim<TView>, Dev<TView>>::createTaskMemset(view, byte, extent);
+        return trait::CreateTaskMemset<Dim<TView>, Dev<TView>>::createTaskMemset(view, byte, extent);
     }
 
     //! Sets the memory to the given value.
@@ -200,7 +200,7 @@ namespace alpaka
             std::is_same_v<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>,
             "The source and the destination view are required to have the same element type!");
 
-        return traits::CreateTaskMemcpy<Dim<TViewDst>, Dev<TViewDst>, Dev<TViewSrc>>::createTaskMemcpy(
+        return trait::CreateTaskMemcpy<Dim<TViewDst>, Dev<TViewDst>, Dev<TViewSrc>>::createTaskMemcpy(
             viewDst,
             viewSrc,
             extent);
@@ -377,7 +377,7 @@ namespace alpaka
     template<typename TElem, typename TDev, typename TExtent>
     auto createStaticDevMemView(TElem* pMem, TDev const& dev, TExtent const& extent)
     {
-        return traits::CreateStaticDevMemView<TDev>::createStaticDevMemView(pMem, dev, extent);
+        return trait::CreateStaticDevMemView<TDev>::createStaticDevMemView(pMem, dev, extent);
     }
 
     //! Creates a view to a device pointer
@@ -394,7 +394,7 @@ namespace alpaka
         using Dim = alpaka::Dim<TExtent>;
         using Idx = alpaka::Idx<TExtent>;
         auto const extentVec = Vec<Dim, Idx>(extent);
-        return traits::CreateViewPlainPtr<TDev>::createViewPlainPtr(
+        return trait::CreateViewPlainPtr<TDev>::createViewPlainPtr(
             dev,
             pMem,
             extentVec,
@@ -413,7 +413,7 @@ namespace alpaka
     template<typename TDev, typename TElem, typename TExtent, typename TPitch>
     auto createView(TDev const& dev, TElem* pMem, TExtent const& extent, TPitch const& pitch)
     {
-        return traits::CreateViewPlainPtr<TDev>::createViewPlainPtr(dev, pMem, extent, pitch);
+        return trait::CreateViewPlainPtr<TDev>::createViewPlainPtr(dev, pMem, extent, pitch);
     }
 
     //! Creates a view to a contiguous container of device-accessible memory.
@@ -451,7 +451,7 @@ namespace alpaka
     template<typename TView, typename TExtent, typename TOffsets>
     auto createSubView(TView& view, TExtent const& extent, TOffsets const& offset = TExtent())
     {
-        return traits::CreateSubView<typename traits::DevType<TView>::type>::createSubView(view, extent, offset);
+        return trait::CreateSubView<typename trait::DevType<TView>::type>::createSubView(view, extent, offset);
     }
 
 } // namespace alpaka

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -37,7 +37,7 @@ namespace alpaka::internal
     public:
         ViewAccessOps()
         {
-            static_assert(experimental::traits::internal::IsView<TView>::value);
+            static_assert(experimental::trait::internal::IsView<TView>::value);
         }
 
         ALPAKA_FN_HOST auto data() -> pointer

--- a/include/alpaka/mem/view/ViewAccessor.hpp
+++ b/include/alpaka/mem/view/ViewAccessor.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Bernhard Manfred Gruber
+/* Copyright 2022 Bernhard Manfred Gruber
 
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -184,7 +184,7 @@ namespace alpaka::experimental
         Vec<DimInt<TDim>, TBufferIdx> extents;
     };
 
-    namespace traits
+    namespace trait
     {
         namespace internal
         {
@@ -268,5 +268,5 @@ namespace alpaka::experimental
                     std::make_index_sequence<Dim::value>{});
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka::experimental

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -71,7 +71,7 @@ namespace alpaka
     };
 
     // Trait specializations for ViewPlainPtr.
-    namespace traits
+    namespace trait
     {
         //! The ViewPlainPtr device type trait specialization.
         template<typename TDev, typename TElem, typename TDim, typename TIdx>
@@ -103,8 +103,8 @@ namespace alpaka
         {
             using type = TElem;
         };
-    } // namespace traits
-    namespace traits
+    } // namespace trait
+    namespace trait
     {
         //! The ViewPlainPtr width get trait specialization.
         template<typename TIdxIntegralConst, typename TDev, typename TElem, typename TDim, typename TIdx>
@@ -120,9 +120,9 @@ namespace alpaka
                 return extent.m_extentElements[TIdxIntegralConst::value];
             }
         };
-    } // namespace traits
+    } // namespace trait
 
-    namespace traits
+    namespace trait
     {
         //! The ViewPlainPtr native pointer get trait specialization.
         template<typename TDev, typename TElem, typename TDim, typename TIdx>
@@ -304,5 +304,5 @@ namespace alpaka
         {
             using type = TIdx;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/mem/view/ViewStdArray.hpp
+++ b/include/alpaka/mem/view/ViewStdArray.hpp
@@ -19,7 +19,7 @@
 
 #include <array>
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The std::array device type trait specialization.
     template<typename TElem, std::size_t Tsize>
@@ -93,4 +93,4 @@ namespace alpaka::traits
     {
         using type = std::size_t;
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait

--- a/include/alpaka/mem/view/ViewStdVector.hpp
+++ b/include/alpaka/mem/view/ViewStdVector.hpp
@@ -19,7 +19,7 @@
 
 #include <vector>
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The std::vector device type trait specialization.
     template<typename TElem, typename TAllocator>
@@ -94,4 +94,4 @@ namespace alpaka::traits
     {
         using type = std::size_t;
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Matthias Werner, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -138,7 +138,7 @@ namespace alpaka
     };
 
     // Trait specializations for ViewSubView.
-    namespace traits
+    namespace trait
     {
         //! The ViewSubView device type trait specialization.
         template<typename TElem, typename TDim, typename TDev, typename TIdx>
@@ -277,9 +277,9 @@ namespace alpaka
             {
                 using Dim = alpaka::Dim<TExtent>;
                 using Idx = alpaka::Idx<TExtent>;
-                using Elem = typename traits::ElemType<TView>::type;
+                using Elem = typename trait::ElemType<TView>::type;
                 return ViewSubView<TDev, Elem, Dim, Idx>(view, extentElements, relativeOffsetsElements);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/offset/Traits.hpp
+++ b/include/alpaka/offset/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -18,7 +18,7 @@
 namespace alpaka
 {
     //! The offset traits.
-    namespace traits
+    namespace trait
     {
         //! The x offset get trait.
         //!
@@ -36,14 +36,14 @@ namespace alpaka
         //! The x offset set trait.
         template<typename TIdx, typename TOffsets, typename TOffset, typename TSfinae = void>
         struct SetOffset;
-    } // namespace traits
+    } // namespace trait
 
     //! \return The offset in the given dimension.
     ALPAKA_NO_HOST_ACC_WARNING
     template<std::size_t Tidx, typename TOffsets>
     ALPAKA_FN_HOST_ACC auto getOffset(TOffsets const& offsets) -> Idx<TOffsets>
     {
-        return traits::GetOffset<DimInt<Tidx>, TOffsets>::getOffset(offsets);
+        return trait::GetOffset<DimInt<Tidx>, TOffsets>::getOffset(offsets);
     }
     //! \return The offset in x dimension.
     ALPAKA_NO_HOST_ACC_WARNING
@@ -72,7 +72,7 @@ namespace alpaka
     template<std::size_t Tidx, typename TOffsets, typename TOffset>
     ALPAKA_FN_HOST_ACC auto setOffset(TOffsets const& offsets, TOffset const& offset) -> void
     {
-        traits::SetOffset<DimInt<Tidx>, TOffsets, TOffset>::setOffset(offsets, offset);
+        trait::SetOffset<DimInt<Tidx>, TOffsets, TOffset>::setOffset(offsets, offset);
     }
     //! Sets the offset in x dimension.
     ALPAKA_NO_HOST_ACC_WARNING
@@ -97,7 +97,7 @@ namespace alpaka
     }
 
     // Trait specializations for unsigned integral types.
-    namespace traits
+    namespace trait
     {
         //! The unsigned integral x offset get trait specialization.
         template<typename TOffsets>
@@ -119,5 +119,5 @@ namespace alpaka
                 offsets = offset;
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/pltf/PltfCpu.hpp
+++ b/include/alpaka/pltf/PltfCpu.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -25,7 +25,7 @@ namespace alpaka
         ALPAKA_FN_HOST PltfCpu() = delete;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU device device type trait specialization.
         template<>
@@ -66,5 +66,5 @@ namespace alpaka
                 return {};
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/pltf/PltfCpuSyclIntel.hpp
+++ b/include/alpaka/pltf/PltfCpuSyclIntel.hpp
@@ -54,7 +54,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL device manager device type trait specialization.
     template<>
@@ -62,6 +62,6 @@ namespace alpaka::traits
     {
         using type = experimental::DevGenericSycl<experimental::PltfCpuSyclIntel>; // = DevCpuSyclIntel
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/pltf/PltfFpgaSyclIntel.hpp
+++ b/include/alpaka/pltf/PltfFpgaSyclIntel.hpp
@@ -36,7 +36,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL device manager device type trait specialization.
     template<>
@@ -44,6 +44,6 @@ namespace alpaka::traits
     {
         using type = experimental::DevGenericSycl<experimental::PltfFpgaSyclIntel>; // = DevFpgaSyclIntel
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/pltf/PltfFpgaSyclXilinx.hpp
+++ b/include/alpaka/pltf/PltfFpgaSyclXilinx.hpp
@@ -54,7 +54,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL device manager device type trait specialization.
     template<>
@@ -62,6 +62,6 @@ namespace alpaka::traits
     {
         using type = experimental::DevGenericSycl<experimental::PltfFpgaSyclXilinx>; // = DevFpgaSyclXilinx
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/pltf/PltfGenericSycl.hpp
+++ b/include/alpaka/pltf/PltfGenericSycl.hpp
@@ -33,7 +33,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL platform device count get trait specialization.
     template<typename TPltf>
@@ -682,6 +682,6 @@ namespace alpaka::traits
         }
 #    endif
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/pltf/PltfGpuSyclIntel.hpp
+++ b/include/alpaka/pltf/PltfGpuSyclIntel.hpp
@@ -55,7 +55,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL device manager device type trait specialization.
     template<>
@@ -63,6 +63,6 @@ namespace alpaka::traits
     {
         using type = experimental::DevGenericSycl<experimental::PltfGpuSyclIntel>; // = DevGpuSyclIntel
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/pltf/PltfOacc.hpp
+++ b/include/alpaka/pltf/PltfOacc.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of Alpaka.
  *
@@ -31,7 +31,7 @@ namespace alpaka
         ALPAKA_FN_HOST PltfOacc() = delete;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The OpenACC platform device count get trait specialization.
         template<>
@@ -44,7 +44,7 @@ namespace alpaka
                 return static_cast<std::size_t>(::acc_get_num_devices(::acc_get_device_type()));
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/pltf/PltfOmp5.hpp
+++ b/include/alpaka/pltf/PltfOmp5.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of Alpaka.
  *
@@ -32,7 +32,7 @@ namespace alpaka
         ALPAKA_FN_HOST PltfOmp5() = delete;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The OpenMP 5 device device type trait specialization.
         template<>
@@ -83,7 +83,7 @@ namespace alpaka
                 return {devIdxOmp5};
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
+++ b/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
@@ -36,7 +36,7 @@ namespace alpaka
         ALPAKA_FN_HOST PltfUniformCudaHipRt() = delete;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CUDA/HIP RT platform device type trait specialization.
         template<>
@@ -268,7 +268,7 @@ namespace alpaka
             }
 #    endif
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/pltf/Traits.hpp
+++ b/include/alpaka/pltf/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -24,7 +24,7 @@ namespace alpaka
     };
 
     //! The platform traits.
-    namespace traits
+    namespace trait
     {
         //! The platform type trait.
         template<typename T, typename TSfinae = void>
@@ -43,24 +43,24 @@ namespace alpaka
         //! The device get trait.
         template<typename T, typename TSfinae = void>
         struct GetDevByIdx;
-    } // namespace traits
+    } // namespace trait
 
     //! The platform type trait alias template to remove the ::type.
     template<typename T>
-    using Pltf = typename traits::PltfType<T>::type;
+    using Pltf = typename trait::PltfType<T>::type;
 
     //! \return The device identified by its index.
     template<typename TPltf>
     ALPAKA_FN_HOST auto getDevCount()
     {
-        return traits::GetDevCount<Pltf<TPltf>>::getDevCount();
+        return trait::GetDevCount<Pltf<TPltf>>::getDevCount();
     }
 
     //! \return The device identified by its index.
     template<typename TPltf>
     ALPAKA_FN_HOST auto getDevByIdx(std::size_t const& devIdx)
     {
-        return traits::GetDevByIdx<Pltf<TPltf>>::getDevByIdx(devIdx);
+        return trait::GetDevByIdx<Pltf<TPltf>>::getDevByIdx(devIdx);
     }
 
     //! \return All the devices available on this accelerator.
@@ -78,12 +78,12 @@ namespace alpaka
         return devs;
     }
 
-    namespace traits
+    namespace trait
     {
         template<typename TPltf, typename TProperty>
         struct QueueType<TPltf, TProperty, std::enable_if_t<concepts::ImplementsConcept<ConceptPltf, TPltf>::value>>
         {
-            using type = typename QueueType<typename alpaka::traits::DevType<TPltf>::type, TProperty>::type;
+            using type = typename QueueType<typename alpaka::trait::DevType<TPltf>::type, TProperty>::type;
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/queue/QueueGenericThreadsBlocking.hpp
+++ b/include/alpaka/queue/QueueGenericThreadsBlocking.hpp
@@ -97,7 +97,7 @@ namespace alpaka
         std::shared_ptr<generic::detail::QueueGenericThreadsBlockingImpl<TDev>> m_spQueueImpl;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU blocking device queue device type trait specialization.
         template<typename TDev>
@@ -160,7 +160,7 @@ namespace alpaka
                 std::lock_guard<std::mutex> lk(queue.m_spQueueImpl->m_mutex);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #include <alpaka/event/EventGenericThreads.hpp>

--- a/include/alpaka/queue/QueueGenericThreadsNonBlocking.hpp
+++ b/include/alpaka/queue/QueueGenericThreadsNonBlocking.hpp
@@ -110,7 +110,7 @@ namespace alpaka
         std::shared_ptr<generic::detail::QueueGenericThreadsNonBlockingImpl<TDev>> m_spQueueImpl;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU non-blocking device queue device type trait specialization.
         template<typename TDev>
@@ -160,7 +160,7 @@ namespace alpaka
                 return queue.m_spQueueImpl->m_workerThread.isIdle();
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #include <alpaka/event/EventGenericThreads.hpp>

--- a/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtBlocking.hpp
@@ -61,7 +61,7 @@ namespace alpaka
     using QueueHipRtBlocking = QueueUniformCudaHipRtBlocking;
 #    endif
 
-    namespace traits
+    namespace trait
     {
         //! The CUDA/HIP RT blocking queue device type trait specialization.
         template<>
@@ -178,7 +178,7 @@ namespace alpaka
                 return queue.getNativeHandle();
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
+++ b/include/alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp
@@ -62,7 +62,7 @@ namespace alpaka
     using QueueHipRtNonBlocking = QueueUniformCudaHipRtNonBlocking;
 #    endif
 
-    namespace traits
+    namespace trait
     {
         //! The CUDA/HIP RT non-blocking queue device type trait specialization.
         template<>
@@ -178,7 +178,7 @@ namespace alpaka
                 return queue.getNativeHandle();
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/queue/Traits.hpp
+++ b/include/alpaka/queue/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -21,7 +21,7 @@ namespace alpaka
     struct ConceptQueue;
 
     //! The queue traits.
-    namespace traits
+    namespace trait
     {
         //! The queue enqueue trait.
         template<typename TQueue, typename TTask, typename TSfinae = void>
@@ -34,7 +34,7 @@ namespace alpaka
         //! Queue for an accelerator
         template<typename TAcc, typename TProperty, typename TSfinae = void>
         struct QueueType;
-    } // namespace traits
+    } // namespace trait
 
     //! Queues the given task in the given queue.
     //!
@@ -45,7 +45,7 @@ namespace alpaka
     template<typename TQueue, typename TTask>
     ALPAKA_FN_HOST auto enqueue(TQueue& queue, TTask&& task) -> void
     {
-        traits::Enqueue<TQueue, std::decay_t<TTask>>::enqueue(queue, std::forward<TTask>(task));
+        trait::Enqueue<TQueue, std::decay_t<TTask>>::enqueue(queue, std::forward<TTask>(task));
     }
 
     //! Tests if the queue is empty (all ops in the given queue have been completed).
@@ -57,14 +57,14 @@ namespace alpaka
     ALPAKA_FN_HOST auto empty(TQueue const& queue) -> bool
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptQueue, TQueue>;
-        return traits::Empty<ImplementationBase>::empty(queue);
+        return trait::Empty<ImplementationBase>::empty(queue);
     }
 
     //! Queue based on the environment and a property
     //!
     //! \tparam TEnv Environment type, e.g.  accelerator, device or a platform.
-    //!              traits::QueueType must be specialized for TEnv
+    //!              trait::QueueType must be specialized for TEnv
     //! \tparam TProperty Property to define the behavior of TEnv.
     template<typename TEnv, typename TProperty>
-    using Queue = typename traits::QueueType<TEnv, TProperty>::type;
+    using Queue = typename trait::QueueType<TEnv, TProperty>::type;
 } // namespace alpaka

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRtBase.hpp
@@ -112,7 +112,7 @@ namespace alpaka
         } // namespace detail
     } // namespace uniform_cuda_hip
 
-    namespace traits
+    namespace trait
     {
         //! The CUDA/HIP RT non-blocking queue device get trait specialization.
         template<>
@@ -158,7 +158,7 @@ namespace alpaka
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(ALPAKA_API_PREFIX(StreamSynchronize)(queue.getNativeHandle()));
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/queue/sycl/QueueGenericSyclBase.hpp
+++ b/include/alpaka/queue/sycl/QueueGenericSyclBase.hpp
@@ -204,7 +204,7 @@ namespace alpaka::experimental
     class EventGenericSycl;
 }
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL blocking queue device type trait specialization.
     template<typename TDev, bool TBlocking>
@@ -279,6 +279,6 @@ namespace alpaka::traits
             return queue.getNativeHandle();
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/rand/Philox/PhiloxBaseCudaArray.hpp
+++ b/include/alpaka/rand/Philox/PhiloxBaseCudaArray.hpp
@@ -15,7 +15,7 @@
 
 namespace alpaka::rand::engine
 {
-    namespace traits
+    namespace trait
     {
         template<typename TScalar>
         struct PhiloxResultContainerTraits;
@@ -46,7 +46,7 @@ namespace alpaka::rand::engine
 
         template<typename TScalar>
         using PhiloxResultContainer = typename PhiloxResultContainerTraits<TScalar>::type;
-    } // namespace traits
+    } // namespace trait
 
     /** Philox backend using array-like interface to CUDA uintN types for the storage of Key and Counter
      *
@@ -63,8 +63,8 @@ namespace alpaka::rand::engine
             = meta::CudaVectorArrayWrapper<unsigned, 4>; ///< Counter type = array-like interface to CUDA uint4
         using Key = meta::CudaVectorArrayWrapper<unsigned, 2>; ///< Key type = array-like interface to CUDA uint2
         template<typename TDistributionResultScalar>
-        using ResultContainer = traits::PhiloxResultContainer<TDistributionResultScalar>; ///< Vector template for
-                                                                                          ///< distribution results
+        using ResultContainer = trait::PhiloxResultContainer<TDistributionResultScalar>; ///< Vector template for
+                                                                                         ///< distribution results
     };
 } // namespace alpaka::rand::engine
 

--- a/include/alpaka/rand/Philox/PhiloxBaseTraits.hpp
+++ b/include/alpaka/rand/Philox/PhiloxBaseTraits.hpp
@@ -16,11 +16,11 @@
 #    include <alpaka/rand/Philox/PhiloxBaseCudaArray.hpp>
 #endif
 
-namespace alpaka::rand::engine::traits
+namespace alpaka::rand::engine::trait
 {
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
     template<typename TAcc>
-    constexpr auto isGPU = std::is_same_v<typename alpaka::traits::DevType<TAcc>::type, alpaka::DevUniformCudaHipRt>;
+    constexpr auto isGPU = std::is_same_v<typename alpaka::trait::DevType<TAcc>::type, alpaka::DevUniformCudaHipRt>;
 #else
     template<typename TAcc>
     constexpr bool isGPU = false;
@@ -54,4 +54,4 @@ namespace alpaka::rand::engine::traits
 
         using Base = PhiloxBaseCommon<Backend, TParams, TImpl>; ///< Base type to be inherited from
     };
-} // namespace alpaka::rand::engine::traits
+} // namespace alpaka::rand::engine::trait

--- a/include/alpaka/rand/Philox/PhiloxSingle.hpp
+++ b/include/alpaka/rand/Philox/PhiloxSingle.hpp
@@ -45,11 +45,11 @@ namespace alpaka::rand::engine
      * @tparam TParams Basic parameters for the Philox algorithm
      */
     template<typename TAcc, typename TParams>
-    class PhiloxSingle : public traits::PhiloxBaseTraits<TAcc, TParams, PhiloxSingle<TAcc, TParams>>::Base
+    class PhiloxSingle : public trait::PhiloxBaseTraits<TAcc, TParams, PhiloxSingle<TAcc, TParams>>::Base
     {
     public:
         /// Specialization for different TAcc backends
-        using Traits = typename traits::PhiloxBaseTraits<TAcc, TParams, PhiloxSingle<TAcc, TParams>>;
+        using Traits = typename trait::PhiloxBaseTraits<TAcc, TParams, PhiloxSingle<TAcc, TParams>>;
 
         using Counter = typename Traits::Counter; ///< Backend-dependent Counter type
         using Key = typename Traits::Key; ///< Backend-dependent Key type

--- a/include/alpaka/rand/Philox/PhiloxVector.hpp
+++ b/include/alpaka/rand/Philox/PhiloxVector.hpp
@@ -42,11 +42,11 @@ namespace alpaka::rand::engine
      * @tparam TParams Basic parameters for the Philox algorithm
      */
     template<typename TAcc, typename TParams>
-    class PhiloxVector : public traits::PhiloxBaseTraits<TAcc, TParams, PhiloxVector<TAcc, TParams>>::Base
+    class PhiloxVector : public trait::PhiloxBaseTraits<TAcc, TParams, PhiloxVector<TAcc, TParams>>::Base
     {
     public:
         /// Specialization for different TAcc backends
-        using Traits = traits::PhiloxBaseTraits<TAcc, TParams, PhiloxVector<TAcc, TParams>>;
+        using Traits = trait::PhiloxBaseTraits<TAcc, TParams, PhiloxVector<TAcc, TParams>>;
 
         using Counter = typename Traits::Counter; ///< Backend-dependent Counter type
         using Key = typename Traits::Key; ///< Backend-dependent Key type

--- a/include/alpaka/rand/RandDefault.hpp
+++ b/include/alpaka/rand/RandDefault.hpp
@@ -165,7 +165,7 @@ namespace alpaka::rand
         };
     } // namespace distribution::gpu
 
-    namespace distribution::traits
+    namespace distribution::trait
     {
         //! The GPU device random number float normal distribution get trait specialization.
         template<typename T>
@@ -195,9 +195,9 @@ namespace alpaka::rand
                 return {};
             }
         };
-    } // namespace distribution::traits
+    } // namespace distribution::trait
 
-    namespace engine::traits
+    namespace engine::trait
     {
         //! The GPU device random number default generator get trait specialization.
         template<>
@@ -213,5 +213,5 @@ namespace alpaka::rand
                 return {seed, subsequence, offset};
             }
         };
-    } // namespace engine::traits
+    } // namespace engine::trait
 } // namespace alpaka::rand

--- a/include/alpaka/rand/RandStdLib.hpp
+++ b/include/alpaka/rand/RandStdLib.hpp
@@ -196,7 +196,7 @@ namespace alpaka::rand
         };
     } // namespace distribution::cpu
 
-    namespace distribution::traits
+    namespace distribution::trait
     {
         //! The CPU device random number float normal distribution get trait specialization.
         template<typename T>
@@ -225,9 +225,9 @@ namespace alpaka::rand
                 return {};
             }
         };
-    } // namespace distribution::traits
+    } // namespace distribution::trait
 
-    namespace engine::traits
+    namespace engine::trait
     {
         //! The CPU device random number default generator get trait specialization.
         template<>
@@ -268,5 +268,5 @@ namespace alpaka::rand
                 return {seed, subsequence, offset};
             }
         };
-    } // namespace engine::traits
+    } // namespace engine::trait
 } // namespace alpaka::rand

--- a/include/alpaka/rand/RandUniformCudaHipRand.hpp
+++ b/include/alpaka/rand/RandUniformCudaHipRand.hpp
@@ -229,7 +229,7 @@ namespace alpaka::rand
         };
     } // namespace distribution::uniform_cuda_hip
 
-    namespace distribution::traits
+    namespace distribution::trait
     {
         //! The CUDA/HIP random number float normal distribution get trait specialization.
         template<typename T>
@@ -263,9 +263,9 @@ namespace alpaka::rand
                 return {};
             }
         };
-    } // namespace distribution::traits
+    } // namespace distribution::trait
 
-    namespace engine::traits
+    namespace engine::trait
     {
         //! The CUDA/HIP random number default generator get trait specialization.
         template<>
@@ -280,7 +280,7 @@ namespace alpaka::rand
                 return {seed, subsequence, offset};
             }
         };
-    } // namespace engine::traits
+    } // namespace engine::trait
 #    endif
 } // namespace alpaka::rand
 

--- a/include/alpaka/rand/Traits.hpp
+++ b/include/alpaka/rand/Traits.hpp
@@ -23,8 +23,8 @@ namespace alpaka::rand
     //! The random number generator distribution specifics.
     namespace distribution
     {
-        //! The random number generator distribution traits.
-        namespace traits
+        //! The random number generator distribution trait.
+        namespace trait
         {
             //! The random number float normal distribution get trait.
             template<typename TRand, typename T, typename TSfinae = void>
@@ -37,7 +37,7 @@ namespace alpaka::rand
             //! The random number integer uniform distribution get trait.
             template<typename TRand, typename T, typename TSfinae = void>
             struct CreateUniformUint;
-        } // namespace traits
+        } // namespace trait
 
         //! \return A normal float distribution with mean 0.0f and standard deviation 1.0f.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -47,7 +47,7 @@ namespace alpaka::rand
             static_assert(std::is_floating_point_v<T>, "The value type T has to be a floating point type!");
 
             using ImplementationBase = concepts::ImplementationBase<ConceptRand, TRand>;
-            return traits::CreateNormalReal<ImplementationBase, T>::createNormalReal(rand);
+            return trait::CreateNormalReal<ImplementationBase, T>::createNormalReal(rand);
         }
         //! \return A uniform floating point distribution [0.0, 1.0).
         ALPAKA_NO_HOST_ACC_WARNING
@@ -57,7 +57,7 @@ namespace alpaka::rand
             static_assert(std::is_floating_point_v<T>, "The value type T has to be a floating point type!");
 
             using ImplementationBase = concepts::ImplementationBase<ConceptRand, TRand>;
-            return traits::CreateUniformReal<ImplementationBase, T>::createUniformReal(rand);
+            return trait::CreateUniformReal<ImplementationBase, T>::createUniformReal(rand);
         }
         //! \return A uniform integer distribution [0, UINT_MAX].
         ALPAKA_NO_HOST_ACC_WARNING
@@ -69,20 +69,20 @@ namespace alpaka::rand
                 "The value type T has to be a unsigned integral type!");
 
             using ImplementationBase = concepts::ImplementationBase<ConceptRand, TRand>;
-            return traits::CreateUniformUint<ImplementationBase, T>::createUniformUint(rand);
+            return trait::CreateUniformUint<ImplementationBase, T>::createUniformUint(rand);
         }
     } // namespace distribution
 
     //! The random number generator engine specifics.
     namespace engine
     {
-        //! The random number generator engine traits.
-        namespace traits
+        //! The random number generator engine trait.
+        namespace trait
         {
             //! The random number default generator engine get trait.
             template<typename TRand, typename TSfinae = void>
             struct CreateDefault;
-        } // namespace traits
+        } // namespace trait
         //! \return A default random number generator engine.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TRand>
@@ -93,7 +93,7 @@ namespace alpaka::rand
             std::uint32_t const& offset = 0)
         {
             using ImplementationBase = concepts::ImplementationBase<ConceptRand, TRand>;
-            return traits::CreateDefault<ImplementationBase>::createDefault(rand, seed, subsequence, offset);
+            return trait::CreateDefault<ImplementationBase>::createDefault(rand, seed, subsequence, offset);
         }
     } // namespace engine
 } // namespace alpaka::rand

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -1,5 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber,
- * Antonio Di Pilato
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -18,23 +17,23 @@
 
 namespace alpaka::test
 {
-    namespace traits
+    namespace trait
     {
         template<typename TDev>
         struct EventHostManualTriggerType;
 
         template<typename TDev>
         struct IsEventHostManualTriggerSupported;
-    } // namespace traits
+    } // namespace trait
 
     //! The event host manual trigger type trait alias template to remove the ::type.
     template<typename TDev>
-    using EventHostManualTrigger = typename traits::EventHostManualTriggerType<TDev>::type;
+    using EventHostManualTrigger = typename trait::EventHostManualTriggerType<TDev>::type;
 
     template<typename TDev>
     ALPAKA_FN_HOST auto isEventHostManualTriggerSupported(TDev const& dev) -> bool
     {
-        return traits::IsEventHostManualTriggerSupported<TDev>::isSupported(dev);
+        return trait::IsEventHostManualTriggerSupported<TDev>::isSupported(dev);
     }
 
     namespace cpu::detail
@@ -107,7 +106,7 @@ namespace alpaka::test
         std::shared_ptr<cpu::detail::EventHostManualTriggerCpuImpl<TDev>> m_spEventImpl;
     };
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct EventHostManualTriggerType<DevCpu>
@@ -157,10 +156,10 @@ namespace alpaka::test
             }
         };
 #endif
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka::test
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The CPU device event device get trait specialization.
     template<typename TDev>
@@ -269,7 +268,7 @@ namespace alpaka::traits
                 { return (enqueueCount != spEventImpl->m_enqueueCount) || spEventImpl->m_bIsReady; });
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
@@ -365,7 +364,7 @@ namespace alpaka::test
         std::shared_ptr<uniform_cuda_hip::detail::EventHostManualTriggerCudaImpl> m_spEventImpl;
     };
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct EventHostManualTriggerType<DevUniformCudaHipRt>
@@ -383,10 +382,10 @@ namespace alpaka::test
                 return result != 0;
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka::test
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The CPU device event device get trait specialization.
     template<>
@@ -479,7 +478,7 @@ namespace alpaka::traits
                 CU_STREAM_WAIT_VALUE_GEQ));
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 #endif
 
 
@@ -571,7 +570,7 @@ namespace alpaka::test
         std::shared_ptr<hip::detail::EventHostManualTriggerHipImpl> m_spEventImpl;
     };
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct EventHostManualTriggerType<DevHipRt>
@@ -591,10 +590,10 @@ namespace alpaka::test
                 return false;
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka::test
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The CPU device event device get trait specialization.
     template<>
@@ -707,7 +706,7 @@ namespace alpaka::traits
 #    endif
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 #endif
 
 #ifdef ALPAKA_ACC_SYCL_ENABLED
@@ -728,7 +727,7 @@ namespace alpaka
             }
         };
 
-        namespace traits
+        namespace trait
         {
             template<typename TPltf>
             struct EventHostManualTriggerType<experimental::DevGenericSycl<TPltf>>
@@ -744,10 +743,10 @@ namespace alpaka
                     return false;
                 }
             };
-        } // namespace traits
+        } // namespace trait
     } // namespace test
 
-    namespace traits
+    namespace trait
     {
         template<typename TPltf>
         struct Enqueue<
@@ -781,6 +780,6 @@ namespace alpaka
                 return true;
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 #endif

--- a/include/alpaka/test/mem/view/Iterator.hpp
+++ b/include/alpaka/test/mem/view/Iterator.hpp
@@ -15,7 +15,7 @@
 
 namespace alpaka::test
 {
-    namespace traits
+    namespace trait
     {
         // \tparam T Type to conditionally make const.
         // \tparam TSource Type to mimic the constness of.
@@ -149,20 +149,20 @@ namespace alpaka::test
                 return IteratorView<TView>(view, extents.prod());
             }
         };
-    } // namespace traits
+    } // namespace trait
 
     template<typename TView>
-    using Iterator = traits::IteratorView<TView>;
+    using Iterator = trait::IteratorView<TView>;
 
     template<typename TView>
     ALPAKA_FN_HOST auto begin(TView& view) -> Iterator<TView>
     {
-        return traits::Begin<TView>::begin(view);
+        return trait::Begin<TView>::begin(view);
     }
 
     template<typename TView>
     ALPAKA_FN_HOST auto end(TView& view) -> Iterator<TView>
     {
-        return traits::End<TView>::end(view);
+        return trait::End<TView>::end(view);
     }
 } // namespace alpaka::test

--- a/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/include/alpaka/test/mem/view/ViewTest.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Jan Stephan, Bernhard Manfred Gruber, Antonio Di
+ * Pilato
  *
  * This file is part of alpaka.
  *
@@ -28,38 +29,38 @@ namespace alpaka::test
         Vec<TDim, TIdx> const& extent,
         Vec<TDim, TIdx> const& offset) -> void
     {
-        // traits::DevType
+        // trait::DevType
         {
             static_assert(
                 std::is_same_v<Dev<TView>, TDev>,
                 "The device type of the view has to be equal to the specified one.");
         }
 
-        // traits::GetDev
+        // trait::GetDev
         {
             REQUIRE(dev == getDev(view));
         }
 
-        // traits::DimType
+        // trait::DimType
         {
             static_assert(
                 Dim<TView>::value == TDim::value,
                 "The dimensionality of the view has to be equal to the specified one.");
         }
 
-        // traits::ElemType
+        // trait::ElemType
         {
             static_assert(
                 std::is_same_v<Elem<TView>, TElem>,
                 "The element type of the view has to be equal to the specified one.");
         }
 
-        // traits::GetExtent
+        // trait::GetExtent
         {
             REQUIRE(extent == getExtentVec(view));
         }
 
-        // traits::GetPitchBytes
+        // trait::GetPitchBytes
         {
             // The pitches have to be at least as large as the values we calculate here.
             auto pitchMinimum = Vec<DimInt<TDim::value + 1u>, TIdx>::ones();
@@ -79,7 +80,7 @@ namespace alpaka::test
             }
         }
 
-        // traits::GetPtrNative
+        // trait::GetPtrNative
         {
             // The view is a const& so the pointer has to point to a const value.
             using NativePtr = decltype(getPtrNative(view));
@@ -101,12 +102,12 @@ namespace alpaka::test
             }
         }
 
-        // traits::GetOffset
+        // trait::GetOffset
         {
             REQUIRE(offset == getOffsetVec(view));
         }
 
-        // traits::IdxType
+        // trait::IdxType
         {
             static_assert(
                 std::is_same_v<Idx<TView>, TIdx>,
@@ -228,7 +229,7 @@ namespace alpaka::test
     template<typename TAcc, typename TView, typename TQueue>
     ALPAKA_FN_HOST auto testViewMutable(TQueue& queue, TView& view) -> void
     {
-        // traits::GetPtrNative
+        // trait::GetPtrNative
         {
             // The view is a non-const so the pointer has to point to a non-const value.
             using NativePtr = decltype(getPtrNative(view));

--- a/include/alpaka/test/queue/Queue.hpp
+++ b/include/alpaka/test/queue/Queue.hpp
@@ -13,7 +13,7 @@
 
 namespace alpaka::test
 {
-    namespace traits
+    namespace trait
     {
         //! The default queue type trait for devices.
         template<typename TDev, typename TSfinae = void>
@@ -43,12 +43,12 @@ namespace alpaka::test
 #    endif
         };
 #endif
-    } // namespace traits
+    } // namespace trait
     //! The queue type that should be used for the given accelerator.
     template<typename TAcc>
-    using DefaultQueue = typename traits::DefaultQueueType<TAcc>::type;
+    using DefaultQueue = typename trait::DefaultQueueType<TAcc>::type;
 
-    namespace traits
+    namespace trait
     {
         //! The blocking queue trait.
         template<typename TQueue, typename TSfinae = void>
@@ -207,10 +207,10 @@ namespace alpaka::test
         };
 #    endif
 #endif
-    } // namespace traits
+    } // namespace trait
     //! The queue type that should be used for the given accelerator.
     template<typename TQueue>
-    using IsBlockingQueue = traits::IsBlockingQueue<TQueue>;
+    using IsBlockingQueue = trait::IsBlockingQueue<TQueue>;
 
     //! A std::tuple holding tuples of devices and corresponding queue types.
     using TestQueues = std::tuple<

--- a/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
+++ b/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
@@ -105,7 +105,7 @@ namespace alpaka
         std::shared_ptr<QueueCpuBlocking> m_spBlockingQueue;
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU blocking device queue device type trait specialization.
         template<>
@@ -296,9 +296,9 @@ namespace alpaka
                     wait(*queue.m_spBlockingQueue, event);
             }
         };
-    } // namespace traits
+    } // namespace trait
     //! The test specifics.
-    namespace test::traits
+    namespace test::trait
     {
         //! The blocking queue trait specialization for a OpenMP2 collective CPU queue.
         template<>
@@ -306,7 +306,7 @@ namespace alpaka
         {
             static constexpr bool value = true;
         };
-    } // namespace test::traits
+    } // namespace test::trait
 } // namespace alpaka
 
 #    include <alpaka/event/EventCpu.hpp>

--- a/include/alpaka/time/TimeOmp.hpp
+++ b/include/alpaka/time/TimeOmp.hpp
@@ -23,7 +23,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         //! The OpenMP accelerator clock operation.
         template<>
@@ -38,7 +38,7 @@ namespace alpaka
                 return static_cast<std::uint64_t>(omp_get_wtime() / omp_get_wtick());
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/time/TimeStdLib.hpp
+++ b/include/alpaka/time/TimeStdLib.hpp
@@ -21,7 +21,7 @@ namespace alpaka
     {
     };
 
-    namespace traits
+    namespace trait
     {
         //! The CPU fibers accelerator clock operation.
         template<>
@@ -35,5 +35,5 @@ namespace alpaka
                     std::chrono::high_resolution_clock::now().time_since_epoch().count());
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/time/TimeUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/time/TimeUniformCudaHipBuiltIn.hpp
@@ -32,7 +32,7 @@ namespace alpaka
 #            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #        endif
 
-    namespace traits
+    namespace trait
     {
         //! The CUDA built-in clock operation.
         template<>
@@ -46,7 +46,7 @@ namespace alpaka
                 return static_cast<std::uint64_t>(clock64());
             }
         };
-    } // namespace traits
+    } // namespace trait
 
 #    endif
 

--- a/include/alpaka/time/Traits.hpp
+++ b/include/alpaka/time/Traits.hpp
@@ -20,13 +20,13 @@ namespace alpaka
     {
     };
 
-    //! The time traits.
-    namespace traits
+    //! The time trait.
+    namespace trait
     {
         //! The clock trait.
         template<typename TTime, typename TSfinae = void>
         struct Clock;
-    } // namespace traits
+    } // namespace trait
 
     //! \return A counter that is increasing every clock cycle.
     //!
@@ -37,6 +37,6 @@ namespace alpaka
         TTime const& time) -> std::uint64_t
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptTime, TTime>;
-        return traits::Clock<ImplementationBase>::clock(time);
+        return trait::Clock<ImplementationBase>::clock(time);
     }
 } // namespace alpaka

--- a/include/alpaka/traits/Traits.hpp
+++ b/include/alpaka/traits/Traits.hpp
@@ -13,8 +13,8 @@
 
 namespace alpaka
 {
-    //! The common traits.
-    namespace traits
+    //! The common trait.
+    namespace trait
     {
         //! The native handle trait.
         template<typename TImpl, typename TSfinae = void>
@@ -26,14 +26,14 @@ namespace alpaka
                 return 0;
             }
         };
-    } // namespace traits
+    } // namespace trait
 
     //! Get the native handle of the alpaka object.
     //! It will return the alpaka object handle if there is any, otherwise it generates a compile time error.
     template<typename TImpl>
     ALPAKA_FN_HOST auto getNativeHandle(TImpl const& impl)
     {
-        return traits::NativeHandle<TImpl>::getNativeHandle(impl);
+        return trait::NativeHandle<TImpl>::getNativeHandle(impl);
     }
 
     //! Alias to the type of the native handle.

--- a/include/alpaka/vec/Traits.hpp
+++ b/include/alpaka/vec/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -21,7 +21,7 @@
 namespace alpaka
 {
     //! The vec traits.
-    namespace traits
+    namespace trait
     {
         //! Trait for selecting a sub-vector.
         template<typename TVec, typename TIndexSequence, typename TSfinae = void>
@@ -38,7 +38,7 @@ namespace alpaka
         //! Trait for concatenating two vectors.
         template<typename TVecL, typename TVecR, typename TSfinae = void>
         struct ConcatVec;
-    } // namespace traits
+    } // namespace trait
 
     //! Builds a new vector by selecting the elements of the source vector in the given order.
     //! Repeating and swizzling elements is allowed.
@@ -47,7 +47,7 @@ namespace alpaka
     template<typename TIndexSequence, typename TVec>
     ALPAKA_FN_HOST_ACC constexpr auto subVecFromIndices(TVec const& vec)
     {
-        return traits::SubVecFromIndices<TVec, TIndexSequence>::subVecFromIndices(vec);
+        return trait::SubVecFromIndices<TVec, TIndexSequence>::subVecFromIndices(vec);
     }
     //! \tparam TVec has to specialize SubVecFromIndices.
     //! \return The sub-vector consisting of the first N elements of the source vector.
@@ -85,7 +85,7 @@ namespace alpaka
     template<typename TVal, typename TVec>
     ALPAKA_FN_HOST_ACC constexpr auto castVec(TVec const& vec)
     {
-        return traits::CastVec<TVal, TVec>::castVec(vec);
+        return trait::CastVec<TVal, TVec>::castVec(vec);
     }
 
     //! \return The reverseVec vector.
@@ -93,7 +93,7 @@ namespace alpaka
     template<typename TVec>
     ALPAKA_FN_HOST_ACC constexpr auto reverseVec(TVec const& vec)
     {
-        return traits::ReverseVec<TVec>::reverseVec(vec);
+        return trait::ReverseVec<TVec>::reverseVec(vec);
     }
 
     //! \return The concatenated vector.
@@ -101,6 +101,6 @@ namespace alpaka
     template<typename TVecL, typename TVecR>
     ALPAKA_FN_HOST_ACC constexpr auto concatVec(TVecL const& vecL, TVecR const& vecR)
     {
-        return traits::ConcatVec<TVecL, TVecR>::concatVec(vecL, vecR);
+        return trait::ConcatVec<TVecL, TVecR>::concatVec(vecL, vecR);
     }
 } // namespace alpaka

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -395,7 +395,7 @@ namespace alpaka
         TVal m_data[TDim::value == 0u ? 1u : TDim::value];
     };
 
-    namespace traits
+    namespace trait
     {
         //! The Vec dimension get trait specialization.
         template<typename TDim, typename TVal>
@@ -454,9 +454,9 @@ namespace alpaka
                 ALPAKA_UNREACHABLE({});
             }
         };
-    } // namespace traits
+    } // namespace trait
 
-    namespace traits
+    namespace trait
     {
         //! ReverseVec specialization for Vec.
         template<typename TDim, typename TVal>
@@ -512,7 +512,7 @@ namespace alpaka
                 return r;
             }
         };
-    } // namespace traits
+    } // namespace trait
 
     namespace detail
     {
@@ -591,7 +591,7 @@ namespace alpaka
         return createVecFromIndexedFnOffset<TDim, detail::CreateOffset, IdxOffset>(offsets);
     }
 
-    namespace traits
+    namespace trait
     {
         //! The Vec extent get trait specialization.
         template<typename TIdxIntegralConst, typename TDim, typename TVal>
@@ -649,7 +649,7 @@ namespace alpaka
                 offsets[TIdxIntegralConst::value] = offset;
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka
 
 #if defined(__clang__)

--- a/include/alpaka/wait/Traits.hpp
+++ b/include/alpaka/wait/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -19,7 +19,7 @@ namespace alpaka
     };
 
     //! The wait traits.
-    namespace traits
+    namespace trait
     {
         //! The thread wait trait.
         template<typename TAwaited, typename TSfinae = void>
@@ -28,20 +28,20 @@ namespace alpaka
         //! The waiter wait trait.
         template<typename TWaiter, typename TAwaited, typename TSfinae = void>
         struct WaiterWaitFor;
-    } // namespace traits
+    } // namespace trait
 
     //! Waits the thread for the completion of the given awaited action to complete.
     template<typename TAwaited>
     ALPAKA_FN_HOST auto wait(TAwaited const& awaited) -> void
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptCurrentThreadWaitFor, TAwaited>;
-        traits::CurrentThreadWaitFor<ImplementationBase>::currentThreadWaitFor(awaited);
+        trait::CurrentThreadWaitFor<ImplementationBase>::currentThreadWaitFor(awaited);
     }
 
     //! The waiter waits for the given awaited action to complete.
     template<typename TWaiter, typename TAwaited>
     ALPAKA_FN_HOST auto wait(TWaiter& waiter, TAwaited const& awaited) -> void
     {
-        traits::WaiterWaitFor<TWaiter, TAwaited>::waiterWaitFor(waiter, awaited);
+        trait::WaiterWaitFor<TWaiter, TAwaited>::waiterWaitFor(waiter, awaited);
     }
 } // namespace alpaka

--- a/include/alpaka/warp/Traits.hpp
+++ b/include/alpaka/warp/Traits.hpp
@@ -22,7 +22,7 @@ namespace alpaka::warp
     };
 
     //! The warp traits.
-    namespace traits
+    namespace trait
     {
         //! The warp size trait.
         template<typename TWarp, typename TSfinae = void>
@@ -47,7 +47,7 @@ namespace alpaka::warp
         //! The active mask trait.
         template<typename TWarp, typename TSfinae = void>
         struct Activemask;
-    } // namespace traits
+    } // namespace trait
 
     //! Returns warp size.
     //!
@@ -58,7 +58,7 @@ namespace alpaka::warp
     ALPAKA_FN_ACC auto getSize(TWarp const& warp) -> std::int32_t
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptWarp, TWarp>;
-        return traits::GetSize<ImplementationBase>::getSize(warp);
+        return trait::GetSize<ImplementationBase>::getSize(warp);
     }
 
     //! Returns a 32- or 64-bit unsigned integer (depending on the
@@ -81,10 +81,10 @@ namespace alpaka::warp
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TWarp>
     ALPAKA_FN_ACC auto activemask(TWarp const& warp)
-        -> decltype(traits::Activemask<concepts::ImplementationBase<ConceptWarp, TWarp>>::activemask(warp))
+        -> decltype(trait::Activemask<concepts::ImplementationBase<ConceptWarp, TWarp>>::activemask(warp))
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptWarp, TWarp>;
-        return traits::Activemask<ImplementationBase>::activemask(warp);
+        return trait::Activemask<ImplementationBase>::activemask(warp);
     }
 
     //! Evaluates predicate for all active threads of the warp and returns
@@ -107,7 +107,7 @@ namespace alpaka::warp
     ALPAKA_FN_ACC auto all(TWarp const& warp, std::int32_t predicate) -> std::int32_t
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptWarp, TWarp>;
-        return traits::All<ImplementationBase>::all(warp, predicate);
+        return trait::All<ImplementationBase>::all(warp, predicate);
     }
 
     //! Evaluates predicate for all active threads of the warp and returns
@@ -130,7 +130,7 @@ namespace alpaka::warp
     ALPAKA_FN_ACC auto any(TWarp const& warp, std::int32_t predicate) -> std::int32_t
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptWarp, TWarp>;
-        return traits::Any<ImplementationBase>::any(warp, predicate);
+        return trait::Any<ImplementationBase>::any(warp, predicate);
     }
 
     //! Evaluates predicate for all non-exited threads in a warp and returns
@@ -157,7 +157,7 @@ namespace alpaka::warp
     ALPAKA_FN_ACC auto ballot(TWarp const& warp, std::int32_t predicate)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptWarp, TWarp>;
-        return traits::Ballot<ImplementationBase>::ballot(warp, predicate);
+        return trait::Ballot<ImplementationBase>::ballot(warp, predicate);
     }
 
     //! Exchange data between threads within a warp.
@@ -191,7 +191,7 @@ namespace alpaka::warp
     ALPAKA_FN_ACC auto shfl(TWarp const& warp, std::int32_t value, std::int32_t srcLane, std::int32_t width = 0)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptWarp, TWarp>;
-        return traits::Shfl<ImplementationBase>::shfl(warp, value, srcLane, width ? width : getSize(warp));
+        return trait::Shfl<ImplementationBase>::shfl(warp, value, srcLane, width ? width : getSize(warp));
     }
 
     //! shfl for float vals
@@ -200,6 +200,6 @@ namespace alpaka::warp
     ALPAKA_FN_ACC auto shfl(TWarp const& warp, float value, std::int32_t srcLane, std::int32_t width = 0)
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptWarp, TWarp>;
-        return traits::Shfl<ImplementationBase>::shfl(warp, value, srcLane, width ? width : getSize(warp));
+        return trait::Shfl<ImplementationBase>::shfl(warp, value, srcLane, width ? width : getSize(warp));
     }
 } // namespace alpaka::warp

--- a/include/alpaka/warp/WarpGenericSycl.hpp
+++ b/include/alpaka/warp/WarpGenericSycl.hpp
@@ -32,7 +32,7 @@ namespace alpaka::experimental::warp
     };
 } // namespace alpaka::experimental::warp
 
-namespace alpaka::warp::traits
+namespace alpaka::warp::trait
 {
     template<typename TDim>
     struct GetSize<experimental::warp::WarpGenericSycl<TDim>>
@@ -117,6 +117,6 @@ namespace alpaka::warp::traits
             return sycl::select_from_group(actual_group, value, src);
         }
     };
-} // namespace alpaka::warp::traits
+} // namespace alpaka::warp::trait
 
 #endif

--- a/include/alpaka/warp/WarpSingleThread.hpp
+++ b/include/alpaka/warp/WarpSingleThread.hpp
@@ -20,7 +20,7 @@ namespace alpaka::warp
     {
     };
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct GetSize<WarpSingleThread>
@@ -88,5 +88,5 @@ namespace alpaka::warp
                 return val;
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka::warp

--- a/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
@@ -34,7 +34,7 @@ namespace alpaka::warp
 #            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #        endif
 
-    namespace traits
+    namespace trait
     {
         template<>
         struct GetSize<WarpUniformCudaHipBuiltIn>
@@ -152,7 +152,7 @@ namespace alpaka::warp
 #        endif
             }
         };
-    } // namespace traits
+    } // namespace trait
 #    endif
 } // namespace alpaka::warp
 

--- a/include/alpaka/workdiv/Traits.hpp
+++ b/include/alpaka/workdiv/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -24,13 +24,13 @@ namespace alpaka
     {
     };
 
-    //! The work division traits.
-    namespace traits
+    //! The work division trait.
+    namespace trait
     {
         //! The work div trait.
         template<typename TWorkDiv, typename TOrigin, typename TUnit, typename TSfinae = void>
         struct GetWorkDiv;
-    } // namespace traits
+    } // namespace trait
 
     //! Get the extent requested.
     ALPAKA_NO_HOST_ACC_WARNING
@@ -38,10 +38,10 @@ namespace alpaka
     ALPAKA_FN_HOST_ACC auto getWorkDiv(TWorkDiv const& workDiv) -> Vec<Dim<TWorkDiv>, Idx<TWorkDiv>>
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptWorkDiv, TWorkDiv>;
-        return traits::GetWorkDiv<ImplementationBase, TOrigin, TUnit>::getWorkDiv(workDiv);
+        return trait::GetWorkDiv<ImplementationBase, TOrigin, TUnit>::getWorkDiv(workDiv);
     }
 
-    namespace traits
+    namespace trait
     {
         //! The work div grid thread extent trait specialization.
         template<typename TWorkDiv>
@@ -76,5 +76,5 @@ namespace alpaka
                     * alpaka::getWorkDiv<origin::Thread, unit::Elems>(workDiv);
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/workdiv/WorkDivGenericSycl.hpp
+++ b/include/alpaka/workdiv/WorkDivGenericSycl.hpp
@@ -37,7 +37,7 @@ namespace alpaka::experimental
     };
 } // namespace alpaka::experimental
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The SYCL accelerator work division dimension get trait specialization.
     template<typename TDim, typename TIdx>
@@ -113,6 +113,6 @@ namespace alpaka::traits
             return workDiv.m_threadElemExtent;
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 #endif

--- a/include/alpaka/workdiv/WorkDivMembers.hpp
+++ b/include/alpaka/workdiv/WorkDivMembers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Benjamin Worpitz, Matthias Werner, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -78,7 +78,7 @@ namespace alpaka
                << workDiv.m_blockThreadExtent << ", threadElemExtent: " << workDiv.m_threadElemExtent << "}");
     }
 
-    namespace traits
+    namespace trait
     {
         //! The WorkDivMembers dimension get trait specialization.
         template<typename TDim, typename TIdx>
@@ -129,5 +129,5 @@ namespace alpaka
                 return workDiv.m_threadElemExtent;
             }
         };
-    } // namespace traits
+    } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/workdiv/WorkDivUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/workdiv/WorkDivUniformCudaHipBuiltIn.hpp
@@ -53,7 +53,7 @@ namespace alpaka
 #            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #        endif
 
-    namespace traits
+    namespace trait
     {
         //! The GPU CUDA/HIP accelerator work division dimension get trait specialization.
         template<typename TDim, typename TIdx>
@@ -118,7 +118,7 @@ namespace alpaka
                 return workDiv.m_threadElemExtent;
             }
         };
-    } // namespace traits
+    } // namespace trait
 
 #    endif
 

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -121,7 +121,7 @@ public:
     }
 };
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The trait for getting the size of the block shared dynamic memory for a kernel.
     template<typename TAcc>
@@ -149,7 +149,7 @@ namespace alpaka::traits
             return static_cast<std::size_t>(2u * blockThreadExtent.prod() * threadElemExtent.prod()) * sizeof(TElem);
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<2u>, std::uint32_t>;
 

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -87,7 +87,7 @@ public:
     }
 };
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The trait for getting the size of the block shared dynamic memory for a kernel.
     template<typename TnumUselessWork, typename Val, typename TAcc>
@@ -104,7 +104,7 @@ namespace alpaka::traits
             return static_cast<std::size_t>(blockThreadExtent.prod() * threadElemExtent.prod()) * sizeof(Val);
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, std::uint32_t>;
 

--- a/test/unit/block/shared/src/BlockSharedMemDyn.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemDyn.cpp
@@ -35,7 +35,7 @@ public:
     }
 };
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The trait for getting the size of the block shared dynamic memory for a kernel.
     template<typename TAcc>
@@ -53,7 +53,7 @@ namespace alpaka::traits
             return static_cast<std::size_t>(gridSize) * sizeof(std::uint32_t);
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 TEMPLATE_LIST_TEST_CASE("sameNonNullAdress", "[blockSharedMemDyn]", alpaka::test::TestAccs)
 {

--- a/test/unit/block/sharedSharing/src/BlockSharedMemSharing.cpp
+++ b/test/unit/block/sharedSharing/src/BlockSharedMemSharing.cpp
@@ -122,7 +122,7 @@ public:
     }
 };
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The trait for getting the size of the block shared dynamic memory for a kernel.
     template<typename TAcc>
@@ -139,7 +139,7 @@ namespace alpaka::traits
             return sizeof(std::uint32_t);
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 TEMPLATE_LIST_TEST_CASE("blockSharedMemDyn", "[blockSharedMemSharing]", TestAccs)
 {

--- a/test/unit/block/sync/src/BlockSync.cpp
+++ b/test/unit/block/sync/src/BlockSync.cpp
@@ -47,7 +47,7 @@ public:
     }
 };
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The trait for getting the size of the block shared dynamic memory for a kernel.
     template<typename TAcc>
@@ -65,7 +65,7 @@ namespace alpaka::traits
             return static_cast<std::size_t>(blockThreadExtent.prod()) * sizeof(Idx);
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 TEMPLATE_LIST_TEST_CASE("synchronize", "[blockSync]", alpaka::test::TestAccs)
 {

--- a/test/unit/kernel/src/KernelWithOmpSchedule.cpp
+++ b/test/unit/kernel/src/KernelWithOmpSchedule.cpp
@@ -76,7 +76,7 @@ struct KernelWithTrait : TBase
 {
 };
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     // Specialize the trait for kernels of type KernelWithTrait<>
     template<typename TBase, typename TAcc>
@@ -92,7 +92,7 @@ namespace alpaka::traits
             return alpaka::omp::Schedule{alpaka::omp::Schedule::Static, 4};
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 // Generic testing routine for the given kernel type
 template<typename TAcc, typename TKernel>

--- a/test/unit/math/src/Buffer.hpp
+++ b/test/unit/math/src/Buffer.hpp
@@ -37,8 +37,8 @@ namespace alpaka
                 {
                     using value_type = TData;
                     static constexpr size_t capacity = Tcapacity;
-                    using Dim = typename alpaka::traits::DimType<TAcc>::type;
-                    using Idx = typename alpaka::traits::IdxType<TAcc>::type;
+                    using Dim = typename alpaka::trait::DimType<TAcc>::type;
+                    using Idx = typename alpaka::trait::IdxType<TAcc>::type;
 
                     // Defines using's for alpaka-buffer.
                     using DevAcc = alpaka::Dev<TAcc>;

--- a/test/unit/mem/copy/src/BufSlicing.cpp
+++ b/test/unit/mem/copy/src/BufSlicing.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Axel Huebl, Benjamin Worpitz, Jakob Krude, Bernhard Manfred Gruber
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Jakob Krude, Bernhard Manfred Gruber
  *
  * This file is part of Alpaka.
  *
@@ -101,7 +101,7 @@ struct TestContainer
         {
             INFO("Dim: " << TDim::value)
             INFO("Idx: " << typeid(TIdx).name())
-            INFO("Acc: " << alpaka::traits::GetAccName<TAcc>::getAccName())
+            INFO("Acc: " << alpaka::trait::GetAccName<TAcc>::getAccName())
             INFO("i: " << i)
             REQUIRE(ptrA[i] == Approx(ptrB[i]));
         }

--- a/test/unit/mem/fence/src/FenceTest.cpp
+++ b/test/unit/mem/fence/src/FenceTest.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Jan Stephan
+/* Copyright 2022 Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -152,7 +152,7 @@ public:
     }
 };
 
-namespace alpaka::traits
+namespace alpaka::trait
 {
     //! The trait for getting the size of the block shared dynamic memory for a kernel.
     template<typename TAcc>
@@ -169,7 +169,7 @@ namespace alpaka::traits
             return 2 * sizeof(int);
         }
     };
-} // namespace alpaka::traits
+} // namespace alpaka::trait
 
 using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, std::size_t>;
 

--- a/test/unit/mem/view/src/Accessor.cpp
+++ b/test/unit/mem/view/src/Accessor.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2021 Bernhard Manfred Gruber
+/* Copyright 2022 Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -20,7 +20,7 @@ namespace alpakaex = alpaka::experimental;
 
 TEST_CASE("IsView", "[accessor]")
 {
-    using alpakaex::traits::internal::IsView;
+    using alpakaex::trait::internal::IsView;
 
     using Dim = alpaka::DimInt<1>;
     using Size = std::size_t;

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Axel Huebl, Benjamin Worpitz, Erik Zenker, Bernhard Manfred Gruber
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Erik Zenker, Bernhard Manfred Gruber
  *
  * This file is part of alpaka.
  *
@@ -37,7 +37,7 @@ namespace alpaka::test
     {
         alpaka::test::testViewImmutable<TElem>(view, dev, extentView, offsetView);
 
-        // alpaka::traits::GetPitchBytes
+        // alpaka::trait::GetPitchBytes
         // The pitch of the view has to be identical to the pitch of the underlying buffer in all dimensions.
         {
             auto const pitchBuf = alpaka::getPitchBytesVec(buf);
@@ -49,7 +49,7 @@ namespace alpaka::test
             }
         }
 
-        // alpaka::traits::GetPtrNative
+        // alpaka::trait::GetPtrNative
         // The native pointer has to be exactly the value we calculate here.
         {
             auto viewPtrNative = reinterpret_cast<std::uint8_t*>(alpaka::getPtrNative(buf));


### PR DESCRIPTION
Fixes #179. The Alpaka namespace "traits" was renamed to "trait" in all its occurrencies. However, are we sure we want to keep the namespace and not removing it entirely to simplify the code, as @bernhardmgruber suggested?