### PR TITLE
Update SysInfo.hpp

### DIFF
--- a/include/alpaka/dev/cpu/SysInfo.hpp
+++ b/include/alpaka/dev/cpu/SysInfo.hpp
@@ -39,6 +39,14 @@
 #include <stdexcept>
 #include <string>
 
+#if BOOST_ARCH_X86
+#    if BOOST_COMP_GNUC || BOOST_COMP_CLANG || BOOST_COMP_PGI
+#        include <cpuid.h>
+#    elif BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
+#        include <intrin.h>
+#    endif
+#endif
+
 namespace alpaka
 {
     namespace cpu
@@ -50,14 +58,12 @@ namespace alpaka
             constexpr int UNKNOWN_COMPILER = 1;
 #if BOOST_ARCH_X86
 #    if BOOST_COMP_GNUC || BOOST_COMP_CLANG || BOOST_COMP_PGI
-#        include <cpuid.h>
             inline auto cpuid(std::uint32_t level, std::uint32_t subfunction, std::uint32_t ex[4]) -> void
             {
                 __cpuid_count(level, subfunction, ex[0], ex[1], ex[2], ex[3]);
             }
 
 #    elif BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
-#        include <intrin.h>
             inline auto cpuid(std::uint32_t level, std::uint32_t subfunction, std::uint32_t ex[4]) -> void
             {
                 __cpuidex(reinterpret_cast<int*>(ex), level, subfunction);

--- a/include/alpaka/dev/cpu/SysInfo.hpp
+++ b/include/alpaka/dev/cpu/SysInfo.hpp
@@ -47,12 +47,8 @@
 #    endif
 #endif
 
-namespace alpaka
+namespace alpaka::cpu::detail
 {
-    namespace cpu
-    {
-        namespace detail
-        {
             constexpr int NO_CPUID = 0;
             constexpr int UNKNOWN_CPU = 0;
             constexpr int UNKNOWN_COMPILER = 1;
@@ -241,6 +237,4 @@ namespace alpaka
 #    error "getFreeGlobalMemSizeBytes not implemented for this system!"
 #endif
             }
-        } // namespace detail
-    } // namespace cpu
-} // namespace alpaka
+} // namespace alpaka::cpu::detail

--- a/include/alpaka/dev/cpu/SysInfo.hpp
+++ b/include/alpaka/dev/cpu/SysInfo.hpp
@@ -49,15 +49,14 @@ namespace alpaka
             constexpr int UNKNOWN_CPU = 0;
             constexpr int UNKNOWN_COMPILER = 1;
 #if BOOST_ARCH_X86
-#    if BOOST_COMP_GNUC || BOOST_COMP_CLANG || (!BOOST_COMP_MSVC_EMULATED && defined(__INTEL_COMPILER))               \
-        || BOOST_COMP_PGI
+#    if BOOST_COMP_GNUC || BOOST_COMP_CLANG || BOOST_COMP_PGI
 #        include <cpuid.h>
             inline auto cpuid(std::uint32_t level, std::uint32_t subfunction, std::uint32_t ex[4]) -> void
             {
                 __cpuid_count(level, subfunction, ex[0], ex[1], ex[2], ex[3]);
             }
 
