### PR TITLE
Change the syntax of saving result of ::omp_get_num_threads()

### DIFF
--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -131,7 +131,7 @@ namespace alpaka
                                         "The OpenMP 2.0 runtime did not create a parallel region!");
                                 }
 
-                                int const numThreads(::omp_get_num_threads());
+                                int const numThreads = ::omp_get_num_threads();
                                 if(numThreads != iBlockThreadCount)
                                 {
                                     throw std::runtime_error(

--- a/include/alpaka/kernel/TaskKernelOmp5.hpp
+++ b/include/alpaka/kernel/TaskKernelOmp5.hpp
@@ -171,7 +171,7 @@ namespace alpaka
                         // The first thread does some checks in the first block executed.
                         if((::omp_get_thread_num() == 0) && (t == 0))
                         {
-                            int const numThreads(::omp_get_num_threads());
+                            int const numThreads = ::omp_get_num_threads();
                             printf("%s omp_get_num_threads: %d\n", __func__, numThreads);
                             if(numThreads != static_cast<int>(blockThreadCount))
                             {


### PR DESCRIPTION
The previously used syntax was valid but sometimes caused internal error for Intel compiler in CI:
```
/home/runner/work/alpaka/alpaka/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp(134): internal error: assertion failed: cd_new_hash_table: malloc failed (cdhashtbl.c, line 134 in cd_new_hash_table)

                                  int const numThreads(::omp_get_num_threads());
```

The changed one suggested by @bernhardmgruber  appears to work around the issue.

I faced this issue sometimes with #1336 and after making the fix in that branch it no longer happened, so I believe it indeed works around the issue.