### PR TITLE
CI: refactor and extend atomic tests

### DIFF
--- a/include/alpaka/atomic/AtomicAtomicRef.hpp
+++ b/include/alpaka/atomic/AtomicAtomicRef.hpp
@@ -162,10 +162,11 @@ namespace alpaka
                 isSupportedByAtomicAtomicRef<T>();
                 alpaka::detail::atomic_ref<T> ref(*addr);
                 T old = ref;
-                T result = ((old >= value) ? 0 : static_cast<T>(old - 1));
+                T result = (old == static_cast<T>(0) || old > value) ? value : static_cast<T>(old - static_cast<T>(1));
                 while(!ref.compare_exchange_weak(old, result))
                 {
-                    result = ((old >= value) ? 0 : static_cast<T>(old - 1));
+                    result
+                        = (old == static_cast<T>(0) || old > value) ? value : static_cast<T>(old - static_cast<T>(1));
                 }
                 return old;
             }

--- a/include/alpaka/atomic/AtomicOmpBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicOmpBuiltIn.hpp
@@ -265,12 +265,20 @@ namespace alpaka
 #        pragma omp atomic capture compare
                 {
                     old = ref;
+
+#        if ALPAKA_COMP_CLANG
+#            pragma clang diagnostic push
+#            pragma clang diagnostic ignored "-Wfloat-equal"
+#        endif
                     // Do not remove the curly brackets of the if body else
                     // icpx 2024.0 is not able to compile the atomics.
                     if(ref == compare)
                     {
                         ref = value;
                     }
+#        if ALPAKA_COMP_CLANG
+#            pragma clang diagnostic pop
+#        endif
                 }
                 return old;
             }

--- a/include/alpaka/core/Config.hpp
+++ b/include/alpaka/core/Config.hpp
@@ -5,24 +5,12 @@
 
 #pragma once
 
+#include "alpaka/core/PP.hpp"
+
 #ifdef __INTEL_COMPILER
 #    warning                                                                                                          \
         "The Intel Classic compiler (icpc) is no longer supported. Please upgrade to the Intel LLVM compiler (ipcx)."
 #endif
-
-#define ALPAKA_VERSION_NUMBER(major, minor, patch)                                                                    \
-    ((((major) % 10000llu) * 100'000'000llu) + (((minor) % 1000llu) * 100000llu) + ((patch) % 100000llu))
-
-#define ALPAKA_VERSION_NUMBER_NOT_AVAILABLE ALPAKA_VERSION_NUMBER(0llu, 0llu, 0llu)
-
-#define ALPAKA_YYYYMMDD_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 10000llu), ((V) / 100llu) % 100llu, (V) % 100llu)
-
-#define ALPAKA_YYYYMM_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 100llu) % 10000llu, (V) % 100llu, 0llu)
-
-#define ALPAKA_VVRRP_10_TO_VERSION(V)                                                                                 \
-    ALPAKA_VERSION_NUMBER(((V) / 1000llu) % 100llu, ((V) / 10llu) % 100llu, (V) % 10llu)
-
-#define ALPAKA_VRP_TO_VERSION(V) ALPAKA_VERSION_NUMBER((V) / 100llu, ((V) / 10llu) % 10llu, (V) % 10llu)
 
 // ######## detect operating systems ########
 
@@ -97,18 +85,36 @@
 #    if defined(__CUDA_ARCH__)
 #        define ALPAKA_ARCH_PTX ALPAKA_VRP_TO_VERSION(__CUDA_ARCH__)
 #    else
-#        define ALPAKA_ARCH_PTX 0
+#        define ALPAKA_ARCH_PTX ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
 #    endif
 #endif
 
-// HIP device compile
-#if !defined(ALPAKA_ARCH_HSA)
+/** HIP device compile
+ *
+ * The version on the host side will always be ALPAKA_VERSION_NUMBER_NOT_AVAILABLE.
+ * On the device side unknown version will be set to ALPAKA_VERSION_NUMBER_NOT_AVAILABLE.
+ *
+ *  Rules:
+ *   - the last two digits will be handled as HEX values and support 0-9 and a-f
+ *   - gfx9xy (numeric): 9xy -> ALPAKA_VERSION_NUMBER(9,x,y)
+ *   - gfx10xy / gfx11xy: stxy -> ALPAKA_VERSION_NUMBER(st,x,y)
+ *   - Suffix: a == 10, b == 11, c == 12
+ *      - gfx90a -> ALPAKA_VERSION_NUMBER(9,0,10)
+ *      - gfx90c -> ALPAKA_VERSION_NUMBER(9,0,12)
+ */
+#if !defined(ALPAKA_ARCH_AMD)
 #    if defined(__HIP__) && defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__ == 1
-#        define ALPAKA_ARCH_HSA 1
+#        define ALPAKA_ARCH_AMD ALPAKA_AMDGPU_ARCH
 #    else
-#        define ALPAKA_ARCH_HSA 0
+#        define ALPAKA_ARCH_AMD ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
 #    endif
 #endif
+
+/** HSA device compile
+ *
+ * This version is equal to ALPAKA_ARCH_AMD and is only carried for backwards compatibility to older ALPAKA versions.
+ */
+#define ALPAKA_ARCH_HSA ALPAKA_ARCH_AMD
 
 // ######## compiler ########
 
@@ -209,7 +215,7 @@
 #    if defined(__CUDACC__) || defined(__CUDA__)
 #        include <cuda.h>
 // CUDA doesn't give us a patch level for the last entry, just zero.
-#        define ALPAKA_LANG_CUDA ALPAKA_VVRRP_10_TO_VERSION(CUDART_VERSION)
+#        define ALPAKA_LANG_CUDA ALPAKA_VVRRP_TO_VERSION(CUDART_VERSION)
 #    else
 #        define ALPAKA_LANG_CUDA ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
 #    endif

