### PR TITLE
MemFenceOmp5: remove acq_rel

### DIFF
--- a/include/alpaka/mem/fence/MemFenceOmp5.hpp
+++ b/include/alpaka/mem/fence/MemFenceOmp5.hpp
@@ -33,7 +33,7 @@ namespace alpaka
             static auto mem_fence(MemFenceOmp5 const&, TMemScope const&)
             {
                 // We only have one fence scope available in OpenMP 5 which encompasses the whole device
-#    pragma omp flush acq_rel
+#    pragma omp flush
             }
         };
     } // namespace trait


### PR DESCRIPTION
The optional `[memory-order-clause]` was introduced in OpenMP 5.0.
`acq_rel` is the default in case nothing is given. Removing to improve
compatibility.