### PR TITLE
add job generator to gitlab ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,9 @@ out
 # clangd files
 .cache/
 compile_commands.json
+
+# python chache
+__pycache__
+
+# default name of the job_generator.py output
+jobs.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,67 +1,39 @@
 # stage description
-# Run Time Tests
-#   For HIP or other backends this is distributed round robin within the file.
-#   For CUDA version Major.X (where X is the latest patch of the major version) distributed round robin
-#   for each compiler within the file.
-#   There are exceptions for intermediate minor versions of CUDA
-#   stageRun0 = all CUDA version Major.0
-#   stageRun1 = all CUDA where minor != 0 and not latest minor version
-# Compile Tests
-#   stageCompileN = round robin distributed within the file
+# generate
+#  creates the actual test jobs via python script
+# run-tests
+#  execute the generated test jobs
+#  the ordering is mainly random
+#  the python generator can schedule some jobs on specific positions
 
 stages:
-  - stageCompile0
-  - stageRun0
-  - stageCompile1
-  - stageRun1
+  - generator
+  - run-test-jobs
 
 
 variables:
-  ALPAKA_GITLAB_CI_CONTAINER_VERSION: "1.4"
-  ALPAKA_CI_OS_NAME: "Linux"
-  alpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE: "ON"
-  alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE: "ON"
-  alpaka_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: "OFF"
-  alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: "OFF"
-  alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "ON"
-  alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: "ON"
-  alpaka_ACC_ANY_BT_OMP5_ENABLE: "OFF"
-  alpaka_ACC_ANY_BT_OACC_ENABLE: "OFF"
-  alpaka_ACC_GPU_CUDA_ENABLE: "OFF"
-  alpaka_ACC_GPU_CUDA_ONLY_MODE: "OFF"
-  alpaka_ACC_GPU_HIP_ENABLE: "OFF"
-  alpaka_ACC_GPU_HIP_ONLY_MODE: "OFF"
-  # If ALPAKA_CI_ANALYSIS is OFF compile and execute runtime tests else compile only.
-  ALPAKA_CI_ANALYSIS: "OFF"
-  ALPAKA_CI_RUN_TESTS: "ON"
-  alpaka_CI: GITLAB
-  # needs to be enabled, that test on the GPU are executed
-  ALPAKA_FORCE_RUNTIME_TEST: "ON"
-  ALPAKA_CI_SANITIZERS: ""
-  ALPAKA_CI_INSTALL_CUDA: "OFF"
-  ALPAKA_CI_INSTALL_HIP: "OFF"
-  ALPAKA_CI_CMAKE_DIR: "$HOME/cmake"
-  BOOST_ROOT: "$HOME/boost"
-  ALPAKA_CI_BOOST_LIB_DIR: "$HOME/boost_libs"
-  ALPAKA_CI_CUDA_DIR: "$HOME/cuda"
-  ALPAKA_CI_HIP_ROOT_DIR: "$HOME/hip"
+  # container version of the generated jobs
+  # should be merged with ALPAKA_GITLAB_CI_CONTAINER_VERSION
+  # see: script/job_generator/generate_job_yaml.py
+  ALPAKA_GITLAB_CI_GENERATOR_CONTAINER_VERSION: "3.0"
 
