### PR TITLE
Set BOOST_LANG_HIP to the HIP version number

### DIFF
--- a/include/alpaka/core/BoostPredef.hpp
+++ b/include/alpaka/core/BoostPredef.hpp
@@ -19,8 +19,7 @@
 #        include <hip/hip_runtime.h>
 // HIP defines "abort()" as "{asm("trap;");}", which breaks some kernels
 #        undef abort
-// there is no HIP_VERSION macro
-#        define BOOST_LANG_HIP BOOST_VERSION_NUMBER_AVAILABLE
+#        define BOOST_LANG_HIP BOOST_VERSION_NUMBER(HIP_VERSION_MAJOR, HIP_VERSION_MINOR, 0)
 #        if defined(BOOST_LANG_CUDA) && BOOST_LANG_CUDA
 #            undef BOOST_LANG_CUDA
 #            define BOOST_LANG_CUDA BOOST_VERSION_NUMBER_NOT_AVAILABLE


### PR DESCRIPTION
Set `BOOST_LANG_HIP` to the HIP version number, as returned by `BOOST_VERSION_NUMBER(HIP_VERSION_MAJOR, HIP_VERSION_MINOR, 0)`.

Note that HIP 4.5.0 has `HIP_VERSION_MINOR == 4`, so is identified as version 4.4.x.