-#    elif BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED) || defined(__INTEL_COMPILER)
+#    elif BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
 #        include <intrin.h>
             inline auto cpuid(std::uint32_t level, std::uint32_t subfunction, std::uint32_t ex[4]) -> void
             {

--- a/include/alpaka/dev/cpu/SysInfo.hpp
+++ b/include/alpaka/dev/cpu/SysInfo.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2020 Benjamin Worpitz, Daniel Vollmer, Erik Zenker, René Widera, Bernhard Manfred Gruber
+/* Copyright 2022 Benjamin Worpitz, Daniel Vollmer, Erik Zenker, René Widera, Bernhard Manfred Gruber, Andrea Bocci
  *
  * This file is part of alpaka.
  *

--- a/include/alpaka/dev/cpu/SysInfo.hpp
+++ b/include/alpaka/dev/cpu/SysInfo.hpp
@@ -49,192 +49,194 @@
 
 namespace alpaka::cpu::detail
 {
-            constexpr int NO_CPUID = 0;
-            constexpr int UNKNOWN_CPU = 0;
-            constexpr int UNKNOWN_COMPILER = 1;
+    constexpr int NO_CPUID = 0;
+    constexpr int UNKNOWN_CPU = 0;
+    constexpr int UNKNOWN_COMPILER = 1;
 #if BOOST_ARCH_X86
 #    if BOOST_COMP_GNUC || BOOST_COMP_CLANG || BOOST_COMP_PGI
-            inline auto cpuid(std::uint32_t level, std::uint32_t subfunction, std::uint32_t ex[4]) -> void
-            {
-                __cpuid_count(level, subfunction, ex[0], ex[1], ex[2], ex[3]);
-            }
+    inline auto cpuid(std::uint32_t level, std::uint32_t subfunction, std::uint32_t ex[4]) -> void
+    {
+        __cpuid_count(level, subfunction, ex[0], ex[1], ex[2], ex[3]);
+    }
 
 #    elif BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)
-            inline auto cpuid(std::uint32_t level, std::uint32_t subfunction, std::uint32_t ex[4]) -> void
-            {
-                __cpuidex(reinterpret_cast<int*>(ex), level, subfunction);
-            }
+    inline auto cpuid(std::uint32_t level, std::uint32_t subfunction, std::uint32_t ex[4]) -> void
+    {
+        __cpuidex(reinterpret_cast<int*>(ex), level, subfunction);
+    }
 #    else
-            inline auto cpuid(std::uint32_t, std::uint32_t, std::uint32_t ex[4]) -> void
-            {
-                ex[0] = ex[2] = ex[3] = NO_CPUID;
-                ex[1] = UNKNOWN_COMPILER;
-            }
+    inline auto cpuid(std::uint32_t, std::uint32_t, std::uint32_t ex[4]) -> void
+    {
+        ex[0] = ex[2] = ex[3] = NO_CPUID;
+        ex[1] = UNKNOWN_COMPILER;
+    }
 #    endif
 #else
-            inline auto cpuid(std::uint32_t, std::uint32_t, std::uint32_t ex[4]) -> void
-            {
-                ex[0] = ex[2] = ex[3] = NO_CPUID;
-                ex[1] = UNKNOWN_CPU;
-            }
+    inline auto cpuid(std::uint32_t, std::uint32_t, std::uint32_t ex[4]) -> void
+    {
+        ex[0] = ex[2] = ex[3] = NO_CPUID;
+        ex[1] = UNKNOWN_CPU;
+    }
 #endif
-            //! \return The name of the CPU the code is running on.
-            inline auto getCpuName() -> std::string
-            {
-                // Get extended ids.
-                std::uint32_t ex[4] = {0};
-                cpuid(0x80000000, 0, ex);
-                std::uint32_t const nExIds(ex[0]);
+    //! \return The name of the CPU the code is running on.
+    inline auto getCpuName() -> std::string
+    {
+        // Get extended ids.
+        std::uint32_t ex[4] = {0};
+        cpuid(0x80000000, 0, ex);
+        std::uint32_t const nExIds(ex[0]);
 
-                if(!nExIds)
-                {
-                    switch(ex[1])
-                    {
-                    case UNKNOWN_COMPILER:
-                        return "<unknown: compiler>";
-                    case UNKNOWN_CPU:
-                        return "<unknown: CPU>";
-                    default:
-                        return "<unknown>";
-                    }
-                }
+        if(!nExIds)
+        {
+            switch(ex[1])
+            {
+            case UNKNOWN_COMPILER:
+                return "<unknown: compiler>";
+            case UNKNOWN_CPU:
+                return "<unknown: CPU>";
+            default:
+                return "<unknown>";
+            }
+        }
 #if BOOST_ARCH_X86
-                // Get the information associated with each extended ID.
-                char cpuBrandString[0x40] = {0};
-                for(std::uint32_t i(0x80000000); i <= nExIds; ++i)
-                {
-                    cpuid(i, 0, ex);
+        // Get the information associated with each extended ID.
+        char cpuBrandString[0x40] = {0};
+        for(std::uint32_t i(0x80000000); i <= nExIds; ++i)
+        {
+            cpuid(i, 0, ex);
 
-                    // Interpret CPU brand string and cache information.
-                    if(i == 0x80000002)
-                    {
-                        std::memcpy(cpuBrandString, ex, sizeof(ex));
-                    }
-                    else if(i == 0x80000003)
-                    {
-                        std::memcpy(cpuBrandString + 16, ex, sizeof(ex));
-                    }
-                    else if(i == 0x80000004)
-                    {
-                        std::memcpy(cpuBrandString + 32, ex, sizeof(ex));
-                    }
-                }
-                return std::string(cpuBrandString);
-#else
-                return std::string("unknown");
-#endif
-            }
-
-            //! \return Pagesize in bytes used by the system.
-            inline size_t getPageSize()
+            // Interpret CPU brand string and cache information.
+            if(i == 0x80000002)
             {
+                std::memcpy(cpuBrandString, ex, sizeof(ex));
+            }
+            else if(i == 0x80000003)
+            {
+                std::memcpy(cpuBrandString + 16, ex, sizeof(ex));
+            }
+            else if(i == 0x80000004)
+            {
+                std::memcpy(cpuBrandString + 32, ex, sizeof(ex));
+            }
+        }
+        return std::string(cpuBrandString);
+#else
+        return std::string("unknown");
+#endif
+    }
+
+    //! \return Pagesize in bytes used by the system.
+    inline size_t getPageSize()
+    {
 #if BOOST_OS_WINDOWS || BOOST_OS_CYGWIN
-                SYSTEM_INFO si;
-                GetSystemInfo(&si);
-                return si.dwPageSize;
+        SYSTEM_INFO si;
+        GetSystemInfo(&si);
+        return si.dwPageSize;
 #elif BOOST_OS_UNIX || BOOST_OS_MACOS
 #    if defined(_SC_PAGESIZE)
-                return static_cast<std::size_t>(sysconf(_SC_PAGESIZE));
+        return static_cast<std::size_t>(sysconf(_SC_PAGESIZE));
 #    else
-                // this is legacy and only used as fallback
-                return = static_cast<size_t>(getpagesize());
+        // this is legacy and only used as fallback
+        return = static_cast<size_t>(getpagesize());
 #    endif
 #else
 #    error "getPageSize not implemented for this system!"
-                return 0;
+        return 0;
 #endif
-            }
+    }
 
-            //! \return The total number of bytes of global memory.
-            //! Adapted from David Robert Nadeau:
-            //! http://nadeausoftware.com/articles/2012/09/c_c_tip_how_get_physical_memory_size_system
-            inline auto getTotalGlobalMemSizeBytes() -> std::size_t
-            {
+    //! \return The total number of bytes of global memory.
+    //! Adapted from David Robert Nadeau:
+    //! http://nadeausoftware.com/articles/2012/09/c_c_tip_how_get_physical_memory_size_system
+    inline auto getTotalGlobalMemSizeBytes() -> std::size_t
+    {
 #if BOOST_OS_WINDOWS
-                MEMORYSTATUSEX status;
-                status.dwLength = sizeof(status);
-                GlobalMemoryStatusEx(&status);
-                return static_cast<std::size_t>(status.ullTotalPhys);
+        MEMORYSTATUSEX status;
+        status.dwLength = sizeof(status);
+        GlobalMemoryStatusEx(&status);
+        return static_cast<std::size_t>(status.ullTotalPhys);
 
 #elif BOOST_OS_CYGWIN
-                // New 64-bit MEMORYSTATUSEX isn't available.
-                MEMORYSTATUS status;
-                status.dwLength = sizeof(status);
-                GlobalMemoryStatus(&status);
-                return static_cast<std::size_t>(status.dwTotalPhys);
+        // New 64-bit MEMORYSTATUSEX isn't available.
+        MEMORYSTATUS status;
+        status.dwLength = sizeof(status);
+        GlobalMemoryStatus(&status);
+        return static_cast<std::size_t>(status.dwTotalPhys);
 
 #elif BOOST_OS_UNIX || BOOST_OS_MACOS
-                // Unix : Prefer sysctl() over sysconf() except sysctl() with HW_REALMEM and HW_PHYSMEM which are not
-                // always reliable
+        // Unix : Prefer sysctl() over sysconf() except sysctl() with HW_REALMEM and HW_PHYSMEM which are not
+        // always reliable
 #    if defined(CTL_HW) && (defined(HW_MEMSIZE) || defined(HW_PHYSMEM64))
-                int mib[2]
-                    = { CTL_HW,
+        int mib[2]
+            = { CTL_HW,
 #        if defined(HW_MEMSIZE) // OSX
-                        HW_MEMSIZE
+                HW_MEMSIZE
 #        elif defined(HW_PHYSMEM64) // NetBSD, OpenBSD.
-                        HW_PHYSMEM64
+                HW_PHYSMEM64
 #        endif
-                      };
-                std::uint64_t size(0);
-                std::size_t sizeLen{sizeof(size)};
-                if(sysctl(mib, 2, &size, &sizeLen, nullptr, 0) < 0)
-                    throw std::logic_error("getTotalGlobalMemSizeBytes failed calling sysctl!");
-                return static_cast<std::size_t>(size);
+              };
+        std::uint64_t size(0);
+        std::size_t sizeLen{sizeof(size)};
+        if(sysctl(mib, 2, &size, &sizeLen, nullptr, 0) < 0)
+            throw std::logic_error("getTotalGlobalMemSizeBytes failed calling sysctl!");
+        return static_cast<std::size_t>(size);
 
 #    elif defined(_SC_AIX_REALMEM) // AIX.
-                return static_cast<std::size_t>(sysconf(_SC_AIX_REALMEM)) * static_cast<std::size_t>(1024);
+        return static_cast<std::size_t>(sysconf(_SC_AIX_REALMEM)) * static_cast<std::size_t>(1024);
 
 #    elif defined(_SC_PHYS_PAGES) // Linux, FreeBSD, OpenBSD, Solaris.
-                return static_cast<std::size_t>(sysconf(_SC_PHYS_PAGES)) * getPageSize();
+        return static_cast<std::size_t>(sysconf(_SC_PHYS_PAGES)) * getPageSize();
 
 #    elif defined(CTL_HW)                                                                                             \
         && (defined(HW_PHYSMEM) || defined(HW_REALMEM)) // FreeBSD, DragonFly BSD, NetBSD, OpenBSD, and OSX.
-                int mib[2]
-                    = { CTL_HW,
+        int mib[2]
+            = { CTL_HW,
 #        if defined(HW_REALMEM) // FreeBSD.
-                        HW_REALMEM;
+                HW_REALMEM
 #        elif defined(HW_PYSMEM) // Others.
-                        HW_PHYSMEM;
+                HW_PHYSMEM
 #        endif
-            };
-            std::uint32_t size(0);
-            std::size_t const sizeLen{sizeof(size)};
-            if(sysctl(mib, 2, &size, &sizeLen, nullptr, 0) < 0)
-                throw std::logic_error("getTotalGlobalMemSizeBytes failed calling sysctl!");
-            return static_cast<std::size_t>(size);
+              };
+        std::uint32_t size(0);
+        std::size_t const sizeLen{sizeof(size)};
+        if(sysctl(mib, 2, &size, &sizeLen, nullptr, 0) < 0)
+            throw std::logic_error("getTotalGlobalMemSizeBytes failed calling sysctl!");
+        return static_cast<std::size_t>(size);
 #    endif
 
 #else
 #    error "getTotalGlobalMemSizeBytes not implemented for this system!"
 #endif
-            } // namespace detail
-            //! \return The free number of bytes of global memory.
-            //! \throws std::logic_error if not implemented on the system and std::runtime_error on other errors.
-            inline auto getFreeGlobalMemSizeBytes() -> std::size_t
-            {
+    }
+
+    //! \return The free number of bytes of global memory.
+    //! \throws std::logic_error if not implemented on the system and std::runtime_error on other errors.
+    inline auto getFreeGlobalMemSizeBytes() -> std::size_t
+    {
 #if BOOST_OS_WINDOWS
-                MEMORYSTATUSEX status;
-                status.dwLength = sizeof(status);
-                GlobalMemoryStatusEx(&status);
-                return static_cast<std::size_t>(status.ullAvailPhys);
+        MEMORYSTATUSEX status;
+        status.dwLength = sizeof(status);
+        GlobalMemoryStatusEx(&status);
+        return static_cast<std::size_t>(status.ullAvailPhys);
 #elif BOOST_OS_LINUX
 #    if defined(_SC_AVPHYS_PAGES)
-                return static_cast<std::size_t>(sysconf(_SC_AVPHYS_PAGES)) * getPageSize();
+        return static_cast<std::size_t>(sysconf(_SC_AVPHYS_PAGES)) * getPageSize();
 #    else
-                // this is legacy and only used as fallback
-                return static_cast<std::size_t>(get_avphys_pages()) * getPageSize();
+        // this is legacy and only used as fallback
+        return static_cast<std::size_t>(get_avphys_pages()) * getPageSize();
 #    endif
 #elif BOOST_OS_MACOS
-                int free_pages = 0;
-                std::size_t len = sizeof(free_pages);
-                if(sysctlbyname("vm.page_free_count", &free_pages, &len, nullptr, 0) < 0)
-                {
-                    throw std::logic_error("getFreeGlobalMemSizeBytes failed calling sysctl(vm.page_free_count)!");
-                }
+        int free_pages = 0;
+        std::size_t len = sizeof(free_pages);
+        if(sysctlbyname("vm.page_free_count", &free_pages, &len, nullptr, 0) < 0)
+        {
+            throw std::logic_error("getFreeGlobalMemSizeBytes failed calling sysctl(vm.page_free_count)!");
+        }
 
-                return static_cast<std::size_t>(free_pages) * getPageSize();
+        return static_cast<std::size_t>(free_pages) * getPageSize();
 #else
 #    error "getFreeGlobalMemSizeBytes not implemented for this system!"
 #endif
-            }
+    }
+
 } // namespace alpaka::cpu::detail


### PR DESCRIPTION
Move `#include`s from `alpaka::cpu::detail` to the global namespace (see #1775).

On Linux, query the OS for free pages instead of reading `/proc/meminfo` (see #1774).

Replace the nested namespace with a nested namespace definition.

Apply code formatting and update copyright notice.