### PR TITLE
Prepare 0.9.0 release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -8,6 +8,11 @@
       "orcid": "0000-0003-3396-6154"
     },
     {
+      "name": "Bocci, Andrea",
+      "affiliation": "CERN",
+      "orcid": "0000-0002-6515-5666"
+    },
+    {
       "name": "Di Pilato, Antonio",
       "affiliation": "CASUS, Helmholtz-Zentrum Dresden-Rossendorf, CERN",
       "orcid": "0000-0002-9233-3632"
@@ -23,9 +28,19 @@
       "orcid": "0000-0001-7848-1690"
     },
     {
+      "name": "Huebl, Axel",
+      "affiliation": "Lawrence Berkeley National Laboratory",
+      "orcid": "0000-0003-1943-7141"
+    },
+    {
       "name": "Kelling, Jeffrey",
       "affiliation": "Helmholtz-Zentrum Dresden-Rossendorf",
       "orcid": "0000-0003-1761-2591"
+    },
+    {
+      "name": "Pantaleo, Felice",
+      "affiliation": "CERN",
+      "orcid": "0000-0003-3266-4357"
     },
     {
       "name": "Stephan, Jan",
@@ -41,6 +56,10 @@
       "name": "Widera, René",
       "affiliation": "Helmholtz-Zentrum Dresden-Rossendorf",
       "orcid": "0000-0003-1642-0459"
+    },
+    {
+      "name": "Worpitz, Benjamin",
+      "affiliation": "LogMeIn Inc."
     }
   ],
   "contributors": [
@@ -52,12 +71,6 @@
     {
       "name": "Gehrke, Valentin",
       "affiliation": "TU Dresden",
-      "type": "Other"
-    },
-    {
-      "name": "Huebl, Axel",
-      "affiliation": "Helmholtz-Zentrum Dresden-Rossendorf, TU Dresden",
-      "orcid": "0000-0003-1943-7141",
       "type": "Other"
     },
     {
@@ -115,11 +128,6 @@
     {
       "name":"Wesarg, Bert",
       "affiliation":"TU Dresden",
-      "type": "Other"
-    },
-    {
-      "affiliation": "Helmholtz-Zentrum Dresden-Rossendorf, TU Dresden, LogMeIn Inc.",
-      "name": "Worpitz, Benjamin",
       "type": "Other"
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.9.0] - 2022-04-14
+## [0.9.0] - 2022-04-21
 ### Compatibility Changes:
 - Platform support added:
   - oneTBB #1456

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Authors
 - Dr. Antonio Di Pilato
 - Simeon Ehrig
 - Bernhard Manfred Gruber*
+- Dr. Axel Huebl
 - Dr. Jeffrey Kelling
 - Dr. Felice Pantaleo
 - Jan Stephan*
@@ -230,7 +231,6 @@ Authors
 - Dr. Michael Bussmann
 - Mat Colgrove
 - Valentin Gehrke
-- Dr. Axel Huebl
 - Maximilian Knespel
 - Jakob Krude
 - Alexander Matthes

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ author = 'Benjamin Worpitz, René Widera, Axel Huebl, Michael Bussmann'
 # The short X.Y version.
 version = u'0.9.0'
 # The full version, including alpha/beta/rc tags.
-release = u'0.9.0-rc1'
+release = u'0.9.0'
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/source/dev/backends.rst
+++ b/docs/source/dev/backends.rst
@@ -357,7 +357,7 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMallocArray            | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMallocHost             | alpaka::allocBuf<TElement>(device, extents) 1D, 2D, 3D suppoorted!                         |
+    | cudaMallocHost             | alpaka::allocBuf<TElement>(device, extents) 1D, 2D, 3D supported!                          |
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMallocManaged          | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
@@ -376,13 +376,13 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMemRangeGetAttributes  | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemcpy                 | alpaka::memcpy(memBufDst, memBufSrc, extents1D)                                            |
+    | cudaMemcpy                 | alpaka::memcpy(queue, memBufDst, memBufSrc, extents1D)                                     |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemcpy2D               | alpaka::memcpy(memBufDst, memBufSrc, extents2D)                                            |
+    | cudaMemcpy2D               | alpaka::memcpy(queue, memBufDst, memBufSrc, extents2D)                                     |
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMemcpy2DArrayToArray   | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemcpy2DAsync          | alpaka::memcpy(memBufDst, memBufSrc, extents2D, queue)                                     |
+    | cudaMemcpy2DAsync          | alpaka::memcpy(queue, memBufDst, memBufSrc, extents2D)                                     |
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMemcpy2DFromArray      | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
@@ -392,17 +392,17 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMemcpy2DToArrayAsync   | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemcpy3D               | alpaka::memcpy(memBufDst, memBufSrc, extents3D)                                            |
+    | cudaMemcpy3D               | alpaka::memcpy(queue, memBufDst, memBufSrc, extents3D)                                     |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemcpy3DAsync          | alpaka::memcpy(memBufDst, memBufSrc, extents3D, queue)                                     |
+    | cudaMemcpy3DAsync          | alpaka::memcpy(queue, memBufDst, memBufSrc, extents3D)                                     |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemcpy3DPeer           | alpaka::memcpy(memBufDst, memBufSrc, extents3D)                                            |
+    | cudaMemcpy3DPeer           | alpaka::memcpy(queue, memBufDst, memBufSrc, extents3D)                                     |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemcpy3DPeerAsync      | alpaka::memcpy(memBufDst, memBufSrc, extents3D, queue)                                     |
+    | cudaMemcpy3DPeerAsync      | alpaka::memcpy(queue, memBufDst, memBufSrc, extents3D)                                     |
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMemcpyArrayToArray     | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemcpyAsync            | alpaka::memcpy(memBufDst, memBufSrc, extents1D, queue)                                     |
+    | cudaMemcpyAsync            | alpaka::memcpy(queue, memBufDst, memBufSrc, extents1D)                                     |
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMemcpyFromArray        | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
@@ -412,9 +412,9 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMemcpyFromSymbolAsync  | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemcpyPeer             | alpaka::memcpy(memBufDst, memBufSrc, extents1D)                                            |
+    | cudaMemcpyPeer             | alpaka::memcpy(queue, memBufDst, memBufSrc, extents1D)                                     |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemcpyPeerAsync        | alpaka::memcpy(memBufDst, memBufSrc, extents1D, queue)                                     |
+    | cudaMemcpyPeerAsync        | alpaka::memcpy(queue, memBufDst, memBufSrc, extents1D)                                     |
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMemcpyToArray          | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
@@ -424,17 +424,17 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMemcpyToSymbolAsync    | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemset                 | alpaka::memset(memBufDst, byte, extents1D)                                                 |
+    | cudaMemset                 | alpaka::memset(queue, memBufDst, byte, extents1D)                                          |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemset2D               | alpaka::memset(memBufDst, byte, extents2D)                                                 |
+    | cudaMemset2D               | alpaka::memset(queue, memBufDst, byte, extents2D)                                          |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemset2DAsync          | alpaka::memset(memBufDst, byte, extents2D, queue)                                          |
+    | cudaMemset2DAsync          | alpaka::memset(queue, memBufDst, byte, extents2D, queue)                                   |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemset3D               | alpaka::memset(memBufDst, byte, extents3D)                                                 |
+    | cudaMemset3D               | alpaka::memset(queue, memBufDst, byte, extents3D)                                          |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemset3DAsync          | alpaka::memset(memBufDst, byte, extents3D, queue)                                          |
+    | cudaMemset3DAsync          | alpaka::memset(queue, memBufDst, byte, extents3D)                                          |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemsetAsync            | alpaka::memset(memBufDst, byte, extents1D, queue)                                          |
+    | cudaMemsetAsync            | alpaka::memset(queue, memBufDst, byte, extents1D)                                          |
     +----------------------------+--------------------------------------------------------------------------------------------+
     | makecudaExtent             | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+


### PR DESCRIPTION
* Updates author list in `README.md`
* Updates author list in `.zenodo.json`
* Updates version number to `0.9.0`.
* `cherry-pick` #1696
* Update release date to 2022-04-21.

The author list was obtained by running `git shortlog -sne 1fa86b6..HEAD`, with `1fa86b6` referring to the `0.8` repository state. In `.zenodo.json` I have updated the affiliations of @BenjaminW3 and @ax3l to reflect their current employers.