### PR TITLE
Introduce `alpaka::math::constants`

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -325,6 +325,25 @@ if(${alpaka_DEBUG} GREATER 1)
 endif()
 
 #-------------------------------------------------------------------------------
+# If available, use C++20 math constants. Otherwise, fall back to M_PI etc.
+if(${alpaka_CXX_STANDARD} VERSION_LESS "20")
+    set(alpaka_HAS_STD_MATH_CONSTANTS FALSE)
+else()
+    try_compile(alpaka_HAS_STD_MATH_CONSTANTS # Result stored here
+                "${PROJECT_BINARY_DIR}/alpakaFeatureTests" # Binary directory for output file
+                SOURCES "${_alpaka_FEATURE_TESTS_DIR}/MathConstants.cpp" # Source file
+                CXX_STANDARD 20
+                CXX_STANDARD_REQUIRED TRUE
+                CXX_EXTENSIONS FALSE)
+endif()
+
+if(NOT alpaka_HAS_STD_MATH_CONSTANTS)
+    message(STATUS "C++20 math constants not found. Falling back to non-standard constants.")
+    # Enable non-standard constants for MSVC.
+    target_compile_definitions(alpaka INTERFACE "$<$<OR:$<CXX_COMPILER_ID:MSVC>,$<AND:$<COMPILE_LANGUAGE:CUDA>,$<PLATFORM_ID:Windows>>>:_USE_MATH_DEFINES>")
+endif()
+
+#-------------------------------------------------------------------------------
 # Find TBB.
 if(alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE)
     find_package(TBB 2021.4.0.0 REQUIRED)

