### PR TITLE
Allow temporary destination views in memset/memcpy

### DIFF
--- a/include/alpaka/mem/buf/oacc/Set.hpp
+++ b/include/alpaka/mem/buf/oacc/Set.hpp
@@ -42,9 +42,10 @@ namespace alpaka::trait
     template<typename TDim>
     struct CreateTaskMemset<TDim, DevOacc>
     {
-        template<typename TExtent, typename TView>
-        ALPAKA_FN_HOST static auto createTaskMemset(TView& view, std::uint8_t const& byte, TExtent const& extent)
+        template<typename TExtent, typename TViewFwd>
+        ALPAKA_FN_HOST static auto createTaskMemset(TViewFwd&& view, std::uint8_t const& byte, TExtent const& extent)
         {
+            using TView = std::remove_reference_t<TViewFwd>;
             using Idx = typename trait::IdxType<TExtent>::type;
             auto pitch = getPitchBytesVec(view);
             auto byteExtent = getExtentVec(extent);
@@ -89,9 +90,13 @@ namespace alpaka::trait
     template<>
     struct CreateTaskMemset<DimInt<0u>, DevOacc>
     {
-        template<typename TExtent, typename TView>
-        ALPAKA_FN_HOST static auto createTaskMemset(TView& view, std::uint8_t const& byte, TExtent const& /* extent */)
+        template<typename TExtent, typename TViewFwd>
+        ALPAKA_FN_HOST static auto createTaskMemset(
+            TViewFwd&& view,
+            std::uint8_t const& byte,
+            TExtent const& /* extent */)
         {
+            using TView = std::remove_reference_t<TViewFwd>;
             static_assert(Dim<TView>::value == 0u, "The view is required to have dimensionality 0!");
             static_assert(Dim<TExtent>::value == 0u, "The extent is required to have dimensionality 0!");
 

--- a/include/alpaka/mem/buf/omp5/Set.hpp
+++ b/include/alpaka/mem/buf/omp5/Set.hpp
@@ -42,9 +42,10 @@ namespace alpaka::trait
     template<typename TDim>
     struct CreateTaskMemset<TDim, DevOmp5>
     {
-        template<typename TExtent, typename TView>
-        ALPAKA_FN_HOST static auto createTaskMemset(TView& view, std::uint8_t const& byte, TExtent const& extent)
+        template<typename TExtent, typename TViewFwd>
+        ALPAKA_FN_HOST static auto createTaskMemset(TViewFwd&& view, std::uint8_t const& byte, TExtent const& extent)
         {
+            using TView = std::remove_reference_t<TViewFwd>;
             using Idx = typename alpaka::trait::IdxType<TExtent>::type;
             auto pitch = getPitchBytesVec(view);
             auto byteExtent = getExtentVec(extent);
@@ -91,9 +92,13 @@ namespace alpaka::trait
     template<>
     struct CreateTaskMemset<DimInt<0u>, DevOmp5>
     {
-        template<typename TExtent, typename TView>
-        ALPAKA_FN_HOST static auto createTaskMemset(TView& view, std::uint8_t const& byte, TExtent const& /* extent */)
+        template<typename TExtent, typename TViewFwd>
+        ALPAKA_FN_HOST static auto createTaskMemset(
+            TViewFwd&& view,
+            std::uint8_t const& byte,
+            TExtent const& /* extent */)
         {
+            using TView = std::remove_reference_t<TViewFwd>;
             static_assert(Dim<TView>::value == 0u, "The view is required to have dimensionality 0!");
             static_assert(Dim<TExtent>::value == 0u, "The extent is required to have dimensionality 0!");
 

--- a/include/alpaka/mem/buf/sycl/Copy.hpp
+++ b/include/alpaka/mem/buf/sycl/Copy.hpp
@@ -75,8 +75,8 @@ namespace alpaka::trait
     template<typename TDim, typename TPltf>
     struct CreateTaskMemcpy<TDim, experimental::DevGenericSycl<TPltf>, DevCpu>
     {
-        template<typename TExtent, typename TViewSrc, typename TViewDst>
-        static auto createTaskMemcpy(TViewDst& viewDst, TViewSrc const& viewSrc, TExtent const& ext)
+        template<typename TExtent, typename TViewSrc, typename TViewDstFwd>
+        static auto createTaskMemcpy(TViewDstFwd&& viewDst, TViewSrc const& viewSrc, TExtent const& ext)
         {
             ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
@@ -85,6 +85,7 @@ namespace alpaka::trait
             using SrcType = ElemType const*;
             using DstType = alpaka::experimental::detail::DstAccessor<ElemType, copy_dim>;
 
+            using TViewDst = std::remove_reference_t<TViewDstFwd>;
             static_assert(!std::is_const_v<TViewDst>, "The destination view cannot be const!");
 
             static_assert(
@@ -112,8 +113,8 @@ namespace alpaka::trait
     template<typename TDim, typename TPltf>
     struct CreateTaskMemcpy<TDim, DevCpu, experimental::DevGenericSycl<TPltf>>
     {
-        template<typename TExtent, typename TViewSrc, typename TViewDst>
-        static auto createTaskMemcpy(TViewDst& viewDst, TViewSrc const& viewSrc, TExtent const& ext)
+        template<typename TExtent, typename TViewSrc, typename TViewDstFwd>
+        static auto createTaskMemcpy(TViewDstFwd&& viewDst, TViewSrc const& viewSrc, TExtent const& ext)
         {
             ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
@@ -122,6 +123,7 @@ namespace alpaka::trait
             using SrcType = alpaka::experimental::detail::SrcAccessor<ElemType, copy_dim>;
             using DstType = ElemType*;
 
+            using TViewDst = std::remove_reference_t<TViewDstFwd>;
             static_assert(!std::is_const_v<TViewDst>, "The destination view cannot be const!");
 
             static_assert(
@@ -151,8 +153,8 @@ namespace alpaka::trait
     template<typename TDim, typename TPltfDst, typename TPltfSrc>
     struct CreateTaskMemcpy<TDim, experimental::DevGenericSycl<TPltfDst>, experimental::DevGenericSycl<TPltfSrc>>
     {
-        template<typename TExtent, typename TViewSrc, typename TViewDst>
-        static auto createTaskMemcpy(TViewDst& viewDst, TViewSrc const& viewSrc, TExtent const& ext)
+        template<typename TExtent, typename TViewSrc, typename TViewDstFwd>
+        static auto createTaskMemcpy(TViewDstFwd&& viewDst, TViewSrc const& viewSrc, TExtent const& ext)
         {
             ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
@@ -161,6 +163,7 @@ namespace alpaka::trait
             using SrcType = alpaka::experimental::detail::SrcAccessor<ElemType, copy_dim>;
             using DstType = alpaka::experimental::detail::DstAccessor<ElemType, copy_dim>;
 
+            using TViewDst = std::remove_reference_t<TViewDstFwd>;
             static_assert(!std::is_const_v<TViewDst>, "The destination view cannot be const!");
 
             static_assert(

--- a/include/alpaka/mem/buf/sycl/Set.hpp
+++ b/include/alpaka/mem/buf/sycl/Set.hpp
@@ -65,12 +65,13 @@ namespace alpaka
         template<typename TDim, typename TPltf>
         struct CreateTaskMemset<TDim, experimental::DevGenericSycl<TPltf>>
         {
-            template<typename TExtent, typename TView>
-            static auto createTaskMemset(TView& view, std::uint8_t const& byte, TExtent const& ext)
+            template<typename TExtent, typename TViewFwd>
+            static auto createTaskMemset(TViewFwd&& view, std::uint8_t const& byte, TExtent const& ext)
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                 constexpr auto set_dim = static_cast<int>(Dim<TExtent>::value);
+                using TView = std::remove_reference_t<TViewFwd>;
                 using ElemType = Elem<TView>;
                 using DstType = alpaka::experimental::detail::Accessor<set_dim>;
 

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -55,8 +55,9 @@ namespace alpaka
 
             using Idx = alpaka::Idx<TExtent>;
 
+            template<typename TViewDstFwd>
             ALPAKA_FN_HOST TaskCopyUniformCudaHip(
-                TViewDst& viewDst,
+                TViewDstFwd&& viewDst,
                 TViewSrc const& viewSrc,
                 [[maybe_unused]] TExtent const& extent,
                 typename TApi::MemcpyKind_t const& uniformMemCpyKind,
@@ -135,8 +136,9 @@ namespace alpaka
 
             using Idx = alpaka::Idx<TExtent>;
 
+            template<typename TViewDstFwd>
             ALPAKA_FN_HOST TaskCopyUniformCudaHip(
-                TViewDst& viewDst,
+                TViewDstFwd&& viewDst,
                 TViewSrc const& viewSrc,
                 TExtent const& extent,
                 typename TApi::MemcpyKind_t const& uniformMemCpyKind,
@@ -223,8 +225,9 @@ namespace alpaka
 
             using Idx = alpaka::Idx<TExtent>;
 
+            template<typename TViewDstFwd>
             ALPAKA_FN_HOST TaskCopyUniformCudaHip(
-                TViewDst& viewDst,
+                TViewDstFwd&& viewDst,
                 TViewSrc const& viewSrc,
                 TExtent const& extent,
                 typename TApi::MemcpyKind_t const& uniformMemcpyKind,
@@ -342,8 +345,9 @@ namespace alpaka
 
             using Idx = alpaka::Idx<TExtent>;
 
+            template<typename TViewDstFwd>
             ALPAKA_FN_HOST TaskCopyUniformCudaHip(
-                TViewDst& viewDst,
+                TViewDstFwd&& viewDst,
                 TViewSrc const& viewSrc,
                 TExtent const& extent,
                 typename TApi::MemcpyKind_t const& uniformMemcpyKind,
@@ -484,24 +488,24 @@ namespace alpaka
         template<typename TApi, typename TDim>
         struct CreateTaskMemcpy<TDim, DevCpu, DevUniformCudaHipRt<TApi>>
         {
-            template<typename TExtent, typename TViewSrc, typename TViewDst>
+            template<typename TExtent, typename TViewSrc, typename TViewDstFwd>
             ALPAKA_FN_HOST static auto createTaskMemcpy(
-                TViewDst& viewDst,
+                TViewDstFwd&& viewDst,
                 TViewSrc const& viewSrc,
-                TExtent const& extent)
-                -> alpaka::detail::TaskCopyUniformCudaHip<TApi, TDim, TViewDst, TViewSrc, TExtent>
+                TExtent const& extent) -> alpaka::detail::
+                TaskCopyUniformCudaHip<TApi, TDim, std::remove_reference_t<TViewDstFwd>, TViewSrc, TExtent>
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                 auto const iDevice = getDev(viewSrc).getNativeHandle();
 
-                return alpaka::detail::TaskCopyUniformCudaHip<TApi, TDim, TViewDst, TViewSrc, TExtent>(
-                    viewDst,
+                return {
+                    std::forward<TViewDstFwd>(viewDst),
                     viewSrc,
                     extent,
                     TApi::memcpyDeviceToHost,
                     iDevice,
-                    iDevice);
+                    iDevice};
             }
         };
 
@@ -509,24 +513,24 @@ namespace alpaka
         template<typename TApi, typename TDim>
         struct CreateTaskMemcpy<TDim, DevUniformCudaHipRt<TApi>, DevCpu>
         {
-            template<typename TExtent, typename TViewSrc, typename TViewDst>
+            template<typename TExtent, typename TViewSrc, typename TViewDstFwd>
             ALPAKA_FN_HOST static auto createTaskMemcpy(
-                TViewDst& viewDst,
+                TViewDstFwd&& viewDst,
                 TViewSrc const& viewSrc,
-                TExtent const& extent)
-                -> alpaka::detail::TaskCopyUniformCudaHip<TApi, TDim, TViewDst, TViewSrc, TExtent>
+                TExtent const& extent) -> alpaka::detail::
+                TaskCopyUniformCudaHip<TApi, TDim, std::remove_reference_t<TViewDstFwd>, TViewSrc, TExtent>
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                 auto const iDevice = getDev(viewDst).getNativeHandle();
 
-                return alpaka::detail::TaskCopyUniformCudaHip<TApi, TDim, TViewDst, TViewSrc, TExtent>(
-                    viewDst,
+                return {
+                    std::forward<TViewDstFwd>(viewDst),
                     viewSrc,
                     extent,
                     TApi::memcpyHostToDevice,
                     iDevice,
-                    iDevice);
+                    iDevice};
             }
         };
 
@@ -534,22 +538,24 @@ namespace alpaka
         template<typename TApi, typename TDim>
         struct CreateTaskMemcpy<TDim, DevUniformCudaHipRt<TApi>, DevUniformCudaHipRt<TApi>>
         {
-            template<typename TExtent, typename TViewSrc, typename TViewDst>
+            template<typename TExtent, typename TViewSrc, typename TViewDstFwd>
             ALPAKA_FN_HOST static auto createTaskMemcpy(
-                TViewDst& viewDst,
+                TViewDstFwd&& viewDst,
                 TViewSrc const& viewSrc,
-                TExtent const& extent)
-                -> alpaka::detail::TaskCopyUniformCudaHip<TApi, TDim, TViewDst, TViewSrc, TExtent>
+                TExtent const& extent) -> alpaka::detail::
+                TaskCopyUniformCudaHip<TApi, TDim, std::remove_reference_t<TViewDstFwd>, TViewSrc, TExtent>
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                return alpaka::detail::TaskCopyUniformCudaHip<TApi, TDim, TViewDst, TViewSrc, TExtent>(
-                    viewDst,
+                auto const iDstDevice = getDev(viewDst).getNativeHandle();
+
+                return {
+                    std::forward<TViewDstFwd>(viewDst),
                     viewSrc,
                     extent,
                     TApi::memcpyDeviceToDevice,
-                    getDev(viewDst).getNativeHandle(),
-                    getDev(viewSrc).getNativeHandle());
+                    iDstDevice,
+                    getDev(viewSrc).getNativeHandle()};
             }
         };
 

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -70,8 +70,12 @@ namespace alpaka
         struct TaskSetUniformCudaHip<TApi, DimInt<0u>, TView, TExtent>
             : public TaskSetUniformCudaHipBase<TApi, DimInt<0u>, TView, TExtent>
         {
-            TaskSetUniformCudaHip(TView& view, std::uint8_t const& byte, TExtent const& extent)
-                : TaskSetUniformCudaHipBase<TApi, DimInt<0u>, TView, TExtent>(view, byte, extent)
+            template<typename TViewFwd>
+            TaskSetUniformCudaHip(TViewFwd&& view, std::uint8_t const& byte, TExtent const& extent)
+                : TaskSetUniformCudaHipBase<TApi, DimInt<0u>, TView, TExtent>(
+                    std::forward<TViewFwd>(view),
+                    byte,
+                    extent)
             {
             }
 
@@ -99,8 +103,12 @@ namespace alpaka
         struct TaskSetUniformCudaHip<TApi, DimInt<1u>, TView, TExtent>
             : public TaskSetUniformCudaHipBase<TApi, DimInt<1u>, TView, TExtent>
         {
-            TaskSetUniformCudaHip(TView& view, std::uint8_t const& byte, TExtent const& extent)
-                : TaskSetUniformCudaHipBase<TApi, DimInt<1u>, TView, TExtent>(view, byte, extent)
+            template<typename TViewFwd>
+            TaskSetUniformCudaHip(TViewFwd&& view, std::uint8_t const& byte, TExtent const& extent)
+                : TaskSetUniformCudaHipBase<TApi, DimInt<1u>, TView, TExtent>(
+                    std::forward<TViewFwd>(view),
+                    byte,
+                    extent)
             {
             }
 
@@ -142,8 +150,12 @@ namespace alpaka
         struct TaskSetUniformCudaHip<TApi, DimInt<2u>, TView, TExtent>
             : public TaskSetUniformCudaHipBase<TApi, DimInt<2u>, TView, TExtent>
         {
-            TaskSetUniformCudaHip(TView& view, std::uint8_t const& byte, TExtent const& extent)
-                : TaskSetUniformCudaHipBase<TApi, DimInt<2u>, TView, TExtent>(view, byte, extent)
+            template<typename TViewFwd>
+            TaskSetUniformCudaHip(TViewFwd&& view, std::uint8_t const& byte, TExtent const& extent)
+                : TaskSetUniformCudaHipBase<TApi, DimInt<2u>, TView, TExtent>(
+                    std::forward<TViewFwd>(view),
+                    byte,
+                    extent)
             {
             }
 
@@ -197,8 +209,12 @@ namespace alpaka
         struct TaskSetUniformCudaHip<TApi, DimInt<3u>, TView, TExtent>
             : public TaskSetUniformCudaHipBase<TApi, DimInt<3u>, TView, TExtent>
         {
-            TaskSetUniformCudaHip(TView& view, std::uint8_t const& byte, TExtent const& extent)
-                : TaskSetUniformCudaHipBase<TApi, DimInt<3u>, TView, TExtent>(view, byte, extent)
+            template<typename TViewFwd>
+            TaskSetUniformCudaHip(TViewFwd&& view, std::uint8_t const& byte, TExtent const& extent)
+                : TaskSetUniformCudaHipBase<TApi, DimInt<3u>, TView, TExtent>(
+                    std::forward<TViewFwd>(view),
+                    byte,
+                    extent)
             {
             }
 

--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -153,3 +153,34 @@ TEMPLATE_LIST_TEST_CASE("viewPlainPtrOperatorTest", "[memView]", alpaka::test::T
 {
     alpaka::test::testViewPlainPtrOperators<TestType, float>();
 }
+
+TEST_CASE("createView", "[memView]")
+{
+    using Dev = alpaka::DevCpu;
+    const auto dev = alpaka::getDevByIdx<alpaka::PltfCpu>(0u);
+
+    std::array<float, 4> a{{1, 2, 3, 4}};
+
+    // pointer overload
+    STATIC_REQUIRE(std::is_same_v<
+                   decltype(alpaka::createView(dev, a.data(), 4)),
+                   alpaka::ViewPlainPtr<Dev, float, alpaka::DimInt<1>, int>>);
+
+    // container overload
+    STATIC_REQUIRE(std::is_same_v<
+                   decltype(alpaka::createView(dev, a, 4L)),
+                   alpaka::ViewPlainPtr<Dev, float, alpaka::DimInt<1>, long>>);
+
+    alpaka::test::DefaultQueue<Dev> queue(dev);
+    std::array<float, 4> b;
+
+    // using as temporaries to memcpy
+    alpaka::memcpy(queue, alpaka::createView(dev, b, 4), alpaka::createView(dev, a, 4));
+    alpaka::wait(queue);
+    CHECK(a == b);
+
+    // using as temporaries to memset
+    alpaka::memset(queue, alpaka::createView(dev, a, 4), 0);
+    alpaka::wait(queue);
+    CHECK(a == std::array<float, 4>{});
+}


### PR DESCRIPTION
This changeset allows temporary view objects to be passed to `alpaka::memset` and `alpaka::memcpy`. It also contains a refactoring of TaskCopyOacc, before applying the changes.

Fixes: #1742 and #642