### PR TITLE
HIP: use build-in `atomicAdd(double)`

### DIFF
--- a/include/alpaka/atomic/AtomicUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicUniformCudaHipBuiltIn.hpp
@@ -124,7 +124,7 @@ namespace alpaka
                 double* const addr,
                 double const& value) -> double
             {
-#        if BOOST_ARCH_PTX >= BOOST_VERSION_NUMBER(6, 0, 0)
+#        if BOOST_ARCH_PTX >= BOOST_VERSION_NUMBER(6, 0, 0) || BOOST_LANG_HIP
                 return ::atomicAdd(addr, value);
 #        else
                 // Code from: http://docs.nvidia.com/cuda/cuda-c-programming-guide/#atomic-functions


### PR DESCRIPTION
HIP is providing for HIP 4.2+ native atomicAdd interfaces for double precision.
Use always the build-in atomicAdd so speedup atomic add.