--- a/cmake/tests/MathConstants.cpp
+++ b/cmake/tests/MathConstants.cpp
@@ -1,0 +1,20 @@
+/* Copyright 2022 Jan Stephan
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <cstdlib>
+#include <numbers>
+
+#if !defined(__cpp_lib_math_constants)
+#    error "Mathematical constants not supported!"
+#endif
+
+auto main() -> int
+{
+    return EXIT_SUCCESS;
+}

--- a/include/alpaka/math/Traits.hpp
+++ b/include/alpaka/math/Traits.hpp
@@ -14,9 +14,134 @@
 
 #include <cmath>
 #include <complex>
+#if __has_include(<numbers>)
+#    include <numbers>
+#endif
 
 namespace alpaka::math
 {
+    namespace constants
+    {
+        /* TODO: Remove the following pragmas once support for clang 5 and 6 is removed. They are necessary because
+        these /  clang versions incorrectly warn about a missing 'extern'. */
+#if BOOST_COMP_CLANG
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wmissing-variable-declarations"
+#endif
+#ifdef __cpp_lib_math_constants
+        inline constexpr double e = std::numbers::e;
+        inline constexpr double log2e = std::numbers::log2e;
+        inline constexpr double log10e = std::numbers::log10e;
+        inline constexpr double pi = std::numbers::pi;
+        inline constexpr double inv_pi = std::numbers::inv_pi;
+        inline constexpr double ln2 = std::numbers::ln2;
+        inline constexpr double ln10 = std::numbers::ln10;
+        inline constexpr double sqrt2 = std::numbers::sqrt2;
+
+        template<typename T>
+        inline constexpr T e_v = std::numbers::e_v<T>;
+
+        template<typename T>
+        inline constexpr T log2e_v = std::numbers::log2e_v<T>;
+
+        template<typename T>
+        inline constexpr T log10e_v = std::numbers::log10e_v<T>;
+
+        template<typename T>
+        inline constexpr T pi_v = std::numbers::pi_v<T>;
+
+        template<typename T>
+        inline constexpr T inv_pi_v = std::numbers::inv_pi_v<T>;
+
+        template<typename T>
+        inline constexpr T ln2_v = std::numbers::ln2_v<T>;
+
+        template<typename T>
+        inline constexpr T ln10_v = std::numbers::ln10_v<T>;
+
+        template<typename T>
+        inline constexpr T sqrt2_v = std::numbers::sqrt2_v<T>;
+#else
+        inline constexpr double e = M_E;
+        inline constexpr double log2e = M_LOG2E;
+        inline constexpr double log10e = M_LOG10E;
+        inline constexpr double pi = M_PI;
+        inline constexpr double inv_pi = M_1_PI;
+        inline constexpr double ln2 = M_LN2;
+        inline constexpr double ln10 = M_LN10;
+        inline constexpr double sqrt2 = M_SQRT2;
+
+        template<typename T>
+        inline constexpr T e_v = static_cast<T>(e);
+
+        template<typename T>
+        inline constexpr T log2e_v = static_cast<T>(log2e);
+
+        template<typename T>
+        inline constexpr T log10e_v = static_cast<T>(log10e);
+
+        template<typename T>
+        inline constexpr T pi_v = static_cast<T>(pi);
+
+        template<typename T>
+        inline constexpr T inv_pi_v = static_cast<T>(inv_pi);
+
+        template<typename T>
+        inline constexpr T ln2_v = static_cast<T>(ln2);
+
+        template<typename T>
+        inline constexpr T ln10_v = static_cast<T>(ln10);
+
+        template<typename T>
+        inline constexpr T sqrt2_v = static_cast<T>(sqrt2);
+
+        // Use predefined float constants when available
+#    if defined(M_Ef)
+        template<>
+        inline constexpr float e_v<float> = M_Ef;
+#    endif
+
+#    if defined(M_LOG2Ef)
+        template<>
+        inline constexpr float log2e_v<float> = M_LOG2Ef;
+#    endif
+
+#    if defined(M_LOG10Ef)
+        template<>
+        inline constexpr float log10e_v<float> = M_LOG10Ef;
+#    endif
+
+#    if defined(M_PIf)
+        template<>
+        inline constexpr float pi_v<float> = M_PIf;
+#    endif
+
+#    if defined(M_1_PIf)
+        template<>
+        inline constexpr float inv_pi_v<float> = M_1_PIf;
+#    endif
+
+#    if defined(M_LN2f)
+        template<>
+        inline constexpr float ln2_v<float> = M_LN2f;
+#    endif
+
+#    if defined(M_LN10f)
+        template<>
+        inline constexpr float ln10_v<float> = M_LN10f;
+#    endif
+
+#    if defined(M_SQRT2f)
+        template<>
+        inline constexpr float sqrt2_v<float> = M_SQRT2f;
+#    endif
+
+#endif
+#if BOOST_COMP_CLANG
+#    pragma clang diagnostic pop
+#endif
+    } // namespace constants
+
     struct ConceptMathAbs
     {
     };

--- a/include/alpaka/rand/RandDefault.hpp
+++ b/include/alpaka/rand/RandDefault.hpp
@@ -151,7 +151,7 @@ namespace alpaka::rand
 
                     // compute z0 and z1
                     const T mag = sigma * math::sqrt(*m_acc, static_cast<T>(-2.) * math::log(*m_acc, u1));
-                    constexpr T twoPi = static_cast<T>(2. * M_PI);
+                    constexpr T twoPi = static_cast<T>(2. * math::constants::pi);
                     // getting two normal number out of this, store one for later
                     m_cache = mag * static_cast<T>(math::cos(*m_acc, twoPi * u2)) + mu;
 


### PR DESCRIPTION
Fixes #1553.

This PR introduces the `alpaka::math::constants` namespace which includes several predefined math constants. These are the intersection of the [C++20 math constants](https://en.cppreference.com/w/cpp/header/numbers) and the non-standard constants defined by [libc](https://www.gnu.org/software/libc/manual/html_node/Mathematical-Constants.html) and [CRT](https://docs.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=msvc-170).

C++20 constants are now preferred. If they are unavailable, `M_PI` and friends will be used. In this case `_USE_MATH_DEFINES` will be added to the MSVC (or nvcc + MSVC) compiler command line.