--- a/include/alpaka/core/HipConfig.hpp
+++ b/include/alpaka/core/HipConfig.hpp
@@ -1,0 +1,134 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/PP.hpp"
+
+// We can not use ALPAKA_LANG_HIP because this file is required by core/config.hpp where ALPAKA_LANG_HIP is defined.
+#if defined(__HIP__)
+
+#    include <hip/hip_version.h>
+
+// version numbers are only defined on the device side
+#    if !defined(ALPAKA_AMDGPU_ARCH) && defined(__HIP__) && __HIP_DEVICE_COMPILE__ == 1
+
+/* Map AMDGPU arch macro -> ALPAKA_VRRPP_TO_VERSION(wrapped code)
+ *  Rules:
+ *   - gfx9xy (numeric): 9xy -> 90x0y  (e.g., 908->90008, 906->90006, 942->90402)
+ *   - gfx10xy / gfx11xy: stxy -> st0x0y (e.g., 1036->100306, 1103->110003)
+ *   - Suffix: a == 10 (90a->90010), b == 11, c == 11
+ *
+ * An overview of AMD GPU architectures can be found here:
+ * https://llvm.org/docs/AMDGPUUsage.html#processors
+ */
+
+#        if defined(__gfx1200__)
+/* RDNA 4 dGPU (RX 9060 XT) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(120000)
+#        elif defined(__gfx1201__)
+/* RDNA 4 dGPU (RX 9070 / 9070 XT) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(120001)
+#        elif defined(__gfx1250__)
+/* RDNA 4 APU (APU) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(120500)
+#        elif defined(__gfx1251__)
+/* RDNA 4 APU variant */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(120501)
+
+#        elif defined(__gfx1153__)
+/* RDNA 3.5 iGPU (Medusa Point / Strix Halo successor) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110503)
+#        elif defined(__gfx1152__)
+/* RDNA 3.5 iGPU (Krackan Point) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110502)
+#        elif defined(__gfx1151__)
+/* RDNA 3.5 iGPU (Strix Halo) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110501)
+#        elif defined(__gfx1150__)
+/* RDNA 3.5 iGPU (Radeon 890M on Strix Point) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110500)
+
+#        elif defined(__gfx1103__)
+/* RDNA 3 APU (Radeon 780M, 760M, ROG Ally Extreme) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110003)
+#        elif defined(__gfx1102__)
+/* RDNA 3 Desktop (RX 7600 / 7600 XT) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110002)
+#        elif defined(__gfx1101__)
+/* RDNA 3 Desktop (RX 7700 / 7700 XT, Pro W7700 / V710) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110001)
+#        elif defined(__gfx1100__)
+/* RDNA 3 Desktop (RX 7900 XT, XTX, Pro W7900) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110000)
+
+#        elif defined(__gfx1036__)
+/* RDNA 2 APU (Radeon Graphics 128-SP iGPU) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100306)
+#        elif defined(__gfx1035__)
+/* RDNA 2 APU (Radeon 660M, 680M) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100305)
+#        elif defined(__gfx1034__)
+/* RDNA 2 Mobile (Pro W6300/W6400, RX 6400-6500) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100304)
+#        elif defined(__gfx1033__)
+/* RDNA 2 APU (Steam Deck) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100303)
+#        elif defined(__gfx1032__)
+/* RDNA 2 Desktop (RX 6600 XT, 6650 XT/S, 6700S) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100302)
+#        elif defined(__gfx1031__)
+/* RDNA 2 Desktop (RX 6700 series, 6750/6850M XT) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100301)
+#        elif defined(__gfx1030__)
+/* RDNA 2 Desktop (RX 6800 / 6900 XT, Pro W6800) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100300)
+
+#        elif defined(__gfx1013__)
+/* RDNA 1 Mobile (RX 5300M / 5500M) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100103)
+#        elif defined(__gfx1012__)
+/* RDNA 1 Desktop (RX 5500 / 5500 XT) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100102)
+#        elif defined(__gfx1011__)
+/* RDNA 1 Desktop (Pro V520) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100101)
+#        elif defined(__gfx1010__)
+/* RDNA 1 Desktop (RX 5700 / 5700 XT, Pro 5600 XT/M) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100100)
+
+#        elif defined(__gfx942__)
+/* CDNA 3 (Instinct MI300 series: MI300/MI300A/MI300X) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90402)
+#        elif defined(__gfx941__)
+/* CDNA 2/3 (Instinct MI210) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90401)
+#        elif defined(__gfx940__)
+/* CDNA 2 (Instinct MI200) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90400)
+
+#        elif defined(__gfx90c__)
+/* CDNA 1 (Renoir APUs), c -> 12 */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90012)
+#        elif defined(__gfx90b__)
+/* (If present) b -> 11 */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90011)
+#        elif defined(__gfx90a__)
+/* CDNA 2 (Instinct MI250 / MI250X), a -> 10 */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90010)
+#        elif defined(__gfx908__)
+/* CDNA 1 (Instinct MI100) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90008)
+#        elif defined(__gfx906__)
+/* Vega 20 (Radeon VII, Instinct MI50/60) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90006)
+
+#        else
+#            error                                                                                                    \
+                "Unknown AMDGPU architecture, please define __gfxXXX__ macro for your target. Until alpaka is updated you can define the macro ALPAKA_AMDGPU_ARCH to avoid this error."
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
+#        endif
+
+#    endif
+#endif

--- a/include/alpaka/core/PP.hpp
+++ b/include/alpaka/core/PP.hpp
@@ -1,0 +1,31 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+/** \file This files provides preprocessor utilities. */
+
+/* version number encoding
+ * 4 digits for major version (max 9999)
+ * 3 digits for minor version (max 999)
+ * 5 digits for patch version (max 99999)
+ * example: version 1.2.3 -> 0001 002 00003
+ */
+#define ALPAKA_VERSION_NUMBER(major, minor, patch)                                                                    \
+    ((((major) % 10000llu) * 100'000'000llu) + (((minor) % 1000llu) * 100000llu) + ((patch) % 100000llu))
+
+#define ALPAKA_VERSION_NUMBER_NOT_AVAILABLE ALPAKA_VERSION_NUMBER(0llu, 0llu, 0llu)
+
+// version number conversion from vendor format to ALPAKA_VERSION_NUMBER
+#define ALPAKA_YYYYMMDD_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 10000llu), ((V) / 100llu) % 100llu, (V) % 100llu)
+
+#define ALPAKA_YYYYMM_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 100llu) % 10000llu, (V) % 100llu, 0llu)
+
+#define ALPAKA_VVRRP_TO_VERSION(V)                                                                                    \
+    ALPAKA_VERSION_NUMBER(((V) / 1000llu) % 10000llu, ((V) / 10llu) % 100llu, (V) % 10llu)
+
+#define ALPAKA_VRP_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 100llu) % 10000llu, ((V) / 10llu) % 10llu, (V) % 10llu)
+
+#define ALPAKA_VRRPP_TO_VERSION(V)                                                                                    \
+    ALPAKA_VERSION_NUMBER(((V) / 10000llu) % 10000llu, ((V) / 100llu) % 100llu, (V) % 100llu)

