### PR TITLE
Add CudaRt and HipRt aliases for Events, Platforms and Buffers

### DIFF
--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -116,6 +116,13 @@ namespace alpaka
     public:
         std::shared_ptr<uniform_cuda_hip::detail::EventUniformCudaHipImpl> m_spEventImpl;
     };
+
+#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+    using EventCudaRt = EventUniformCudaHipRt;
+#    else
+    using EventHipRt = EventUniformCudaHipRt;
+#    endif
+
     namespace trait
     {
         //! The CUDA/HIP RT device event device type trait specialization.

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -81,6 +81,14 @@ namespace alpaka
         TIdx m_pitchBytes;
     };
 
+#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+    template<typename TElem, typename TDim, typename TIdx>
+    using BufCudaRt = BufUniformCudaHipRt<TElem, TDim, TIdx>;
+#    else
+    template<typename TElem, typename TDim, typename TIdx>
+    using BufHipRt = BufUniformCudaHipRt<TElem, TDim, TIdx>;
+#    endif
+
     namespace trait
     {
         //! The BufUniformCudaHipRt device type trait specialization.

--- a/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
+++ b/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
@@ -36,6 +36,12 @@ namespace alpaka
         ALPAKA_FN_HOST PltfUniformCudaHipRt() = delete;
     };
 
+#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+    using PltfCudaRt = PltfUniformCudaHipRt;
+#    else
+    using PltfHipRt = PltfUniformCudaHipRt;
+#    endif
+
     namespace trait
     {
         //! The CUDA/HIP RT platform device type trait specialization.


### PR DESCRIPTION
Add `EventCudaRt` and `EventHipRt` aliases for `EventUniformCudaHipRt`.
Add `PltfCudaRt` and `PltfHipRt` aliases for `PltfUniformCudaHipRt`.
Add `BufCudaRt` and `BufHipRt` template aliases for `BufUniformCudaHipRt`.