-include:
-  - local: '/script/gitlabci/job_base.yml'
-  - local: '/script/gitlabci/job_cuda9.2.yml'
-  - local: '/script/gitlabci/job_cuda10.0.yml'
-  - local: '/script/gitlabci/job_cuda10.1.yml'
-  - local: '/script/gitlabci/job_cuda10.2.yml'
-  - local: '/script/gitlabci/job_cuda11.0.yml'
-  - local: '/script/gitlabci/job_cuda11.1.yml'
-  - local: '/script/gitlabci/job_cuda11.2.yml'
-  - local: '/script/gitlabci/job_cuda11.3.yml'
-  - local: '/script/gitlabci/job_cuda11.4.yml'
-  - local: '/script/gitlabci/job_cuda11.5.yml'
-  - local: '/script/gitlabci/job_cuda11.6.yml'
-  - local: '/script/gitlabci/job_hip4.2.yml'
-  - local: '/script/gitlabci/job_hip4.3.yml'
-  - local: '/script/gitlabci/job_hip4.5.yml'
-  - local: '/script/gitlabci/job_hip5.0.yml'
-  - local: '/script/gitlabci/job_hip5.1.yml'
-  - local: '/script/gitlabci/job_hip5.2.yml'
+generate:
+  stage: generator
+  image: alpine:latest
+  script:
+    - apk update && apk add python3~=3.10 py3-pip
+    - pip3 install -r script/job_generator/requirements.txt
+    - python3 script/job_generator/job_generator.py ${ALPAKA_GITLAB_CI_GENERATOR_CONTAINER_VERSION}
+    - cat jobs.yml
+  artifacts:
+    paths:
+      - jobs.yml
+    expire_in: 1 week
+
+run-tests:
+  stage: run-test-jobs
+  trigger:
+    include:
+      - artifact: jobs.yml
+        job: generate
+    strategy: depend

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,6 +33,7 @@ extensions = [
     'breathe',
     'sphinxcontrib.programoutput',
 #    'matplotlib.sphinxext.plot_directive'
+    'sphinx.ext.autosectionlabel',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/dev/ci.rst
+++ b/docs/source/dev/ci.rst
@@ -1,5 +1,5 @@
-Continuous Integration
-======================
+Automatic Testing
+=================
 
 For automatic testing we use two different systems: ``GitHub Actions`` and ``GitLab CI``. ``GitHub Actions`` are used for a wide range of build tests and also some CPU runtime tests. ``GitLab CI`` allows us to run runtime tests on GPUs and CPU architectures other than x86, like ARM or IBM POWER.
 
@@ -11,11 +11,151 @@ The configuration of ``GitHub Actions`` can be found in the ``.github/workflows/
 GitLab CI
 ---------
 
-We use ``GitLab CI`` because it allows us to use self-hosted system, e.g. GPU systems. The GitHub repository is mirrored on https://gitlab.com/hzdr/crp/alpaka . Every commit or pull request is automatically mirrored to GitLab and triggers the CI. The configuration of the ``GitLab CI`` is stored in the file ``.gitlab-ci.yml``. The workflow of a ``GitLab CI`` is different from ``GitHub Actions``. Instead of downloading an unmodified container from ``Docker Hub`` and preparing the environment during the test job, ``GitLab CI`` uses containers which are already prepared for the tests. The containers are built in an `extra repository <https://gitlab.hzdr.de/crp/alpaka-group-container>`_ and contain all dependencies for alpaka. All available containers can be found `here <https://gitlab.hzdr.de/crp/alpaka-group-container/container_registry>`_. The scripts to build alpaka and run the tests are shared with ``GitHub Actions`` and located at ``script/``.
+We use ``GitLab CI`` because it allows us to use self-hosted system, e.g. GPU systems.
+The GitHub repository is mirrored on https://gitlab.com/hzdr/crp/alpaka .
+Every commit or pull request is automatically mirrored to GitLab and triggers the CI.
+The configuration of the ``GitLab CI`` is stored in the file ``.gitlab-ci.yml``.
+The workflow of a ``GitLab CI`` is different from ``GitHub Actions``.
+Instead of downloading an unmodified container from ``Docker Hub`` and preparing the environment during the test job, ``GitLab CI`` uses containers which are already prepared for the tests.
+The containers are built in an `extra repository <https://gitlab.hzdr.de/crp/alpaka-group-container>`_ and contain all dependencies for alpaka.
+All available containers can be found `here <https://gitlab.hzdr.de/crp/alpaka-group-container/container_registry>`_.
+The scripts to build alpaka and run the tests are shared with ``GitHub Actions`` and located at ``script/``.
+
+Most of the jobs for the GitLab CI are generated automatically.
+For more information, see the section :ref:`The Job Generator`.
+
+It is also possible to define custom jobs, see :ref:`Custom jobs`.
 
 .. figure:: /images/arch_gitlab_mirror.svg
    :alt: Relationship between GitHub.com, GitLab.com and HZDR gitlab-ci runners
 
    Relationship between GitHub.com, GitLab.com and HZDR gitlab-ci runners
 
-To change how the tests are built and executed, modify the code in the `alpaka repository <https://github.com/alpaka-group/alpaka>`_. If the container environment with the dependencies needs to be changed, please open an issue or contribute to `alpaka-group-container repository <https://gitlab.hzdr.de/crp/alpaka-group-container>`_.
+The Container Registry
+++++++++++++++++++++++
+
+Alpaka uses containers in which as many dependencies as possible are already installed to save job execution time.
+The available containers can be found `here <https://gitlab.hzdr.de/crp/alpaka-group-container/container_registry>`_.
+Each container provides a tool called ``agc-manager`` to check if a software is installed. The documentation for ``agc-manager`` can be found `here <https://gitlab.hzdr.de/crp/alpaka-group-container/-/tree/master/tools>`_.
+A common way to check if a software is already installed is to use an ``if else statement``.
+If a software is not installed yet, you can install it every time at job runtime.
+
+.. code-block:: bash
+
+ if agc-manager -e boost@${ALPAKA_CI_BOOST_VER} ; then
+   export ALPAKA_CI_BOOST_ROOT=$(agc-manager -b boost@${ALPAKA_CI_BOOST_VER})
+ else
+   # install boost
+ fi
+
+This statement installs a specific boost version until the boost version is pre-installed in the container.
+To install a specific software permanently in the container, please open an issue in the `alpaka-group-container repository <https://gitlab.hzdr.de/crp/alpaka-group-container/-/issues>`_.
+
+The Job Generator
++++++++++++++++++
+
+Alpaka supports a large number of different compilers with different versions and build configurations.
+To manage this large set of possible test cases, we use a job generator that generates the CI jobs for the different compiler and build configuration combinations.
+The jobs do not cover all possible combinations, as it would be too much to run the entire CI pipeline in a reasonable amount of time.
+Instead, the job generator uses `pairwise testing <https://en.wikipedia.org/wiki/All-pairs_testing>`_.
+
+The stages of the job generator are:
+
+.. figure:: /images/job_generator_flow.svg
+   :alt: workflow fo the CI job generator
+
+The job generator is located at `script/job_generator/ <https://github.com/alpaka-group/alpaka/tree/develop/script/job_generator/>`_.
+The code is split into two parts. One part is alpaka-specific and stored in this repository.
+The other part is valid for all alpaka-based projects and stored in the `alpaka-job-coverage library <https://pypi.org/project/alpaka-job-coverage/>`_.
+
+Run Job Generator Offline
+*************************
+
+First you need to install the dependencies.
+It is highly recommended to use a virtual environment.
+You can create one for example with the `venv <https://docs.python.org/3/library/venv.html>`_-Python module or with `miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
+Once you have created a virtual environment, you should activate it and install the Python packages via:
+
+.. code-block:: bash
+
+ pip install -r script/job_generator/requirements.txt
+
+After installing the Python package, you can simply run the job generator via:
+
+.. code-block:: bash
+
+ # 3.0 is the version of the docker container image
+ # run `python ci/job_generator/job_generator.py --help` to see more options
+ python script/job_generator/job_generator.py 3.0
+
+The generator creates a ``jobs.yaml`` in the current directory with all job combinations.
+
+Filter and Reorder Jobs
+***********************
+
+The job generator provides the ability to filter and reorder the generated job matrix using `Python <https://docs.python.org/3/howto/regex.html>`_ regex.
+The regex is applied via the commit message for the current commit:
+
+.. code-block::
+
+  Add function to filter and reorder CI jobs
+
+  This commit message demonstrates how it works. The job filter removes
+  all jobs whose names do not begin with NVCC or GCC. Then the jobs are
+  reordered. First all GCC11 are executed, then all GCC8 and then the
+  rest.
+
+  CI_FILTER: ^NVCC|^GCC
+  CI_REORDER: ^GCC11 ^GCC8
+
+The job generator looks for a line starting with the prefix ``CI_FILTER`` to filter the jobs or ``CI_REORDER`` to reorder the jobs.
+The filter statement is a single regex.
+The reorder statement can consist of multiple regex separated by a whitespace.
+For reordering, the jobs have the same order as the regex.
+This means that all orders matching the first regex are executed first, then the orders matching the second regex and so on.
+At the end, all orders that do not match any regex are executed.
+**Attention:** the order is only guaranteed across waves.
+Within a wave, it is not guaranteed which job will start first.
+
+It is not necessary that both prefixes are used.
+One of them or none is also possible.
+
+.. hint::
+
+  You can test your regex offline before creating and pushing a commit. The ``job_generator.py`` provides the ``--filter`` and ``--reorder`` flags that do the same thing as the lines starting with ``CI_FILTER`` and ``CI_REORDER`` in the commit message.
+
+Develop new Feature for the alpaka-job-coverage Library
+*******************************************************
+
+Sometimes one needs to implement a new function or fix a bug in the alpaka-job-coverage library while they are implementing a new function or fixing a bug in the alpaka job generator.
+Affected filter rules can be recognized by the fact that they only use parameters defined in this `globals.py <https://github.com/alpaka-group/alpaka-job-matrix-library/blob/main/src/alpaka_job_coverage/globals.py>`_.
+
+The following steps explain how to set up a development environment for the alpaka-job-coverage library and test your changes with the alpaka job generator.
+
+We strongly recommend using a Python virtual environment.
+
+.. code-block:: bash
+
+ # if not already done, clone repositories
+ git clone https://github.com/alpaka-group/alpaka-job-matrix-library.git
+ git clone https://github.com/alpaka-group/alpaka.git
+
+ cd alpaka-job-matrix-library
+ # link the files from the alpaka-job-matrix-library project folder into the site-packages folder of your environment
+ # make the package available in the Python interpreter via `import alpaka_job_coverage`
+ # if you change a src file in the folder, the changes are immediately available (if you use a Python interpreter instance, you have to restart it)
+ python setup.py develop
+ cd ..
+ cd alpaka
+ pip install -r script/job_generator/requirements.txt
+
+Now you can simply run the alpaka job generator.
+If you change the source code in the project folder alpaka-job-matrix-library, it will be immediately available for the next generator run.
+
+Custom jobs
++++++++++++
+
+You can create custom jobs that are defined as a yaml file.
+You can add the path of the folder to the function ``add_custom_jobs()`` in ``script/job_generator/custom_job.py``.
+The function automatically read all files in the folder, which matches a filter function and loads the GitLab CI jobs.
+The custom jobs are added to the same job list as the generated jobs and distributed to the waves.

--- a/docs/source/images/job_generator_flow.svg
+++ b/docs/source/images/job_generator_flow.svg
@@ -1,0 +1,1086 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="236.56773mm"
+   height="584.47296mm"
+   viewBox="0 0 236.56773 584.47296"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="job_generator_flow.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path880"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path877"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-5"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-3-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-5-9"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-1-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-2-0"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-3-2-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-5-9-3"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-1-2-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-2-0-9"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-3-2-2-4"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-5-9-3-7"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-1-2-5"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-2-0-5"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-3-2-2-47"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-5-9-3-6"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-1-2-5-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-2-0-5-7"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-3-2-2-47-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-5-9-3-6-6"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-1-2-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-2-0-4"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-3-2-2-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-5-9-3-5"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-1-2-9"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-2-0-49"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-3-2-2-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-5-9-3-9"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-1-2-4"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-2-0-8"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-3-2-2-1"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-5-9-3-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-1-2-48"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-2-0-1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-3-2-2-03"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path880-5-9-3-0"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.35"
+     inkscape:cx="-100.02344"
+     inkscape:cy="1096.1123"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1142"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-left="2"
+     fit-margin-top="2"
+     fit-margin-bottom="2"
+     fit-margin-right="2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-4.6415702,-3.1197373)">
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.00011039;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect815"
+       width="102.05357"
+       height="32.694939"
+       x="10.205358"
+       y="6.6197925"
+       ry="4.7080145"
+       rx="6.0309305" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="28.348215"
+       y="25.235117"
+       id="text819"><tspan
+         sodipodi:role="line"
+         id="tspan817"
+         x="28.348215"
+         y="26.701349"
+         style="stroke-width:0.26458332" /></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="61.148083"
+       y="21.702223"
+       id="text823"><tspan
+         sodipodi:role="line"
+         id="tspan821"
+         x="62.045185"
+         y="21.702223"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332">assemble different software </tspan><tspan
+         sodipodi:role="line"
+         x="61.148083"
+         y="27.346668"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan825">versions as input for generator</tspan></text>
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2, 1;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect815-3"
+       width="102.05357"
+       height="32.694939"
+       x="136.61835"
+       y="6.6197925"
+       ry="0"
+       rx="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="187.48589"
+       y="18.880001"
+       id="text823-6"><tspan
+         sodipodi:role="line"
+         x="188.38298"
+         y="18.880001"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan825-5">e.g. different compilers and </tspan><tspan
+         sodipodi:role="line"
+         x="188.38298"
+         y="24.524445"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan869">versions of it </tspan><tspan
+         sodipodi:role="line"
+         x="187.48589"
+         y="30.16889"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan867">-&gt; defined in version.py</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
+       d="M 61.232144,40.814786 V 62.196349"
+       id="path875"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="63.217293"
+       y="50.234081"
+       id="text873"><tspan
+         sodipodi:role="line"
+         id="tspan871"
+         x="63.217293"
+         y="50.234081"
+         style="stroke-width:0.26458332">List of Input paramater</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3)"
+       d="M 136.11123,22.967262 H 114.72967"
+       id="path875-6"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.00011039;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect815-7"
+       width="102.05357"
+       height="32.694939"
+       x="10.205358"
+       y="64.667084"
+       ry="4.7080145"
+       rx="6.030931" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="61.168755"
+       y="82.571739"
+       id="text823-0"><tspan
+         sodipodi:role="line"
+         x="61.168755"
+         y="82.571739"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan825-3">generate sparse job matrix</tspan></text>
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.00000002, 1.00000001;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect815-3-6"
+       width="102.05357"
+       height="32.694939"
+       x="136.61835"
+       y="64.667084"
+       ry="0"
+       rx="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="187.80559"
+       y="80.296593"
+       id="text823-6-0"><tspan
+         sodipodi:role="line"
+         x="187.80559"
+         y="80.296593"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan867-6">apply different filter rules</tspan><tspan
+         id="tspan2029"
+         sodipodi:role="line"
+         x="187.80559"
+         y="85.94104"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332">to avoid invalid combination</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-1)"
+       d="M 61.232144,98.862076 V 120.24365"
+       id="path875-1"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="64.804794"
+       y="108.28137"
+       id="text873-8"><tspan
+         sodipodi:role="line"
+         id="tspan871-7"
+         x="64.804794"
+         y="108.28137"
+         style="line-height:1;stroke-width:0.26458332">Job matrix with different combinations of the input paramater</tspan><tspan
+         id="tspan2031"
+         sodipodi:role="line"
+         x="64.804794"
+         y="113.92582"
+         style="line-height:1;stroke-width:0.26458332">e.g. host compiler: gcc 10 + device compier: nvcc 11.4</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-2)"
+       d="M 136.11123,81.014555 H 114.72967"
+       id="path875-6-9"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.00011039;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect815-7-5"
+       width="102.05357"
+       height="32.694939"
+       x="8.1416254"
+       y="529.04547"
+       ry="4.7080145"
+       rx="6.030931" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="59.200108"
+       y="547.49719"
+       id="text823-0-9"><tspan
+         sodipodi:role="line"
+         x="59.200108"
+         y="547.49719"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan825-3-2">write to file</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-1-2)"
+       d="m 59.168411,563.24046 v 21.38157"
+       id="path875-1-1"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="61.153557"
+       y="572.65973"
+       id="text873-8-2"><tspan
+         sodipodi:role="line"
+         id="tspan871-7-9"
+         x="61.153557"
+         y="572.65973"
+         style="stroke-width:0.26458332">gitlab-ci.yaml</tspan></text>
+    <g
+       id="g1900-7-8"
+       transform="translate(46.965013,46.473847)">
+      <rect
+         rx="6.030931"
+         ry="4.7080145"
+         y="76.24054"
+         x="-36.759655"
+         height="32.694939"
+         width="102.05357"
+         id="rect815-7-5-4"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.00011039;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+      <text
+         id="text823-0-9-5"
+         y="91.322968"
+         x="14.183071"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan825-3-2-3"
+           style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="91.322968"
+           x="15.080173"
+           sodipodi:role="line">add or change parameter of job </tspan><tspan
+           style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="96.967415"
+           x="14.183071"
+           sodipodi:role="line"
+           id="tspan2191">matrix</tspan></text>
+      <rect
+         rx="0"
+         ry="0"
+         y="76.24054"
+         x="89.653336"
+         height="32.694939"
+         width="102.05357"
+         id="rect815-3-6-8-6"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.00000002, 1.00000001;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+      <text
+         id="text823-6-0-9-1"
+         y="88.500748"
+         x="140.52089"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan867-6-6-3"
+           style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="88.500748"
+           x="141.418"
+           sodipodi:role="line">e.g. decide which job is </tspan><tspan
+           style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="94.145195"
+           x="140.52089"
+           sodipodi:role="line"
+           id="tspan2198">compile only or run also tests</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path875-1-1-2"
+         d="M 14.267131,110.43553 V 131.8171"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-1-2-1)" />
+      <text
+         id="text873-8-2-0"
+         y="119.85483"
+         x="16.252277"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="119.85483"
+           x="16.252277"
+           id="tspan871-7-9-6"
+           sodipodi:role="line">Job matrix</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path875-6-9-3-1"
+         d="M 89.146218,92.588009 H 67.764658"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-2-2-4)" />
+    </g>
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.00011039;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect815-7-5-6"
+       width="102.05357"
+       height="32.694939"
+       x="10.205358"
+       y="180.76167"
+       ry="4.7080145"
+       rx="6.030931" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="61.148083"
+       y="198.66632"
+       id="text823-0-9-9"><tspan
+         sodipodi:role="line"
+         x="61.148083"
+         y="198.66632"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan825-3-2-7">shuffle jobs</tspan></text>
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.00000002, 1.00000001;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect815-3-6-8-4"
+       width="102.05357"
+       height="32.694939"
+       x="136.61835"
+       y="180.76167"
+       ry="0"
+       rx="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="187.62643"
+       y="190.19966"
+       id="text823-6-0-9-5"><tspan
+         sodipodi:role="line"
+         x="188.52354"
+         y="190.19966"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan867-6-6-4">the output of the job generator has </tspan><tspan
+         id="tspan2483"
+         sodipodi:role="line"
+         x="187.62643"
+         y="195.8441"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332">systematic like first all gcc versions</tspan><tspan
+         id="tspan2485"
+         sodipodi:role="line"
+         x="188.52353"
+         y="201.48856"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332">-&gt; increase test coverage </tspan><tspan
+         id="tspan2487"
+         sodipodi:role="line"
+         x="187.62643"
+         y="207.133"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332">in the first jobs</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-1-2-5)"
+       d="m 61.232144,214.95667 v 21.38157"
+       id="path875-1-1-7"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="63.217289"
+       y="224.37596"
+       id="text873-8-2-4"><tspan
+         sodipodi:role="line"
+         id="tspan871-7-9-4"
+         x="63.217289"
+         y="224.37596"
+         style="stroke-width:0.26458332">Job matrix</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-2-2-47)"
+       d="M 136.11123,197.10915 H 114.72967"
+       id="path875-6-9-3-3"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.00011039;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect815-7-5-6-8"
+       width="102.05357"
+       height="32.694939"
+       x="10.205358"
+       y="238.80898"
+       ry="4.7080145"
+       rx="6.030931" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="61.113632"
+       y="256.71362"
+       id="text823-0-9-9-4"><tspan
+         sodipodi:role="line"
+         x="61.113632"
+         y="256.71362"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan825-3-2-7-1">reorder jobs</tspan></text>
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.00000002, 1.00000001;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect815-3-6-8-4-4"
+       width="102.05357"
+       height="32.694939"
+       x="136.61835"
+       y="238.80898"
+       ry="0"
+       rx="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="187.38528"
+       y="251.06918"
+       id="text823-6-0-9-5-9"><tspan
+         sodipodi:role="line"
+         x="188.28239"
+         y="251.06918"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan867-6-6-4-6">move specific jobs to a </tspan><tspan
+         sodipodi:role="line"
+         x="188.28239"
+         y="256.71362"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan2554">specific position in the </tspan><tspan
+         sodipodi:role="line"
+         x="187.38528"
+         y="262.35806"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan2556">job execution queue</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-1-2-5-0)"
+       d="m 61.232144,273.00397 v 21.38157"
+       id="path875-1-1-7-8"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="63.217289"
+       y="282.42328"
+       id="text873-8-2-4-9"><tspan
+         sodipodi:role="line"
+         id="tspan871-7-9-4-2"
+         x="63.217289"
+         y="282.42328"
+         style="stroke-width:0.26458332">Job matrix</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-2-2-47-8)"
+       d="M 136.11123,255.15645 H 114.72967"
+       id="path875-6-9-3-3-6"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.00011039;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect815-7-5-48"
+       width="102.05357"
+       height="32.694939"
+       x="10.205358"
+       y="296.85629"
+       ry="4.7080145"
+       rx="6.030931" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="61.226631"
+       y="314.76096"
+       id="text823-0-9-7"><tspan
+         sodipodi:role="line"
+         x="61.226631"
+         y="314.76096"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan825-3-2-72">generate yaml code</tspan></text>
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.00000002, 1.00000001;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect815-3-6-8-7"
+       width="102.05357"
+       height="32.694939"
+       x="136.61835"
+       y="296.85629"
+       ry="0"
+       rx="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="187.48589"
+       y="306.29428"
+       id="text823-6-0-9-2"><tspan
+         sodipodi:role="line"
+         x="188.383"
+         y="306.29428"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan867-6-6-1">depending of parameters of each </tspan><tspan
+         id="tspan2733"
+         sodipodi:role="line"
+         x="188.383"
+         y="311.93872"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332">job in the job matrix </tspan><tspan
+         id="tspan2735"
+         sodipodi:role="line"
+         x="188.38298"
+         y="317.58316"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332">generate script, variable, </tspan><tspan
+         id="tspan2737"
+         sodipodi:role="line"
+         x="187.48589"
+         y="323.2276"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332">tag and other section</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-1-2-6)"
+       d="m 61.232144,331.05127 v 21.38157"
+       id="path875-1-1-0"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="63.217289"
+       y="340.47058"
+       id="text873-8-2-6"><tspan
+         sodipodi:role="line"
+         id="tspan871-7-9-1"
+         x="63.217289"
+         y="340.47058"
+         style="stroke-width:0.26458332">List of jobs, defined in GitLab CI yaml</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-2-2-9)"
+       d="M 136.11123,313.20375 H 114.72967"
+       id="path875-6-9-3-5"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.00011039;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect815-7-5-7"
+       width="102.05357"
+       height="32.694939"
+       x="10.205358"
+       y="354.90356"
+       ry="4.7080145"
+       rx="6.030931" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="61.200451"
+       y="372.80823"
+       id="text823-0-9-71"><tspan
+         sodipodi:role="line"
+         x="61.200451"
+         y="372.80823"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan825-3-2-5">add custom jobs</tspan></text>
+    <rect
+       style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.00000002, 1.00000001;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers"
+       id="rect815-3-6-8-9"
+       width="102.05357"
+       height="32.694939"
+       x="136.61835"
+       y="354.90356"
+       ry="0"
+       rx="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="187.83038"
+       y="369.98599"
+       id="text823-6-0-9-7"><tspan
+         sodipodi:role="line"
+         x="187.83038"
+         y="369.98599"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+         id="tspan867-6-6-7">the jobs are written in GitLab Ci</tspan><tspan
+         id="tspan2957"
+         sodipodi:role="line"
+         x="187.83038"
+         y="375.63043"
+         style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332">yaml and loaded from file</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-1-2-9)"
+       d="m 61.232144,389.09857 v 21.38157"
+       id="path875-1-1-3"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       x="63.217289"
+       y="398.51785"
+       id="text873-8-2-65"><tspan
+         sodipodi:role="line"
+         id="tspan871-7-9-63"
+         x="63.217289"
+         y="398.51785"
+         style="stroke-width:0.26458332">List of jobs, defined in GitLab CI yaml</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-2-2-0)"
+       d="M 136.11123,371.25105 H 114.72967"
+       id="path875-6-9-3-9"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g3534"
+       transform="translate(0,-4.0583092)">
+      <rect
+         rx="6.030931"
+         ry="4.7080145"
+         y="417.00919"
+         x="8.1416254"
+         height="32.694939"
+         width="102.05357"
+         id="rect815-7-5-3"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.00011039;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+      <text
+         id="text823-0-9-90"
+         y="434.91385"
+         x="59.136715"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan825-3-2-8"
+           style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="434.91385"
+           x="59.136715"
+           sodipodi:role="line">apply filter and reorder rules</tspan></text>
+      <rect
+         rx="0"
+         ry="0"
+         y="417.00919"
+         x="134.55461"
+         height="32.694939"
+         width="102.05357"
+         id="rect815-3-6-8-5"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.00000002, 1.00000001;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+      <text
+         id="text823-6-0-9-0"
+         y="429.26938"
+         x="185.42215"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan867-6-6-38"
+           style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="429.26938"
+           x="186.31924"
+           sodipodi:role="line">the rules are temporary and </tspan><tspan
+           style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="434.91382"
+           x="186.31924"
+           sodipodi:role="line"
+           id="tspan3175">defined in a git commit message </tspan><tspan
+           style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="440.55826"
+           x="185.42215"
+           sodipodi:role="line"
+           id="tspan3177">-&gt; filter by job name</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path875-1-1-5"
+         d="m 59.168411,451.20417 v 21.38157"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-1-2-4)" />
+      <text
+         id="text873-8-2-61"
+         y="460.62347"
+         x="61.153557"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="460.62347"
+           x="61.153557"
+           id="tspan871-7-9-15"
+           sodipodi:role="line">List of jobs, defined in GitLab CI yaml</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path875-6-9-3-98"
+         d="M 134.0475,433.35665 H 112.66594"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-2-2-1)" />
+      <rect
+         rx="6.030931"
+         ry="4.7080145"
+         y="475.05649"
+         x="8.1416254"
+         height="32.694939"
+         width="102.05357"
+         id="rect815-7-5-44"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.00011039;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+      <text
+         id="text823-0-9-4"
+         y="493.50821"
+         x="59.150497"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan825-3-2-6"
+           style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="493.50821"
+           x="59.150497"
+           sodipodi:role="line">distribute to waves</tspan></text>
+      <rect
+         rx="0"
+         ry="0"
+         y="475.05649"
+         x="134.55461"
+         height="32.694939"
+         width="102.05357"
+         id="rect815-3-6-8-3"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.00000002, 1.00000001;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers" />
+      <text
+         id="text823-6-0-9-17"
+         y="485.04156"
+         x="185.57787"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan867-6-6-6"
+           style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="485.04156"
+           x="186.47496"
+           sodipodi:role="line">waves contains n jobs and runs </tspan><tspan
+           style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="490.686"
+           x="186.47498"
+           sodipodi:role="line"
+           id="tspan3454">sequential, the jobs inside </tspan><tspan
+           style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="496.33044"
+           x="186.47498"
+           sodipodi:role="line"
+           id="tspan3456">a wave runs in parallel </tspan><tspan
+           style="line-height:1;text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           y="501.97488"
+           x="185.57787"
+           sodipodi:role="line"
+           id="tspan3458">-&gt; enable fair use of CI ressources</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path875-1-1-21"
+         d="m 59.168411,509.25147 v 21.38157"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-1-2-48)" />
+      <text
+         id="text873-8-2-7"
+         y="518.67078"
+         x="61.153557"
+         style="font-style:normal;font-weight:normal;font-size:5.64444447px;line-height:0;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="stroke-width:0.26458332"
+           y="518.67078"
+           x="61.153557"
+           id="tspan871-7-9-8"
+           sodipodi:role="line">List of lists of jobs, defined in GitLab CI yaml</tspan></text>
+      <path
+         inkscape:connector-curvature="0"
+         id="path875-6-9-3-57"
+         d="M 134.0475,491.40395 H 112.66594"
+         style="fill:none;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend-3-2-2-03)" />
+    </g>
+  </g>
+</svg>

