### PR TITLE
Removed deprecated cudaStreamAddCallback

### DIFF
--- a/docs/source/dev/backends.rst
+++ b/docs/source/dev/backends.rst
@@ -268,7 +268,9 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +------------------------------+---------------------------------------------------------+
     | CUDA                         | alpaka                                                  |
     +==============================+=========================================================+
-    | cudaStreamAddCallback        | alpaka::enqueue(queue, [](){dosomething();})            |
+    | cudaLaunchHostFunc           | alpaka::enqueue(queue, [](){dosomething();})            |
+    |                              |                                                         |
+    | cudaStreamAddCallback        | \                                                       |
     +------------------------------+---------------------------------------------------------+
     | cudaStreamAttachMemAsync     | --                                                      |
     +------------------------------+---------------------------------------------------------+


### PR DESCRIPTION
As pointed out in #391, `cudaStreamAddCallback` is deprecated and the [documentation](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g74aa9f4b1c2f12d994bf13876a5a2498) suggests the usage of `cudaLaunchHostFunc`. The corresponding function for `hip` was only added in the `develop` branch [recently](https://github.com/ROCm-Developer-Tools/HIP/pull/2512) and will be used in future releases of alpaka. 