### PR TITLE
Small fixes required for gcc-12

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -241,26 +241,30 @@ if(alpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE OR
    alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE OR
    alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE)
 
-    # Check for C++20 std::atomic_ref first
-    if(${alpaka_CXX_STANDARD} VERSION_GREATER_EQUAL "20")
-        try_compile(alpaka_HAS_STD_ATOMIC_REF # Result stored here
-                    "${PROJECT_BINARY_DIR}/alpakaFeatureTests" # Binary directory for output file
-                    SOURCES "${_alpaka_FEATURE_TESTS_DIR}/StdAtomicRef.cpp" # Source file
-                    CXX_STANDARD 20
-                    CXX_STANDARD_REQUIRED TRUE
-                    CXX_EXTENSIONS FALSE)
-        if(alpaka_HAS_STD_ATOMIC_REF)
-            message(STATUS "std::atomic_ref<T> found")
-            target_compile_definitions(alpaka INTERFACE ALPAKA_HAS_STD_ATOMIC_REF)
-        else()
-            message(STATUS "std::atomic_ref<T> NOT found")
+    if(NOT alpaka_ACC_CPU_DISABLE_ATOMIC_REF)
+        # Check for C++20 std::atomic_ref first
+        if(${alpaka_CXX_STANDARD} VERSION_GREATER_EQUAL "20")
+            try_compile(alpaka_HAS_STD_ATOMIC_REF # Result stored here
+                        "${PROJECT_BINARY_DIR}/alpakaFeatureTests" # Binary directory for output file
+                        SOURCES "${_alpaka_FEATURE_TESTS_DIR}/StdAtomicRef.cpp" # Source file
+                        CXX_STANDARD 20
+                        CXX_STANDARD_REQUIRED TRUE
+                        CXX_EXTENSIONS FALSE)
+            if(alpaka_HAS_STD_ATOMIC_REF AND (NOT alpaka_ACC_CPU_DISABLE_ATOMIC_REF))
+                message(STATUS "std::atomic_ref<T> found")
+                target_compile_definitions(alpaka INTERFACE ALPAKA_HAS_STD_ATOMIC_REF)
+            else()
+                message(STATUS "std::atomic_ref<T> NOT found")
+            endif()
+        endif()
+
+        if(Boost_ATOMIC_FOUND AND (NOT alpaka_HAS_STD_ATOMIC_REF))
+            message(STATUS "boost::atomic_ref<T> found")
+            target_link_libraries(alpaka INTERFACE Boost::atomic)
         endif()
     endif()
 
-    if(Boost_ATOMIC_FOUND AND (NOT alpaka_HAS_STD_ATOMIC_REF) AND (NOT alpaka_ACC_CPU_DISABLE_ATOMIC_REF))
-        message(STATUS "boost::atomic_ref<T> found")
-        target_link_libraries(alpaka INTERFACE Boost::atomic)
-    else()
+    if(alpaka_ACC_CPU_DISABLE_ATOMIC_REF OR ((NOT alpaka_HAS_STD_ATOMIC_REF) AND (NOT Boost_ATOMIC_FOUND)))
         message(STATUS "atomic_ref<T> was not found or manually disabled. Falling back to lock-based CPU atomics.")
         target_compile_definitions(alpaka INTERFACE ALPAKA_DISABLE_ATOMIC_ATOMICREF)
     endif()

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -55,7 +55,7 @@ namespace alpaka
                 DevCpu dev,
                 TElem* pMem,
                 std::function<void(TElem*)> deleter,
-                TExtent const& extent)
+                TExtent const& extent) noexcept
                 : m_dev(std::move(dev))
                 , m_extentElements(getExtentVecEnd<TDim>(extent))
                 , m_pMem(pMem)

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -50,7 +50,7 @@ namespace alpaka
         public:
             //! Constructor
             template<typename TExtent>
-            ALPAKA_FN_HOST BufOmp5Impl(DevOmp5 const& dev, TElem* const pMem, TExtent const& extent)
+            ALPAKA_FN_HOST BufOmp5Impl(DevOmp5 const& dev, TElem* const pMem, TExtent const& extent) noexcept
                 : m_dev(dev)
                 , m_extentElements(getExtentVecEnd<TDim>(extent))
                 , m_pMem(pMem)

