### PR TITLE
fix host memory alloc and pinning on OpenPower systems

### DIFF
--- a/include/alpaka/dev/cpu/SysInfo.hpp
+++ b/include/alpaka/dev/cpu/SysInfo.hpp
@@ -123,6 +123,26 @@ namespace alpaka
                 return std::string("unknown");
 #endif
             }
+
+            //! \return Pagesize in bytes used by the system.
+            inline size_t getPageSize()
+            {
+#if BOOST_OS_WINDOWS || BOOST_OS_CYGWIN
+                SYSTEM_INFO si;
+                GetSystemInfo(&si);
+                return si.dwPageSize;
+#elif BOOST_OS_UNIX || BOOST_OS_MACOS
+#    if defined(_SC_PAGESIZE)
+                return static_cast<std::size_t>(sysconf(_SC_PAGESIZE));
+#    else
+                return = static_cast<size_t>(getpagesize());
+#    endif
+#else
+#    error "getPageSize not implemented for this system!"
+                return 0;
+#endif
+            }
+
             //! \return The total number of bytes of global memory.
             //! Adapted from David Robert Nadeau:
             //! http://nadeausoftware.com/articles/2012/09/c_c_tip_how_get_physical_memory_size_system
@@ -156,21 +176,17 @@ namespace alpaka
                 std::uint64_t size(0);
                 std::size_t sizeLen{sizeof(size)};
                 if(sysctl(mib, 2, &size, &sizeLen, nullptr, 0) < 0)
-                {
                     throw std::logic_error("getTotalGlobalMemSizeBytes failed calling sysctl!");
-                }
                 return static_cast<std::size_t>(size);
 
 #    elif defined(_SC_AIX_REALMEM) // AIX.
                 return static_cast<std::size_t>(sysconf(_SC_AIX_REALMEM)) * static_cast<std::size_t>(1024);
 
-#    elif defined(_SC_PHYS_PAGES) && defined(_SC_PAGESIZE) // Linux, FreeBSD, OpenBSD, Solaris.
-                return static_cast<std::size_t>(sysconf(_SC_PHYS_PAGES))
-                    * static_cast<std::size_t>(sysconf(_SC_PAGESIZE));
+#    elif defined(_SC_PHYS_PAGES) // Linux, FreeBSD, OpenBSD, Solaris.
+                return static_cast<std::size_t>(sysconf(_SC_PHYS_PAGES)) * getPageSize();
 
-#    elif defined(_SC_PHYS_PAGES) && defined(_SC_PAGE_SIZE) // Legacy.
-                return static_cast<std::size_t>(sysconf(_SC_PHYS_PAGES))
-                    * static_cast<std::size_t>(sysconf(_SC_PAGE_SIZE));
+#    elif defined(_SC_PHYS_PAGES) // Legacy.
+                return static_cast<std::size_t>(sysconf(_SC_PHYS_PAGES)) * getPageSize();
 
 #    elif defined(CTL_HW)                                                                                             \
         && (defined(HW_PHYSMEM) || defined(HW_REALMEM)) // FreeBSD, DragonFly BSD, NetBSD, OpenBSD, and OSX.
@@ -185,9 +201,7 @@ namespace alpaka
             std::uint32_t size(0);
             std::size_t const sizeLen{sizeof(size)};
             if(sysctl(mib, 2, &size, &sizeLen, nullptr, 0) < 0)
-            {
                 throw std::logic_error("getTotalGlobalMemSizeBytes failed calling sysctl!");
-            }
             return static_cast<std::size_t>(size);
 #    endif
 
@@ -238,13 +252,8 @@ namespace alpaka
                 {
                     throw std::logic_error("getFreeGlobalMemSizeBytes failed calling sysctl(vm.page_free_count)!");
                 }
-                int page_size = 0;
-                len = sizeof(page_size);
-                if(sysctlbyname("vm.pagesize", &page_size, &len, nullptr, 0) < 0)
-                {
-                    throw std::logic_error("getFreeGlobalMemSizeBytes failed calling sysctl(vm.pagesize)!");
-                }
-                return static_cast<std::size_t>(free_pages) * static_cast<std::size_t>(page_size);
+
+                return static_cast<std::size_t>(free_pages) * getPageSize();
 #else
 #    error "getFreeGlobalMemSizeBytes not implemented for this system!"
 #endif

