### PR TITLE
Accumulate memcpy/memset static_asserts

### DIFF
--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -39,29 +39,6 @@ namespace alpaka
             using SrcSize = Idx<TViewSrc>;
             using Elem = alpaka::Elem<TViewSrc>;
 
-            static_assert(!std::is_const_v<TViewDst>, "The destination view can not be const!");
-
-            static_assert(
-                Dim<TViewDst>::value == Dim<TViewSrc>::value,
-                "The source and the destination view are required to have the same dimensionality!");
-            static_assert(
-                Dim<TViewDst>::value == Dim<TExtent>::value,
-                "The views and the extent are required to have the same dimensionality!");
-            static_assert(
-                Dim<TViewDst>::value == TDim::value,
-                "The destination view and the input TDim are required to have the same dimensionality!");
-
-            static_assert(
-                meta::IsIntegralSuperset<DstSize, ExtentSize>::value,
-                "The destination view and the extent are required to have compatible idx type!");
-            static_assert(
-                meta::IsIntegralSuperset<SrcSize, ExtentSize>::value,
-                "The source view and the extent are required to have compatible idx type!");
-
-            static_assert(
-                std::is_same_v<alpaka::Elem<TViewDst>, std::remove_const_t<alpaka::Elem<TViewSrc>>>,
-                "The source and the destination view are required to have the same element type!");
-
             template<typename TViewFwd>
             TaskCopyCpuBase(TViewFwd&& viewDst, TViewSrc const& viewSrc, TExtent const& extent)
                 : m_extent(getExtentVec(extent))
