### PR TITLE
add tags for each alpaka accelerator

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -12,6 +12,7 @@
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLED
 
 // Base classes.
+#    include <alpaka/acc/Tags.hpp>
 #    include <alpaka/atomic/AtomicCpu.hpp>
 #    include <alpaka/atomic/AtomicHierarchy.hpp>
 #    include <alpaka/atomic/AtomicNoOp.hpp>
@@ -78,7 +79,8 @@ namespace alpaka
         public rand::RandStdLib,
         public TimeStdLib,
         public warp::WarpSingleThread,
-        public concepts::Implements<ConceptAcc, AccCpuFibers<TDim, TIdx>>
+        public concepts::Implements<ConceptAcc, AccCpuFibers<TDim, TIdx>>,
+        public concepts::Implements<ConceptAccCpuFibers, AccCpuFibers<TDim, TIdx>>
     {
         static_assert(
             sizeof(TIdx) >= sizeof(int),

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -16,6 +16,7 @@
 #    endif
 
 // Base classes.
+#    include <alpaka/acc/Tags.hpp>
 #    include <alpaka/atomic/AtomicCpu.hpp>
 #    include <alpaka/atomic/AtomicHierarchy.hpp>
 #    include <alpaka/atomic/AtomicNoOp.hpp>
@@ -79,7 +80,8 @@ namespace alpaka
         public rand::RandStdLib,
         public TimeOmp,
         public warp::WarpSingleThread,
-        public concepts::Implements<ConceptAcc, AccCpuOmp2Blocks<TDim, TIdx>>
+        public concepts::Implements<ConceptAcc, AccCpuOmp2Blocks<TDim, TIdx>>,
+        public concepts::Implements<ConceptAccCpuOmp2Blocks, AccCpuOmp2Blocks<TDim, TIdx>>
     {
         static_assert(
             sizeof(TIdx) >= sizeof(int),

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -16,6 +16,7 @@
 #    endif
 
 // Base classes.
+#    include <alpaka/acc/Tags.hpp>
 #    include <alpaka/atomic/AtomicCpu.hpp>
 #    include <alpaka/atomic/AtomicHierarchy.hpp>
 #    include <alpaka/atomic/AtomicOmpBuiltIn.hpp>
@@ -80,7 +81,8 @@ namespace alpaka
         public rand::RandStdLib,
         public TimeOmp,
         public warp::WarpSingleThread,
-        public concepts::Implements<ConceptAcc, AccCpuOmp2Threads<TDim, TIdx>>
+        public concepts::Implements<ConceptAcc, AccCpuOmp2Threads<TDim, TIdx>>,
+        public concepts::Implements<ConceptAccCpuOmp2Threads, AccCpuOmp2Threads<TDim, TIdx>>
     {
         static_assert(
             sizeof(TIdx) >= sizeof(int),

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -12,6 +12,7 @@
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
 
 // Base classes.
+#    include <alpaka/acc/Tags.hpp>
 #    include <alpaka/atomic/AtomicCpu.hpp>
 #    include <alpaka/atomic/AtomicHierarchy.hpp>
 #    include <alpaka/atomic/AtomicNoOp.hpp>
@@ -73,7 +74,8 @@ namespace alpaka
         public rand::RandStdLib,
         public TimeStdLib,
         public warp::WarpSingleThread,
-        public concepts::Implements<ConceptAcc, AccCpuSerial<TDim, TIdx>>
+        public concepts::Implements<ConceptAcc, AccCpuSerial<TDim, TIdx>>,
+        public concepts::Implements<ConceptAccCpuSerial, AccCpuSerial<TDim, TIdx>>
     {
         static_assert(
             sizeof(TIdx) >= sizeof(int),

--- a/include/alpaka/acc/AccCpuSyclIntel.hpp
+++ b/include/alpaka/acc/AccCpuSyclIntel.hpp
@@ -12,6 +12,7 @@
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_BACKEND_ONEAPI) && defined(ALPAKA_SYCL_ONEAPI_CPU)
 
 #    include <alpaka/acc/AccGenericSycl.hpp>
+#    include <alpaka/acc/Tags.hpp>
 #    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/DemangleTypeNames.hpp>
 #    include <alpaka/core/Sycl.hpp>
@@ -38,6 +39,7 @@ namespace alpaka::experimental
     class AccCpuSyclIntel
         : public AccGenericSycl<TDim, TIdx>
         , public concepts::Implements<ConceptAcc, AccCpuSyclIntel<TDim, TIdx>>
+        , public concepts::Implements<ConceptAccCpuSyclIntel, AccCpuSyclIntel<TDim, TIdx>>
     {
     public:
         using AccGenericSycl<TDim, TIdx>::AccGenericSycl;

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -12,6 +12,7 @@
 #ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
 
 // Base classes.
+#    include <alpaka/acc/Tags.hpp>
 #    include <alpaka/atomic/AtomicCpu.hpp>
 #    include <alpaka/atomic/AtomicHierarchy.hpp>
 #    include <alpaka/atomic/AtomicNoOp.hpp>
@@ -70,7 +71,8 @@ namespace alpaka
         public rand::RandStdLib,
         public TimeStdLib,
         public warp::WarpSingleThread,
-        public concepts::Implements<ConceptAcc, AccCpuTbbBlocks<TDim, TIdx>>
+        public concepts::Implements<ConceptAcc, AccCpuTbbBlocks<TDim, TIdx>>,
+        public concepts::Implements<ConceptAccCpuTbbBlocks, AccCpuTbbBlocks<TDim, TIdx>>
     {
         static_assert(
             sizeof(TIdx) >= sizeof(int),

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -12,6 +12,7 @@
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
 
 // Base classes.
+#    include <alpaka/acc/Tags.hpp>
 #    include <alpaka/atomic/AtomicCpu.hpp>
 #    include <alpaka/atomic/AtomicHierarchy.hpp>
 #    include <alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp>
@@ -75,7 +76,8 @@ namespace alpaka
         public rand::RandStdLib,
         public TimeStdLib,
         public warp::WarpSingleThread,
-        public concepts::Implements<ConceptAcc, AccCpuThreads<TDim, TIdx>>
+        public concepts::Implements<ConceptAcc, AccCpuThreads<TDim, TIdx>>,
+        public concepts::Implements<ConceptAccCpuThreads, AccCpuThreads<TDim, TIdx>>
     {
         static_assert(
             sizeof(TIdx) >= sizeof(int),

--- a/include/alpaka/acc/AccFpgaSyclIntel.hpp
+++ b/include/alpaka/acc/AccFpgaSyclIntel.hpp
@@ -12,6 +12,7 @@
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_BACKEND_ONEAPI) && defined(ALPAKA_SYCL_ONEAPI_FPGA)
 
 #    include <alpaka/acc/AccGenericSycl.hpp>
+#    include <alpaka/acc/Tags.hpp>
 #    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/DemangleTypeNames.hpp>
 #    include <alpaka/core/Sycl.hpp>
@@ -37,6 +38,7 @@ namespace alpaka::experimental
     class AccFpgaSyclIntel
         : public AccGenericSycl<TDim, TIdx>
         , public concepts::Implements<ConceptAcc, AccFpgaSyclIntel<TDim, TIdx>>
+        , public concepts::Implements<ConceptAccFpgaSyclIntel, AccFpgaSyclIntel<TDim, TIdx>>
     {
     public:
         using AccGenericSycl<TDim, TIdx>::AccGenericSycl;

--- a/include/alpaka/acc/AccFpgaSyclXilinx.hpp
+++ b/include/alpaka/acc/AccFpgaSyclXilinx.hpp
@@ -12,6 +12,7 @@
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_BACKEND_XILINX)
 
 #    include <alpaka/acc/AccGenericSycl.hpp>
+#    include <alpaka/acc/Tags.hpp>
 #    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/DemangleTypeNames.hpp>
 #    include <alpaka/core/Sycl.hpp>
@@ -37,6 +38,7 @@ namespace alpaka::experimental
     class AccFpgaSyclXilinx
         : public AccGenericSycl<TDim, TIdx>
         , public concepts::Implements<ConceptAcc, AccFpgaSyclXilinx<TDim, TIdx>>
+        , public concepts::Implements<ConceptAccFpgaSyclXilinx, AccFpgaSyclXilinx<TDim, TIdx>>
     {
     public:
         using AccGenericSycl<TDim, TIdx>::AccGenericSycl;

--- a/include/alpaka/acc/AccGenericSycl.hpp
+++ b/include/alpaka/acc/AccGenericSycl.hpp
@@ -13,6 +13,7 @@
 #ifdef ALPAKA_ACC_SYCL_ENABLED
 
 // Base classes.
+#    include <alpaka/acc/Tags.hpp>
 #    include <alpaka/atomic/AtomicGenericSycl.hpp>
 #    include <alpaka/atomic/AtomicHierarchy.hpp>
 #    include <alpaka/block/shared/dyn/BlockSharedMemDynGenericSycl.hpp>
@@ -63,6 +64,7 @@ namespace alpaka::experimental
         , public IntrinsicGenericSycl
         , public MemFenceGenericSycl
         , public warp::WarpGenericSycl<TDim>
+        , public concepts::Implements<ConceptAccGenericSycl, AccGenericSycl<TDim, TIdx>>
     {
     public:
 #    ifdef ALPAKA_SYCL_IOSTREAM_ENABLED

--- a/include/alpaka/acc/AccGpuSyclIntel.hpp
+++ b/include/alpaka/acc/AccGpuSyclIntel.hpp
@@ -12,6 +12,7 @@
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_BACKEND_ONEAPI) && defined(ALPAKA_SYCL_ONEAPI_GPU)
 
 #    include <alpaka/acc/AccGenericSycl.hpp>
+#    include <alpaka/acc/Tags.hpp>
 #    include <alpaka/core/Concepts.hpp>
 #    include <alpaka/core/DemangleTypeNames.hpp>
 #    include <alpaka/core/Sycl.hpp>
@@ -37,6 +38,7 @@ namespace alpaka::experimental
     class AccGpuSyclIntel
         : public AccGenericSycl<TDim, TIdx>
         , public concepts::Implements<ConceptAcc, AccGpuSyclIntel<TDim, TIdx>>
+        , public concepts::Implements<ConceptAccGpuSyclIntel, AccGpuSyclIntel<TDim, TIdx>>
     {
     public:
         using AccGenericSycl<TDim, TIdx>::AccGenericSycl;

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -73,7 +73,8 @@ namespace alpaka
         public rand::RandUniformCudaHipRand<TApi>,
         public TimeUniformCudaHipBuiltIn,
         public warp::WarpUniformCudaHipBuiltIn,
-        public concepts::Implements<ConceptAcc, AccGpuUniformCudaHipRt<TApi, TDim, TIdx>>
+        public concepts::Implements<ConceptAcc, AccGpuUniformCudaHipRt<TApi, TDim, TIdx>>,
+        public concepts::Implements<typename TApi::AccTag_t, AccGpuUniformCudaHipRt<TApi, TDim, TIdx>>
     {
         static_assert(
             sizeof(TIdx) >= sizeof(int),

--- a/include/alpaka/acc/AccOacc.hpp
+++ b/include/alpaka/acc/AccOacc.hpp
@@ -16,6 +16,7 @@
 #    endif
 
 // Base classes.
+#    include <alpaka/acc/Tags.hpp>
 #    include <alpaka/core/DemangleTypeNames.hpp>
 #    include <alpaka/ctx/block/CtxBlockOacc.hpp>
 #    include <alpaka/idx/bt/IdxBtLinear.hpp>
@@ -81,6 +82,7 @@ namespace alpaka
         , public concepts::Implements<ConceptAtomicGrids, AccOacc<TDim, TIdx>>
         , public concepts::Implements<ConceptAtomicBlocks, AccOacc<TDim, TIdx>>
         , public concepts::Implements<ConceptAtomicThreads, AccOacc<TDim, TIdx>>
+        , public concepts::Implements<ConceptAccOacc, AccOacc<TDim, TIdx>>
     {
         template<typename TDim2, typename TIdx2, typename TKernelFnObj, typename... TArgs>
         friend class ::alpaka::TaskKernelOacc;

--- a/include/alpaka/acc/AccOmp5.hpp
+++ b/include/alpaka/acc/AccOmp5.hpp
@@ -22,6 +22,7 @@
 #    endif
 
 // Base classes.
+#    include <alpaka/acc/Tags.hpp>
 #    include <alpaka/atomic/AtomicHierarchy.hpp>
 #    include <alpaka/atomic/AtomicOmpBuiltIn.hpp>
 #    include <alpaka/block/shared/OffloadUseBuiltInSharedMem.hpp>
@@ -131,6 +132,7 @@ namespace alpaka
         , public TimeOmp
         , public warp::WarpSingleThread
         , public concepts::Implements<ConceptAcc, AccOmp5<TDim, TIdx>>
+        , public concepts::Implements<ConceptAccOmp5, AccOmp5<TDim, TIdx>>
     {
         static_assert(
             sizeof(TIdx) >= sizeof(int),

--- a/include/alpaka/acc/Tags.hpp
+++ b/include/alpaka/acc/Tags.hpp
@@ -1,0 +1,32 @@
+/* Copyright 2022 René Widera
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+namespace alpaka
+{
+    struct ConceptAccCpuFiber;
+    struct ConceptAccCpuOmp2Blocks;
+    struct ConceptAccCpuOmp2Threads;
+    struct ConceptAccCpuSerial;
+    struct ConceptAccCpuSyclIntel;
+
+    struct ConceptTaskKernelCpuTbbBlocks;
+    struct ConceptAccCpuThreads;
+    struct ConceptAccFpgaSyclIntel;
+    struct ConceptAccFpgaSyclXilinx;
+    struct ConceptAccCudaRt;
+    struct ConceptAccHipRt;
+
+    struct ConceptAccGenericSycl;
+    struct ConceptAccGpuSyclIntel;
+
+    struct ConceptAccOacc;
+    struct ConceptAccOmp5;
+} // namespace alpaka

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -31,6 +31,7 @@
 #include <alpaka/acc/AccGpuSyclIntel.hpp>
 #include <alpaka/acc/AccOacc.hpp>
 #include <alpaka/acc/AccOmp5.hpp>
+#include <alpaka/acc/Tags.hpp>
 #include <alpaka/acc/Traits.hpp>
 // atomic
 #include <alpaka/atomic/AtomicCpu.hpp>

--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -11,6 +11,8 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
+#    include <alpaka/acc/Tags.hpp>
+
 #    include <boost/predef.h>
 #    include <cuda_runtime_api.h>
 
@@ -18,6 +20,9 @@ namespace alpaka
 {
     struct ApiCudaRt
     {
+        // alpaka acc tag
+        using AccTag_t = ConceptAccCuda;
+
         // Names
         static constexpr char name[] = "Cuda";
         static constexpr auto version = BOOST_PREDEF_MAKE_10_VVRRP(CUDART_VERSION);

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -11,6 +11,7 @@
 
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
 
+#    include <alpaka/acc/Tags.hpp>
 #    include <alpaka/core/BoostPredef.hpp>
 
 #    include <hip/hip_runtime_api.h>
@@ -19,6 +20,9 @@ namespace alpaka
 {
     struct ApiHipRt
     {
+        // alpaka acc tag
+        using AccTag_t = ConceptAccHip;
+
         // Names
         static constexpr char name[] = "Hip";
         static constexpr auto version = BOOST_LANG_HIP;


### PR DESCRIPTION
We discussed today again in the alpaka meeting that it would be nice to have accelerator tags #1246 so that there is no need to use `#ifdef` to write traits for accelerators.
I had some free minutes and therefore drafted this PR.

- Provide a file `alpaka/acc/Tags.hpp` with tags for each alpaka accelerator.
- Add a concept to uniquely identifies each accelerator with an acc concept
tag.

PIConGPU example to show the possible effect of the tag.

Code snipped without tags.
```C++
template<typename T_Acc = cupla::AccThreadSeq>
struct GetDefaultStrategy
{
    using type = strategy::StridedCachedSupercells;
};

template<typename T_Acc = cupla::AccThreadSeq>
using GetDefaultStrategy_t = typename GetDefaultStrategy<T_Acc>::type;

#if(ALPAKA_ACC_GPU_CUDA_ENABLED == 1)
template<typename... T_Args>
struct GetDefaultStrategy<alpaka::AccGpuUniformCudaHipRt<alpaka::ApiCudaRt, T_Args...>>
{
    // GPU Utilization is higher compared to `StridedCachedSupercells`
    using type = strategy::CachedSupercells;
};
#endif

#if(ALPAKA_ACC_GPU_HIP_ENABLED == 1)
template<typename... T_Args>
struct GetDefaultStrategy<alpaka::AccGpuUniformCudaHipRt<alpaka::ApiHipRt, T_Args...>>
{
    // GPU Utilization is higher compared to `StridedCachedSupercells`
    using type = strategy::CachedSupercellsScaled<2>;
};
#endif
```

will be changed to without `#ifdef`

```C++
template<typename T_Acc = cupla::AccThreadSeq, typename = void>
struct GetDefaultStrategy
{
    using type = strategy::StridedCachedSupercells;
};

template<typename T_Acc = cupla::AccThreadSeq>
using GetDefaultStrategy_t = typename GetDefaultStrategy<T_Acc>::type;

template<typename T_Acc>
struct GetDefaultStrategy<T_Acc, std::enable_if_t<alpaka::concepts::ImplementsConcept<alpaka::ConceptAccCuda, T_Acc>::value>>
{
    // GPU Utilization is higher compared to `StridedCachedSupercells`
    using type = strategy::CachedSupercells;
};

template<typename T_Acc>
struct GetDefaultStrategy<T_Acc, std::enable_if_t<alpaka::concepts::ImplementsConcept<alpaka::ConceptAccHip, T_Acc>::value>>
{
    // GPU Utilization is higher compared to `StridedCachedSupercells`
    using type = strategy::CachedSupercellsScaled<2>;
};
```

CC-ing: @SimeonEhrig 