--- a/test/unit/math/src/mathComplexDouble.cpp
+++ b/test/unit/math/src/mathComplexDouble.cpp
@@ -1,4 +1,4 @@
-/** Copyright 2022 Jakob Krude, Benjamin Worpitz, Bernhard Manfred Gruber, Sergei Bastrakov
+/** Copyright 2022 Jakob Krude, Benjamin Worpitz, Bernhard Manfred Gruber, Sergei Bastrakov, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -37,9 +37,24 @@ TEMPLATE_LIST_TEST_CASE("mathOpsComplexDouble", "[math] [operator]", TestAccFunc
     testTemplate.template operator()<alpaka::Complex<double>>();
 }
 
-#ifdef __cpp_lib_is_layout_compatible
-TEMPLATE_LIST_TEST_CASE("mathOpsComplexDouble", "[layout]", TestAccs)
+TEST_CASE("mathArrayOrientedComplexDouble", "[array-oriented]")
 {
-    STATIC_REQUIRE(std::is_layout_compatible_v<alpaka::Complex<double> std::complex<double>>);
+    // Ensure that our implementation matches the behaviour of std::complex with regard to array-oriented access.
+    // See https://en.cppreference.com/w/cpp/numeric/complex - Array-oriented access - for more information.
+    auto const complex_alpaka = alpaka::Complex<double>{42., 42.};
+    auto const complex_std = std::complex<double>{42., 42.};
+
+    auto const real_alpaka = reinterpret_cast<double const(&)[2]>(complex_alpaka)[0];
+    auto const real_std = reinterpret_cast<double const(&)[2]>(complex_std)[0];
+    REQUIRE(alpaka::math::floatEqualExactNoWarning(real_alpaka, real_std));
+
+    auto const imag_alpaka = reinterpret_cast<double const(&)[2]>(complex_alpaka)[1];
+    auto const imag_std = reinterpret_cast<double const(&)[2]>(complex_std)[1];
+    REQUIRE(alpaka::math::floatEqualExactNoWarning(imag_alpaka, imag_std));
 }
-#endif
+
+TEST_CASE("mathPaddingComplexDouble", "[padding]")
+{
+    // Ensure that we don't accidentally introduce padding
+    STATIC_REQUIRE(sizeof(alpaka::Complex<double>) == 2 * sizeof(double));
+}

--- a/test/unit/math/src/mathComplexFloat.cpp
+++ b/test/unit/math/src/mathComplexFloat.cpp
@@ -1,4 +1,4 @@
-/** Copyright 2022 Jakob Krude, Benjamin Worpitz, Bernhard Manfred Gruber, Sergei Bastrakov
+/** Copyright 2022 Jakob Krude, Benjamin Worpitz, Bernhard Manfred Gruber, Sergei Bastrakov, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -37,9 +37,24 @@ TEMPLATE_LIST_TEST_CASE("mathOpsComplexFloat", "[math] [operator]", TestAccFunct
     testTemplate.template operator()<alpaka::Complex<float>>();
 }
 
-#ifdef __cpp_lib_is_layout_compatible
-TEMPLATE_LIST_TEST_CASE("mathOpsComplexFloat", "[layout]", TestAccs)
+TEST_CASE("mathArrayOrientedComplexFloat", "[array-oriented]")
 {
-    STATIC_REQUIRE(std::is_layout_compatible_v<alpaka::Complex<float>, std::complex<float>>);
+    // Ensure that our implementation matches the behaviour of std::complex with regard to array-oriented access.
+    // See https://en.cppreference.com/w/cpp/numeric/complex - Array-oriented access - for more information.
+    auto const complex_alpaka = alpaka::Complex<float>{42.f, 42.f};
+    auto const complex_std = std::complex<float>{42.f, 42.f};
+
+    auto const real_alpaka = reinterpret_cast<float const(&)[2]>(complex_alpaka)[0];
+    auto const real_std = reinterpret_cast<float const(&)[2]>(complex_std)[0];
+    REQUIRE(alpaka::math::floatEqualExactNoWarning(real_alpaka, real_std));
+
+    auto const imag_alpaka = reinterpret_cast<float const(&)[2]>(complex_alpaka)[1];
+    auto const imag_std = reinterpret_cast<float const(&)[2]>(complex_std)[1];
+    REQUIRE(alpaka::math::floatEqualExactNoWarning(imag_alpaka, imag_std));
 }
-#endif
+
+TEST_CASE("mathPaddingComplexFloat", "[padding]")
+{
+    // Ensure that we don't accidentally introduce padding
+    STATIC_REQUIRE(sizeof(alpaka::Complex<float>) == 2 * sizeof(float));
+}


### PR DESCRIPTION
Fixes #1720.

1. Our layout tests for our complex implementation were too strict. They now check for the requirements without failing to compile.
2. gcc-12 complained about two constructors not being `noexcept`. Added `noexcept` to make gcc happy.