@@ -184,34 +161,7 @@ namespace alpaka
         template<typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyCpu<DimInt<0u>, TViewDst, TViewSrc, TExtent>
         {
-            using ExtentSize = Idx<TExtent>;
-            using Scalar = Vec<DimInt<0u>, ExtentSize>;
-            using DstSize = Idx<TViewDst>;
-            using SrcSize = Idx<TViewSrc>;
             using Elem = alpaka::Elem<TViewSrc>;
-
-            static_assert(!std::is_const_v<TViewDst>, "The destination view can not be const!");
-
-            static_assert(
-                Dim<TViewDst>::value == Dim<TViewSrc>::value,
-                "The source and the destination view are required to have the same dimensionality!");
-            static_assert(
-                Dim<TViewDst>::value == Dim<TExtent>::value,
-                "The views and the extent are required to have the same dimensionality!");
-            static_assert(
-                Dim<TViewDst>::value == 0u,
-                "The destination view and the input TDim are required to have the same dimensionality!");
-
-            static_assert(
-                meta::IsIntegralSuperset<DstSize, ExtentSize>::value,
-                "The destination view and the extent are required to have compatible idx type!");
-            static_assert(
-                meta::IsIntegralSuperset<SrcSize, ExtentSize>::value,
-                "The source view and the extent are required to have compatible idx type!");
-
-            static_assert(
-                std::is_same_v<alpaka::Elem<TViewDst>, std::remove_const_t<alpaka::Elem<TViewSrc>>>,
-                "The source and the destination view are required to have the same element type!");
 
             template<typename TViewDstFwd>
             TaskCopyCpu(TViewDstFwd&& viewDst, TViewSrc const& viewSrc, [[maybe_unused]] TExtent const& extent)
@@ -227,6 +177,7 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
             ALPAKA_FN_HOST auto printDebug() const -> void
             {
+                using Scalar = Vec<DimInt<0u>, Idx<TExtent>>;
                 std::cout << __func__ << " e: " << Scalar() << " ewb: " << sizeof(Elem) << " de: " << Scalar()
                           << " dptr: " << reinterpret_cast<void*>(m_dstMemNative) << " dpitchb: " << Scalar()
                           << " se: " << Scalar() << " sptr: " << reinterpret_cast<void const*>(m_srcMemNative)

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -32,19 +32,6 @@ namespace alpaka
             using DstSize = Idx<TView>;
             using Elem = alpaka::Elem<TView>;
 
-            static_assert(!std::is_const_v<TView>, "The destination view can not be const!");
-
-            static_assert(
-                Dim<TView>::value == Dim<TExtent>::value,
-                "The destination view and the extent are required to have the same dimensionality!");
-            static_assert(
-                Dim<TView>::value == TDim::value,
-                "The destination view and the input TDim are required to have the same dimensionality!");
-
-            static_assert(
-                meta::IsIntegralSuperset<DstSize, ExtentSize>::value,
-                "The view and the extent are required to have compatible idx type!");
-
             template<typename TViewFwd>
             TaskSetCpuBase(TViewFwd&& view, std::uint8_t const& byte, TExtent const& extent)
                 : m_byte(byte)
@@ -151,19 +138,6 @@ namespace alpaka
             using Scalar = Vec<DimInt<0u>, ExtentSize>;
             using DstSize = Idx<TView>;
             using Elem = alpaka::Elem<TView>;
-
-            static_assert(!std::is_const_v<TView>, "The destination view can not be const!");
-
-            static_assert(
-                Dim<TView>::value == Dim<TExtent>::value,
-                "The destination view and the extent are required to have the same dimensionality!");
-            static_assert(
-                Dim<TView>::value == 0u,
-                "The destination view and the input TDim are required to have the same dimensionality!");
-
-            static_assert(
-                meta::IsIntegralSuperset<DstSize, ExtentSize>::value,
-                "The view and the extent are required to have compatible idx type!");
 
             template<typename TViewFwd>
             TaskSetCpu(TViewFwd&& view, std::uint8_t const& byte, [[maybe_unused]] TExtent const& extent)

--- a/include/alpaka/mem/buf/oacc/Copy.hpp
+++ b/include/alpaka/mem/buf/oacc/Copy.hpp
@@ -77,23 +77,6 @@ namespace alpaka
                 using SrcSize = alpaka::Idx<TViewSrc>;
                 using Elem = alpaka::Elem<TViewSrc>;
 
-                static_assert(!std::is_const_v<TViewDst>, "The destination view can not be const!");
-
-                static_assert(
-                    Dim<TViewSrc>::value == TDim::value,
-                    "The source view is required to have dimensionality TDim!");
-                static_assert(
-                    Dim<TViewDst>::value == Dim<TViewSrc>::value,
-                    "The source and the destination view are required to have the same dimensionality!");
-                static_assert(
-                    Dim<TViewDst>::value == Dim<TExtent>::value,
-                    "The views and the extent are required to have the same dimensionality!");
-                // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
-                static_assert(
-                    std::is_same<alpaka::Elem<TViewDst>, typename std::remove_const<alpaka::Elem<TViewSrc>>::type>::
-                        value,
-                    "The source and the destination view are required to have the same element type!");
-
                 using Idx = alpaka::Idx<TExtent>;
 
                 template<typename TViewDstFwd>
@@ -199,22 +182,8 @@ namespace alpaka
             template<typename TViewDst, typename TViewSrc, typename TExtent, typename TCopyPred>
             struct TaskCopyOacc<DimInt<0u>, TViewDst, TViewSrc, TExtent, TCopyPred>
             {
-                using ExtentSize = alpaka::Idx<TExtent>;
-                using DstSize = alpaka::Idx<TViewDst>;
-                using SrcSize = alpaka::Idx<TViewSrc>;
                 using Elem = alpaka::Elem<TViewSrc>;
                 using Idx = alpaka::Idx<TExtent>;
-
-                static_assert(!std::is_const<TViewDst>::value, "The destination view can not be const!");
-
-                static_assert(Dim<TViewSrc>::value == 0u, "The source view is required to have dimensionality 0!");
-                static_assert(Dim<TViewDst>::value == 0u, "The source view is required to have dimensionality 0!");
-                static_assert(Dim<TExtent>::value == 0u, "The extent is required to have dimensionality 0!");
-                // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
-                static_assert(
-                    std::is_same<alpaka::Elem<TViewDst>, typename std::remove_const<alpaka::Elem<TViewSrc>>::type>::
-                        value,
-                    "The source and the destination views are required to have the same element type!");
 
                 template<typename TViewDstFwd>
                 ALPAKA_FN_HOST TaskCopyOacc(

--- a/include/alpaka/mem/buf/oacc/Set.hpp
+++ b/include/alpaka/mem/buf/oacc/Set.hpp
@@ -97,9 +97,6 @@ namespace alpaka::trait
             TExtent const& /* extent */)
         {
             using TView = std::remove_reference_t<TViewFwd>;
-            static_assert(Dim<TView>::value == 0u, "The view is required to have dimensionality 0!");
-            static_assert(Dim<TExtent>::value == 0u, "The extent is required to have dimensionality 0!");
-
             using ExtIdx = Idx<TExtent>;
             using Dim0 = DimInt<0u>;
             using Acc = AccOacc<Dim0, ExtIdx>;

--- a/include/alpaka/mem/buf/omp5/Copy.hpp
+++ b/include/alpaka/mem/buf/omp5/Copy.hpp
@@ -38,24 +38,6 @@ namespace alpaka
         template<typename TDim, typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyOmp5
         {
-            static_assert(!std::is_const_v<TViewDst>, "The destination view can not be const!");
-
-            static_assert(
-                Dim<TViewSrc>::value == TDim::value,
-                "The source view is required to have dimensionality TDim!");
-            static_assert(
-                Dim<TViewDst>::value == Dim<TViewSrc>::value,
-                "The source and the destination views are required to have the same dimensionality!");
-            static_assert(
-                Dim<TViewDst>::value == Dim<TExtent>::value,
-                "The views and the extent are required to have the same dimensionality!");
-            // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
-            static_assert(
-                std::is_same_v<Elem<TViewDst>, typename std::remove_const<Elem<TViewSrc>>::type>,
-                "The source and the destination views are required to have the same element type!");
-
-            using Idx = alpaka::Idx<TExtent>;
-
             template<typename TViewDstFwd>
             ALPAKA_FN_HOST TaskCopyOmp5(
                 TViewDstFwd&& viewDst,
@@ -152,16 +134,6 @@ namespace alpaka
         template<typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyOmp5<DimInt<0u>, TViewDst, TViewSrc, TExtent>
         {
-            static_assert(!std::is_const_v<TViewDst>, "The destination view can not be const!");
-
-            static_assert(Dim<TViewSrc>::value == 0u, "The source view is required to have dimensionality 0!");
-            static_assert(Dim<TViewDst>::value == 0u, "The destination view is required to have dimensionality 0!");
-            static_assert(Dim<TExtent>::value == 0u, "The extent is required to have dimensionality 0!");
-            // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
-            static_assert(
-                std::is_same_v<Elem<TViewDst>, typename std::remove_const<Elem<TViewSrc>>::type>,
-                "The source and the destination view are required to have the same element type!");
-
             using Idx = alpaka::Idx<TExtent>;
 
             template<typename TViewDstFwd>
@@ -215,16 +187,6 @@ namespace alpaka
         template<typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyOmp5<DimInt<1u>, TViewDst, TViewSrc, TExtent>
         {
-            static_assert(!std::is_const_v<TViewDst>, "The destination view can not be const!");
-
-            static_assert(Dim<TViewSrc>::value == 1u, "The source view is required to have dimensionality 1!");
-            static_assert(Dim<TViewDst>::value == 1u, "The destination view is required to have dimensionality 1!");
-            static_assert(Dim<TExtent>::value == 1u, "The extent is required to have dimensionality 1!");
-            // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
-            static_assert(
-                std::is_same_v<Elem<TViewDst>, typename std::remove_const<Elem<TViewSrc>>::type>,
-                "The source and the destination view are required to have the same element type!");
-
             using Idx = alpaka::Idx<TExtent>;
 
             template<typename TViewDstFwd>

--- a/include/alpaka/mem/buf/omp5/Set.hpp
+++ b/include/alpaka/mem/buf/omp5/Set.hpp
@@ -99,9 +99,6 @@ namespace alpaka::trait
             TExtent const& /* extent */)
         {
             using TView = std::remove_reference_t<TViewFwd>;
-            static_assert(Dim<TView>::value == 0u, "The view is required to have dimensionality 0!");
-            static_assert(Dim<TExtent>::value == 0u, "The extent is required to have dimensionality 0!");
-
             using ExtIdx = Idx<TExtent>;
             using Dim0 = DimInt<0u>;
             using Acc = AccOmp5<Dim0, ExtIdx>;

--- a/include/alpaka/mem/buf/sycl/Copy.hpp
+++ b/include/alpaka/mem/buf/sycl/Copy.hpp
@@ -85,21 +85,6 @@ namespace alpaka::trait
             using SrcType = ElemType const*;
             using DstType = alpaka::experimental::detail::DstAccessor<ElemType, copy_dim>;
 
-            using TViewDst = std::remove_reference_t<TViewDstFwd>;
-            static_assert(!std::is_const_v<TViewDst>, "The destination view cannot be const!");
-
-            static_assert(
-                Dim<TViewDst>::value == Dim<std::remove_const_t<TViewSrc>>::value,
-                "The source and the destination view are required to have the same dimensionality!");
-
-            static_assert(
-                Dim<TViewDst>::value == Dim<TExtent>::value,
-                "The views and the extent are required to have the same dimensionality!");
-
-            static_assert(
-                std::is_same_v<Elem<TViewDst>, ElemType>,
-                "The source and the destination view are required to have the same element type!");
-
             auto const range = experimental::detail::make_sycl_range(ext);
             auto const offset = experimental::detail::make_sycl_offset(viewDst);
 
@@ -122,21 +107,6 @@ namespace alpaka::trait
             using ElemType = Elem<std::remove_const_t<TViewSrc>>;
             using SrcType = alpaka::experimental::detail::SrcAccessor<ElemType, copy_dim>;
             using DstType = ElemType*;
-
-            using TViewDst = std::remove_reference_t<TViewDstFwd>;
-            static_assert(!std::is_const_v<TViewDst>, "The destination view cannot be const!");
-
-            static_assert(
-                Dim<TViewDst>::value == Dim<std::remove_const_t<TViewSrc>>::value,
-                "The source and the destination view are required to have the same dimensionality!");
-
-            static_assert(
-                Dim<TViewDst>::value == Dim<TExtent>::value,
-                "The views and the extent are required to have the same dimensionality!");
-
-            static_assert(
-                std::is_same_v<Elem<TViewDst>, ElemType>,
-                "The source and the destination view are required to have the same element type!");
 
             auto const range = experimental::detail::make_sycl_range(ext);
             auto const offset = experimental::detail::make_sycl_offset(viewSrc);
@@ -162,21 +132,6 @@ namespace alpaka::trait
             using ElemType = Elem<std::remove_const_t<TViewSrc>>;
             using SrcType = alpaka::experimental::detail::SrcAccessor<ElemType, copy_dim>;
             using DstType = alpaka::experimental::detail::DstAccessor<ElemType, copy_dim>;
-
-            using TViewDst = std::remove_reference_t<TViewDstFwd>;
-            static_assert(!std::is_const_v<TViewDst>, "The destination view cannot be const!");
-
-            static_assert(
-                Dim<TViewDst>::value == Dim<std::remove_const_t<TViewSrc>>::value,
-                "The source and the destination view are required to have the same dimensionality!");
-
-            static_assert(
-                Dim<TViewDst>::value == Dim<TExtent>::value,
-                "The views and the extent are required to have the same dimensionality!");
-
-            static_assert(
-                std::is_same_v<Elem<TViewDst>, ElemType>,
-                "The source and the destination view are required to have the same element type!");
 
             auto const range = experimental::detail::make_sycl_range(ext);
             auto const offset_src = experimental::detail::make_sycl_offset(viewSrc);

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -43,16 +43,6 @@ namespace alpaka
         template<typename TApi, typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyUniformCudaHip<TApi, DimInt<0u>, TViewDst, TViewSrc, TExtent>
         {
-            static_assert(!std::is_const_v<TViewDst>, "The destination view can not be const!");
-
-            static_assert(Dim<TViewSrc>::value == 0u, "The source view is required to have dimensionality 0!");
-            static_assert(Dim<TViewDst>::value == 0u, "The destination view is required to have dimensionality 0!");
-            static_assert(Dim<TExtent>::value == 0u, "The extent is required to have dimensionality 0!");
-            // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
-            static_assert(
-                std::is_same_v<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>,
-                "The source and the destination views are required to have the same element type!");
-
             using Idx = alpaka::Idx<TExtent>;
 
             template<typename TViewDstFwd>
@@ -124,16 +114,6 @@ namespace alpaka
         template<typename TApi, typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyUniformCudaHip<TApi, DimInt<1u>, TViewDst, TViewSrc, TExtent>
         {
-            static_assert(!std::is_const_v<TViewDst>, "The destination view can not be const!");
-
-            static_assert(Dim<TViewSrc>::value == 1u, "The source view is required to have dimensionality 1!");
-            static_assert(Dim<TViewDst>::value == 1u, "The destination view is required to have dimensionality 1!");
-            static_assert(Dim<TExtent>::value == 1u, "The extent is required to have dimensionality 1!");
-            // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
-            static_assert(
-                std::is_same_v<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>,
-                "The source and the destination views are required to have the same element type!");
-
             using Idx = alpaka::Idx<TExtent>;
 
             template<typename TViewDstFwd>
@@ -214,15 +194,6 @@ namespace alpaka
         template<typename TApi, typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyUniformCudaHip<TApi, DimInt<2u>, TViewDst, TViewSrc, TExtent>
         {
-            static_assert(!std::is_const_v<TViewDst>, "The destination view can not be const!");
-            static_assert(Dim<TViewSrc>::value == 2u, "The source view is required to have dimensionality 2!");
-            static_assert(Dim<TViewDst>::value == 2u, "The destination view is required to have dimensionality 2!");
-            static_assert(Dim<TExtent>::value == 2u, "The extent is required to have dimensionality 2!");
-            // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
-            static_assert(
-                std::is_same_v<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>,
-                "The source and the destination views are required to have the same element type!");
-
             using Idx = alpaka::Idx<TExtent>;
 
             template<typename TViewDstFwd>
@@ -334,15 +305,6 @@ namespace alpaka
         template<typename TApi, typename TViewDst, typename TViewSrc, typename TExtent>
         struct TaskCopyUniformCudaHip<TApi, DimInt<3u>, TViewDst, TViewSrc, TExtent>
         {
-            static_assert(!std::is_const_v<TViewDst>, "The destination view can not be const!");
-            static_assert(Dim<TViewSrc>::value == 3u, "The source view is required to have dimensionality 3!");
-            static_assert(Dim<TViewDst>::value == 3u, "The destination view is required to have dimensionality 3!");
-            static_assert(Dim<TExtent>::value == 3u, "The extent is required to have dimensionality 3!");
-            // TODO: Maybe check for Idx of TViewDst and TViewSrc to have greater or equal range than TExtent.
-            static_assert(
-                std::is_same_v<Elem<TViewDst>, std::remove_const_t<Elem<TViewSrc>>>,
-                "The source and the destination views are required to have the same element type!");
-
             using Idx = alpaka::Idx<TExtent>;
 
             template<typename TViewDstFwd>

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -47,11 +47,6 @@ namespace alpaka
                 , m_extent(extent)
                 , m_iDevice(getDev(view).getNativeHandle())
             {
-                static_assert(!std::is_const_v<TView>, "The destination view can not be const!");
-
-                static_assert(
-                    Dim<TView>::value == Dim<TExtent>::value,
-                    "The destination view and the extent are required to have the same dimensionality!");
             }
 
         protected:
@@ -82,13 +77,6 @@ namespace alpaka
             template<typename TQueue>
             auto enqueue(TQueue& queue) const -> void
             {
-                static_assert(
-                    Dim<TView>::value == 0u,
-                    "The destination buffer is required to be 0-dimensional (scalar) for this specialization!");
-                static_assert(
-                    Dim<TView>::value == Dim<TExtent>::value,
-                    "The destination buffer and the extent are required to have the same dimensionality!");
-
                 // Initiate the memory set.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memsetAsync(
                     getPtrNative(this->m_view),
@@ -115,13 +103,6 @@ namespace alpaka
             template<typename TQueue>
             auto enqueue(TQueue& queue) const -> void
             {
-                static_assert(
-                    Dim<TView>::value == 1u,
-                    "The destination buffer is required to be 1-dimensional for this specialization!");
-                static_assert(
-                    Dim<TView>::value == Dim<TExtent>::value,
-                    "The destination buffer and the extent are required to have the same dimensionality!");
-
                 using Idx = Idx<TExtent>;
 
                 auto& view = this->m_view;
@@ -162,13 +143,6 @@ namespace alpaka
             template<typename TQueue>
             auto enqueue(TQueue& queue) const -> void
             {
-                static_assert(
-                    Dim<TView>::value == 2u,
-                    "The destination buffer is required to be 2-dimensional for this specialization!");
-                static_assert(
-                    Dim<TView>::value == Dim<TExtent>::value,
-                    "The destination buffer and the extent are required to have the same dimensionality!");
-
                 using Idx = Idx<TExtent>;
 
                 auto& view = this->m_view;
@@ -221,13 +195,6 @@ namespace alpaka
             template<typename TQueue>
             auto enqueue(TQueue& queue) const -> void
             {
-                static_assert(
-                    Dim<TView>::value == 3u,
-                    "The destination buffer is required to be 3-dimensional for this specialization!");
-                static_assert(
-                    Dim<TView>::value == Dim<TExtent>::value,
-                    "The destination buffer and the extent are required to have the same dimensionality!");
-
                 using Elem = alpaka::Elem<TView>;
                 using Idx = Idx<TExtent>;
 


### PR DESCRIPTION
This change moves all `static_assert`s used in the memcpy and memset task implementations into the traits and thus deduplicates them.