### PR TITLE
Smarter `atomic_ref` selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,9 @@ set(_alpaka_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
 # Normalize the path (e.g. remove ../)
 get_filename_component(_alpaka_ROOT_DIR ${_alpaka_ROOT_DIR} ABSOLUTE)
 
+# Compiler feature tests.
+set(_alpaka_FEATURE_TESTS_DIR "${_alpaka_ROOT_DIR}/cmake/tests")
+
 # Add common functions.
 set(_alpaka_COMMON_FILE "${_alpaka_ROOT_DIR}/cmake/common.cmake")
 include(${_alpaka_COMMON_FILE})
@@ -181,5 +184,7 @@ if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
                   "${_alpaka_ROOT_DIR}/cmake/addLibrary.cmake"
                   "${_alpaka_ROOT_DIR}/cmake/alpakaCommon.cmake"
                   "${_alpaka_ROOT_DIR}/cmake/common.cmake"
+            DESTINATION "${_alpaka_INSTALL_CMAKEDIR}")
+    install(DIRECTORY "${_alpaka_ROOT_DIR}/cmake/tests"
             DESTINATION "${_alpaka_INSTALL_CMAKEDIR}")
 endif()

--- a/cmake/alpakaConfig.cmake.in
+++ b/cmake/alpakaConfig.cmake.in
@@ -24,6 +24,9 @@ set(_alpaka_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
 # Normalize the path (e.g. remove ../)
 get_filename_component(_alpaka_ROOT_DIR ${_alpaka_ROOT_DIR} ABSOLUTE)
 
+# Compiler feature tests.
+set(_alpaka_FEATURE_TESTS_DIR "${_alpaka_ROOT_DIR}/tests")
+
 # Add common functions.
 set(_alpaka_COMMON_FILE "${_alpaka_ROOT_DIR}/common.cmake")
 include(${_alpaka_COMMON_FILE})

--- a/cmake/tests/StdAtomicRef.cpp
+++ b/cmake/tests/StdAtomicRef.cpp
@@ -1,0 +1,20 @@
+/* Copyright 2022 Jan Stephan
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <atomic>
+#include <cstdlib>
+
+#if !defined(__cpp_lib_atomic_ref)
+#    error "std::atomic_ref<T> not supported!"
+#endif
+
+auto main() -> int
+{
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Fixes #1572. This PR changes the way the CPU atomic implementation is selected according to the following rules:

1. Check if we're in C++20 mode. If so, check for C++20 `atomic_ref` using a custom CMake feature check. If successful, use C++20 `std::atomic_ref<T>`. If unsuccessful, go to 2.
2. If Boost.Atomic has been found and the user did not disable `boost::atomic_ref<T>` explicitly, use `boost::atomic_ref<T>`. Otherwise, go to 3.
3. Use the legacy lock-based atomics.

Note: This change mostly affects the CMake part of alpaka. Standalone users need to supply the `-DALPAKA_HAS_STD_ATOMIC_REF` flag themselves when using a conformant C++ standard library (currently only libstdc++ and MSVC STL. libc++ does not support this.)