### PR TITLE
Add a new API to allocate pinned host memory

### DIFF
--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -29,7 +29,7 @@ namespace alpaka
         using Error_t = ::cudaError_t;
         using Event_t = ::cudaEvent_t;
         using Extent_t = ::cudaExtent;
-        using Flag_t = int;
+        using Flag_t = unsigned int;
         using FuncAttributes_t = ::cudaFuncAttributes;
         using HostFn_t = void (*)(void* data); // same as cudaHostFn_t, without the CUDART_CB calling convention
         using Limit_t = ::cudaLimit;
@@ -139,7 +139,7 @@ namespace alpaka
             return ::cudaEventCreate(event);
         }
 
-        static inline Error_t eventCreateWithFlags(Event_t* event, unsigned int flags)
+        static inline Error_t eventCreateWithFlags(Event_t* event, Flag_t flags)
         {
             return ::cudaEventCreateWithFlags(event, flags);
         }
@@ -226,7 +226,7 @@ namespace alpaka
             return ::cudaGetSymbolAddress(devPtr, symbol);
         }
 
-        static inline Error_t hostGetDevicePointer(void** pDevice, void* pHost, unsigned int flags)
+        static inline Error_t hostGetDevicePointer(void** pDevice, void* pHost, Flag_t flags)
         {
             return ::cudaHostGetDevicePointer(pDevice, pHost, flags);
         }
@@ -236,12 +236,12 @@ namespace alpaka
             return ::cudaFreeHost(ptr);
         }
 
-        static inline Error_t hostMalloc(void** ptr, size_t size, unsigned int flags)
+        static inline Error_t hostMalloc(void** ptr, size_t size, Flag_t flags)
         {
             return ::cudaHostAlloc(ptr, size, flags);
         }
 
-        static inline Error_t hostRegister(void* ptr, size_t size, unsigned int flags)
+        static inline Error_t hostRegister(void* ptr, size_t size, Flag_t flags)
         {
             return ::cudaHostRegister(ptr, size, flags);
         }
@@ -354,7 +354,7 @@ namespace alpaka
             return ::cudaStreamCreate(pStream);
         }
 
-        static inline Error_t streamCreateWithFlags(Stream_t* pStream, unsigned int flags)
+        static inline Error_t streamCreateWithFlags(Stream_t* pStream, Flag_t flags)
         {
             return ::cudaStreamCreateWithFlags(pStream, flags);
         }
@@ -374,7 +374,7 @@ namespace alpaka
             return ::cudaStreamSynchronize(stream);
         }
 
-        static inline Error_t streamWaitEvent(Stream_t stream, Event_t event, unsigned int flags)
+        static inline Error_t streamWaitEvent(Stream_t stream, Event_t event, Flag_t flags)
         {
             return ::cudaStreamWaitEvent(stream, event, flags);
         }

--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -52,6 +52,13 @@ namespace alpaka
         static constexpr Flag_t eventDisableTiming = cudaEventDisableTiming;
         static constexpr Flag_t eventInterprocess = cudaEventInterprocess;
 
+        static constexpr Flag_t hostMallocDefault = cudaHostAllocDefault;
+        static constexpr Flag_t hostMallocMapped = cudaHostAllocMapped;
+        static constexpr Flag_t hostMallocPortable = cudaHostAllocPortable;
+        static constexpr Flag_t hostMallocWriteCombined = cudaHostAllocWriteCombined;
+        static constexpr Flag_t hostMallocCoherent = cudaHostAllocDefault; // Not supported.
+        static constexpr Flag_t hostMallocNonCoherent = cudaHostAllocDefault; // Not supported.
+
         static constexpr Flag_t hostRegisterDefault = cudaHostRegisterDefault;
         static constexpr Flag_t hostRegisterPortable = cudaHostRegisterPortable;
         static constexpr Flag_t hostRegisterMapped = cudaHostRegisterMapped;
@@ -222,6 +229,16 @@ namespace alpaka
         static inline Error_t hostGetDevicePointer(void** pDevice, void* pHost, unsigned int flags)
         {
             return ::cudaHostGetDevicePointer(pDevice, pHost, flags);
+        }
+
+        static inline Error_t hostFree(void* ptr)
+        {
+            return ::cudaFreeHost(ptr);
+        }
+
+        static inline Error_t hostMalloc(void** ptr, size_t size, unsigned int flags)
+        {
+            return ::cudaHostAlloc(ptr, size, flags);
         }
 
         static inline Error_t hostRegister(void* ptr, size_t size, unsigned int flags)

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -52,6 +52,13 @@ namespace alpaka
         static constexpr Flag_t eventDisableTiming = hipEventDisableTiming;
         static constexpr Flag_t eventInterprocess = hipEventInterprocess;
 
+        static constexpr Flag_t hostMallocDefault = hipHostMallocDefault;
+        static constexpr Flag_t hostMallocMapped = hipHostMallocMapped;
+        static constexpr Flag_t hostMallocPortable = hipHostMallocPortable;
+        static constexpr Flag_t hostMallocWriteCombined = hipHostMallocWriteCombined;
+        static constexpr Flag_t hostMallocCoherent = hipHostMallocCoherent;
+        static constexpr Flag_t hostMallocNonCoherent = hipHostMallocNonCoherent;
+
         static constexpr Flag_t hostRegisterDefault = hipHostRegisterDefault;
         static constexpr Flag_t hostRegisterPortable = hipHostRegisterPortable;
         static constexpr Flag_t hostRegisterMapped = hipHostRegisterMapped;