--- a/test/unit/atomic/src/AtomicFunctors.hpp
+++ b/test/unit/atomic/src/AtomicFunctors.hpp
@@ -1,0 +1,143 @@
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Jan Stephan, Bernhard Manfred Gruber,
+ * Antonio Di Pilato
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! @file This file provides functors where a atomic function and the corresponding operation availble within one
+//! object. This allwos testing of the atomic function and atomicOp<Op>() without the usage of function pointers whcih
+//! is not suppoted by all backends.
+
+#include <alpaka/atomic/Op.hpp>
+#include <alpaka/atomic/Traits.hpp>
+
+#include <utility>
+
+namespace alpaka::test::unit::atomic
+{
+    struct Add
+    {
+        using Op = alpaka::AtomicAdd;
+
+        template<typename... TArgs>
+        static ALPAKA_FN_ACC auto atomic(TArgs&&... args)
+        {
+            return alpaka::atomicAdd(std::forward<TArgs>(args)...);
+        }
+    };
+
+    struct Sub
+    {
+        using Op = alpaka::AtomicSub;
+
+        template<typename... TArgs>
+        static ALPAKA_FN_ACC auto atomic(TArgs&&... args)
+        {
+            return alpaka::atomicSub(std::forward<TArgs>(args)...);
+        }
+    };
+
+    struct Min
+    {
+        using Op = alpaka::AtomicMin;
+
+        template<typename... TArgs>
+        static ALPAKA_FN_ACC auto atomic(TArgs&&... args)
+        {
+            return alpaka::atomicMin(std::forward<TArgs>(args)...);
+        }
+    };
+
+    struct Max
+    {
+        using Op = alpaka::AtomicMax;
+
+        template<typename... TArgs>
+        static ALPAKA_FN_ACC auto atomic(TArgs&&... args)
+        {
+            return alpaka::atomicMax(std::forward<TArgs>(args)...);
+        }
+    };
+
+    struct Exch
+    {
+        using Op = alpaka::AtomicExch;
+
+        template<typename... TArgs>
+        static ALPAKA_FN_ACC auto atomic(TArgs&&... args)
+        {
+            return alpaka::atomicExch(std::forward<TArgs>(args)...);
+        }
+    };
+
+    struct Dec
+    {
+        using Op = alpaka::AtomicDec;
+
+        template<typename... TArgs>
+        static ALPAKA_FN_ACC auto atomic(TArgs&&... args)
+        {
+            return alpaka::atomicDec(std::forward<TArgs>(args)...);
+        }
+    };
+
+    struct Inc
+    {
+        using Op = alpaka::AtomicInc;
+
+        template<typename... TArgs>
+        static ALPAKA_FN_ACC auto atomic(TArgs&&... args)
+        {
+            return alpaka::atomicInc(std::forward<TArgs>(args)...);
+        }
+    };
+
+    struct Cas
+    {
+        using Op = alpaka::AtomicCas;
+
+        template<typename... TArgs>
+        static ALPAKA_FN_ACC auto atomic(TArgs&&... args)
+        {
+            return alpaka::atomicCas(std::forward<TArgs>(args)...);
+        }
+    };
+
+    struct Or
+    {
+        using Op = alpaka::AtomicOr;
+
+        template<typename... TArgs>
+        static ALPAKA_FN_ACC auto atomic(TArgs&&... args)
+        {
+            return alpaka::atomicOr(std::forward<TArgs>(args)...);
+        }
+    };
+
+    struct Xor
+    {
+        using Op = alpaka::AtomicXor;
+
+        template<typename... TArgs>
+        static ALPAKA_FN_ACC auto atomic(TArgs&&... args)
+        {
+            return alpaka::atomicXor(std::forward<TArgs>(args)...);
+        }
+    };
+
+    struct And
+    {
+        using Op = alpaka::AtomicAnd;
+
+        template<typename... TArgs>
+        static ALPAKA_FN_ACC auto atomic(TArgs&&... args)
+        {
+            return alpaka::atomicAnd(std::forward<TArgs>(args)...);
+        }
+    };
+
+} // namespace alpaka::test::unit::atomic

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -37,13 +37,12 @@ ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC auto equals(double a, double b) -> bool
 
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename THierarchy, typename TOp, typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicCall(TAcc const& acc, bool* success, T operandOrig, T value) -> void
+ALPAKA_FN_ACC auto testAtomicCall(TAcc const& acc, bool* success, T& operand, T operandOrig, T value) -> void
 {
     auto op = typename TOp::Op{};
 
     // check if the function `alpaka::atomicOp<*>` is callable
     {
-        auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
         // left operand is half of the right
         operand = operandOrig;
         T reference = operand;
@@ -58,7 +57,6 @@ ALPAKA_FN_ACC auto testAtomicCall(TAcc const& acc, bool* success, T operandOrig,
 
     // check if the function `alpaka::atomic*()` is callable
     {
-        auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
         // left operand is half of the right
         operand = operandOrig;
         T reference = operand;
@@ -74,7 +72,7 @@ ALPAKA_FN_ACC auto testAtomicCall(TAcc const& acc, bool* success, T operandOrig,
 
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename THierarchy, typename TOp, typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicCombinations(TAcc const& acc, bool* success, T operandOrig) -> void
+ALPAKA_FN_ACC auto testAtomicCombinations(TAcc const& acc, bool* success, T& operand, T operandOrig) -> void
 {
     // helper variables to avoid compiler conversion warnings/errors
     T constexpr one = static_cast<T>(1);
@@ -82,36 +80,35 @@ ALPAKA_FN_ACC auto testAtomicCombinations(TAcc const& acc, bool* success, T oper
     {
         // left operand is half of the right
         T const value = static_cast<T>(operandOrig / two);
-        testAtomicCall<THierarchy, TOp>(acc, success, operandOrig, value);
+        testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
     }
     {
         // left operand is twice as large as the right
         T const value = static_cast<T>(operandOrig * two);
-        testAtomicCall<THierarchy, TOp>(acc, success, operandOrig, value);
+        testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
     }
     {
         // left operand is larger by one
         T const value = static_cast<T>(operandOrig + one);
-        testAtomicCall<THierarchy, TOp>(acc, success, operandOrig, value);
+        testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
     }
     {
         // left operand is smaller by one
         T const value = static_cast<T>(operandOrig - one);
-        testAtomicCall<THierarchy, TOp>(acc, success, operandOrig, value);
+        testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
     }
     {
         // both operands are equal
         T const value = operandOrig;
-        testAtomicCall<THierarchy, TOp>(acc, success, operandOrig, value);
+        testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
     }
 }
 
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename THierarchy, typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicCas(TAcc const& acc, bool* success, T operandOrig) -> void
+ALPAKA_FN_ACC auto testAtomicCas(TAcc const& acc, bool* success, T& operand, T operandOrig) -> void
 {
     T const value = static_cast<T>(4);
-    auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
 
     // with match
     {
@@ -153,21 +150,21 @@ ALPAKA_FN_ACC auto testAtomicCas(TAcc const& acc, bool* success, T operandOrig) 
 //! check threads hierarchy
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename TOp, typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicHierarchies(TAcc const& acc, bool* success, T operandOrig) -> void
+ALPAKA_FN_ACC auto testAtomicHierarchies(TAcc const& acc, bool* success, T& operand, T operandOrig) -> void
 {
-    testAtomicCombinations<alpaka::hierarchy::Threads, TOp>(acc, success, operandOrig);
-    testAtomicCombinations<alpaka::hierarchy::Blocks, TOp>(acc, success, operandOrig);
-    testAtomicCombinations<alpaka::hierarchy::Grids, TOp>(acc, success, operandOrig);
+    testAtomicCombinations<alpaka::hierarchy::Threads, TOp>(acc, success, operand, operandOrig);
+    testAtomicCombinations<alpaka::hierarchy::Blocks, TOp>(acc, success, operand, operandOrig);
+    testAtomicCombinations<alpaka::hierarchy::Grids, TOp>(acc, success, operand, operandOrig);
 }
 
 //! check all alpaka hierarchies
 ALPAKA_NO_HOST_ACC_WARNING
 template<typename TOp, typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicCasHierarchies(TAcc const& acc, bool* success, T operandOrig) -> void
+ALPAKA_FN_ACC auto testAtomicCasHierarchies(TAcc const& acc, bool* success, T& operand, T operandOrig) -> void
 {
-    testAtomicCas<alpaka::hierarchy::Threads>(acc, success, operandOrig);
-    testAtomicCas<alpaka::hierarchy::Blocks>(acc, success, operandOrig);
-    testAtomicCas<alpaka::hierarchy::Grids>(acc, success, operandOrig);
+    testAtomicCas<alpaka::hierarchy::Threads>(acc, success, operand, operandOrig);
+    testAtomicCas<alpaka::hierarchy::Blocks>(acc, success, operand, operandOrig);
+    testAtomicCas<alpaka::hierarchy::Grids>(acc, success, operand, operandOrig);
 }
 
 template<typename TAcc, typename T, typename Sfinae = void>
@@ -177,17 +174,26 @@ public:
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, T operandOrig) const -> void
     {
-        testAtomicHierarchies<Add>(acc, success, operandOrig);
-        testAtomicHierarchies<Sub>(acc, success, operandOrig);
-        testAtomicHierarchies<Exch>(acc, success, operandOrig);
+        auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
+
+        testAtomicHierarchies<Add>(acc, success, operand, operandOrig);
+        testAtomicHierarchies<Sub>(acc, success, operand, operandOrig);
+        testAtomicHierarchies<Exch>(acc, success, operand, operandOrig);
+        testAtomicHierarchies<Min>(acc, success, operand, operandOrig);
+        testAtomicHierarchies<Max>(acc, success, operand, operandOrig);
+
+        testAtomicHierarchies<And>(acc, success, operand, operandOrig);
+        testAtomicHierarchies<Or>(acc, success, operand, operandOrig);
+        testAtomicHierarchies<Xor>(acc, success, operand, operandOrig);
+
         if constexpr(std::is_unsigned_v<T>)
         {
             // atomicInc / atomicDec are implemented only for unsigned integer types
-            testAtomicHierarchies<Inc>(acc, success, operandOrig);
-            testAtomicHierarchies<Dec>(acc, success, operandOrig);
+            testAtomicHierarchies<Inc>(acc, success, operand, operandOrig);
+            testAtomicHierarchies<Dec>(acc, success, operand, operandOrig);
         }
 
-        testAtomicCasHierarchies<alpaka::hierarchy::Threads>(acc, success, operandOrig);
+        testAtomicCasHierarchies<alpaka::hierarchy::Threads>(acc, success, operand, operandOrig);
     }
 };
 
@@ -199,92 +205,24 @@ public:
     ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, T operandOrig) const -> void
     {
-        testAtomicHierarchies<Add>(acc, success, operandOrig);
-        testAtomicHierarchies<Sub>(acc, success, operandOrig);
-        testAtomicHierarchies<Exch>(acc, success, operandOrig);
+        auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
 
-        // Inc, Dec are not supported on float/double types
+        testAtomicHierarchies<Add>(acc, success, operand, operandOrig);
+        testAtomicHierarchies<Sub>(acc, success, operand, operandOrig);
+        testAtomicHierarchies<Exch>(acc, success, operand, operandOrig);
+        testAtomicHierarchies<Min>(acc, success, operand, operandOrig);
+        testAtomicHierarchies<Max>(acc, success, operand, operandOrig);
 
-        testAtomicCasHierarchies<alpaka::hierarchy::Threads>(acc, success, operandOrig);
+        // Inc, Dec, Or, And, Xor are not supported on float/double types
+
+        testAtomicCasHierarchies<alpaka::hierarchy::Threads>(acc, success, operand, operandOrig);
     }
 };
 
-template<typename TAcc, typename T, typename Sfinae = void>
-class AtomicCompareOperationsTestKernel
-{
-public:
-    ALPAKA_NO_HOST_ACC_WARNING
-    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, T operandOrig) const -> void
-    {
-        testAtomicHierarchies<Min>(acc, success, operandOrig);
-        testAtomicHierarchies<Max>(acc, success, operandOrig);
-    }
-};
-
-template<typename TAcc, typename T, typename Sfinae = void>
-class AtomicBitOperationsTestKernel
-{
-public:
-    ALPAKA_NO_HOST_ACC_WARNING
-    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, T operandOrig) const -> void
-    {
-        testAtomicHierarchies<And>(acc, success, operandOrig);
-        testAtomicHierarchies<Or>(acc, success, operandOrig);
-        testAtomicHierarchies<Xor>(acc, success, operandOrig);
-    }
-};
-
-template<typename TAcc, typename T>
-class AtomicBitOperationsTestKernel<TAcc, T, std::enable_if_t<std::is_floating_point_v<T>>>
-{
-public:
-    ALPAKA_NO_HOST_ACC_WARNING
-    ALPAKA_FN_ACC auto operator()(TAcc const& /* acc */, bool* success, T /* operandOrig */) const -> void
-    {
-        // Do not perform bitwise atomic operations for floating point types
-        ALPAKA_CHECK(*success, true);
-    }
-};
 
 
 template<typename TApi, typename TDim, typename TIdx, typename T>
 class AtomicTestKernel<
-    alpaka::AccGpuUniformCudaHipRt<TApi, TDim, TIdx>,
-    T,
-    std::enable_if_t<sizeof(T) != 4u && sizeof(T) != 8u>>
-{
-public:
-    ALPAKA_NO_HOST_ACC_WARNING
-    ALPAKA_FN_ACC auto operator()(
-        alpaka::AccGpuUniformCudaHipRt<TApi, TDim, TIdx> const& /* acc */,
-        bool* success,
-        T /* operandOrig */) const -> void
-    {
-        // Only 32/64bit atomics are supported
-        ALPAKA_CHECK(*success, true);
-    }
-};
-
-template<typename TApi, typename TDim, typename TIdx, typename T>
-class AtomicBitOperationsTestKernel<
-    alpaka::AccGpuUniformCudaHipRt<TApi, TDim, TIdx>,
-    T,
-    std::enable_if_t<!std::is_floating_point_v<T> && (sizeof(T) != 4u && sizeof(T) != 8u)>>
-{
-public:
-    ALPAKA_NO_HOST_ACC_WARNING
-    ALPAKA_FN_ACC auto operator()(
-        alpaka::AccGpuUniformCudaHipRt<TApi, TDim, TIdx> const& /* acc */,
-        bool* success,
-        T /* operandOrig */) const -> void
-    {
-        // Only 32/64bit atomics are supported
-        ALPAKA_CHECK(*success, true);
-    }
-};
-
-template<typename TApi, typename TDim, typename TIdx, typename T>
-class AtomicCompareOperationsTestKernel<
     alpaka::AccGpuUniformCudaHipRt<TApi, TDim, TIdx>,
     T,
     std::enable_if_t<sizeof(T) != 4u && sizeof(T) != 8u>>
@@ -318,34 +256,6 @@ public:
     }
 };
 