--- a/script/job_generator/alpaka_filter.py
+++ b/script/job_generator/alpaka_filter.py
@@ -1,0 +1,5 @@
+from typing import List
+
+
+def alpaka_post_filter(row: List) -> bool:
+    return True

--- a/script/job_generator/custom_job.py
+++ b/script/job_generator/custom_job.py
@@ -1,0 +1,69 @@
+"""Add custom jobs. For example loaded from a yaml file."""
+
+from genericpath import isfile
+import os, yaml
+from typing import List, Dict, Callable
+from typeguard import typechecked
+
+
+@typechecked
+def read_jobs_from_folder(
+    path: str, filter: Callable = lambda name: True
+) -> List[Dict[str, Dict]]:
+    """Read all job descriptions from the files located in a specific folder.
+    The function ignore sub folders.
+
+    Args:
+        path (str): Path of the folder, where the job files are located
+        filter (Callable, optional): Filter function, which takes the filename as argument. If the
+        function returns False, the file is ignored.
+
+    Returns:
+        List[Dict[str, Dict]]: List of GitLab CI jobs
+    """
+    if not os.path.exists(path):
+        print(f"\033[31mERROR: {path} does not exists\033[m")
+        exit(1)
+    if not os.listdir(path):
+        print(f"\033[33mWARNING: {path} is empty\033[m")
+        return []
+
+    custom_job_list: List[Dict[str, Dict]] = []
+
+    for file_name in os.listdir(path):
+        abs_file_path = os.path.join(path, file_name)
+        if os.path.isfile(abs_file_path) and filter(file_name):
+            with open(abs_file_path, "r", encoding="utf8") as job_yaml:
+                for job_name, job_body in yaml.load(
+                    job_yaml, yaml.loader.SafeLoader
+                ).items():
+                    custom_job_list.append({job_name: job_body})
+
+    return custom_job_list
+
+
+@typechecked
+def add_custom_jobs(job_matrix_yaml: List[Dict[str, Dict]], container_version: float):
+    """Read custom jobs from yaml files and add it to the job_matrix_yaml.
+
+    Args:
+        job_matrix_yaml (List[Dict[str, Dict]]): The job matrix, containing the yaml code
+        for each job.
+        container_version (float): Used container version.
+
+    Raises:
+        RuntimeError: Throw error, if yaml file of custom jobs does not exits.
+    """
+    # load custom jobs from the folder script/gitlabci
+    script_gitlab_ci_folder = os.path.abspath(
+        os.path.join(os.path.abspath(__file__), "../../gitlabci/")
+    )
+
+    for path in [script_gitlab_ci_folder]:
+        job_matrix_yaml += read_jobs_from_folder(
+            path,
+            # filter file names
+            lambda name: name != "job_base.yml"
+            and name.startswith("job_")
+            and name.endswith(".yml"),
+        )