@@ -232,6 +239,16 @@ namespace alpaka
         static inline Error_t hostGetDevicePointer(void** pDevice, void* pHost, unsigned int flags)
         {
             return ::hipHostGetDevicePointer(pDevice, pHost, flags);
+        }
+
+        static inline Error_t hostFree(void* ptr)
+        {
+            return ::hipHostFree(ptr);
+        }
+
+        static inline Error_t hostMalloc(void** ptr, size_t size, unsigned int flags)
+        {
+            return ::hipHostMalloc(ptr, size, flags);
         }
 
         static inline Error_t hostRegister(void* ptr, size_t size, unsigned int flags)

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -29,7 +29,7 @@ namespace alpaka
         using Error_t = ::hipError_t;
         using Event_t = ::hipEvent_t;
         using Extent_t = ::hipExtent;
-        using Flag_t = int;
+        using Flag_t = unsigned int;
         using FuncAttributes_t = ::hipFuncAttributes;
         using HostFn_t = void (*)(void* data); // same as hipHostFn_t
         using Limit_t = ::hipLimit_t;
@@ -153,7 +153,7 @@ namespace alpaka
             return ::hipEventCreate(event);
         }
 
-        static inline Error_t eventCreateWithFlags(Event_t* event, unsigned int flags)
+        static inline Error_t eventCreateWithFlags(Event_t* event, Flag_t flags)
         {
             return ::hipEventCreateWithFlags(event, flags);
         }
@@ -236,7 +236,7 @@ namespace alpaka
             return ::hipGetSymbolAddress(devPtr, symbol);
         }
 
-        static inline Error_t hostGetDevicePointer(void** pDevice, void* pHost, unsigned int flags)
+        static inline Error_t hostGetDevicePointer(void** pDevice, void* pHost, Flag_t flags)
         {
             return ::hipHostGetDevicePointer(pDevice, pHost, flags);
         }
@@ -246,12 +246,12 @@ namespace alpaka
             return ::hipHostFree(ptr);
         }
 
-        static inline Error_t hostMalloc(void** ptr, size_t size, unsigned int flags)
+        static inline Error_t hostMalloc(void** ptr, size_t size, Flag_t flags)
         {
             return ::hipHostMalloc(ptr, size, flags);
         }
 
-        static inline Error_t hostRegister(void* ptr, size_t size, unsigned int flags)
+        static inline Error_t hostRegister(void* ptr, size_t size, Flag_t flags)
         {
             return ::hipHostRegister(ptr, size, flags);
         }
@@ -352,7 +352,7 @@ namespace alpaka
             return ::hipStreamCreate(pStream);
         }
 
-        static inline Error_t streamCreateWithFlags(Stream_t* pStream, unsigned int flags)
+        static inline Error_t streamCreateWithFlags(Stream_t* pStream, Flag_t flags)
         {
             return ::hipStreamCreateWithFlags(pStream, flags);
         }
@@ -372,7 +372,7 @@ namespace alpaka
             return ::hipStreamSynchronize(stream);
         }
 
-        static inline Error_t streamWaitEvent(Stream_t stream, Event_t event, unsigned int flags)
+        static inline Error_t streamWaitEvent(Stream_t stream, Event_t event, Flag_t flags)
         {
             return ::hipStreamWaitEvent(stream, event, flags);
         }

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -272,6 +272,19 @@ namespace alpaka
         {
         };
 
+        //! The pinned/mapped memory allocation trait specialization.
+        template<typename TElem, typename TDim, typename TIdx>
+        struct BufAllocMapped<TElem, TDim, TIdx, DevCpu>
+        {
+            template<typename TExtent>
+            ALPAKA_FN_HOST static auto allocMappedBuf(DevCpu const& host, DevCpu const&, TExtent const& extent)
+                -> BufCpu<TElem, TDim, TIdx>
+            {
+                // Allocate standard host memory.
+                return allocBuf(host, extent);
+            }
+        };
+
         //! The BufCpu memory mapping trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct Map<BufCpu<TElem, TDim, TIdx>, DevCpu>

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -14,6 +14,9 @@
 
 namespace alpaka
 {
+    //! The CPU device handle.
+    class DevCpu;
+
     //! The buffer traits.
     namespace trait
     {
@@ -34,6 +37,10 @@ namespace alpaka
         struct HasAsyncBufSupport : public std::false_type
         {
         };
+
+        //! The pinned/mapped memory allocator trait.
+        template<typename TElem, typename TDim, typename TIdx, typename TDev>
+        struct BufAllocMapped;
 
         //! The memory mapping trait.
         template<typename TBuf, typename TDev, typename TSfinae = void>
@@ -109,6 +116,22 @@ namespace alpaka
 #if BOOST_COMP_CLANG
 #    pragma clang diagnostic pop
 #endif
+
+    //! Allocates pinned/mapped memory on host, accessible by the given device.
+    //!
+    //! \tparam TElem The element type of the returned buffer.
+    //! \tparam TIdx The linear index type of the buffer.
+    //! \tparam TExtent The extent type of the buffer.
+    //! \tparam TDev The type of device the buffer is accessible from.
+    //! \param host The host device to allocate the buffer on.
+    //! \param dev The device to make the memory accessible from.
+    //! \param extent The extent of the buffer.
+    //! \return The newly allocated buffer.
+    template<typename TElem, typename TIdx, typename TExtent, typename TDev>
+    ALPAKA_FN_HOST auto allocMappedBuf(DevCpu const& host, TDev const& dev, TExtent const& extent = TExtent())
+    {
+        return trait::BufAllocMapped<TElem, Dim<TExtent>, TIdx, TDev>::allocMappedBuf(host, dev, extent);
+    }
 
     //! Maps the buffer into the memory of the given device.
     //!


### PR DESCRIPTION
Allocates pinned/mapped memory on host, accessible by the given device:
  - for the CPU device, uses standard memory allocations;
  - for CUDA/HIP devices, uses the `cudaHostAlloc`/`hipHostMalloc` API.