### PR TITLE
Add ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT macro

### DIFF
--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -221,9 +221,20 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
+                // If ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT is defined, positive, and a power of 2, use it as the
+                // default alignment for host memory allocations. Otherwise, the alignment is chosen to enable optimal
+                // performance dependant on the target architecture.
+#if defined(ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT)
+                static_assert(
+                    ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT > 0
+                        && ((ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT & (ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT - 1)) == 0),
+                    "If defined, ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT must be a power of 2.");
+                constexpr std::size_t alignment = static_cast<std::size_t>(ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT);
+#else
+                constexpr std::size_t alignment = core::vectorization::defaultAlignment;
+#endif
                 // alpaka::AllocCpuAligned is stateless
-                using Allocator
-                    = AllocCpuAligned<std::integral_constant<std::size_t, core::vectorization::defaultAlignment>>;
+                using Allocator = AllocCpuAligned<std::integral_constant<std::size_t, alignment>>;
                 static_assert(std::is_empty_v<Allocator>, "AllocCpuAligned is expected to be stateless");
                 auto* memPtr = alpaka::malloc<TElem>(Allocator{}, static_cast<std::size_t>(getExtentProduct(extent)));
                 auto deleter = [](TElem* ptr) { alpaka::free(Allocator{}, ptr); };
@@ -245,9 +256,20 @@ namespace alpaka
                     "The BufCpu buffer can only be used with a queue on a DevCpu device!");
                 DevCpu const& dev = getDev(queue);
 
+                // If ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT is defined, positive, and a power of 2, use it as the
+                // default alignment for host memory allocations. Otherwise, the alignment is chosen to enable optimal
+                // performance dependant on the target architecture.
+#if defined(ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT)
+                static_assert(
+                    ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT > 0
+                        && ((ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT & (ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT - 1)) == 0),
+                    "If defined, ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT must be a power of 2.");
+                constexpr std::size_t alignment = static_cast<std::size_t>(ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT);
+#else
+                constexpr std::size_t alignment = core::vectorization::defaultAlignment;
+#endif
                 // alpaka::AllocCpuAligned is stateless
-                using Allocator
-                    = AllocCpuAligned<std::integral_constant<std::size_t, core::vectorization::defaultAlignment>>;
+                using Allocator = AllocCpuAligned<std::integral_constant<std::size_t, alignment>>;
                 static_assert(std::is_empty_v<Allocator>, "AllocCpuAligned is expected to be stateless");
                 auto* memPtr = alpaka::malloc<TElem>(Allocator{}, static_cast<std::size_t>(getExtentProduct(extent)));
                 auto deleter = [queue = std::move(queue)](TElem* ptr) mutable


### PR DESCRIPTION
If `ALPAKA_DEFAULT_HOST_MEMORY_ALIGNMENT` is defined, use it as the default alignment for host memory allocations.
A compile-time check ensures that it is positive and a power of 2.

Otherwise, the alignment is chosen to enable optimal performance dependant on the target architecture.
