### PR TITLE
OpenACC fixes for gcc12

### DIFF
--- a/include/alpaka/mem/buf/BufOacc.hpp
+++ b/include/alpaka/mem/buf/BufOacc.hpp
@@ -1,5 +1,5 @@
-/* Copyright 2022 Jeffrey Kelling, Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera, Bernhard Manfred
- * Gruber, Antonio Di Pilato
+/* Copyright 2022 Jeffrey Kelling, Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera,
+ *                Bernhard Manfred Gruber, Antonio Di Pilato, Jan Stephan
  *
  * This file is part of Alpaka.
  *
@@ -51,7 +51,7 @@ namespace alpaka
         public:
             //! Constructor
             template<typename TExtent>
-            ALPAKA_FN_HOST BufOaccImpl(DevOacc const& dev, TElem* const pMem, TExtent const& extent)
+            ALPAKA_FN_HOST BufOaccImpl(DevOacc const& dev, TElem* const pMem, TExtent const& extent) noexcept
                 : m_dev(dev)
                 , m_extentElements(getExtentVecEnd<TDim>(extent))
                 , m_pMem(pMem)

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Alexander Matthes, Benjamin Worpitz, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2022 Alexander Matthes, Benjamin Worpitz, Andrea Bocci, Bernhard Manfred Gruber, Jan Stephan
  *
  * This file is part of alpaka.
  *
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <alpaka/core/BoostPredef.hpp>
 #include <alpaka/core/Common.hpp>
 #include <alpaka/mem/view/Traits.hpp>
 
@@ -81,7 +82,13 @@ namespace alpaka
     //! \param extent The extent of the buffer.
     //! \return The newly allocated buffer.
     template<typename TElem, typename TIdx, typename TExtent, typename TDev>
-    ALPAKA_FN_HOST auto allocBuf(TDev const& dev, TExtent const& extent = TExtent())
+#if(BOOST_COMP_GNUC == BOOST_VERSION_NUMBER(12, 1, 0)) && defined(_OPENACC) && defined(NDEBUG)
+    // Force O2 optimization level with GCC 12.1, OpenACC and Release mode.
+    // See https://github.com/alpaka-group/alpaka/issues/1752
+    [[gnu::optimize("O2")]]
+#endif
+    ALPAKA_FN_HOST auto
+    allocBuf(TDev const& dev, TExtent const& extent = TExtent())
     {
         return trait::BufAlloc<TElem, Dim<TExtent>, TIdx, TDev>::allocBuf(dev, extent);
     }


### PR DESCRIPTION
This PR works around two issues that appeared in #1713 with gcc12 and OpenACC.

1. `BufOaccImpl` is now `noexcept`. gcc complained about this.
2. `allocBuf` is now force-optimized with the `-O2` level because it breaks on `-O3`. This is a work-around for #1752.