### PR TITLE
Make Philox random engines trivially copyable

### DIFF
--- a/include/alpaka/rand/Philox/PhiloxSingle.hpp
+++ b/include/alpaka/rand/Philox/PhiloxSingle.hpp
@@ -135,10 +135,6 @@ namespace alpaka::rand::engine
             advanceState();
         }
 
-        ALPAKA_FN_HOST_ACC PhiloxSingle(PhiloxSingle const& other) : state{other.state}
-        {
-        }
-
         /** Get the next random number
          *
          * @return The next random number

--- a/include/alpaka/rand/Philox/PhiloxVector.hpp
+++ b/include/alpaka/rand/Philox/PhiloxVector.hpp
@@ -92,10 +92,6 @@ namespace alpaka::rand::engine
             nextVector();
         }
 
-        ALPAKA_FN_HOST_ACC PhiloxVector(PhiloxVector const& other) : state{other.state}
-        {
-        }
-
         /** Get the next vector of random numbers
          *
          * @return The next vector of random numbers

--- a/include/alpaka/rand/RandPhilox.hpp
+++ b/include/alpaka/rand/RandPhilox.hpp
@@ -56,10 +56,6 @@ namespace alpaka::rand
         {
         }
 
-        ALPAKA_FN_HOST_ACC Philox4x32x10(EngineVariant state) : engineVariant(state)
-        {
-        }
-
         // STL UniformRandomBitGenerator concept
         // https://en.cppreference.com/w/cpp/named_req/UniformRandomBitGenerator
         using result_type = std::uint32_t;
@@ -111,10 +107,6 @@ namespace alpaka::rand
             std::uint32_t const subsequence = 0,
             std::uint32_t const offset = 0)
             : engineVariant(seed, subsequence, offset)
-        {
-        }
-
-        ALPAKA_FN_HOST_ACC Philox4x32x10Vector(EngineVariant state) : engineVariant(state)
         {
         }
 

--- a/include/alpaka/rand/RandUniformCudaHipRand.hpp
+++ b/include/alpaka/rand/RandUniformCudaHipRand.hpp
@@ -76,13 +76,7 @@ namespace alpaka::rand
         public:
             // After calling this constructor the instance is not valid initialized and
             // need to be overwritten with a valid object
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-            ALPAKA_FN_HOST_ACC Xor() : state(curandStateXORWOW_t{})
-#        else
-            ALPAKA_FN_HOST_ACC Xor() : state(hiprandStateXORWOW_t{})
-#        endif
-            {
-            }
+            Xor() = default;
 
             __device__ Xor(
                 std::uint32_t const& seed,
@@ -105,9 +99,9 @@ namespace alpaka::rand
             friend class distribution::uniform_cuda_hip::UniformUint;
 
 #        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-            curandStateXORWOW_t state;
+            curandStateXORWOW_t state = curandStateXORWOW_t{};
 #        else
-            hiprandStateXORWOW_t state;
+            hiprandStateXORWOW_t state = hiprandStateXORWOW_t{};
 #        endif
 
         public:

--- a/include/alpaka/rand/Traits.hpp
+++ b/include/alpaka/rand/Traits.hpp
@@ -83,7 +83,9 @@ namespace alpaka::rand
             template<typename TRand, typename TSfinae = void>
             struct CreateDefault;
         } // namespace trait
-        //! \return A default random number generator engine.
+        //! \return A default random number generator engine. Its type is guaranteed to be trivially copyable.
+        //!         Except HIP accelerator for HIP versions below 5.2 as its internal state was not trivially copyable.
+        //!         The limitation was discussed in PR #1778.
         ALPAKA_NO_HOST_ACC_WARNING
         template<typename TRand>
         ALPAKA_FN_HOST_ACC auto createDefault(

--- a/test/unit/rand/src/RandTest.cpp
+++ b/test/unit/rand/src/RandTest.cpp
@@ -1,4 +1,5 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, René Widera, Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, René Widera, Jan Stephan, Bernhard Manfred Gruber,
+ *                Sergei Bastrakov
  *
  * This file is part of alpaka.
  *
@@ -13,6 +14,8 @@
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
+
+#include <type_traits>
 
 class RandTestKernel
 {
@@ -94,4 +97,34 @@ TEMPLATE_LIST_TEST_CASE("defaultRandomGeneratorIsWorking", "[rand]", alpaka::tes
     RandTestKernel kernel;
 
     REQUIRE(fixture(kernel));
+}
+
+//! Helper trait to check if the given accelerator is HIP
+template<typename TAcc>
+struct IsAccHIP : public std::false_type
+{
+};
+
+#if defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+template<typename TDim, typename TIdx>
+struct IsAccHIP<alpaka::AccGpuHipRt<TDim, TIdx>> : public std::true_type
+{
+};
+#endif
+
+TEMPLATE_LIST_TEST_CASE("defaultRandomGeneratorIsTriviallyCopyable", "[rand]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+    using DefaultEngine = decltype(alpaka::rand::engine::createDefault(std::declval<Acc>(), 0u, 0u, 0u));
+    constexpr auto isEngineTriviallyCopyable = std::is_trivially_copyable_v<DefaultEngine>;
+    // For older HIP versions the internal HIPrand/ROCrand state was not trivially copyable.
+    // This causes alpaka rand state for the HIP accelerator and those versions to also not be trivially copyable.
+    // It was fixed on AMD side in https://github.com/ROCmSoftwarePlatform/rocRAND/pull/252.
+    // Thus we guard the test to skip HIP accelerator and older HIP versions.
+#if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && (BOOST_LANG_HIP < BOOST_VERSION_NUMBER(5, 2, 0))
+    if constexpr(!IsAccHIP<Acc>::value)
+        STATIC_REQUIRE(isEngineTriviallyCopyable);
+#else
+    STATIC_REQUIRE(isEngineTriviallyCopyable);
+#endif
 }


### PR DESCRIPTION
Manually implemented copy constructor prevented it, while not implementing any non-default logic. This made it impossible to pass it to kernels by value (normally we pass those by pointer e.g. in our examples, so did not notice before).

I checked the `std::is_trivially_copyable_v` before and after the change to confirm it.

cc @jkelling who reported the issue for his branch of PIConGPU.