-template<typename TDim, typename TIdx, typename T>
-class AtomicBitOperationsTestKernel<
-    alpaka::AccOacc<TDim, TIdx>,
-    T,
-    std::enable_if_t<!std::is_floating_point_v<T> && (sizeof(T) != 4u && sizeof(T) != 8u)>>
-{
-public:
-    ALPAKA_NO_HOST_ACC_WARNING
-    ALPAKA_FN_ACC auto operator()(alpaka::AccOacc<TDim, TIdx> const& /* acc */, bool* success, T /* operandOrig */)
-        const -> void
-    {
-        // Only 32/64bit atomics are supported
-        ALPAKA_CHECK(*success, true);
-    }
-};
-
-template<typename TDim, typename TIdx, typename T>
-class AtomicCompareOperationsTestKernel<
-    alpaka::AccOacc<TDim, TIdx>,
-    T,
-    std::enable_if_t<sizeof(T) != 4u && sizeof(T) != 8u>>
-{
-public:
-    ALPAKA_NO_HOST_ACC_WARNING
-    ALPAKA_FN_ACC auto operator()(alpaka::AccOacc<TDim, TIdx> const& /* acc */, bool* success, T /* operandOrig */)
-        const -> void
-    {
-        // Only 32/64bit atomics are supported
 template<typename TAcc, typename T>
 struct TestAtomicOperations
 {
@@ -358,17 +268,8 @@ struct TestAtomicOperations
 
         T value = static_cast<T>(32);
 
-        // The tests are split into multiple kernel to avoid breaking the maximum kernel size.
-        // clang (HIP) e.g. shows compile error: 'error: stack size limit exceeded (155632) in
-        // _ZN6alpaka16uniform_cuda_hip6de'
         AtomicTestKernel<TAcc, T> kernel;
         REQUIRE(fixture(kernel, value));
-
-        AtomicBitOperationsTestKernel<TAcc, T> kernelBitOps;
-        REQUIRE(fixture(kernelBitOps, value));
-
-        AtomicCompareOperationsTestKernel<TAcc, T> kernelCompareOps;
-        REQUIRE(fixture(kernelCompareOps, value));
     }
 };
 

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -75,8 +75,8 @@ template<typename THierarchy, typename TOp, typename TAcc, typename T>
 ALPAKA_FN_ACC auto testAtomicCombinations(TAcc const& acc, bool* success, T& operand, T operandOrig) -> void
 {
     // helper variables to avoid compiler conversion warnings/errors
-    T constexpr one = static_cast<T>(1);
-    T constexpr two = static_cast<T>(2);
+    constexpr T one = static_cast<T>(1);
+    constexpr T two = static_cast<T>(2);
     {
         // left operand is half of the right
         T const value = static_cast<T>(operandOrig / two);
@@ -147,27 +147,7 @@ ALPAKA_FN_ACC auto testAtomicCas(TAcc const& acc, bool* success, T& operand, T o
     }
 }
 
-//! check threads hierarchy
-ALPAKA_NO_HOST_ACC_WARNING
-template<typename TOp, typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicHierarchies(TAcc const& acc, bool* success, T& operand, T operandOrig) -> void
-{
-    testAtomicCombinations<alpaka::hierarchy::Threads, TOp>(acc, success, operand, operandOrig);
-    testAtomicCombinations<alpaka::hierarchy::Blocks, TOp>(acc, success, operand, operandOrig);
-    testAtomicCombinations<alpaka::hierarchy::Grids, TOp>(acc, success, operand, operandOrig);
-}
-
-//! check all alpaka hierarchies
-ALPAKA_NO_HOST_ACC_WARNING
-template<typename TOp, typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicCasHierarchies(TAcc const& acc, bool* success, T& operand, T operandOrig) -> void
-{
-    testAtomicCas<alpaka::hierarchy::Threads>(acc, success, operand, operandOrig);
-    testAtomicCas<alpaka::hierarchy::Blocks>(acc, success, operand, operandOrig);
-    testAtomicCas<alpaka::hierarchy::Grids>(acc, success, operand, operandOrig);
-}
-
-template<typename TAcc, typename T, typename Sfinae = void>
+template<typename THierarchy, typename TAcc, typename T, typename Sfinae = void>
 class AtomicTestKernel
 {
 public:
@@ -176,30 +156,29 @@ public:
     {
         auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
 
-        testAtomicHierarchies<Add>(acc, success, operand, operandOrig);
-        testAtomicHierarchies<Sub>(acc, success, operand, operandOrig);
-        testAtomicHierarchies<Exch>(acc, success, operand, operandOrig);
-        testAtomicHierarchies<Min>(acc, success, operand, operandOrig);
-        testAtomicHierarchies<Max>(acc, success, operand, operandOrig);
+        testAtomicCombinations<THierarchy, Add>(acc, success, operand, operandOrig);
+        testAtomicCombinations<THierarchy, Sub>(acc, success, operand, operandOrig);
+        testAtomicCombinations<THierarchy, Exch>(acc, success, operand, operandOrig);
+        testAtomicCombinations<THierarchy, Min>(acc, success, operand, operandOrig);
+        testAtomicCombinations<THierarchy, Max>(acc, success, operand, operandOrig);
 
-        testAtomicHierarchies<And>(acc, success, operand, operandOrig);
-        testAtomicHierarchies<Or>(acc, success, operand, operandOrig);
-        testAtomicHierarchies<Xor>(acc, success, operand, operandOrig);
+        testAtomicCombinations<THierarchy, And>(acc, success, operand, operandOrig);
+        testAtomicCombinations<THierarchy, Or>(acc, success, operand, operandOrig);
+        testAtomicCombinations<THierarchy, Xor>(acc, success, operand, operandOrig);
 
         if constexpr(std::is_unsigned_v<T>)
         {
             // atomicInc / atomicDec are implemented only for unsigned integer types
-            testAtomicHierarchies<Inc>(acc, success, operand, operandOrig);
-            testAtomicHierarchies<Dec>(acc, success, operand, operandOrig);
+            testAtomicCombinations<THierarchy, Inc>(acc, success, operand, operandOrig);
+            testAtomicCombinations<THierarchy, Dec>(acc, success, operand, operandOrig);
         }
 
-        testAtomicCasHierarchies<alpaka::hierarchy::Threads>(acc, success, operand, operandOrig);
+        testAtomicCas<THierarchy>(acc, success, operand, operandOrig);
     }
 };
 
-
-template<typename TAcc, typename T>
-class AtomicTestKernel<TAcc, T, std::enable_if_t<std::is_floating_point_v<T>>>
+template<typename THierarchy, typename TAcc, typename T>
+class AtomicTestKernel<THierarchy, TAcc, T, std::enable_if_t<std::is_floating_point_v<T>>>
 {
 public:
     ALPAKA_NO_HOST_ACC_WARNING
@@ -207,52 +186,15 @@ public:
     {
         auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
 
-        testAtomicHierarchies<Add>(acc, success, operand, operandOrig);
-        testAtomicHierarchies<Sub>(acc, success, operand, operandOrig);
-        testAtomicHierarchies<Exch>(acc, success, operand, operandOrig);
-        testAtomicHierarchies<Min>(acc, success, operand, operandOrig);
-        testAtomicHierarchies<Max>(acc, success, operand, operandOrig);
+        testAtomicCombinations<THierarchy, Add>(acc, success, operand, operandOrig);
+        testAtomicCombinations<THierarchy, Sub>(acc, success, operand, operandOrig);
+        testAtomicCombinations<THierarchy, Exch>(acc, success, operand, operandOrig);
+        testAtomicCombinations<THierarchy, Min>(acc, success, operand, operandOrig);
+        testAtomicCombinations<THierarchy, Max>(acc, success, operand, operandOrig);
 
         // Inc, Dec, Or, And, Xor are not supported on float/double types
 
-        testAtomicCasHierarchies<alpaka::hierarchy::Threads>(acc, success, operand, operandOrig);
-    }
-};
-
-
-
-template<typename TApi, typename TDim, typename TIdx, typename T>
-class AtomicTestKernel<
-    alpaka::AccGpuUniformCudaHipRt<TApi, TDim, TIdx>,
-    T,
-    std::enable_if_t<sizeof(T) != 4u && sizeof(T) != 8u>>
-{
-public:
-    ALPAKA_NO_HOST_ACC_WARNING
-    ALPAKA_FN_ACC auto operator()(
-        alpaka::AccGpuUniformCudaHipRt<TApi, TDim, TIdx> const& /* acc */,
-        bool* success,
-        T /* operandOrig */) const -> void
-    {
-        // Only 32/64bit atomics are supported
-        ALPAKA_CHECK(*success, true);
-    }
-};
-
-#endif
-
-#if defined(ALPAKA_ACC_ANY_BT_OACC_ENABLED)
-
-template<typename TDim, typename TIdx, typename T>
-class AtomicTestKernel<alpaka::AccOacc<TDim, TIdx>, T, std::enable_if_t<sizeof(T) != 4u && sizeof(T) != 8u>>
-{
-public:
-    ALPAKA_NO_HOST_ACC_WARNING
-    ALPAKA_FN_ACC auto operator()(alpaka::AccOacc<TDim, TIdx> const& /* acc */, bool* success, T /* operandOrig */)
-        const -> void
-    {
-        // Only 32/64bit atomics are supported
-        ALPAKA_CHECK(*success, true);
+        testAtomicCas<THierarchy>(acc, success, operand, operandOrig);
     }
 };
 
@@ -268,8 +210,14 @@ struct TestAtomicOperations
 
         T value = static_cast<T>(32);
 
-        AtomicTestKernel<TAcc, T> kernel;
-        REQUIRE(fixture(kernel, value));
+        AtomicTestKernel<alpaka::hierarchy::Threads, TAcc, T> kernelAtomicThreads;
+        REQUIRE(fixture(kernelAtomicThreads, value));
+
+        AtomicTestKernel<alpaka::hierarchy::Blocks, TAcc, T> kernelAtomicBlocks;
+        REQUIRE(fixture(kernelAtomicBlocks, value));
+
+        AtomicTestKernel<alpaka::hierarchy::Grids, TAcc, T> kernelAtomicGrids;
+        REQUIRE(fixture(kernelAtomicGrids, value));
     }
 };
 

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -20,7 +20,7 @@
 using namespace alpaka::test::unit::atomic;
 
 template<typename T1, typename T2>
-ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC auto equals(T1 a, T2 b) -> bool
+constexpr auto equals(T1 a, T2 b) -> bool
 {
     return a == b;
 }
@@ -35,7 +35,6 @@ ALPAKA_FN_INLINE ALPAKA_FN_HOST_ACC auto equals(double a, double b) -> bool
     return alpaka::math::floatEqualExactNoWarning(a, b);
 }
 
-ALPAKA_NO_HOST_ACC_WARNING
 template<typename THierarchy, typename TOp, typename TAcc, typename T>
 ALPAKA_FN_ACC auto testAtomicCall(TAcc const& acc, bool* success, T& operand, T operandOrig, T value) -> void
 {
@@ -70,133 +69,129 @@ ALPAKA_FN_ACC auto testAtomicCall(TAcc const& acc, bool* success, T& operand, T 
     }
 }
 
-ALPAKA_NO_HOST_ACC_WARNING
-template<typename THierarchy, typename TOp, typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicCombinations(TAcc const& acc, bool* success, T& operand, T operandOrig) -> void
-{
-    // helper variables to avoid compiler conversion warnings/errors
-    constexpr T one = static_cast<T>(1);
-    constexpr T two = static_cast<T>(2);
-    {
-        // left operand is half of the right
-        T const value = static_cast<T>(operandOrig / two);
-        testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
-    }
-    {
-        // left operand is twice as large as the right
-        T const value = static_cast<T>(operandOrig * two);
-        testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
-    }
-    {
-        // left operand is larger by one
-        T const value = static_cast<T>(operandOrig + one);
-        testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
-    }
-    {
-        // left operand is smaller by one
-        T const value = static_cast<T>(operandOrig - one);
-        testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
-    }
-    {
-        // both operands are equal
-        T const value = operandOrig;
-        testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
-    }
-}
-
-ALPAKA_NO_HOST_ACC_WARNING
-template<typename THierarchy, typename TAcc, typename T>
-ALPAKA_FN_ACC auto testAtomicCas(TAcc const& acc, bool* success, T& operand, T operandOrig) -> void
-{
-    T const value = static_cast<T>(4);
-
-    // with match
-    {
-        T const compare = operandOrig;
-        T const reference = value;
-        {
-            operand = operandOrig;
-            T const ret = alpaka::atomicOp<alpaka::AtomicCas>(acc, &operand, compare, value, THierarchy{});
-            ALPAKA_CHECK(*success, equals(operandOrig, ret));
-            ALPAKA_CHECK(*success, equals(operand, reference));
-        }
-        {
-            operand = operandOrig;
-            T const ret = alpaka::atomicCas(acc, &operand, compare, value, THierarchy{});
-            ALPAKA_CHECK(*success, equals(operandOrig, ret));
-            ALPAKA_CHECK(*success, equals(operand, reference));
-        }
-    }
-
-    // without match
-    {
-        T const compare = static_cast<T>(operandOrig + static_cast<T>(1));
-        T const reference = operandOrig;
-        {
-            operand = operandOrig;
-            T const ret = alpaka::atomicOp<alpaka::AtomicCas>(acc, &operand, compare, value, THierarchy{});
-            ALPAKA_CHECK(*success, equals(operandOrig, ret));
-            ALPAKA_CHECK(*success, equals(operand, reference));
-        }
-        {
-            operand = operandOrig;
-            T const ret = alpaka::atomicCas(acc, &operand, compare, value, THierarchy{});
-            ALPAKA_CHECK(*success, equals(operandOrig, ret));
-            ALPAKA_CHECK(*success, equals(operand, reference));
-        }
-    }
-}
-
-template<typename THierarchy, typename TAcc, typename T, typename Sfinae = void>
+template<typename THierarchy, typename TAcc, typename T, typename TOp, typename Sfinae = void>
 class AtomicTestKernel
 {
 public:
-    ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, T operandOrig) const -> void
     {
         auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
 
-        testAtomicCombinations<THierarchy, Add>(acc, success, operand, operandOrig);
-        testAtomicCombinations<THierarchy, Sub>(acc, success, operand, operandOrig);
-        testAtomicCombinations<THierarchy, Exch>(acc, success, operand, operandOrig);
-        testAtomicCombinations<THierarchy, Min>(acc, success, operand, operandOrig);
-        testAtomicCombinations<THierarchy, Max>(acc, success, operand, operandOrig);
-
-        testAtomicCombinations<THierarchy, And>(acc, success, operand, operandOrig);
-        testAtomicCombinations<THierarchy, Or>(acc, success, operand, operandOrig);
-        testAtomicCombinations<THierarchy, Xor>(acc, success, operand, operandOrig);
-
-        if constexpr(std::is_unsigned_v<T>)
+        // helper variables to avoid compiler conversion warnings/errors
+        constexpr T one = static_cast<T>(1);
+        constexpr T two = static_cast<T>(2);
         {
-            // atomicInc / atomicDec are implemented only for unsigned integer types
-            testAtomicCombinations<THierarchy, Inc>(acc, success, operand, operandOrig);
-            testAtomicCombinations<THierarchy, Dec>(acc, success, operand, operandOrig);
+            // left operand is half of the right
+            T const value = static_cast<T>(operandOrig / two);
+            testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
         }
-
-        testAtomicCas<THierarchy>(acc, success, operand, operandOrig);
+        {
+            // left operand is twice as large as the right
+            T const value = static_cast<T>(operandOrig * two);
+            testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
+        }
+        {
+            // left operand is larger by one
+            T const value = static_cast<T>(operandOrig + one);
+            testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
+        }
+        {
+            // left operand is smaller by one
+            T const value = static_cast<T>(operandOrig - one);
+            testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
+        }
+        {
+            // both operands are equal
+            T const value = operandOrig;
+            testAtomicCall<THierarchy, TOp>(acc, success, operand, operandOrig, value);
+        }
     }
 };
 
 template<typename THierarchy, typename TAcc, typename T>
