### PR TITLE
Cancel running workflows when updating PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ name: Continuous Integration
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 ################################################################################
 # NOTE: Testing the full matrix is not practical.
 # Therefore we aim to have each value been set in at lest one job.


### PR DESCRIPTION
This changes the CI to cancel existing workflows when a PR is updated. See also: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency