### PR TITLE
CMake: rename `USE_alpaka_*` to `alpaka_USE_*`

### DIFF
--- a/example/bufferCopy/CMakeLists.txt
+++ b/example/bufferCopy/CMakeLists.txt
@@ -34,9 +34,9 @@ project(${_TARGET_NAME} LANGUAGES CXX)
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    option(USE_alpaka_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
 
-    if(USE_alpaka_SOURCE_TREE)
+    if(alpaka_USE_SOURCE_TREE)
         # Don't build the examples recursively
         set(alpaka_BUILD_EXAMPLES OFF)
         add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")

--- a/example/heatEquation/CMakeLists.txt
+++ b/example/heatEquation/CMakeLists.txt
@@ -35,9 +35,9 @@ project(${_TARGET_NAME} LANGUAGES CXX)
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    option(USE_alpaka_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
 
-    if(USE_alpaka_SOURCE_TREE)
+    if(alpaka_USE_SOURCE_TREE)
         # Don't build the examples recursively
         set(alpaka_BUILD_EXAMPLES OFF)
         add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")

--- a/example/helloWorld/CMakeLists.txt
+++ b/example/helloWorld/CMakeLists.txt
@@ -34,9 +34,9 @@ project(${_TARGET_NAME} LANGUAGES CXX)
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    option(USE_alpaka_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
 
-    if(USE_alpaka_SOURCE_TREE)
+    if(alpaka_USE_SOURCE_TREE)
         # Don't build the examples recursively
         set(alpaka_BUILD_EXAMPLES OFF)
         add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")

--- a/example/helloWorldLambda/CMakeLists.txt
+++ b/example/helloWorldLambda/CMakeLists.txt
@@ -34,9 +34,9 @@ project(${_TARGET_NAME} LANGUAGES CXX)
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    option(USE_alpaka_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
 
-    if(USE_alpaka_SOURCE_TREE)
+    if(alpaka_USE_SOURCE_TREE)
         # Don't build the examples recursively
         set(alpaka_BUILD_EXAMPLES OFF)
         add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")

--- a/example/kernelSpecialization/CMakeLists.txt
+++ b/example/kernelSpecialization/CMakeLists.txt
@@ -34,9 +34,9 @@ project(${_TARGET_NAME} LANGUAGES CXX)
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    option(USE_alpaka_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
 
-    if(USE_alpaka_SOURCE_TREE)
+    if(alpaka_USE_SOURCE_TREE)
         # Don't build the examples recursively
         set(alpaka_BUILD_EXAMPLES OFF)
         add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")

--- a/example/monteCarloIntegration/CMakeLists.txt
+++ b/example/monteCarloIntegration/CMakeLists.txt
@@ -35,9 +35,9 @@ project(${_TARGET_NAME} LANGUAGES CXX)
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    option(USE_alpaka_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
 
-    if(USE_alpaka_SOURCE_TREE)
+    if(alpaka_USE_SOURCE_TREE)
         # Don't build the examples recursively
         set(alpaka_BUILD_EXAMPLES OFF)
         add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")

--- a/example/openMPSchedule/CMakeLists.txt
+++ b/example/openMPSchedule/CMakeLists.txt
@@ -34,9 +34,9 @@ project(${_TARGET_NAME} LANGUAGES CXX)
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    option(USE_alpaka_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
 
-    if(USE_alpaka_SOURCE_TREE)
+    if(alpaka_USE_SOURCE_TREE)
         # Don't build the examples recursively
         set(alpaka_BUILD_EXAMPLES OFF)
         add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")

--- a/example/randomCells2D/CMakeLists.txt
+++ b/example/randomCells2D/CMakeLists.txt
@@ -35,9 +35,9 @@ project(${_TARGET_NAME} LANGUAGES CXX)
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    option(USE_alpaka_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
 
-    if(USE_alpaka_SOURCE_TREE)
+    if(alpaka_USE_SOURCE_TREE)
         # Don't build the examples recursively
         set(alpaka_BUILD_EXAMPLES OFF)
         add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")

--- a/example/randomStrategies/CMakeLists.txt
+++ b/example/randomStrategies/CMakeLists.txt
@@ -35,9 +35,9 @@ project(${_TARGET_NAME} LANGUAGES CXX)
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    option(USE_alpaka_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
 
-    if(USE_alpaka_SOURCE_TREE)
+    if(alpaka_USE_SOURCE_TREE)
         # Don't build the examples recursively
         set(alpaka_BUILD_EXAMPLES OFF)
         add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")

--- a/example/reduce/CMakeLists.txt
+++ b/example/reduce/CMakeLists.txt
@@ -34,9 +34,9 @@ project(${_TARGET_NAME} LANGUAGES CXX)
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    option(USE_alpaka_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
 
-    if(USE_alpaka_SOURCE_TREE)
+    if(alpaka_USE_SOURCE_TREE)
         # Don't build the examples recursively
         set(alpaka_BUILD_EXAMPLES OFF)
         add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")

--- a/example/vectorAdd/CMakeLists.txt
+++ b/example/vectorAdd/CMakeLists.txt
@@ -35,9 +35,9 @@ project(${_TARGET_NAME} LANGUAGES CXX)
 # Find alpaka.
 
 if(NOT TARGET alpaka::alpaka)
-    option(USE_alpaka_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
 
-    if(USE_alpaka_SOURCE_TREE)
+    if(alpaka_USE_SOURCE_TREE)
         # Don't build the examples recursively
         set(alpaka_BUILD_EXAMPLES OFF)
         add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")


### PR DESCRIPTION
fix: https://github.com/alpaka-group/alpaka/pull/1653#pullrequestreview-915445778

The nameing will group all alpaka variables when `ccmake` or `cmake -LA` is used.
Additionally it fits into the naming schema e.g. Boost is using `Boost_USE_MULTITHREADED` or `Boost_USE_STATIC_LIBS`.