-class AtomicTestKernel<THierarchy, TAcc, T, std::enable_if_t<std::is_floating_point_v<T>>>
+class AtomicTestKernel<THierarchy, TAcc, T, Cas, void>
 {
 public:
-    ALPAKA_NO_HOST_ACC_WARNING
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, T operandOrig) const -> void
     {
         auto& operand = alpaka::declareSharedVar<T, __COUNTER__>(acc);
 
-        testAtomicCombinations<THierarchy, Add>(acc, success, operand, operandOrig);
-        testAtomicCombinations<THierarchy, Sub>(acc, success, operand, operandOrig);
-        testAtomicCombinations<THierarchy, Exch>(acc, success, operand, operandOrig);
-        testAtomicCombinations<THierarchy, Min>(acc, success, operand, operandOrig);
-        testAtomicCombinations<THierarchy, Max>(acc, success, operand, operandOrig);
+        T const value = static_cast<T>(4);
 
-        // Inc, Dec, Or, And, Xor are not supported on float/double types
+        // with match
+        {
+            T const compare = operandOrig;
+            T const reference = value;
+            {
+                operand = operandOrig;
+                T const ret = alpaka::atomicOp<alpaka::AtomicCas>(acc, &operand, compare, value, THierarchy{});
+                ALPAKA_CHECK(*success, equals(operandOrig, ret));
+                ALPAKA_CHECK(*success, equals(operand, reference));
+            }
+            {
+                operand = operandOrig;
+                T const ret = alpaka::atomicCas(acc, &operand, compare, value, THierarchy{});
+                ALPAKA_CHECK(*success, equals(operandOrig, ret));
+                ALPAKA_CHECK(*success, equals(operand, reference));
+            }
+        }
 
-        testAtomicCas<THierarchy>(acc, success, operand, operandOrig);
+        // without match
+        {
+            T const compare = static_cast<T>(operandOrig + static_cast<T>(1));
+            T const reference = operandOrig;
+            {
+                operand = operandOrig;
+                T const ret = alpaka::atomicOp<alpaka::AtomicCas>(acc, &operand, compare, value, THierarchy{});
+                ALPAKA_CHECK(*success, equals(operandOrig, ret));
+                ALPAKA_CHECK(*success, equals(operand, reference));
+            }
+            {
+                operand = operandOrig;
+                T const ret = alpaka::atomicCas(acc, &operand, compare, value, THierarchy{});
+                ALPAKA_CHECK(*success, equals(operandOrig, ret));
+                ALPAKA_CHECK(*success, equals(operand, reference));
+            }
+        }
     }
 };