--- a/script/job_generator/generate_job_yaml.py
+++ b/script/job_generator/generate_job_yaml.py
@@ -1,0 +1,248 @@
+"""Create GitLab-CI job description written in yaml from the job matrix."""
+
+from typing import List, Dict, Tuple
+from typeguard import typechecked
+import os, yaml
+from packaging import version as pk_version
+
+
+from alpaka_job_coverage.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
+
+
+@typechecked
+def get_env_var_name(variable_name: str) -> str:
+    """Transform string to a shape, which is allowed as environment variable.
+
+    Args:
+        variable_name (str): Variable name.
+
+    Returns:
+        str: Transformed variable name.
+    """
+    return variable_name.upper().replace("-", "_")
+
+
+@typechecked
+def job_prefix_coding(job: Dict[str, Tuple[str, str]]) -> str:
+    """Generate prefix for job name, depending of the available software versions.
+
+    Args:
+        job (Dict[str, Tuple[str, str]]): Job dict.
+
+    Returns:
+        str: Job name Prefix.
+    """
+    version_str = ""
+
+    return version_str
+
+
+@typechecked
+def job_image(job: Dict[str, Tuple[str, str]], container_version: float) -> str:
+    """Generate the image url deppending on the host and device compiler and the selected backend
+    of the job.
+
+    Args:
+        job (Dict[str, Tuple[str, str]]): Job dict.
+        container_version (float): Container version tag.
+
+    Returns:
+        str: Full container url, which can be used with docker pull.
+    """
+    container_url = "registry.hzdr.de/crp/alpaka-group-container/"
+    container_url += "alpaka-ci-ubuntu" + job[UBUNTU][VERSION]
+
+    # If only the GCC is used, use special gcc version of the container.
+    if job[HOST_COMPILER][NAME] == GCC and job[DEVICE_COMPILER][NAME] == GCC:
+        container_url += "-gcc"
+
+    if (
+        ALPAKA_ACC_GPU_CUDA_ENABLE in job
+        and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] != OFF
+    ):
+        # Cast cuda version shape. E.g. from 11.0 to 110
+        container_url += "-cuda" + str(
+            int(float(job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION]) * 10)
+        )
+        if job[HOST_COMPILER][NAME] == GCC:
+            container_url += "-gcc"
+
+    if (
+        ALPAKA_ACC_GPU_HIP_ENABLE in job
+        and job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION] != OFF
+    ):
+        container_url += "-rocm" + job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION]
+
+    # append container tag
+    container_url += ":" + str(container_version)
+    return container_url
+
+
+@typechecked
+def job_variables(job: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
+    """Add variables to the job depending of the job dict.
+
+    Args:
+        job (Dict[str, Tuple[str, str]]): Job dict
+
+    Returns:
+        Dict[str, str]: Dict of {variable name : variable value}.
+    """
+    variables: Dict[str, str] = {}
+
+    return variables
+
+
+@typechecked
+def job_tags(job: Dict[str, Tuple[str, str]]) -> List[str]:
+    """Add tags to select the correct runner, e.g. CPU only or Nvidia GPU.
+
+    Args:
+        job (Dict[str, Tuple[str, str]]): Job dict.
+
+    Returns:
+        List[str]: List of tags.
+    """
+    if (
+        ALPAKA_ACC_GPU_CUDA_ENABLE in job
+        and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] != OFF
+    ):
+        return ["x86_64", "cuda"]
+    if (
+        ALPAKA_ACC_GPU_HIP_ENABLE in job
+        and job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION] != OFF
+    ):
+        return ["x86_64", "rocm"]
+    return ["x86_64", "cpuonly"]
+
+
+def global_variables() -> Dict[str, str]:
+    """Generate global variables for the test jobs.
+
+    Returns:
+        Dict[str, str]: global variables
+    """
+    variables: Dict[str, str] = {}
+
+    variables["ALPAKA_GITLAB_CI_CONTAINER_VERSION"] = "1.4"
+    variables["ALPAKA_CI_OS_NAME"] = "Linux"
+    variables["alpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE"] = "ON"
+    variables["alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE"] = "ON"
+    variables["alpaka_ACC_CPU_B_SEQ_T_FIBERS_ENABLE"] = "OFF"
+    variables["alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE"] = "OFF"
+    variables["alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE"] = "ON"
+    variables["alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE"] = "ON"
+    variables["alpaka_ACC_ANY_BT_OMP5_ENABLE"] = "OFF"
+    variables["alpaka_ACC_ANY_BT_OACC_ENABLE"] = "OFF"
+    variables["alpaka_ACC_GPU_CUDA_ENABLE"] = "OFF"
+    variables["alpaka_ACC_GPU_CUDA_ONLY_MODE"] = "OFF"
+    variables["alpaka_ACC_GPU_HIP_ENABLE"] = "OFF"
+    variables["alpaka_ACC_GPU_HIP_ONLY_MODE"] = "OFF"
+    # If ALPAKA_CI_ANALYSIS is OFF compile and execute runtime tests else compile only.
+    variables["ALPAKA_CI_ANALYSIS"] = "OFF"
+    variables["ALPAKA_CI_RUN_TESTS"] = "ON"
+    variables["alpaka_CI"] = "GITLAB"
+    # needs to be enabled, that test on the GPU are executed
+    variables["ALPAKA_FORCE_RUNTIME_TEST"] = "ON"
+    variables["ALPAKA_CI_SANITIZERS"] = ""
+    variables["ALPAKA_CI_INSTALL_CUDA"] = "OFF"
+    variables["ALPAKA_CI_INSTALL_HIP"] = "OFF"
+    variables["ALPAKA_CI_CMAKE_DIR"] = "$HOME/cmake"
+    variables["BOOST_ROOT"] = "$HOME/boost"
+    variables["ALPAKA_CI_BOOST_LIB_DIR"] = "$HOME/boost_libs"
+    variables["ALPAKA_CI_CUDA_DIR"] = "$HOME/cuda"
+    variables["ALPAKA_CI_HIP_ROOT_DIR"] = "$HOME/hip"
+
+    return variables
+
+
+@typechecked
+def create_job(
+    job: Dict[str, Tuple[str, str]], container_version: float
+) -> Dict[str, Dict]:
+    """Create complete GitLab-CI yaml for a single job
+
+    Args:
+        job (Dict[str, Tuple[str, str]]): Job dict.
+        stage_number (int): Number of the stage. Required for the stage attribute.
+        container_version (float): Container version tag.
+
+    Returns:
+        Dict[str, Dict]: Job yaml.
+    """
+
+    # TODO: implement me!
+
+    return {}
+
+
+@typechecked
+def generate_job_yaml_list(
+    job_matrix: List[Dict[str, Tuple[str, str]]],
+    container_version: float,
+) -> List[Dict[str, Dict]]:
+    """Generate the job yaml for each job in the job matrix.
+
+    Args:
+        job_matrix (List[List[Dict[str, Tuple[str, str]]]]): Job Matrix
+        container_version (float): Container version tag.
+
+    Returns:
+        List[Dict[str, Dict]]: List of GitLab-CI jobs. The key of a dict entry
+        is the job name and the value is the body.
+    """
+    job_matrix_yaml: Dict[str, Dict] = []
+    for job in job_matrix:
+        job_matrix_yaml.append(create_job(job, container_version))
+
+    return job_matrix_yaml
+
+
+@typechecked
+def write_job_yaml(
+    job_matrix: List[List[Dict[str, Dict]]],
+    path: str,
+):
+    """Write GitLab-CI jobs to file.
+
+    Args:
+        job_matrix (List[List[Dict[str, Dict]]]): List of GitLab-CI jobs. The
+        key of a dict entry is the job name and the value is the body.
+        path (str): Path of the GitLab-CI yaml file.
+    """
+    with open(path, "w", encoding="utf-8") as output_file:
+        # setup all stages
+        stages: Dict[str, List[str]] = {"stages": []}
+        for stage_number in range(len(job_matrix)):
+            stages["stages"].append(f"stage{stage_number}")
+        yaml.dump(stages, output_file)
+        output_file.write("\n")
+
+        # add global variables for all jobs
+        yaml.dump({"variables": global_variables()}, output_file)
+        output_file.write("\n")
+
+        # TODO: remove me, when all cuda and hip custom jobs are generated by the job generator
+        # The CUDA and HIP jobs inherent from a job template written in yaml
+        script_path = os.path.abspath(__file__)
+        with open(
+            os.path.abspath(
+                os.path.join(os.path.dirname(script_path), "../gitlabci/job_base.yml")
+            ),
+            "r",
+            encoding="utf8",
+        ) as file:
+            job_base_yaml = yaml.load(file, yaml.loader.SafeLoader)
+        yaml.dump(job_base_yaml, output_file)
+
+        # Writes each job separately to the file.
+        # If all jobs would be collected first in dict, the order would be not guarantied.
+        for stage_number, wave in enumerate(job_matrix):
+            # Improve the readability of the generated job yaml
+            output_file.write(f"# <<<<<<<<<<<<< stage {stage_number} >>>>>>>>>>>>>\n\n")
+            for job in wave:
+                # the first key is the name
+                job[list(job.keys())[0]]["stage"] = "stage" + str(stage_number)
+
+                yaml.dump(job, output_file)
+                output_file.write("\n")

