### PR TITLE
Fix mixed-type and mixed-precision pow() implementation

### DIFF
--- a/include/alpaka/math/Complex.hpp
+++ b/include/alpaka/math/Complex.hpp
@@ -501,25 +501,28 @@ namespace alpaka
     //! Complex power of a complex number
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename T, typename U>
-    constexpr ALPAKA_FN_HOST_ACC Complex<T> pow(Complex<T> const& x, Complex<U> const& y)
+    constexpr ALPAKA_FN_HOST_ACC auto pow(Complex<T> const& x, Complex<U> const& y)
     {
-        return std::pow(std::complex<T>(x), std::complex<U>(y));
+        // Use same type promotion as std::pow
+        auto const result = std::pow(std::complex<T>(x), std::complex<U>(y));
+        using ValueType = typename decltype(result)::value_type;
+        return Complex<ValueType>(result);
     }
 
     //! Real power of a complex number
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename T, typename U>
-    constexpr ALPAKA_FN_HOST_ACC Complex<T> pow(Complex<T> const& x, U const& y)
+    constexpr ALPAKA_FN_HOST_ACC auto pow(Complex<T> const& x, U const& y)
     {
-        return std::pow(std::complex<T>(x), y);
+        return pow(x, Complex<U>(y));
     }
 
     //! Complex power of a real number
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename T, typename U>
-    constexpr ALPAKA_FN_HOST_ACC Complex<T> pow(T const& x, Complex<U> const& y)
+    constexpr ALPAKA_FN_HOST_ACC auto pow(T const& x, Complex<U> const& y)
     {
-        return std::pow(x, std::complex<U>(y));
+        return pow(Complex<T>(x), y);
     }
 
     //! Projection onto the Riemann sphere

--- a/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
@@ -739,8 +739,12 @@ namespace alpaka::math
             template<typename TCtx>
             __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& base, Complex<U> const& exponent)
             {
+                // Type promotion matching rules of complex std::pow but simplified given our math only supports float
+                // and double, no long double.
+                using Promoted
+                    = Complex<std::conditional_t<is_decayed_v<T, float> && is_decayed_v<U, float>, float, double>>;
                 // pow(z1, z2) = e^(z2 * log(z1))
-                return exp(ctx, exponent * log(ctx, base));
+                return exp(ctx, Promoted{exponent} * log(ctx, Promoted{base}));
             }
         };
 

--- a/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
@@ -721,7 +721,7 @@ namespace alpaka::math
                 if constexpr(is_decayed_v<TBase, float> && is_decayed_v<TExp, float>)
                     return ::powf(base, exp);
                 else if constexpr(is_decayed_v<TBase, double> || is_decayed_v<TExp, double>)
-                    return ::pow(base, exp);
+                    return ::pow(static_cast<double>(base), static_cast<double>(exp));
                 else
                     static_assert(!sizeof(TBase), "Unsupported data type");
 

--- a/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
@@ -748,6 +748,30 @@ namespace alpaka::math
             }
         };
 
+        //! The CUDA pow trait specialization for complex and real types.
+        template<typename T, typename U>
+        struct Pow<PowUniformCudaHipBuiltIn, Complex<T>, U>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& base, U const& exponent)
+            {
+                return pow(ctx, base, Complex<U>{exponent});
+            }
+        };
+
+        //! The CUDA pow trait specialization for real and complex types.
+        template<typename T, typename U>
+        struct Pow<PowUniformCudaHipBuiltIn, T, Complex<U>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            __host__ __device__ auto operator()(TCtx const& ctx, T const& base, Complex<U> const& exponent)
+            {
+                return pow(ctx, Complex<T>{base}, exponent);
+            }
+        };
+
         //! The CUDA remainder trait specialization.
         template<typename Tx, typename Ty>
         struct Remainder<

--- a/test/unit/math/src/Defines.hpp
+++ b/test/unit/math/src/Defines.hpp
@@ -98,6 +98,26 @@ namespace alpaka
                     return arg1 + arg2;
                 }
 