+
+template<typename TAcc, typename T, typename TOp>
+void runTest(auto& fixture, T value)
+{
+    INFO(
+        "execute test: " << alpaka::core::demangled<TAcc> << ", Type:" << alpaka::core::demangled<T>
+                         << ", Operation:" << alpaka::core::demangled<TOp>);
+    // exclude all operations not supported for floating point types
+    constexpr bool skipFloatTestsFor
+        = std::is_floating_point_v<T>
+          && (std::is_same_v<TOp, Inc> || std::is_same_v<TOp, Dec> || std::is_same_v<TOp, Or>
+              || std::is_same_v<TOp, And> || std::is_same_v<TOp, Xor>);
+    if constexpr(!skipFloatTestsFor)
+    {
+        // only unsigned types are supported for Inc and Dec
+        constexpr bool isOpIncOrDec = (std::is_same_v<TOp, Inc> || std::is_same_v<TOp, Dec>);
+        if constexpr(!isOpIncOrDec || (isOpIncOrDec && std::is_unsigned_v<T>) )
+        {
+            AtomicTestKernel<alpaka::hierarchy::Threads, TAcc, T, TOp> kernelAtomicThreads;
+            REQUIRE(fixture(kernelAtomicThreads, value));
+
+            AtomicTestKernel<alpaka::hierarchy::Blocks, TAcc, T, TOp> kernelAtomicBlocks;
+            REQUIRE(fixture(kernelAtomicBlocks, value));
+
+            AtomicTestKernel<alpaka::hierarchy::Grids, TAcc, T, TOp> kernelAtomicGrids;
+            REQUIRE(fixture(kernelAtomicGrids, value));
+        }
+        else
+            INFO(
+                "  skip:" << alpaka::core::demangled<TAcc> << ", Type:" << alpaka::core::demangled<T>
+                          << ", Operation:" << alpaka::core::demangled<TOp>);
+    }
+    else
+        INFO(
+            "  skip:" << alpaka::core::demangled<TAcc> << ", Type:" << alpaka::core::demangled<T>
+                      << ", Operation:" << alpaka::core::demangled<TOp>);
+}
 
 template<typename TAcc, typename T>
 struct TestAtomicOperations
@@ -210,14 +205,11 @@ struct TestAtomicOperations
 
         T value = static_cast<T>(32);
 
-        AtomicTestKernel<alpaka::hierarchy::Threads, TAcc, T> kernelAtomicThreads;
-        REQUIRE(fixture(kernelAtomicThreads, value));
+        // It is required to create one kernel per tested operations else some compilers compile time e.g clang for HIP
+        // is exploding and the test will not compile within the CI wall time.
+        auto operations = std::make_tuple(Add{}, Sub{}, Exch{}, Min{}, Max{}, Inc{}, Dec{}, Or{}, And{}, Xor{}, Cas{});
 
-        AtomicTestKernel<alpaka::hierarchy::Blocks, TAcc, T> kernelAtomicBlocks;
-        REQUIRE(fixture(kernelAtomicBlocks, value));
-
-        AtomicTestKernel<alpaka::hierarchy::Grids, TAcc, T> kernelAtomicGrids;
-        REQUIRE(fixture(kernelAtomicGrids, value));
+        std::apply([&]<typename... TOp>(TOp...) { (runTest<TAcc, T, TOp>(fixture, value), ...); }, operations);
     }
 };
 

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -179,8 +179,6 @@ public:
     {
         testAtomicHierarchies<Add>(acc, success, operandOrig);
         testAtomicHierarchies<Sub>(acc, success, operandOrig);
-        testAtomicHierarchies<Min>(acc, success, operandOrig);
-        testAtomicHierarchies<Max>(acc, success, operandOrig);
         testAtomicHierarchies<Exch>(acc, success, operandOrig);
         if constexpr(std::is_unsigned_v<T>)
         {
@@ -188,13 +186,11 @@ public:
             testAtomicHierarchies<Inc>(acc, success, operandOrig);
             testAtomicHierarchies<Dec>(acc, success, operandOrig);
         }
-        testAtomicHierarchies<And>(acc, success, operandOrig);
-        testAtomicHierarchies<Or>(acc, success, operandOrig);
-        testAtomicHierarchies<Xor>(acc, success, operandOrig);
 
         testAtomicCasHierarchies<alpaka::hierarchy::Threads>(acc, success, operandOrig);
     }
 };
+
 
 template<typename TAcc, typename T>
 class AtomicTestKernel<TAcc, T, std::enable_if_t<std::is_floating_point_v<T>>>
@@ -205,18 +201,51 @@ public:
     {
         testAtomicHierarchies<Add>(acc, success, operandOrig);
         testAtomicHierarchies<Sub>(acc, success, operandOrig);
-        testAtomicHierarchies<Min>(acc, success, operandOrig);
-        testAtomicHierarchies<Max>(acc, success, operandOrig);
         testAtomicHierarchies<Exch>(acc, success, operandOrig);
 
-        // Inc, Dec, Or, And, Xor  are not supported on float/double types
+        // Inc, Dec are not supported on float/double types
 
         testAtomicCasHierarchies<alpaka::hierarchy::Threads>(acc, success, operandOrig);
     }
 };
 
-#if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && ALPAKA_LANG_CUDA)                                                         \
-    || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_LANG_HIP)
+template<typename TAcc, typename T, typename Sfinae = void>
+class AtomicCompareOperationsTestKernel
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, T operandOrig) const -> void
+    {
+        testAtomicHierarchies<Min>(acc, success, operandOrig);
+        testAtomicHierarchies<Max>(acc, success, operandOrig);
+    }
+};
+
+template<typename TAcc, typename T, typename Sfinae = void>
+class AtomicBitOperationsTestKernel
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, T operandOrig) const -> void
+    {
+        testAtomicHierarchies<And>(acc, success, operandOrig);
+        testAtomicHierarchies<Or>(acc, success, operandOrig);
+        testAtomicHierarchies<Xor>(acc, success, operandOrig);
+    }
+};
+
+template<typename TAcc, typename T>
+class AtomicBitOperationsTestKernel<TAcc, T, std::enable_if_t<std::is_floating_point_v<T>>>
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    ALPAKA_FN_ACC auto operator()(TAcc const& /* acc */, bool* success, T /* operandOrig */) const -> void
+    {
+        // Do not perform bitwise atomic operations for floating point types
+        ALPAKA_CHECK(*success, true);
+    }
+};
+
 
 template<typename TApi, typename TDim, typename TIdx, typename T>
 class AtomicTestKernel<
