### PR TITLE
Make QueueGenericThreadsNonBlocking complete tasks on destruction.

### DIFF
--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -81,6 +81,7 @@
 #include <alpaka/core/Positioning.hpp>
 #include <alpaka/core/RemoveRestrict.hpp>
 #include <alpaka/core/Sycl.hpp>
+#include <alpaka/core/ThreadTraits.hpp>
 #include <alpaka/core/Unreachable.hpp>
 #include <alpaka/core/Unroll.hpp>
 #include <alpaka/core/Utility.hpp>

--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -503,12 +503,15 @@ namespace alpaka::core
                 // Checks whether pool is being destroyed, if so, stop running (lazy check without mutex).
                 while(!m_bShutdownFlag)
                 {
-                    auto currentTaskPackage = std::shared_ptr<ITaskPkg>{nullptr};
-
-                    // Use popTask so we only ever have one reference to the ITaskPkg
-                    if(popTask(currentTaskPackage))
+                    // enter anonymous scope to limit lifetime of `currentTaskPackage`: destroy before entering wait
                     {
-                        currentTaskPackage->runTask();
+                        auto currentTaskPackage = std::shared_ptr<ITaskPkg>{nullptr};
+
+                        // Use popTask so we only ever have one reference to the ITaskPkg
+                        if(popTask(currentTaskPackage))
+                        {
+                            currentTaskPackage->runTask();
+                        }
                     }
                     {
                         std::unique_lock<TMutex> lock(m_mtxWakeup);

--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, René Widera, Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, René Widera, Jan Stephan, Bernhard Manfred Gruber, Jeffrey Kelling
  *
  * This file is part of alpaka.
  *
@@ -15,6 +15,7 @@
 // Therefore, we can not even parse those parts when compiling device code.
 #include <alpaka/core/BoostPredef.hpp>
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/ThreadTraits.hpp>
 
 #include <atomic>
 #include <exception>
@@ -228,6 +229,8 @@ namespace alpaka::core
             bool TisYielding = true>
         class ConcurrentExecPool final
         {
+            using Type = ConcurrentExecPool<TIdx, TConcurrentExec, TPromise, TYield, TMutex, TCondVar, TisYielding>;
+
         public:
             //! Creates a concurrent executor pool with a specific number of concurrent executors and a maximum
             //! number of queued tasks.
@@ -235,11 +238,7 @@ namespace alpaka::core
             //! \param concurrentExecutionCount
             //!    The guaranteed number of concurrent executors used in the pool.
             //!    This is also the maximum number of tasks worked on concurrently.
-            ConcurrentExecPool(TIdx concurrentExecutionCount)
-                : m_vConcurrentExecs()
-                , m_qTasks()
-                , m_numActiveTasks(0u)
-                , m_bShutdownFlag(false)
+            ConcurrentExecPool(TIdx concurrentExecutionCount) : m_vConcurrentExecs(), m_qTasks()
             {
                 if(concurrentExecutionCount < 1)
                 {
@@ -324,6 +323,12 @@ namespace alpaka::core
                 return m_numActiveTasks == 0u;
             }
 
+            void detach(std::unique_ptr<Type>&& self)
+            {
+                m_self = std::move(self);
+                m_bDetachedFlag = true;
+            }
+
         private:
             //! The function the concurrent executors are executing.
             void concurrentExecFn()
@@ -340,6 +345,12 @@ namespace alpaka::core
                     }
                     else
                     {
+                        if(m_bDetachedFlag.exchange(false))
+                        {
+                            // Pool was detached and is idle, delete
+                            auto self = std::move(m_self);
+                            return;
+                        }
                         TYield::yield();
                     }
                 }
@@ -350,7 +361,10 @@ namespace alpaka::core
             {
                 for(auto&& concurrentExec : m_vConcurrentExecs)
                 {
-                    concurrentExec.join();
+                    if(!isThisThread(concurrentExec))
+                        concurrentExec.join();
+                    else
+                        concurrentExec.detach();
                 }
             }
             //! Pops a task from the queue.
@@ -366,8 +380,10 @@ namespace alpaka::core
         private:
             std::vector<TConcurrentExec> m_vConcurrentExecs;
             ThreadSafeQueue<std::shared_ptr<ITaskPkg>> m_qTasks;
-            std::atomic<std::uint32_t> m_numActiveTasks;
-            std::atomic<bool> m_bShutdownFlag;
+            std::atomic<std::uint32_t> m_numActiveTasks = 0u;
+            std::atomic<bool> m_bShutdownFlag = false;
+            std::atomic<bool> m_bDetachedFlag = false;
+            std::unique_ptr<Type> m_self = nullptr;
         };
 
         //! ConcurrentExecPool using a condition variable to wait for new work.
@@ -387,6 +403,8 @@ namespace alpaka::core
             typename TCondVar>
         class ConcurrentExecPool<TIdx, TConcurrentExec, TPromise, TYield, TMutex, TCondVar, false> final
         {
+            using Type = ConcurrentExecPool<TIdx, TConcurrentExec, TPromise, TYield, TMutex, TCondVar, false>;
+
         public:
             //! Creates a concurrent executors pool with a specific number of concurrent executors and a maximum
             //! number of queued tasks.
@@ -397,10 +415,8 @@ namespace alpaka::core
             ConcurrentExecPool(TIdx concurrentExecutionCount)
                 : m_vConcurrentExecs()
                 , m_qTasks()
-                , m_numActiveTasks(0u)
                 , m_mtxWakeup()
                 , m_cvWakeup()
-                , m_bShutdownFlag(false)
             {
                 if(concurrentExecutionCount < 1)
                 {
@@ -479,9 +495,9 @@ namespace alpaka::core
                 {
                     std::lock_guard<TMutex> lock(m_mtxWakeup);
                     m_qTasks.push(std::move(upTaskPackage));
-
-                    m_cvWakeup.notify_one();
                 }
+
+                m_cvWakeup.notify_one();
 
                 return future;
             }
@@ -494,6 +510,17 @@ namespace alpaka::core
             [[nodiscard]] auto isIdle() const -> bool
             {
                 return m_numActiveTasks == 0u;
+            }
+
+            void detach(std::unique_ptr<Type>&& self)
+            {
+                m_self = std::move(self);
+
+                {
+                    std::lock_guard<TMutex> lock(m_mtxWakeup);
+                    m_bDetachedFlag = true;
+                }
+                m_cvWakeup.notify_one();
             }
 
         private:
@@ -517,13 +544,23 @@ namespace alpaka::core
                         std::unique_lock<TMutex> lock(m_mtxWakeup);
                         if(m_qTasks.empty())
                         {
+                            if(m_bDetachedFlag)
+                            {
+                                // Pool was detached and is idle, delete
+                                auto self = std::move(m_self);
+                                lock.unlock();
+                                return;
+                            }
+
                             // If the shutdown flag has been set since the last check, return now.
                             if(m_bShutdownFlag)
                             {
                                 return;
                             }
 
-                            m_cvWakeup.wait(lock, [this]() { return ((!m_qTasks.empty()) || m_bShutdownFlag); });
+                            m_cvWakeup.wait(
+                                lock,
+                                [this]() { return ((!m_qTasks.empty()) || m_bShutdownFlag || m_bDetachedFlag); });
                         }
                     }
                 }
@@ -534,7 +571,10 @@ namespace alpaka::core
             {
                 for(auto&& concurrentExec : m_vConcurrentExecs)
                 {
-                    concurrentExec.join();
+                    if(!isThisThread(concurrentExec))
+                        concurrentExec.join();
+                    else
+                        concurrentExec.detach();
                 }
             }
             //! Pops a task from the queue.
@@ -550,11 +590,14 @@ namespace alpaka::core
         private:
             std::vector<TConcurrentExec> m_vConcurrentExecs;
             ThreadSafeQueue<std::shared_ptr<ITaskPkg>> m_qTasks;
-            std::atomic<std::uint32_t> m_numActiveTasks;
+            std::atomic<std::uint32_t> m_numActiveTasks = 0u;
 
             TMutex m_mtxWakeup;
             TCondVar m_cvWakeup;
-            std::atomic<bool> m_bShutdownFlag;
+            std::atomic<bool> m_bShutdownFlag = false;
+
+            std::atomic<bool> m_bDetachedFlag = false;
+            std::unique_ptr<Type> m_self = nullptr;
         };
     } // namespace detail
 } // namespace alpaka::core