--- a/include/alpaka/dev/cpu/SysInfo.hpp
+++ b/include/alpaka/dev/cpu/SysInfo.hpp
@@ -135,6 +135,7 @@ namespace alpaka
 #    if defined(_SC_PAGESIZE)
                 return static_cast<std::size_t>(sysconf(_SC_PAGESIZE));
 #    else
+                // this is legacy and only used as fallback
                 return = static_cast<size_t>(getpagesize());
 #    endif
 #else
@@ -183,9 +184,6 @@ namespace alpaka
                 return static_cast<std::size_t>(sysconf(_SC_AIX_REALMEM)) * static_cast<std::size_t>(1024);
 
 #    elif defined(_SC_PHYS_PAGES) // Linux, FreeBSD, OpenBSD, Solaris.
-                return static_cast<std::size_t>(sysconf(_SC_PHYS_PAGES)) * getPageSize();
-
-#    elif defined(_SC_PHYS_PAGES) // Legacy.
                 return static_cast<std::size_t>(sysconf(_SC_PHYS_PAGES)) * getPageSize();
 
 #    elif defined(CTL_HW)                                                                                             \

--- a/include/alpaka/mem/alloc/AllocCpuAligned.hpp
+++ b/include/alpaka/mem/alloc/AllocCpuAligned.hpp
@@ -12,6 +12,7 @@
 #include <alpaka/core/AlignedAlloc.hpp>
 #include <alpaka/core/Common.hpp>
 #include <alpaka/core/Concepts.hpp>
+#include <alpaka/dev/cpu/SysInfo.hpp>
 #include <alpaka/mem/alloc/Traits.hpp>
 
 #include <algorithm>
@@ -37,16 +38,15 @@ namespace alpaka
                 std::size_t const& sizeElems) -> T*
             {
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-                // For CUDA host memory must be aligned to 4 kib to pin it with `cudaHostRegister`,
+                // For CUDA/HIP host memory must be aligned to 4 kib to pin it with `cudaHostRegister`,
                 // this was described in older programming guides but was removed later.
                 // From testing with PIConGPU and cuda-memcheck we found out that the alignment is still required.
                 //
                 // For HIP the required alignment is the size of a cache line.
                 // https://rocm-developer-tools.github.io/HIP/group__Memory.html#gab8258f051e1a1f7385f794a15300e674
-                // To avoid issues with HIP(cuda) the alignment will be set also for HIP(clang)
-                // to 4kib.
-                // @todo evaluate requirements when the HIP ecosystem is more stable
-                constexpr size_t minAlignement = std::max<size_t>(TAlignment::value, 4096);
+                // On most x86 systems the page size is 4KiB and on OpenPower 64KiB.
+                // Page size can be tested on the terminal with: `getconf PAGE_SIZE`
+                size_t minAlignement = std::max<size_t>(TAlignment::value, cpu::detail::getPageSize());
 #else
                 constexpr size_t minAlignement = TAlignment::value;
 #endif
@@ -61,7 +61,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto free(AllocCpuAligned<TAlignment> const& /* alloc */, T const* const ptr) -> void
             {
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-                constexpr size_t minAlignement = std::max<size_t>(TAlignment::value, 4096);
+                size_t minAlignement = std::max<size_t>(TAlignment::value, cpu::detail::getPageSize());
 #else
                 constexpr size_t minAlignement = TAlignment::value;
 #endif


### PR DESCRIPTION
The alignment requirements to pin host memory on OpenPower systems are not fulfilled.

We tried to fix this issue already in the past in #873. Unfortunately, the issue still exists and was reproducible with PIConGPU and cuda-memcheck. After applying this fix the error is solved.

~~This PR introduces a new boost dependency to the header only lib `boost::interprocess` :-(.
I thought about fixing it with macros guards but we do not know if we will run on ARM+CUDA again into this issue or if the system is running with huge pages we will definitely have this issue again, therefore I decided to use boost.~~

@j-stephan Can we discuss in the next developer meeting if we create with this fix a bug fix release 0.9.1, else we need to switch with PIConGPU to the current alpaka dev for 1.0.