@@ -231,13 +260,92 @@ public:
         bool* success,
         T /* operandOrig */) const -> void
     {
-        // All other types are not supported by CUDA/HIP atomic operations.
+        // Only 32/64bit atomics are supported
+        ALPAKA_CHECK(*success, true);
+    }
+};
+
+template<typename TApi, typename TDim, typename TIdx, typename T>
+class AtomicBitOperationsTestKernel<
+    alpaka::AccGpuUniformCudaHipRt<TApi, TDim, TIdx>,
+    T,
+    std::enable_if_t<!std::is_floating_point_v<T> && (sizeof(T) != 4u && sizeof(T) != 8u)>>
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    ALPAKA_FN_ACC auto operator()(
+        alpaka::AccGpuUniformCudaHipRt<TApi, TDim, TIdx> const& /* acc */,
+        bool* success,
+        T /* operandOrig */) const -> void
+    {
+        // Only 32/64bit atomics are supported
+        ALPAKA_CHECK(*success, true);
+    }
+};
+
+template<typename TApi, typename TDim, typename TIdx, typename T>
+class AtomicCompareOperationsTestKernel<
+    alpaka::AccGpuUniformCudaHipRt<TApi, TDim, TIdx>,
+    T,
+    std::enable_if_t<sizeof(T) != 4u && sizeof(T) != 8u>>
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    ALPAKA_FN_ACC auto operator()(
+        alpaka::AccGpuUniformCudaHipRt<TApi, TDim, TIdx> const& /* acc */,
+        bool* success,
+        T /* operandOrig */) const -> void
+    {
+        // Only 32/64bit atomics are supported
         ALPAKA_CHECK(*success, true);
     }
 };
 
 #endif
 
+#if defined(ALPAKA_ACC_ANY_BT_OACC_ENABLED)
+
+template<typename TDim, typename TIdx, typename T>
+class AtomicTestKernel<alpaka::AccOacc<TDim, TIdx>, T, std::enable_if_t<sizeof(T) != 4u && sizeof(T) != 8u>>
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    ALPAKA_FN_ACC auto operator()(alpaka::AccOacc<TDim, TIdx> const& /* acc */, bool* success, T /* operandOrig */)
+        const -> void
+    {
+        // Only 32/64bit atomics are supported
+        ALPAKA_CHECK(*success, true);
+    }
+};
+
+template<typename TDim, typename TIdx, typename T>
+class AtomicBitOperationsTestKernel<
+    alpaka::AccOacc<TDim, TIdx>,
+    T,
+    std::enable_if_t<!std::is_floating_point_v<T> && (sizeof(T) != 4u && sizeof(T) != 8u)>>
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    ALPAKA_FN_ACC auto operator()(alpaka::AccOacc<TDim, TIdx> const& /* acc */, bool* success, T /* operandOrig */)
+        const -> void
+    {
+        // Only 32/64bit atomics are supported
+        ALPAKA_CHECK(*success, true);
+    }
+};
+
+template<typename TDim, typename TIdx, typename T>
+class AtomicCompareOperationsTestKernel<
+    alpaka::AccOacc<TDim, TIdx>,
+    T,
+    std::enable_if_t<sizeof(T) != 4u && sizeof(T) != 8u>>
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    ALPAKA_FN_ACC auto operator()(alpaka::AccOacc<TDim, TIdx> const& /* acc */, bool* success, T /* operandOrig */)
+        const -> void
+    {
+        // Only 32/64bit atomics are supported
 template<typename TAcc, typename T>
 struct TestAtomicOperations
 {
@@ -248,10 +356,19 @@ struct TestAtomicOperations
 
         alpaka::test::KernelExecutionFixture<TAcc> fixture(alpaka::Vec<Dim, Idx>::ones());
 
-        AtomicTestKernel<TAcc, T> kernel;
-
         T value = static_cast<T>(32);
+
+        // The tests are split into multiple kernel to avoid breaking the maximum kernel size.
+        // clang (HIP) e.g. shows compile error: 'error: stack size limit exceeded (155632) in
+        // _ZN6alpaka16uniform_cuda_hip6de'
+        AtomicTestKernel<TAcc, T> kernel;
         REQUIRE(fixture(kernel, value));
+
+        AtomicBitOperationsTestKernel<TAcc, T> kernelBitOps;
+        REQUIRE(fixture(kernelBitOps, value));
+
+        AtomicCompareOperationsTestKernel<TAcc, T> kernelCompareOps;
+        REQUIRE(fixture(kernelCompareOps, value));
     }
 };
 

--- a/test/unit/core/src/ConfigTest.cpp
+++ b/test/unit/core/src/ConfigTest.cpp
@@ -39,19 +39,35 @@ TEST_CASE("printDefines", "[core]")
 TEST_CASE("configVersionMacros", "")
 {
     static_assert(ALPAKA_VERSION_NUMBER(2025, 2, 1) == 202'500'200'001);
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_VERSION_NUMBER(12025, 2, 1) == 202'500'200'001);
+    static_assert(ALPAKA_VERSION_NUMBER(12025, 2, 1) == ALPAKA_VERSION_NUMBER(2025, 2, 1));
 
     static_assert(ALPAKA_VERSION_NUMBER_NOT_AVAILABLE == 0000000000000);
     static_assert(ALPAKA_VERSION_NUMBER_NOT_AVAILABLE == ALPAKA_VERSION_NUMBER(0, 0, 0));
 
     static_assert(ALPAKA_YYYYMMDD_TO_VERSION(20'250'201) == 202'500'200'001);
     static_assert(ALPAKA_YYYYMMDD_TO_VERSION(20'250'201) == ALPAKA_VERSION_NUMBER(2025, 2, 1));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_YYYYMMDD_TO_VERSION(120'250'201) == ALPAKA_VERSION_NUMBER(2025, 2, 1));
 
     static_assert(ALPAKA_YYYYMM_TO_VERSION(202502) == 202'500'200'000);
     static_assert(ALPAKA_YYYYMM_TO_VERSION(202502) == ALPAKA_VERSION_NUMBER(2025, 2, 0));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_YYYYMM_TO_VERSION(1'202'502) == ALPAKA_VERSION_NUMBER(2025, 2, 0));
 
-    static_assert(ALPAKA_VVRRP_10_TO_VERSION(12081) == 1'200'800'001);
-    static_assert(ALPAKA_VVRRP_10_TO_VERSION(12081) == ALPAKA_VERSION_NUMBER(12, 8, 1));
+    static_assert(ALPAKA_VVRRP_TO_VERSION(12081) == 1'200'800'001);
+    static_assert(ALPAKA_VVRRP_TO_VERSION(12081) == ALPAKA_VERSION_NUMBER(12, 8, 1));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_VVRRP_TO_VERSION(12'345'081) == ALPAKA_VERSION_NUMBER(2345, 8, 1));
 
     static_assert(ALPAKA_VRP_TO_VERSION(751) == 700'500'001);
     static_assert(ALPAKA_VRP_TO_VERSION(751) == ALPAKA_VERSION_NUMBER(7, 5, 1));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_VRP_TO_VERSION(1'234'567) == ALPAKA_VERSION_NUMBER(2345, 6, 7));
+
+    static_assert(ALPAKA_VRRPP_TO_VERSION(120503) == 1'200'500'003);
+    static_assert(ALPAKA_VRRPP_TO_VERSION(120503) == ALPAKA_VERSION_NUMBER(12, 5, 3));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_VRRPP_TO_VERSION(123'451'513) == ALPAKA_VERSION_NUMBER(2345, 15, 13));
 }


### PR DESCRIPTION
- [ ] merge after #2582 (first commit contains the fix for atomicDec)

clang CUDA is exposing `atomic*_block()` function signatures even if these can not be used by the selected architecture.
This leads to compile issues if clang is used as CUDA compiler.

Our tests cases have not checked all combinations of atomics, therefore the second commit refactors the atomic tests and fixes #1769:

- test all hierarchies which can be used for atomics
- extent test cases to test for equal, smaller, larger, and zero as left side operand
- test calling `atomic*()` and `atomicOp<*>()`
