### PR TITLE
Set policy CMP0091 to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 
 cmake_minimum_required(VERSION 3.18)
 
-cmake_policy(SET CMP0091 OLD)
+cmake_policy(SET CMP0091 NEW)
 
 include(CMakePrintHelpers)
 


### PR DESCRIPTION
This was introduced in e7fae73e7786 to fix the VS2017 build. Support for
VS2017 has been dropped in the meantime.

Fixes: #1744