### PR TITLE
test: extend ALPAKA_CHECK to show better error messages

### DIFF
--- a/include/alpaka/test/Check.hpp
+++ b/include/alpaka/test/Check.hpp
@@ -9,28 +9,33 @@
 
 #pragma once
 
+#include <alpaka/core/BoostPredef.hpp>
+
 #include <cstdio>
 
 // TODO: SYCL doesn't have a way to detect if we're looking at device or host code. This needs a workaround so that
 // SYCL and other back-ends are compatible.
 #ifdef ALPAKA_ACC_SYCL_ENABLED
-#    define ALPAKA_CHECK(success, expression)                                                                         \
+#    define ALPAKA_CHECK_DO(file, line, success, expression)                                                          \
         do                                                                                                            \
         {                                                                                                             \
             if(!(expression))                                                                                         \
             {                                                                                                         \
-                acc.cout << "ALPAKA_CHECK failed because '!(" << #expression << ")'\n";                               \
+                acc.cout << "ALPAKA_CHECK failed because '!(" << #expression << ")' in " << file << ":" << line       \
+                         << "\n";                                                                                     \
                 success = false;                                                                                      \
             }                                                                                                         \
         } while(0)
 #else
-#    define ALPAKA_CHECK(success, expression)                                                                         \
+#    define ALPAKA_CHECK_DO(file, line, success, expression)                                                          \
         do                                                                                                            \
         {                                                                                                             \
             if(!(expression))                                                                                         \
             {                                                                                                         \
-                printf("ALPAKA_CHECK failed because '!(%s)'\n", #expression);                                         \
+                printf("ALPAKA_CHECK failed because '!(%s)' in %s:%d\n", #expression, file, line);                    \
                 success = false;                                                                                      \
             }                                                                                                         \
         } while(0)
 #endif
+
+#define ALPAKA_CHECK(success, expression) ALPAKA_CHECK_DO(__FILE__, __LINE__, success, expression)

--- a/include/alpaka/test/Check.hpp
+++ b/include/alpaka/test/Check.hpp
@@ -16,7 +16,7 @@
 // TODO: SYCL doesn't have a way to detect if we're looking at device or host code. This needs a workaround so that
 // SYCL and other back-ends are compatible.
 #ifdef ALPAKA_ACC_SYCL_ENABLED
-#    define ALPAKA_CHECK_DO(file, line, success, expression)                                                          \
+#    define ALPAKA_CHECK_DO(printMsg, file, line, success, expression)                                                \
         do                                                                                                            \
         {                                                                                                             \
             if(!(expression))                                                                                         \
@@ -27,7 +27,7 @@
             }                                                                                                         \
         } while(0)
 #else
-#    define ALPAKA_CHECK_DO(file, line, success, expression)                                                          \
+#    define ALPAKA_CHECK_DO(printMsg, file, line, success, expression)                                                \
         do                                                                                                            \
         {                                                                                                             \
             if(!(expression))                                                                                         \
@@ -38,4 +38,17 @@
         } while(0)
 #endif
 
-#define ALPAKA_CHECK(success, expression) ALPAKA_CHECK_DO(__FILE__, __LINE__, success, expression)
+#if BOOST_LANG_HIP == BOOST_VERSION_NUMBER(4, 5, 0)
+// disable message print to avoid compiler error: 'error: stack size limit exceeded (181896) in _ZN6alpaka...'
+#    define ALPAKA_CHECK(printMsg, file, line, success, expression)                                                   \
+        do                                                                                                            \
+        {                                                                                                             \
+            if(!(expression))                                                                                         \
+            {                                                                                                         \
+                printf("ALPAKA_CHECK failed because '!(%s)' in %s:%d\n", #expression, file, line);                    \
+                success = false;                                                                                      \
+            }                                                                                                         \
+        } while(0)
+#else
+#    define ALPAKA_CHECK(success, expression) ALPAKA_CHECK_DO(__FILE__, __LINE__, success, expression)
+#endif


### PR DESCRIPTION
To know where a test fails the line and file can be very useful.

before:
```
1: ALPAKA_CHECK failed because '!(equals(operandOrig, ret))'
1: ALPAKA_CHECK failed because '!(equals(operandOrig, ret))'
```

after:
```
1: ALPAKA_CHECK failed because '!(equals(operandOrig, ret))' in alpaka/test/unit/atomic/src/AtomicTest.cpp:90
1: ALPAKA_CHECK failed because '!(equals(operandOrig, ret))' in alpaka/test/unit/atomic/src/AtomicTest.cpp:96
```