--- a/script/job_generator/job_generator.py
+++ b/script/job_generator/job_generator.py
@@ -1,0 +1,153 @@
+"""Generate GitLab-CI test jobs yaml for the vikunja CI."""
+import argparse
+import sys, os
+from typing import List, Dict, Tuple
+from collections import OrderedDict
+
+import alpaka_job_coverage as ajc
+from alpaka_job_coverage.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from alpaka_job_coverage.util import filter_job_list, reorder_job_list
+
+from versions import (
+    get_sw_tuple_list,
+    get_compiler_versions,
+    get_backend_matrix,
+)
+from alpaka_filter import alpaka_post_filter
+from custom_job import add_custom_jobs
+from reorder_jobs import reorder_jobs
+from generate_job_yaml import generate_job_yaml_list, write_job_yaml
+from verify import verify
+
+
+def get_args() -> argparse.Namespace:
+    """Define and parse the commandline arguments.
+
+    Returns:
+        argparse.Namespace: The commandline arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="Calculate job matrix and create GitLab CI .yml."
+    )
+
+    parser.add_argument(
+        "version", type=float, help="Version number of the used CI container."
+    )
+    parser.add_argument(
+        "--print-combinations",
+        action="store_true",
+        help="Display combination matrix.",
+    )
+    parser.add_argument(
+        "--verify", action="store_true", help="Verify generated combination matrix"
+    )
+    parser.add_argument(
+        "-a",
+        "--all",
+        action="store_true",
+        help="Combine flags: --print-combinations and --verify",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output-path",
+        type=str,
+        default="./jobs.yml",
+        help="Path of the generated jobs yaml.",
+    )
+
+    parser.add_argument(
+        "--filter",
+        type=str,
+        default="",
+        help="Filter the jobs with a Python regex that checks the job names.",
+    )
+
+    parser.add_argument(
+        "--reorder",
+        type=str,
+        default="",
+        help="Orders jobs by their names. Expects a string consisting of one or more Python regex. "
+        'The regex are separated by whitespaces. For example, the regex "^NVCC ^GCC" has the '
+        "behavior that all NVCC jobs are executed first and then all GCC jobs.",
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = get_args()
+
+    # setup the parameters
+    parameters: OrderedDict = OrderedDict()
+    enable_clang_cuda = True
+    parameters[HOST_COMPILER] = get_compiler_versions(clang_cuda=enable_clang_cuda)
+    parameters[DEVICE_COMPILER] = get_compiler_versions(clang_cuda=enable_clang_cuda)
+    parameters[BACKENDS] = get_backend_matrix()
+    parameters[CMAKE] = get_sw_tuple_list(CMAKE)
+    parameters[BOOST] = get_sw_tuple_list(BOOST)
+    parameters[UBUNTU] = get_sw_tuple_list(UBUNTU)
+    parameters[CXX_STANDARD] = get_sw_tuple_list(CXX_STANDARD)
+
+    # TODO: uncomment me, if not all entries in parameter are empty
+    # job_matrix: List[Dict[str, Tuple[str, str]]] = ajc.create_job_list(
+    #    parameters=parameters,
+    #    post_filter=alpaka_post_filter,
+    #    pair_size=2,
+    # )
+    job_matrix: List[Dict[str, Tuple[str, str]]] = []
+
+    if args.print_combinations or args.all:
+        print(f"number of combinations before reorder: {len(job_matrix)}")
+
+    # TODO: add function here to decide, if job only compiles or also execute the tests
+
+    ajc.shuffle_job_matrix(job_matrix)
+    reorder_jobs(job_matrix)
+
+    if args.print_combinations or args.all:
+        for compiler in job_matrix:
+            print(compiler)
+
+        print(f"number of combinations: {len(job_matrix)}")
+
+    if args.verify or args.all:
+        if not verify(job_matrix):
+            sys.exit(1)
+
+    job_matrix_yaml = generate_job_yaml_list(
+        job_matrix=job_matrix, container_version=args.version
+    )
+    add_custom_jobs(job_matrix_yaml, args.version)
+
+    filter_regix = args.filter
+    reorder_regix = args.reorder
+
+    COMMIT_MESSAGE_FILTER_PREFIX = "CI_FILTER:"
+    COMMIT_MESSAGE_REORDER_PREFIX = "CI_REORDER:"
+
+    # If the environment variable CI_COMMIT_MESSAGE exists (like in GitLabCI Job),
+    # check for the prefixes and overwrite argument values of --filter and --reorder if
+    # prefix was found in the beginning of a line.
+    if os.getenv("CI_COMMIT_MESSAGE"):
+        for line in os.getenv("CI_COMMIT_MESSAGE").split("\n"):
+            striped_line = line.strip()
+            if striped_line.strip().startswith(COMMIT_MESSAGE_FILTER_PREFIX):
+                filter_regix = striped_line[len(COMMIT_MESSAGE_FILTER_PREFIX) :].strip()
+            if striped_line.startswith(COMMIT_MESSAGE_REORDER_PREFIX):
+                reorder_regix = striped_line[
+                    len(COMMIT_MESSAGE_REORDER_PREFIX) :
+                ].strip()
+
+    if filter_regix:
+        job_matrix_yaml = filter_job_list(job_matrix_yaml, filter_regix)
+
+    if reorder_regix:
+        job_matrix_yaml = reorder_job_list(job_matrix_yaml, reorder_regix)
+
+    wave_job_matrix = ajc.distribute_to_waves(job_matrix_yaml, 10)
+
+    write_job_yaml(
+        job_matrix=wave_job_matrix,
+        path=args.output_path,
+    )

--- a/script/job_generator/reorder_jobs.py
+++ b/script/job_generator/reorder_jobs.py
@@ -1,0 +1,20 @@
+"""Functions to modify order of the job list.
+"""
+
+from typing import List, Dict, Tuple
+
+from typeguard import typechecked
+
+from alpaka_job_coverage.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from alpaka_job_coverage.util import search_and_move_job
+from versions import sw_versions
+
+
+@typechecked
+def reorder_jobs(job_matrix: List[Dict[str, Tuple[str, str]]]):
+    """Vikunja specific function, to move jobs, which matches certain properties to the first waves.
+
+    Args:
+        job_matrix (List[Dict[str, Tuple[str, str]]]): The job_matrix.
+    """
+    pass

--- a/script/job_generator/requirements.txt
+++ b/script/job_generator/requirements.txt
@@ -1,0 +1,5 @@
+alpaka-job-coverage >= 1.2.1
+allpairspy == 2.5.0
+typeguard
+pyaml
+types-PyYAML

--- a/script/job_generator/verify.py
+++ b/script/job_generator/verify.py
@@ -1,0 +1,26 @@
+"""Verification of the results.
+"""
+
+from typing import List, Dict, Tuple
+from typeguard import typechecked
+
+from alpaka_job_coverage.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
+from alpaka_job_coverage.util import strict_equal
+import versions
+
+
+@typechecked
+def verify(combinations: List[Dict[str, Tuple[str, str]]]) -> bool:
+    """Check if job matrix fullfill certain requirements.
+    Args:
+        combinations (List[Dict[str, Tuple[str, str]]]): The job matrix.
+
+    Returns:
+        bool: True if all checks passes, otherwise False.
+    """
+
+    # print("\033[31mverification failed\033[m")
+    print("\033[33mWARNING: no verification tests implemented\033[m")
+    # print("\033[32mverification was fine\033[m")
+
+    return True

--- a/script/job_generator/versions.py
+++ b/script/job_generator/versions.py
@@ -1,0 +1,95 @@
+"""Used software in the CI tests."""
+
+from typing import Dict, List, Tuple
+from typeguard import typechecked
+
+from alpaka_job_coverage.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
+
+
+# TODO: only an example
+# sw_versions: Dict[str, List[str]] = {
+#     GCC: ["7", "8", "9", "10", "11"],
+#     CLANG: ["7", "8", "9", "10", "11", "12", "13", "14", "15"],
+#     NVCC: ["11.0", "11.1", "11.2", "11.3", "11.4", "11.5", "11.6"],
+#     HIPCC: ["4.3", "4.5", "5.0", "5.1", "5.2"],
+#     BACKENDS: [
+#         ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE,
+#         ALPAKA_ACC_GPU_CUDA_ENABLE,
+#         # ALPAKA_ACC_GPU_HIP_ENABLE,
+#     ],
+#     UBUNTU: ["20.04"],
+#     CMAKE: ["3.18.6", "3.19.8", "3.20.6", "3.21.6", "3.22.3"],
+#     BOOST: [
+#         "1.74.0",
+#         "1.75.0",
+#         "1.76.0",
+#         "1.77.0",
+#         "1.78.0",
+#     ],
+#     CXX_STANDARD: ["17", "20"],
+# }
+
+sw_versions: Dict[str, List[str]] = {
+    GCC: [],
+    CLANG: [],
+    NVCC: [],
+    HIPCC: [],
+    BACKENDS: [],
+    UBUNTU: [],
+    CMAKE: [],
+    BOOST: [],
+    CXX_STANDARD: [],
+}
+
+
+@typechecked
+def get_compiler_versions(clang_cuda: bool = True) -> List[Tuple[str, str]]:
+    """Generate a list of compiler name version tuple.
+
+    Args:
+        clang_cuda (bool, optional): If true, create entries for cling-cuda basing on the clang
+        version. Defaults to True.
+
+    Returns:
+        List[Tuple[str, str]]: The compiler name version tuple list.
+    """
+    compilers: List[Tuple[str, str]] = []
+
+    # only use keys defined in sw_versions
+    for compiler_name in set(sw_versions.keys()).intersection(
+        [GCC, CLANG, NVCC, HIPCC]
+    ):
+        for version in sw_versions[compiler_name]:
+            compilers.append((compiler_name, version))
+            if clang_cuda and compiler_name == CLANG:
+                compilers.append((CLANG_CUDA, version))
+
+    return compilers
+
+
+@typechecked
+def get_backend_matrix() -> List[List[Tuple[str, str]]]:
+    """Generate backend list, where only backend is active on the same time.
+
+    Returns:
+        List[List[Tuple[str, str]]]: The backend list.
+    """
+
+    return []
+
+
+@typechecked
+def get_sw_tuple_list(name: str) -> List[Tuple[str, str]]:
+    """Creates a list of software name version tuples for a software name.
+
+    Args:
+        name (str): Name of the software
+
+    Returns:
+        List[Tuple[str, str]]: List of software name versions tuples.
+    """
+    tuple_list: List[Tuple[str, str]] = []
+    for version in sw_versions[name]:
+        tuple_list.append((name, version))
+
+    return tuple_list


### PR DESCRIPTION
The new GitLab CI pipeline makes easier to cover all the possible build configurations of alpaka. The pipeline starts with a job generator, which combines the different build parameter, like CMake version, compiler (version), enabled backends and more. But the generator does not generate all possible combination, because the job number would become to big and complete run would take a long time. Instead the job generator use [all-pairs](https://en.wikipedia.org/wiki/All-pairs_testing) testing, keep a good test coverage and reduce the number of test job significantly.

The CI pipeline enables also additional features:
- add custom jobs
- distribute the jobs on stages/waves (typical 10) to enable fair use of the CI resources
- shuffle and reorder Jobs hard coded in the script
- filter and reorder CI jobs via Git commit message

# Current state

This PR contains all stages of the CI pipeline, but not every stage is implemented yet. At the moment, the CI does not generate any job via combination. Instead only custom jobs are executed.

Up coming jobs/PR's:

- create a single job and implement support for the [alpaka-groups-container](https://gitlab.hzdr.de/crp/alpaka-group-container) including the `agc-manager` tool
- add more `gcc` and `clang` jobs
- replace the `CUDA` and `HIP` custom jobs with auto generated jobs
- add more compilers, backends ...