### PR TITLE
Remove concept ConceptUniformCudaHip

### DIFF
--- a/include/alpaka/acc/Traits.hpp
+++ b/include/alpaka/acc/Traits.hpp
@@ -25,10 +25,6 @@
 
 namespace alpaka
 {
-    struct ConceptUniformCudaHip
-    {
-    };
-
     struct ConceptAcc
     {
     };
@@ -54,18 +50,6 @@ namespace alpaka
                 return typeid(TAcc).name();
             }
         };
-
-        //! The GPU CUDA accelerator device properties get trait specialization.
-        template<typename TAcc>
-        struct GetAccDevProps<TAcc, std::enable_if_t<concepts::ImplementsConcept<ConceptUniformCudaHip, TAcc>::value>>
-        {
-            ALPAKA_FN_HOST static auto getAccDevProps(typename alpaka::trait::DevType<TAcc>::type const& dev)
-                -> AccDevProps<typename trait::DimType<TAcc>::type, typename trait::IdxType<TAcc>::type>
-            {
-                using ImplementationBase = typename concepts::ImplementationBase<ConceptUniformCudaHip, TAcc>;
-                return GetAccDevProps<ImplementationBase>::getAccDevProps(dev);
-            }
-        };
     } // namespace trait
 
     //! The accelerator type trait alias template to remove the ::type.
@@ -89,56 +73,8 @@ namespace alpaka
         return trait::GetAccName<TAcc>::getAccName();
     }
 
-    namespace detail
-    {
-        template<typename TAcc>
-        struct CheckFnReturnType<
-            TAcc,
-            std::enable_if_t<concepts::ImplementsConcept<ConceptUniformCudaHip, TAcc>::value>>
-        {
-            template<typename TKernelFnObj, typename... TArgs>
-            void operator()(TKernelFnObj const& kernelFnObj, TArgs const&... args)
-            {
-                using ImplementationBase = typename concepts::ImplementationBase<ConceptUniformCudaHip, TAcc>;
-                CheckFnReturnType<ImplementationBase>{}(kernelFnObj, args...);
-            }
-        };
-    } // namespace detail
-
     namespace trait
     {
-        //! The GPU HIP accelerator device type trait specialization.
-        template<typename TAcc>
-        struct DevType<TAcc, std::enable_if_t<concepts::ImplementsConcept<ConceptUniformCudaHip, TAcc>::value>>
-        {
-            using ImplementationBase = typename concepts::ImplementationBase<ConceptUniformCudaHip, TAcc>;
-            using type = typename DevType<ImplementationBase>::type;
-        };
-
-        //! The CPU HIP execution task platform type trait specialization.
-        template<typename TAcc>
-        struct PltfType<TAcc, std::enable_if_t<concepts::ImplementsConcept<ConceptUniformCudaHip, TAcc>::value>>
-        {
-            using ImplementationBase = typename concepts::ImplementationBase<ConceptUniformCudaHip, TAcc>;
-            using type = typename PltfType<ImplementationBase>::type;
-        };
-
-        //! The GPU HIP accelerator dimension getter trait specialization.
-        template<typename TAcc>
-        struct DimType<TAcc, std::enable_if_t<concepts::ImplementsConcept<ConceptUniformCudaHip, TAcc>::value>>
-        {
-            using ImplementationBase = typename concepts::ImplementationBase<ConceptUniformCudaHip, TAcc>;
-            using type = typename DimType<ImplementationBase>::type;
-        };
-
-        //! The GPU HIP accelerator idx type trait specialization.
-        template<typename TAcc>
-        struct IdxType<TAcc, std::enable_if_t<concepts::ImplementsConcept<ConceptUniformCudaHip, TAcc>::value>>
-        {
-            using ImplementationBase = typename concepts::ImplementationBase<ConceptUniformCudaHip, TAcc>;
-            using type = typename IdxType<ImplementationBase>::type;
-        };
-
         template<typename TAcc, typename TProperty>
         struct QueueType<TAcc, TProperty, std::enable_if_t<concepts::ImplementsConcept<ConceptAcc, TAcc>::value>>
         {


### PR DESCRIPTION
With refactoring #1665 the concept `ConceptUniformCudaHip` is no longer used, therefore it is removed completely.

Note: I thought about giving `TaskKernelGpuUniformCudaHipRt` this concept because w use the concept in `malloMC` https://github.com/alpaka-group/mallocMC/blob/bb2b32a4a56f7c892e14454bf6aa373a4870c32c/src/include/mallocMC/mallocMC_utils.hpp#L266-L267 
but decided against it.
