### PR TITLE
BufCpu::deleter: rm ignore_unused lambda for captured queue

### DIFF
--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -503,12 +503,14 @@ namespace alpaka::core
                 // Checks whether pool is being destroyed, if so, stop running (lazy check without mutex).
                 while(!m_bShutdownFlag)
                 {
-                    auto currentTaskPackage = std::shared_ptr<ITaskPkg>{nullptr};
-
-                    // Use popTask so we only ever have one reference to the ITaskPkg
-                    if(popTask(currentTaskPackage))
                     {
-                        currentTaskPackage->runTask();
+                        auto currentTaskPackage = std::shared_ptr<ITaskPkg>{nullptr};
+
+                        // Use popTask so we only ever have one reference to the ITaskPkg
+                        if(popTask(currentTaskPackage))
+                        {
+                            currentTaskPackage->runTask();
+                        }
                     }
                     {
                         std::unique_lock<TMutex> lock(m_mtxWakeup);

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -276,12 +276,10 @@ namespace alpaka
                 {
                     alpaka::enqueue(
                         queue,
-                        [ptr, queue]()
+                        [ptr, queue]() // capture queue to keep it alive until all memory operations are complete
                         {
                             // free the memory
                             alpaka::free(Allocator{}, ptr);
-                            // keep the queue alive until all memory operations are complete
-                            [&queue = std::as_const(queue)]() {}();
                         });
                 };
 

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -162,27 +162,35 @@ TEMPLATE_LIST_TEST_CASE("memBufConstTest", "[memBuf]", alpaka::test::TestAccs)
 template<typename TAcc>
 static auto testAsyncBufferImmutable(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
 {
-    using Dev = alpaka::Dev<TAcc>;
-    using Pltf = alpaka::Pltf<Dev>;
-    using Queue = alpaka::test::DefaultQueue<Dev>;
+    {
+        using Dev = alpaka::Dev<TAcc>;
+        using Pltf = alpaka::Pltf<Dev>;
+        using Queue = alpaka::test::DefaultQueue<Dev>;
 
-    using Elem = float;
-    using Dim = alpaka::Dim<TAcc>;
-    using Idx = alpaka::Idx<TAcc>;
+        using Elem = float;
+        using Dim = alpaka::Dim<TAcc>;
+        using Idx = alpaka::Idx<TAcc>;
 
-    Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
-    Queue queue(dev);
+        Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+        Queue queue(dev);
 
-    // memory is allocated when the queue reaches this point
-    auto const buf = alpaka::allocAsyncBuf<Elem, Idx>(queue, extent);
+        // memory is allocated when the queue reaches this point
+        auto const buf = alpaka::allocAsyncBuf<Elem, Idx>(queue, extent);
 
-    // synchronous operations must wait for the memory to be available
-    alpaka::wait(queue);
-    auto const offset = alpaka::Vec<Dim, Idx>::zeros();
-    alpaka::test::testViewImmutable<Elem>(buf, dev, extent, offset);
+        // synchronous operations must wait for the memory to be available
+        alpaka::wait(queue);
+        auto const offset = alpaka::Vec<Dim, Idx>::zeros();
+        alpaka::test::testViewImmutable<Elem>(buf, dev, extent, offset);
 
-    // the buffer will queue the deallocation of the memory when it goes out of scope,
-    // and extend the lifetime of the queue until all memory operations have completed.
+        // the buffer will queue the deallocation of the memory when it goes out of scope,
+        // and extend the lifetime of the queue until all memory operations have completed.
+        // delay the end end of the queue to push the buffer deletetion task
+        // after all local refs to queue have been dropped
+        alpaka::enqueue(queue, []() { std::this_thread::sleep_for(std::chrono::microseconds(1000)); });
+        [](auto) {}(std::move(queue));
+    }
+
+    std::this_thread::sleep_for(std::chrono::microseconds(1200));
 }
 
 TEMPLATE_LIST_TEST_CASE("memBufAsyncConstTest", "[memBuf]", alpaka::test::TestAccs)


### PR DESCRIPTION
Remove replacement of `alpaka_ignore` from `BufCPU::deleter`: no compiler covered by the CI is raising an unused there. Maybe this is because the notice, that the capture-by-copy by itself has an effect due to the non-trivial copy ctor.

Also : move and rephrase the comment about why the queue is being captured to make it more clear.

Closes #1726