+                // https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
+                template<typename TAcc, typename FP>
+                ALPAKA_FN_ACC auto almost_equal(TAcc const& acc, FP x, FP y, int ulp)
+                    -> std::enable_if_t<!std::numeric_limits<FP>::is_integer, bool>
+                {
+                    // the machine epsilon has to be scaled to the magnitude of the values used
+                    // and multiplied by the desired precision in ULPs (units in the last place)
+                    return alpaka::math::abs(acc, x - y)
+                        <= std::numeric_limits<FP>::epsilon() * alpaka::math::abs(acc, x + y) * static_cast<FP>(ulp)
+                        // unless the result is subnormal
+                        || alpaka::math::abs(acc, x - y) < std::numeric_limits<FP>::min();
+                }
+
+                //! Version for alpaka::Complex
+                template<typename TAcc, typename FP>
+                ALPAKA_FN_ACC bool almost_equal(TAcc const& acc, alpaka::Complex<FP> x, alpaka::Complex<FP> y, int ulp)
+                {
+                    return almost_equal(acc, x.real(), y.real(), ulp) && almost_equal(acc, x.imag(), y.imag(), ulp);
+                }
+
             } // namespace math
         } // namespace unit
     } // namespace test

--- a/test/unit/math/src/powMixedTypes.cpp
+++ b/test/unit/math/src/powMixedTypes.cpp
@@ -7,6 +7,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include "Defines.hpp"
+
 #include <alpaka/math/Traits.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 #include <alpaka/test/acc/TestAccs.hpp>
@@ -15,26 +17,6 @@
 #include <catch2/catch.hpp>
 
 #include <type_traits>
-
-// https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
-template<typename TAcc, typename FP>
-ALPAKA_FN_ACC auto almost_equal(TAcc const& acc, FP x, FP y, int ulp)
-    -> std::enable_if_t<!std::numeric_limits<FP>::is_integer, bool>
-{
-    // the machine epsilon has to be scaled to the magnitude of the values used
-    // and multiplied by the desired precision in ULPs (units in the last place)
-    return alpaka::math::abs(acc, x - y)
-        <= std::numeric_limits<FP>::epsilon() * alpaka::math::abs(acc, x + y) * static_cast<FP>(ulp)
-        // unless the result is subnormal
-        || alpaka::math::abs(acc, x - y) < std::numeric_limits<FP>::min();
-}
-
-//! Version for alpaka::Complex
-template<typename TAcc, typename FP>
-ALPAKA_FN_ACC bool almost_equal(TAcc const& acc, alpaka::Complex<FP> x, alpaka::Complex<FP> y, int ulp)
-{
-    return almost_equal(acc, x.real(), y.real(), ulp) && almost_equal(acc, x.imag(), y.imag(), ulp);
-}
 
 template<typename TExpected>
 class PowMixedTypesTestKernel
@@ -46,6 +28,7 @@ public:
     {
         auto expected = alpaka::math::pow(acc, TExpected{arg1}, TExpected{arg2});
         auto actual = alpaka::math::pow(acc, arg1, arg2);
+        using alpaka::test::unit::math::almost_equal;
         ALPAKA_CHECK(*success, almost_equal(acc, expected, actual, 1));
     }
 };