--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -59,7 +59,7 @@ namespace alpaka::core
                 }
                 else
                 {
-                    t = std::queue<T>::front();
+                    t = std::move(std::queue<T>::front());
                     std::queue<T>::pop();
                     return true;
                 }
@@ -200,7 +200,7 @@ namespace alpaka::core
             {
                 auto ret = fn0();
                 fn1();
-                return std::move(ret);
+                return ret;
             }
             else
             {

--- a/include/alpaka/core/Fibers.hpp
+++ b/include/alpaka/core/Fibers.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz
+/* Copyright 2022 Benjamin Worpitz, Jeffrey Kelling
  *
  * This file is part of alpaka.
  *
@@ -45,4 +45,21 @@
 #        pragma warning(pop)
 #    endif
 
+#    include <alpaka/core/ThreadTraits.hpp>
+
+namespace alpaka
+{
+    namespace trait
+    {
+        //! boost::fiber implementation of IsThisThread trait.
+        template<>
+        struct IsThisThread<boost::fibers::fiber>
+        {
+            ALPAKA_FN_HOST static auto isThisThread(const boost::fibers::fiber& fiber) -> bool
+            {
+                return boost::this_fiber::get_id() == fiber.get_id();
+            }
+        };
+    } // namespace trait
+} // namespace alpaka
 #endif

--- a/include/alpaka/core/ThreadTraits.hpp
+++ b/include/alpaka/core/ThreadTraits.hpp
@@ -1,0 +1,46 @@
+/* Copyright 2022 Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/Common.hpp>
+
+#include <thread>
+#include <utility>
+
+namespace alpaka
+{
+    //! The host thread traits.
+    namespace trait
+    {
+        //! The queue enqueue trait.
+        template<typename TThread, typename TSfinae = void>
+        struct IsThisThread;
+    } // namespace trait
+
+    //! Checks if the given thread handle is a handle for the executing thread.
+    template<typename TThread>
+    ALPAKA_FN_HOST auto isThisThread(const TThread& thread) -> bool
+    {
+        return trait::IsThisThread<TThread>::isThisThread(thread);
+    }
+
+    namespace trait
+    {
+        //! C++ STL threads implementation of IsThisThread trait.
+        template<>
+        struct IsThisThread<std::thread>
+        {
+            ALPAKA_FN_HOST static auto isThisThread(const std::thread& thread) -> bool
+            {
+                return std::this_thread::get_id() == thread.get_id();
+            }
+        };
+    } // namespace trait
+} // namespace alpaka

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -86,6 +86,11 @@ namespace alpaka
             m_spDevCpuImpl->registerQueue(spQueue);
         }
 
+        auto registerCleanup(cpu::detail::DevCpuImpl::CleanerFunctor c) const -> void
+        {
+            m_spDevCpuImpl->registerCleanup(c);
+        }
+
         [[nodiscard]] auto getNativeHandle() const noexcept
         {
             return 0;

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <alpaka/dev/Traits.hpp>
+#include <alpaka/dev/common/QueueRegistry.hpp>
 #include <alpaka/dev/cpu/SysInfo.hpp>
 #include <alpaka/mem/buf/Traits.hpp>
 #include <alpaka/pltf/Traits.hpp>
@@ -48,46 +49,7 @@ namespace alpaka
     namespace cpu::detail
     {
         //! The CPU device implementation.
-        class DevCpuImpl
-        {
-        public:
-            ALPAKA_FN_HOST auto getAllExistingQueues() const -> std::vector<std::shared_ptr<cpu::ICpuQueue>>
-            {
-                std::vector<std::shared_ptr<cpu::ICpuQueue>> vspQueues;
-
-                std::lock_guard<std::mutex> lk(m_Mutex);
-                vspQueues.reserve(std::size(m_queues));
-
-                for(auto it = std::begin(m_queues); it != std::end(m_queues);)
-                {
-                    auto spQueue(it->lock());
-                    if(spQueue)
-                    {
-                        vspQueues.emplace_back(std::move(spQueue));
-                        ++it;
-                    }
-                    else
-                    {
-                        it = m_queues.erase(it);
-                    }
-                }
-                return vspQueues;
-            }
-
-            //! Registers the given queue on this device.
-            //! NOTE: Every queue has to be registered for correct functionality of device wait operations!
-            ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<cpu::ICpuQueue> spQueue) const -> void
-            {
-                std::lock_guard<std::mutex> lk(m_Mutex);
-
-                // Register this queue on the device.
-                m_queues.push_back(spQueue);
-            }
-
-        private:
-            std::mutex mutable m_Mutex;
-            std::vector<std::weak_ptr<cpu::ICpuQueue>> mutable m_queues;
-        };
+        using DevCpuImpl = alpaka::detail::QueueRegistry<cpu::ICpuQueue>;
     } // namespace cpu::detail
 
     //! The CPU device handle.

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -16,6 +16,7 @@
 #    endif
 
 #    include <alpaka/dev/Traits.hpp>
+#    include <alpaka/dev/common/QueueRegistry.hpp>
 #    include <alpaka/mem/buf/Traits.hpp>
 #    include <alpaka/pltf/PltfOacc.hpp>
 #    include <alpaka/pltf/Traits.hpp>
@@ -43,7 +44,7 @@ namespace alpaka
     namespace oacc::detail
     {
         //! The OpenACC device implementation.
-        class DevOaccImpl
+        class DevOaccImpl : public : alpaka::detail::QueueRegistry<IGenericThreadsQueue<DevOmp5>>
         {
         public:
             DevOaccImpl(int iDevice) noexcept : m_deviceType(::acc_get_device_type()), m_iDevice(iDevice)
@@ -54,40 +55,6 @@ namespace alpaka
 #    pragma acc parallel loop vector default(present) deviceptr(gridsLock)
                 for(std::size_t a = 0; a < 2; ++a)
                     gridsLock[a] = 0u;
-            }
-
-            ALPAKA_FN_HOST auto getAllExistingQueues() const
-                -> std::vector<std::shared_ptr<IGenericThreadsQueue<DevOacc>>>
-            {
-                std::vector<std::shared_ptr<IGenericThreadsQueue<DevOacc>>> vspQueues;
-
-                std::lock_guard<std::mutex> lk(m_Mutex);
-                vspQueues.reserve(std::size(m_queues));
-
-                for(auto it = std::begin(m_queues); it != std::end(m_queues);)
-                {
-                    auto spQueue(it->lock());
-                    if(spQueue)
-                    {
-                        vspQueues.emplace_back(std::move(spQueue));
-                        ++it;
-                    }
-                    else
-                    {
-                        it = m_queues.erase(it);
-                    }
-                }
-                return vspQueues;
-            }
-
-            //! Registers the given queue on this device.
-            //! NOTE: Every queue has to be registered for correct functionality of device wait operations!
-            ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<IGenericThreadsQueue<DevOacc>> spQueue) -> void
-            {
-                std::lock_guard<std::mutex> lk(m_Mutex);
-
-                // Register this queue on the device.
-                m_queues.push_back(std::move(spQueue));
             }
 
             [[nodiscard]] auto getNativeHandle() const noexcept -> int
@@ -128,8 +95,6 @@ namespace alpaka
             }
 
         private:
-            std::mutex mutable m_Mutex;
-            std::vector<std::weak_ptr<IGenericThreadsQueue<DevOacc>>> mutable m_queues;
             acc_device_t m_deviceType;
             int m_iDevice;
             std::uint32_t* m_gridsLock = nullptr;

--- a/include/alpaka/dev/DevOacc.hpp
+++ b/include/alpaka/dev/DevOacc.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Jan Stephan, Bernhard Manfred Gruber, Antonio Di Pilato
+/* Copyright 2022 Benjamin Worpitz, Jan Stephan, Bernhard Manfred Gruber, Antonio Di Pilato, Jeffrey Kelling
  *
  * This file is part of Alpaka.
  *
@@ -44,7 +44,7 @@ namespace alpaka
     namespace oacc::detail
     {
         //! The OpenACC device implementation.
-        class DevOaccImpl : public : alpaka::detail::QueueRegistry<IGenericThreadsQueue<DevOmp5>>
+        class DevOaccImpl : public alpaka::detail::QueueRegistry<IGenericThreadsQueue<DevOacc>>
         {
         public:
             DevOaccImpl(int iDevice) noexcept : m_deviceType(::acc_get_device_type()), m_iDevice(iDevice)
@@ -185,6 +185,11 @@ namespace alpaka
         ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<IGenericThreadsQueue<DevOacc>> spQueue) const -> void
         {
             m_devOaccImpl->registerQueue(spQueue);
+        }
+
+        auto registerCleanup(oacc::detail::DevOaccImpl::CleanerFunctor c) const -> void
+        {
+            m_devOaccImpl->registerCleanup(c);
         }
 
     private:

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Jan Stephan, Bernhard Manfred Gruber, Antonio Di Pilato
+/* Copyright 2022 Benjamin Worpitz, Jan Stephan, Bernhard Manfred Gruber, Antonio Di Pilato, Jeffrey Kelling
  *
  * This file is part of Alpaka.
  *
@@ -17,6 +17,7 @@
 
 #    include <alpaka/core/Omp5.hpp>
 #    include <alpaka/dev/Traits.hpp>
+#    include <alpaka/dev/common/QueueRegistry.hpp>
 #    include <alpaka/mem/buf/Traits.hpp>
 #    include <alpaka/pltf/Traits.hpp>
 #    include <alpaka/queue/Properties.hpp>
@@ -47,7 +48,7 @@ namespace alpaka
     namespace omp5::detail
     {
         //! The Omp5 device implementation.
-        class DevOmp5Impl
+        class DevOmp5Impl : public : alpaka::detail::QueueRegistry<IGenericThreadsQueue<DevOmp5>>
         {
         public:
             DevOmp5Impl(int iDevice) noexcept : m_iDevice(iDevice)
@@ -57,40 +58,6 @@ namespace alpaka
             {
                 for(auto& a : m_staticMemMap)
                     omp_target_free(a.second.first, getNativeHandle());
-            }
-
-            ALPAKA_FN_HOST auto getAllExistingQueues() const
-                -> std::vector<std::shared_ptr<IGenericThreadsQueue<DevOmp5>>>
-            {
-                std::vector<std::shared_ptr<IGenericThreadsQueue<DevOmp5>>> vspQueues;
-
-                std::lock_guard<std::mutex> lk(m_Mutex);
-                vspQueues.reserve(std::size(m_queues));
-
-                for(auto it = std::begin(m_queues); it != std::end(m_queues);)
-                {
-                    auto spQueue(it->lock());
-                    if(spQueue)
-                    {
-                        vspQueues.emplace_back(std::move(spQueue));
-                        ++it;
-                    }
-                    else
-                    {
-                        it = m_queues.erase(it);
-                    }
-                }
-                return vspQueues;
-            }
-
-            //! Registers the given queue on this device.
-            //! NOTE: Every queue has to be registered for correct functionality of device wait operations!
-            ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<IGenericThreadsQueue<DevOmp5>> spQueue) -> void
-            {
-                std::lock_guard<std::mutex> lk(m_Mutex);
-
-                // Register this queue on the device.
-                m_queues.push_back(spQueue);
             }
 
             [[nodiscard]] auto getNativeHandle() const noexcept -> int
@@ -129,8 +96,6 @@ namespace alpaka
             }
 
         private:
-            std::mutex mutable m_Mutex;
-            std::vector<std::weak_ptr<IGenericThreadsQueue<DevOmp5>>> mutable m_queues;
             const int m_iDevice;
 
             std::map<void*, std::pair<void*, std::size_t>> m_staticMemMap;

--- a/include/alpaka/dev/DevOmp5.hpp
+++ b/include/alpaka/dev/DevOmp5.hpp
@@ -48,7 +48,7 @@ namespace alpaka
     namespace omp5::detail
     {
         //! The Omp5 device implementation.
-        class DevOmp5Impl : public : alpaka::detail::QueueRegistry<IGenericThreadsQueue<DevOmp5>>
+        class DevOmp5Impl : public alpaka::detail::QueueRegistry<IGenericThreadsQueue<DevOmp5>>
         {
         public:
             DevOmp5Impl(int iDevice) noexcept : m_iDevice(iDevice)
@@ -145,6 +145,11 @@ namespace alpaka
         ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<IGenericThreadsQueue<DevOmp5>> spQueue) const -> void
         {
             m_spDevOmp5Impl->registerQueue(spQueue);
+        }
+
+        auto registerCleanup(omp5::detail::DevOmp5Impl::CleanerFunctor c) const -> void
+        {
+            m_spDevOmp5Impl->registerCleanup(c);
         }
 
     public:

--- a/include/alpaka/dev/common/QueueRegistry.hpp
+++ b/include/alpaka/dev/common/QueueRegistry.hpp
@@ -1,0 +1,65 @@
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Jeffrey Kelling
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/core/Common.hpp>
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace alpaka
+{
+    namespace detail
+    {
+        //! The CPU device implementation.
+        template<typename TQueue>
+        class QueueRegistry
+        {
+        public:
+            ALPAKA_FN_HOST auto getAllExistingQueues() const -> std::vector<std::shared_ptr<TQueue>>
+            {
+                std::vector<std::shared_ptr<TQueue>> vspQueues;
+
+                std::lock_guard<std::mutex> lk(m_Mutex);
+                vspQueues.reserve(std::size(m_queues));
+
+                for(auto it = std::begin(m_queues); it != std::end(m_queues);)
+                {
+                    auto spQueue(it->lock());
+                    if(spQueue)
+                    {
+                        vspQueues.emplace_back(std::move(spQueue));
+                        ++it;
+                    }
+                    else
+                    {
+                        it = m_queues.erase(it);
+                    }
+                }
+                return vspQueues;
+            }
+
+            //! Registers the given queue on this device.
+            //! NOTE: Every queue has to be registered for correct functionality of device wait operations!
+            ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<TQueue> spQueue) const -> void
+            {
+                std::lock_guard<std::mutex> lk(m_Mutex);
+
+                // Register this queue on the device.
+                m_queues.push_back(spQueue);
+            }
+
+        private:
+            std::mutex mutable m_Mutex;
+            std::vector<std::weak_ptr<TQueue>> mutable m_queues;
+        };
+    } // namespace detail
+} // namespace alpaka

--- a/include/alpaka/event/EventGenericThreads.hpp
+++ b/include/alpaka/event/EventGenericThreads.hpp
@@ -154,7 +154,7 @@ namespace alpaka
                     auto const enqueueCount = spEventImpl->m_enqueueCount;
 
                     // Enqueue a task that only resets the events flag if it is completed.
-                    spEventImpl->m_future = queueImpl.m_workerThread.enqueueTask(
+                    spEventImpl->m_future = queueImpl.m_workerThread->enqueueTask(
                         [spEventImpl, enqueueCount]()
                         {
                             std::unique_lock<std::mutex> lk2(spEventImpl->m_mutex);
@@ -314,7 +314,7 @@ namespace alpaka
                     auto const enqueueCount = spEventImpl->m_enqueueCount;
 
                     // Enqueue a task that waits for the given event.
-                    queueImpl.m_workerThread.enqueueTask(
+                    queueImpl.m_workerThread->enqueueTask(
                         [spEventImpl, enqueueCount]()
                         {
                             std::unique_lock<std::mutex> lk2(spEventImpl->m_mutex);

--- a/include/alpaka/kernel/TaskKernelOacc.hpp
+++ b/include/alpaka/kernel/TaskKernelOacc.hpp
@@ -226,8 +226,8 @@ namespace alpaka
                 QueueOaccNonBlocking& queue,
                 TaskKernelOacc<TDim, TIdx, TKernelFnObj, TArgs...> const& task) -> void
             {
-                queue.m_spQueueImpl->m_workerThread.enqueueTask([&queue, task]()
-                                                                { task(queue.m_spQueueImpl->m_dev); });
+                queue.m_spQueueImpl->m_workerThread->enqueueTask([&queue, task]()
+                                                                 { task(queue.m_spQueueImpl->m_dev); });
             }
         };
     } // namespace trait

--- a/include/alpaka/kernel/TaskKernelOmp5.hpp
+++ b/include/alpaka/kernel/TaskKernelOmp5.hpp
@@ -261,8 +261,8 @@ namespace alpaka
                 QueueOmp5NonBlocking& queue,
                 TaskKernelOmp5<TDim, TIdx, TKernelFnObj, TArgs...> const& task) -> void
             {
-                queue.m_spQueueImpl->m_workerThread.enqueueTask([&queue, task]()
-                                                                { task(queue.m_spQueueImpl->m_dev); });
+                queue.m_spQueueImpl->m_workerThread->enqueueTask([&queue, task]()
+                                                                 { task(queue.m_spQueueImpl->m_dev); });
             }
         };
     } // namespace trait

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -276,12 +276,10 @@ namespace alpaka
                 {
                     alpaka::enqueue(
                         queue,
-                        [ptr, queue]()
+                        [ptr]()
                         {
                             // free the memory
                             alpaka::free(Allocator{}, ptr);
-                            // keep the queue alive until all memory operations are complete
-                            [&queue = std::as_const(queue)]() {}();
                         });
                 };
 

--- a/include/alpaka/queue/QueueGenericThreadsNonBlocking.hpp
+++ b/include/alpaka/queue/QueueGenericThreadsNonBlocking.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, Jan Stephan, Bernhard Manfred Gruber, Jeffrey Kelling
  *
  * This file is part of alpaka.
  *
@@ -57,12 +57,21 @@ namespace alpaka
                     false>; // If the threads should yield.
 
             public:
-                explicit QueueGenericThreadsNonBlockingImpl(TDev dev) : m_dev(std::move(dev)), m_workerThread(1u)
+                explicit QueueGenericThreadsNonBlockingImpl(TDev dev)
+                    : m_dev(std::move(dev))
+                    , m_workerThread(std::make_unique<ThreadPool>(1u))
                 {
                 }
                 QueueGenericThreadsNonBlockingImpl(QueueGenericThreadsNonBlockingImpl<TDev> const&) = delete;
+                QueueGenericThreadsNonBlockingImpl(QueueGenericThreadsNonBlockingImpl<TDev>&&) = delete;
                 auto operator=(QueueGenericThreadsNonBlockingImpl<TDev> const&)
                     -> QueueGenericThreadsNonBlockingImpl<TDev>& = delete;
+                auto operator=(QueueGenericThreadsNonBlockingImpl&&)
+                    -> QueueGenericThreadsNonBlockingImpl<TDev>& = delete;
+                ~QueueGenericThreadsNonBlockingImpl() override
+                {
+                    m_workerThread->detach(std::move(m_workerThread));
+                }
 
                 void enqueue(EventGenericThreads<TDev>& ev) final
                 {
@@ -77,7 +86,7 @@ namespace alpaka
             public:
                 TDev const m_dev; //!< The device this queue is bound to.
 
-                ThreadPool m_workerThread;
+                std::unique_ptr<ThreadPool> m_workerThread;
             };
         } // namespace detail
     } // namespace generic
@@ -148,7 +157,7 @@ namespace alpaka
                 // ConcurrentExecPool.hpp.
                 if constexpr(!((BOOST_COMP_CLANG_CUDA != BOOST_VERSION_NUMBER_NOT_AVAILABLE)
                                && (BOOST_ARCH_PTX != BOOST_VERSION_NUMBER_NOT_AVAILABLE)))
-                    queue.m_spQueueImpl->m_workerThread.enqueueTask(task);
+                    queue.m_spQueueImpl->m_workerThread->enqueueTask(task);
             }
         };
         //! The CPU non-blocking device queue test trait specialization.
@@ -157,7 +166,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto empty(QueueGenericThreadsNonBlocking<TDev> const& queue) -> bool
             {
-                return queue.m_spQueueImpl->m_workerThread.isIdle();
+                return queue.m_spQueueImpl->m_workerThread->isIdle();
             }
         };
     } // namespace trait

--- a/include/alpaka/queue/QueueGenericThreadsNonBlocking.hpp
+++ b/include/alpaka/queue/QueueGenericThreadsNonBlocking.hpp
@@ -70,6 +70,15 @@ namespace alpaka
                     -> QueueGenericThreadsNonBlockingImpl<TDev>& = delete;
                 ~QueueGenericThreadsNonBlockingImpl() override
                 {
+                    m_dev.registerCleanup(
+                        [pool = std::weak_ptr<ThreadPool>(m_workerThread)]() noexcept
+                        {
+                            auto s = pool.lock();
+                            if(s)
+                            {
+                                s = s->takeDetachHandle();
+                            }
+                        });
                     m_workerThread->detach(std::move(m_workerThread));
                 }
 
@@ -86,7 +95,7 @@ namespace alpaka
             public:
                 TDev const m_dev; //!< The device this queue is bound to.
 
-                std::unique_ptr<ThreadPool> m_workerThread;
+                std::shared_ptr<ThreadPool> m_workerThread;
             };
         } // namespace detail
     } // namespace generic

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -221,7 +221,7 @@ namespace alpaka::trait
             auto const enqueueCount = spEventImpl->m_enqueueCount;
 
             // Enqueue a task that only resets the events flag if it is completed.
-            queue.m_spQueueImpl->m_workerThread.enqueueTask(
+            queue.m_spQueueImpl->m_workerThread->enqueueTask(
                 [spEventImpl, enqueueCount]()
                 {
                     std::unique_lock<std::mutex> lk2(spEventImpl->m_mutex);


### PR DESCRIPTION
The deleter task of BudCpu dioes not need to hold a `shared_ptr` to the queue, because the queue manages the task, not vice-versa.

Also: bundling the removal of an `std::move()`  from a `return` statement from `TaskPkg` (belonging to `ConcurrentExecPool`) in here, which I came across investigating the issue. (I think this is too small of a fix for its own PR, thugh: *do not squash this*)

Replaces https://github.com/alpaka-group/alpaka/pull/1727

Closes https://github.com/alpaka-group/alpaka/issues/1726