--- a/test/unit/math/src/powMixedTypes.cpp
+++ b/test/unit/math/src/powMixedTypes.cpp
@@ -1,0 +1,84 @@
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred Gruber, Sergei Bastrakov
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <alpaka/math/Traits.hpp>
+#include <alpaka/test/KernelExecutionFixture.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
+#include <alpaka/test/queue/Queue.hpp>
+
+#include <catch2/catch.hpp>
+
+#include <type_traits>
+
+// https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
+template<typename TAcc, typename FP>
+ALPAKA_FN_ACC auto almost_equal(TAcc const& acc, FP x, FP y, int ulp)
+    -> std::enable_if_t<!std::numeric_limits<FP>::is_integer, bool>
+{
+    // the machine epsilon has to be scaled to the magnitude of the values used
+    // and multiplied by the desired precision in ULPs (units in the last place)
+    return alpaka::math::abs(acc, x - y)
+        <= std::numeric_limits<FP>::epsilon() * alpaka::math::abs(acc, x + y) * static_cast<FP>(ulp)
+        // unless the result is subnormal
+        || alpaka::math::abs(acc, x - y) < std::numeric_limits<FP>::min();
+}
+
+//! Version for alpaka::Complex
+template<typename TAcc, typename FP>
+ALPAKA_FN_ACC bool almost_equal(TAcc const& acc, alpaka::Complex<FP> x, alpaka::Complex<FP> y, int ulp)
+{
+    return almost_equal(acc, x.real(), y.real(), ulp) && almost_equal(acc, x.imag(), y.imag(), ulp);
+}
+
+template<typename TExpected>
+class PowMixedTypesTestKernel
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAcc, typename TArg1, typename TArg2>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, TArg1 const arg1, TArg2 const arg2) const -> void
+    {
+        auto expected = alpaka::math::pow(acc, TExpected{arg1}, TExpected{arg2});
+        auto actual = alpaka::math::pow(acc, arg1, arg2);
+        ALPAKA_CHECK(*success, almost_equal(acc, expected, actual, 1));
+    }
+};
+
+using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, std::size_t>;
+
+TEMPLATE_LIST_TEST_CASE("powMixedTypes", "[powMixedTypes]", TestAccs)
+{
+    using Acc = TestType;
+    using Dim = alpaka::Dim<Acc>;
+    using Idx = alpaka::Idx<Acc>;
+
+    alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::ones());
+
+    PowMixedTypesTestKernel<float> kernelFloat;
+    PowMixedTypesTestKernel<double> kernelDouble;
+    PowMixedTypesTestKernel<alpaka::Complex<float>> kernelComplexFloat;
+    PowMixedTypesTestKernel<alpaka::Complex<double>> kernelComplexDouble;
+
+    float const floatArg = 0.35f;
+    double const doubleArg = 0.24;
+    alpaka::Complex<float> floatComplexArg{0.35f, -0.24f};
+    alpaka::Complex<double> doubleComplexArg{0.35, -0.24};
+
+    // all combinations of pow(real, real)
+    REQUIRE(fixture(kernelFloat, floatArg, floatArg));
+    REQUIRE(fixture(kernelDouble, floatArg, doubleArg));
+    REQUIRE(fixture(kernelDouble, doubleArg, floatArg));
+    REQUIRE(fixture(kernelDouble, doubleArg, doubleArg));
+
+    // all combinations of pow(complex, complex)
+    REQUIRE(fixture(kernelComplexFloat, floatComplexArg, floatComplexArg));
+    REQUIRE(fixture(kernelComplexDouble, floatComplexArg, doubleComplexArg));
+    REQUIRE(fixture(kernelComplexDouble, doubleComplexArg, floatComplexArg));
+    REQUIRE(fixture(kernelComplexDouble, doubleComplexArg, doubleComplexArg));
+}

--- a/test/unit/math/src/powMixedTypes.cpp
+++ b/test/unit/math/src/powMixedTypes.cpp
@@ -76,6 +76,18 @@ TEMPLATE_LIST_TEST_CASE("powMixedTypes", "[powMixedTypes]", TestAccs)
     REQUIRE(fixture(kernelDouble, doubleArg, floatArg));
     REQUIRE(fixture(kernelDouble, doubleArg, doubleArg));
 
+    // all combinations of pow(real, complex)
+    REQUIRE(fixture(kernelComplexFloat, floatArg, floatComplexArg));
+    REQUIRE(fixture(kernelComplexDouble, floatArg, doubleComplexArg));
+    REQUIRE(fixture(kernelComplexDouble, doubleArg, floatComplexArg));
+    REQUIRE(fixture(kernelComplexDouble, doubleArg, doubleComplexArg));
+
+    // all combinations of pow(complex, real)
+    REQUIRE(fixture(kernelComplexFloat, floatComplexArg, floatArg));
+    REQUIRE(fixture(kernelComplexDouble, floatComplexArg, doubleArg));
+    REQUIRE(fixture(kernelComplexDouble, doubleComplexArg, floatArg));
+    REQUIRE(fixture(kernelComplexDouble, doubleComplexArg, doubleArg));
+
     // all combinations of pow(complex, complex)
     REQUIRE(fixture(kernelComplexFloat, floatComplexArg, floatComplexArg));
     REQUIRE(fixture(kernelComplexDouble, floatComplexArg, doubleComplexArg));


### PR DESCRIPTION
Fix issues #1731 and #1732, also add tests to cover these cases.

Edit: originally the PR concerned only implementation of `pow()` for `Complex<>`, but as it became clear with tests, there was also an issue for mixed `float`-`double` `pow` on CUDA/HIP. So the PR is now mostly, but not fully, for `Complex`.