### PR TITLE
Support std::experimental::mdspan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ concurrency:
 # alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE             : {ON, OFF}
 # alpaka_ACC_GPU_HIP_ENABLE                     : {ON, OFF}
 #   [ON] ALPAKA_CI_HIP_BRANCH                   : {rocm-4.2}
+# alpaka_USE_MDSPAN                             : {OFF, FETCH, SYSTEM}
 
 # if you add/remove any CI variable, also update docker_ci.sh
 env:
@@ -76,6 +77,7 @@ env:
   alpaka_ACC_GPU_CUDA_ONLY_MODE: OFF
   alpaka_ACC_GPU_HIP_ENABLE: OFF
   alpaka_ACC_GPU_HIP_ONLY_MODE: OFF
+  alpaka_USE_MDSPAN: OFF
   CMAKE_INSTALL_PREFIX: ${{ github.workspace }}/_install
 
 jobs:
@@ -167,7 +169,7 @@ jobs:
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 11,       ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.74.0, ALPAKA_CI_CMAKE_VER: 3.18.6, OMP_NUM_THREADS: 4, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:20.04", alpaka_DEBUG: 2, alpaka_ACC_ANY_BT_OMP5_ENABLE: ON, CMAKE_CXX_FLAGS: "-foffload=disable", OMP_TARGET_OFFLOAD: "DISABLED", alpaka_OFFLOAD_MAX_BLOCK_SIZE: 2, alpaka_CHECK_HEADERS: ON}
         - name: linux_gcc-12_release_c++20
           os: ubuntu-22.04
-          env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 12,       ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.79.0, ALPAKA_CI_CMAKE_VER: 3.23.1, OMP_NUM_THREADS: 2, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:22.04", alpaka_CXX_STANDARD: 20}
+          env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 12,       ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.79.0, ALPAKA_CI_CMAKE_VER: 3.23.1, OMP_NUM_THREADS: 2, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:22.04", alpaka_CXX_STANDARD: 20, alpaka_USE_MDSPAN: "FETCH"}
         - name: linux_gcc-12_release_oacc_c++20
           os: ubuntu-22.04
           env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 12,       ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.78.0, ALPAKA_CI_CMAKE_VER: 3.22.6, OMP_NUM_THREADS: 2, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:22.04", CMAKE_CXX_FLAGS: "-foffload=disable", alpaka_ACC_ANY_BT_OACC_ENABLE: ON, alpaka_OFFLOAD_MAX_BLOCK_SIZE: 1, ACC_DEVICE_TYPE: "host", alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF, alpaka_CHECK_HEADERS: ON, alpaka_CXX_STANDARD: 20}

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -909,7 +909,13 @@ elseif (alpaka_USE_MDSPAN STREQUAL "FETCH")
         GIT_REPOSITORY https://github.com/kokkos/mdspan.git
         GIT_TAG 973ef6415a6396e5f0a55cb4c99afd1d1d541681
     )
-    FetchContent_MakeAvailable(mdspan)
+    # we don't use FetchContent_MakeAvailable(mdspan) since it would also install mdspan
+    # see also: https://stackoverflow.com/questions/65527126/how-to-disable-installation-a-fetchcontent-dependency
+    FetchContent_GetProperties(mdspan)
+    if(NOT mdspan_POPULATED)
+        FetchContent_Populate(mdspan)
+        add_subdirectory(${mdspan_SOURCE_DIR} ${mdspan_BINARY_DIR} EXCLUDE_FROM_ALL)
+    endif()
     target_link_libraries(alpaka INTERFACE std::mdspan)
     target_compile_definitions(alpaka INTERFACE ALPAKA_USE_MDSPAN)
 elseif (alpaka_USE_MDSPAN STREQUAL "OFF")

--- a/docs/source/advanced/cmake.rst
+++ b/docs/source/advanced/cmake.rst
@@ -78,6 +78,15 @@ alpaka_DEBUG_OFFLOAD_ASSUME_HOST
 
      Allow host-only contructs like assert in offload code in debug mode.
 
+alpaka_USE_MDSPAN
+  .. code-block::
+
+     Enable/Disable the use of `std::experimental::mdspan`:
+
+     "OFF" - Disable mdspan
+     "SYSTEM" - Enable mdspan and acquire it via `find_package` from your system
+     "FETCH" - Enable mdspan and download it via CMake's `FetchContent` from GitHub. The dependency will not be installed when you install alpaka.
+
 .. _cpu-serial:
 
 CPU Serial

--- a/example/bufferCopy/CMakeLists.txt
+++ b/example/bufferCopy/CMakeLists.txt
@@ -45,6 +45,11 @@ if(NOT TARGET alpaka::alpaka)
     endif()
 endif()
 
+if (alpaka_USE_MDSPAN STREQUAL "OFF")
+    message(STATUS "The bufferCopy example requires mdspan. Please set alpaka_USE_MDSPAN accordingly. Example disabled.")
+    return()
+endif ()
+
 #-------------------------------------------------------------------------------
 # Add executable.
 

--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -22,34 +22,19 @@
 #include <cstdint>
 #include <iostream>
 
-template<size_t width>
-ALPAKA_FN_ACC auto linIdxToPitchedIdx(size_t const globalIdx, size_t const pitch) -> size_t
-{
-    const size_t idx_x = globalIdx % width;
-    const size_t idx_y = globalIdx / width;
-    return idx_x + idx_y * pitch;
-}
-
 //! Prints all elements of the buffer.
 struct PrintBufferKernel
 {
-    template<typename TAcc, typename TData, typename TExtent>
-    ALPAKA_FN_ACC auto operator()(
-        TAcc const& acc,
-        TData const* const buffer,
-        TExtent const& extents,
-        size_t const pitch) const -> void
+    template<typename TAcc, typename MdSpan>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, MdSpan data) const -> void
     {
-        auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-        auto const globalThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+        auto const idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+        auto const gridSize = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
-        auto const linearizedGlobalThreadIdx = alpaka::mapIdx<1u>(globalThreadIdx, globalThreadExtent);
-
-        for(size_t i(linearizedGlobalThreadIdx[0]); i < extents.prod(); i += globalThreadExtent.prod())
-        {
-            // NOTE: hard-coded for unsigned int
-            printf("%u:%u ", static_cast<uint32_t>(i), static_cast<uint32_t>(buffer[linIdxToPitchedIdx<2>(i, pitch)]));
-        }
+        for(size_t z = idx[0]; z < data.extent(0); z += gridSize[0])
+            for(size_t y = idx[1]; y < data.extent(1); y += gridSize[1])
+                for(size_t x = idx[2]; x < data.extent(2); x += gridSize[2])
+                    printf("%zu,%zu,%zu:%u ", z, y, x, static_cast<uint32_t>(data(z, y, x)));
     }
 };
 
@@ -57,48 +42,39 @@ struct PrintBufferKernel
 //! Tests if the value of the buffer on index i is equal to i.
 struct TestBufferKernel
 {
-    template<typename TAcc, typename TData, typename TExtent>
-    ALPAKA_FN_ACC auto operator()(
-        TAcc const& acc,
-        TData const* const
-#ifndef NDEBUG
-            data
-#endif
-        ,
-        TExtent const& extents,
-        size_t const
-#ifndef NDEBUG
-            pitch
-#endif
-    ) const -> void
+    template<typename TAcc, typename MdSpan>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, MdSpan data) const -> void
     {
-        auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-        auto const globalThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+        using Vec = alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>>;
 
-        auto const linearizedGlobalThreadIdx = alpaka::mapIdx<1u>(globalThreadIdx, globalThreadExtent);
+        auto const idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+        auto const gridSize = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
-        for(size_t i(linearizedGlobalThreadIdx[0]); i < extents.prod(); i += globalThreadExtent.prod())
-        {
-            ALPAKA_ASSERT_OFFLOAD(data[linIdxToPitchedIdx<2>(i, pitch)] == i);
-        }
+        for(size_t z = idx[0]; z < data.extent(0); z += gridSize[0])
+            for(size_t y = idx[1]; y < data.extent(1); y += gridSize[1])
+                for(size_t x = idx[2]; x < data.extent(2); x += gridSize[2])
+                    ALPAKA_ASSERT_OFFLOAD(
+                        data(z, y, x)
+                        == alpaka::mapIdx<1u>(Vec{z, y, x}, Vec{data.extent(0), data.extent(1), data.extent(2)})[0]);
     }
 };
 
 //! Fills values of buffer with increasing elements starting from 0
 struct FillBufferKernel
 {
-    template<typename TAcc, typename TData, typename TExtent>
-    ALPAKA_FN_ACC auto operator()(TAcc const& acc, TData* const data, TExtent const& extents) const -> void
+    template<typename TAcc, typename MdSpan>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, MdSpan data) const -> void
     {
-        auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-        auto const globalThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+        using Vec = alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>>;
 
-        auto const linearizedGlobalThreadIdx = alpaka::mapIdx<1u>(globalThreadIdx, globalThreadExtent);
+        auto const idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+        auto const gridSize = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
-        for(size_t i(linearizedGlobalThreadIdx[0]); i < extents.prod(); i += globalThreadExtent.prod())
-        {
-            data[i] = static_cast<TData>(i);
-        }
+        for(size_t z = idx[0]; z < data.extent(0); z += gridSize[0])
+            for(size_t y = idx[1]; y < data.extent(1); y += gridSize[1])
+                for(size_t x = idx[2]; x < data.extent(2); x += gridSize[2])
+                    data(z, y, x)
+                        = alpaka::mapIdx<1u>(Vec{z, y, x}, Vec{data.extent(0), data.extent(1), data.extent(2)})[0];
     }
 };
 
@@ -212,30 +188,26 @@ auto main() -> int
     // elements of a buffer directly, but
     // you can get the pointer to the memory
     // (getPtrNative).
-    Data* const pHostBuffer = alpaka::getPtrNative(hostBuffer);
+    auto hostBufferMdSpan = alpaka::experimental::getMdSpan(hostBuffer);
 
     // This pointer can be used to directly write
     // some values into the buffer memory.
     // Mind, that only a host can write on host memory.
     // The same holds true for device memory.
-    for(Idx i(0); i < extents.prod(); ++i)
-    {
-        pHostBuffer[i] = static_cast<Data>(i);
-    }
+    for(Idx z(0); z < extents[0]; ++z)
+        for(Idx y(0); y < extents[1]; ++y)
+            for(Idx x(0); x < extents[2]; ++x)
+                hostBufferMdSpan(z, y, x) = static_cast<Data>(z * extents[1] * extents[2] + y * extents[2] + x);
 
     // Memory views and buffers can also be initialized by executing a kernel.
     // To pass a buffer into a kernel, you can pass the
     // native pointer into the kernel invocation.
-    Data* const pHostViewPlainPtr = alpaka::getPtrNative(hostViewPlainPtr);
+    auto hostViewPlainPtrMdSpan = alpaka::experimental::getMdSpan(hostViewPlainPtr);
 
     FillBufferKernel fillBufferKernel;
 
-    alpaka::exec<Host>(
-        hostQueue,
-        hostWorkDiv,
-        fillBufferKernel,
-        pHostViewPlainPtr, // 1st kernel argument
-        extents); // 2nd kernel argument
+    alpaka::exec<Host>(hostQueue, hostWorkDiv, fillBufferKernel,
+                       hostViewPlainPtrMdSpan); // 1st kernel argument
 
 
     // Copy host to device Buffer
@@ -266,25 +238,12 @@ auto main() -> int
     // This kernel tests if the copy operations
     // were successful. In the case something
     // went wrong an assert will fail.
-    Data const* const pDeviceBuffer1 = alpaka::getPtrNative(deviceBuffer1);
-    Data const* const pDeviceBuffer2 = alpaka::getPtrNative(deviceBuffer2);
+    auto deviceBufferMdSpan1 = alpaka::experimental::getMdSpan(deviceBuffer1);
+    auto deviceBufferMdSpan2 = alpaka::experimental::getMdSpan(deviceBuffer2);
 
     TestBufferKernel testBufferKernel;
-    alpaka::exec<Acc>(
-        devQueue,
-        devWorkDiv,
-        testBufferKernel,
-        pDeviceBuffer1, // 1st kernel argument
-        extents, // 2nd kernel argument
-        deviceBuffer1Pitch); // 3rd kernel argument
-
-    alpaka::exec<Acc>(
-        devQueue,
-        devWorkDiv,
-        testBufferKernel,
-        pDeviceBuffer2, // 1st kernel argument
-        extents, // 2nd kernel argument
-        deviceBuffer2Pitch); // 3rd kernel argument
+    alpaka::exec<Acc>(devQueue, devWorkDiv, testBufferKernel, deviceBufferMdSpan1);
+    alpaka::exec<Acc>(devQueue, devWorkDiv, testBufferKernel, deviceBufferMdSpan2);
 
 
     // Print device Buffer
@@ -298,43 +257,19 @@ auto main() -> int
     // completely distorted.
 
     PrintBufferKernel printBufferKernel;
-    alpaka::exec<Acc>(
-        devQueue,
-        devWorkDiv,
-        printBufferKernel,
-        pDeviceBuffer1, // 1st kernel argument
-        extents, // 2nd kernel argument
-        deviceBuffer1Pitch); // 3rd kernel argument
+    alpaka::exec<Acc>(devQueue, devWorkDiv, printBufferKernel, deviceBufferMdSpan1);
     alpaka::wait(devQueue);
     std::cout << std::endl;
 
-    alpaka::exec<Acc>(
-        devQueue,
-        devWorkDiv,
-        printBufferKernel,
-        pDeviceBuffer2, // 1st kernel argument
-        extents, // 2nd kernel argument
-        deviceBuffer2Pitch); // 3rd kernel argument
+    alpaka::exec<Acc>(devQueue, devWorkDiv, printBufferKernel, deviceBufferMdSpan2);
     alpaka::wait(devQueue);
     std::cout << std::endl;
 
-    alpaka::exec<Host>(
-        hostQueue,
-        hostWorkDiv,
-        printBufferKernel,
-        pHostBuffer, // 1st kernel argument
-        extents, // 2nd kernel argument
-        hostBuffer1Pitch); // 3rd kernel argument
+    alpaka::exec<Host>(hostQueue, hostWorkDiv, printBufferKernel, hostBufferMdSpan);
     alpaka::wait(hostQueue);
     std::cout << std::endl;
 
-    alpaka::exec<Host>(
-        hostQueue,
-        hostWorkDiv,
-        printBufferKernel,
-        pHostViewPlainPtr, // 1st kernel argument
-        extents, // 2nd kernel argument
-        hostViewPlainPtrPitch); // 3rd kernel argument
+    alpaka::exec<Host>(hostQueue, hostWorkDiv, printBufferKernel, hostViewPlainPtrMdSpan);
     alpaka::wait(hostQueue);
     std::cout << std::endl;
 

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -25,6 +25,9 @@
 #include <iosfwd>
 #include <type_traits>
 #include <vector>
+#ifdef ALPAKA_USE_MDSPAN
+#    include <experimental/mdspan>
+#endif
 
 namespace alpaka
 {

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -481,4 +481,124 @@ namespace alpaka
         return trait::CreateSubView<typename trait::DevType<TView>::type>::createSubView(view, extent, offset);
     }
 
+#ifdef ALPAKA_USE_MDSPAN
+    namespace experimental
+    {
+        // import mdspan into alpaka::experimental namespace. see: https://eel.is/c++draft/mdspan.syn
+        using std::experimental::default_accessor;
+        using std::experimental::dextents;
+        using std::experimental::extents;
+        using std::experimental::layout_left;
+        using std::experimental::layout_right;
+        using std::experimental::layout_stride;
+        using std::experimental::mdspan;
+        // import submdspan as well, which is not standardized yet
+        using std::experimental::full_extent;
+        using std::experimental::submdspan;
+
+        namespace traits
+        {
+            namespace detail
+            {
+                template<typename ElementType>
+                struct ByteIndexedAccessor
+                {
+                    using offset_policy = ByteIndexedAccessor;
+                    using element_type = ElementType;
+                    using reference = ElementType&;
+
+                    using data_handle_type
+                        = std::conditional_t<std::is_const_v<ElementType>, std::byte const*, std::byte*>;
+
+                    constexpr ByteIndexedAccessor() noexcept = default;
+
+                    ALPAKA_FN_HOST_ACC
+                    constexpr data_handle_type offset(data_handle_type p, size_t i) const noexcept
+                    {
+                        return p + i;
+                    }
+
+                    ALPAKA_FN_HOST_ACC
+                    constexpr reference access(data_handle_type p, size_t i) const noexcept
+                    {
+                        assert(i % alignof(ElementType) == 0);
+#    if BOOST_COMP_GNUC
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wcast-align"
+#    endif
+                        return *reinterpret_cast<ElementType*>(p + i);
+#    if BOOST_COMP_GNUC
+#        pragma GCC diagnostic pop
+#    endif
+                    }
+                };
+
+                template<typename TView, std::size_t... Is>
+                ALPAKA_FN_HOST auto makeExtents(TView const& view, std::index_sequence<Is...>)
+                {
+                    return std::experimental::dextents<Idx<TView>, Dim<TView>::value>{getExtent<Is>(view)...};
+                }
+
+                template<typename TView, std::size_t... Is>
+                ALPAKA_FN_HOST auto makeStrides(TView const& view, std::index_sequence<Is...>)
+                {
+                    constexpr auto fastestIndexPitch = static_cast<Idx<TView>>(sizeof(Elem<TView>));
+                    [[maybe_unused]] constexpr auto dim = Dim<TView>::value;
+                    // alpaka pitches are right-shifted by 1. We skip getPitchBytes<0> (the size in bytes of the entire
+                    // buffer) and append the element size last
+                    return std::array<Idx<TView>, dim>{
+                        (Is < dim - 1 ? getPitchBytes<Is + 1>(view) : fastestIndexPitch)...};
+                }
+            } // namespace detail
+
+            //! Customization point for getting an mdspan from a view.
+            template<typename TView, typename TSfinae = void>
+            struct GetMdSpan
+            {
+                ALPAKA_FN_HOST static auto getMdSpan(TView& view)
+                {
+                    constexpr auto dim = Dim<TView>::value;
+                    using Element = Elem<TView>;
+                    auto extents = detail::makeExtents(view, std::make_index_sequence<dim>{});
+                    auto* ptr = reinterpret_cast<std::byte*>(getPtrNative(view));
+                    auto const strides = detail::makeStrides(view, std::make_index_sequence<dim>{});
+                    layout_stride::mapping<decltype(extents)> m{extents, strides};
+                    return mdspan<Element, decltype(extents), layout_stride, detail::ByteIndexedAccessor<Element>>{
+                        ptr,
+                        m};
+                }
+
+                ALPAKA_FN_HOST static auto getMdSpanTransposed(TView& view)
+                {
+                    constexpr auto dim = Dim<TView>::value;
+                    using Element = Elem<TView>;
+                    auto extents = detail::makeExtents(view, std::make_index_sequence<dim>{});
+                    auto* ptr = reinterpret_cast<std::byte*>(getPtrNative(view));
+                    auto strides = detail::makeStrides(view, std::make_index_sequence<dim>{});
+                    std::reverse(begin(strides), end(strides));
+                    layout_stride::mapping<decltype(extents)> m{extents, strides};
+                    return mdspan<Element, decltype(extents), layout_stride, detail::ByteIndexedAccessor<Element>>{
+                        ptr,
+                        m};
+                }
+            };
+        } // namespace traits
+
+        //! Gets a std::mdspan from the given view. The memory layout is determined by the pitches of the view.
+        template<typename TView>
+        ALPAKA_FN_HOST auto getMdSpan(TView& view)
+        {
+            return traits::GetMdSpan<TView>::getMdSpan(view);
+        }
+
+        //! Gets a std::mdspan from the given view. The memory layout is determined by the reversed pitches of the
+        //! view. This effectively also reverses the extents of the view. In order words, if you create a transposed
+        //! mdspan on a 10x5 element view, the mdspan will have an iteration space of 5x10.
+        template<typename TView>
+        ALPAKA_FN_HOST auto getMdSpanTransposed(TView& view)
+        {
+            return traits::GetMdSpan<TView>::getMdSpanTransposed(view);
+        }
+    } // namespace experimental
+#endif
 } // namespace alpaka

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -454,6 +454,19 @@ namespace alpaka
     template<typename TFirstIndex, typename... TRestIndices>
     Vec(TFirstIndex&&, TRestIndices&&...) -> Vec<DimInt<1 + sizeof...(TRestIndices)>, std::decay_t<TFirstIndex>>;
 
+    //! Converts a Vec to a std::array
+    template<typename TDim, typename TVal>
+    ALPAKA_FN_HOST_ACC constexpr auto toArray(Vec<TDim, TVal> const& v) -> std::array<TVal, TDim::value>
+    {
+        std::array<TVal, TDim::value> a{};
+        if constexpr(TDim::value > 0)
+        {
+            for(unsigned i = 0; i < TDim::value; i++)
+                a[i] = v[i];
+        }
+        return a;
+    }
+
     //! \return The element-wise minimum of one or more vectors.
     ALPAKA_NO_HOST_ACC_WARNING
     template<

--- a/script/docker_ci.sh
+++ b/script/docker_ci.sh
@@ -188,5 +188,9 @@ if [ ! -z "${CMAKE_INSTALL_PREFIX+x}" ]
 then
     ALPAKA_DOCKER_ENV_LIST+=("--env" "CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
 fi
+if [ ! -z "${alpaka_USE_MDSPAN+x}" ]
+then
+    ALPAKA_DOCKER_ENV_LIST+=("--env" "alpaka_USE_MDSPAN=${alpaka_USE_MDSPAN}")
+fi
 
 docker_retry docker run -v "$(pwd)":"$(pwd)" -w "$(pwd)" "${ALPAKA_DOCKER_ENV_LIST[@]}" "${ALPAKA_CI_DOCKER_BASE_IMAGE_NAME}" /bin/bash -c "source ./script/install.sh && ./script/run.sh"

--- a/test/unit/mem/view/src/MdSpan.cpp
+++ b/test/unit/mem/view/src/MdSpan.cpp
@@ -1,0 +1,159 @@
+/* Copyright 2022 Bernhard Manfred Gruber
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#ifdef ALPAKA_USE_MDSPAN
+#    include <alpaka/alpaka.hpp>
+#    include <alpaka/test/Extent.hpp>
+#    include <alpaka/test/acc/TestAccs.hpp>
+#    include <alpaka/test/mem/view/ViewTest.hpp>
+
+#    include <catch2/catch_template_test_macros.hpp>
+
+#    if defined(__NVCC__) && !defined(__CUDACC_EXTENDED_LAMBDA__)
+#        error "mdspan requires nvcc's extended lambdas"
+#    endif
+
+namespace
+{
+    template<std::size_t... Is>
+    constexpr auto make_reverse_index_sequence_impl(std::index_sequence<Is...>)
+    {
+        return std::index_sequence<(sizeof...(Is) - Is - 1)...>{};
+    }
+
+    template<std::size_t N>
+    using make_reverse_index_sequence = decltype(make_reverse_index_sequence_impl(std::make_index_sequence<N>{}));
+} // namespace
+
+#    if BOOST_COMP_NVCC
+#        define NOEXCEPT_UNLESS_NVCC
+#    else
+#        define NOEXCEPT_UNLESS_NVCC noexcept
+#    endif
+
+TEMPLATE_LIST_TEST_CASE("mdSpan", "[memView]", alpaka::test::TestAccs)
+{
+    using TElem = int;
+
+    using Acc = TestType;
+    using Dev = alpaka::Dev<Acc>;
+    using Dim = alpaka::Dim<Acc>;
+    using Idx = alpaka::Idx<Acc>;
+    using Vec = alpaka::Vec<Dim, Idx>;
+
+    auto const dev = alpaka::getDevByIdx<alpaka::Pltf<Dev>>(0u);
+    auto queue = alpaka::Queue<Dev, alpaka::Blocking>(dev);
+
+    auto const extent
+        = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+    auto buf = alpaka::allocBuf<TElem, Idx>(dev, extent);
+    alpaka::test::iotaFillView(queue, buf);
+
+    auto const mds = alpaka::experimental::getMdSpan(buf);
+    alpaka::test::KernelExecutionFixture<Acc> fixture(Vec::ones());
+    CHECK(fixture(
+        [=] ALPAKA_FN_ACC(Acc const&, bool* success) NOEXCEPT_UNLESS_NVCC
+        {
+            auto counter = 0;
+            alpaka::meta::ndLoopIncIdx(
+                extent,
+                [&](auto ind)
+                {
+                    [[maybe_unused]] auto const a = alpaka::toArray(ind);
+                    ALPAKA_CHECK(*success, mds(a) == counter);
+                    counter++;
+                });
+        }));
+
+    auto extentTransposed = extent;
+    std::reverse(extentTransposed.begin(), extentTransposed.end());
+    auto const mdst = alpaka::experimental::getMdSpanTransposed(buf);
+    CHECK(fixture(
+        [=] ALPAKA_FN_ACC(Acc const&, bool* success) NOEXCEPT_UNLESS_NVCC
+        {
+            auto counter = 0;
+            alpaka::meta::ndLoop(
+                make_reverse_index_sequence<Dim::value>{},
+                extentTransposed,
+                [&](auto ind)
+                {
+                    [[maybe_unused]] auto const a = alpaka::toArray(ind);
+                    ALPAKA_CHECK(*success, mdst(a) == counter);
+                    counter++;
+                });
+        }));
+}
+
+TEMPLATE_LIST_TEST_CASE("submdspan", "[memView]", alpaka::test::TestAccs)
+{
+    using TElem = int;
+
+    using Acc = TestType;
+    using Dev = alpaka::Dev<Acc>;
+    using Dim = alpaka::Dim<Acc>;
+    using Idx = alpaka::Idx<Acc>;
+    using Vec = alpaka::Vec<Dim, Idx>;
+
+    auto const dev = alpaka::getDevByIdx<alpaka::Pltf<Dev>>(0u);
+    auto queue = alpaka::Queue<Dev, alpaka::Blocking>(dev);
+
+    auto const extent = alpaka::Vec{2, 3}; // 2 rows, 3 cols
+    auto buf = alpaka::allocBuf<TElem, int>(dev, extent);
+    alpaka::test::iotaFillView(queue, buf);
+
+    auto const mds = alpaka::experimental::getMdSpan(buf);
+    alpaka::test::KernelExecutionFixture<Acc> fixture(Vec::ones());
+    CHECK(fixture(
+        [=] ALPAKA_FN_ACC(Acc const&, bool* success) NOEXCEPT_UNLESS_NVCC
+        {
+            ALPAKA_CHECK(*success, mds(0, 0) == 0);
+            ALPAKA_CHECK(*success, mds(0, 1) == 1);
+            ALPAKA_CHECK(*success, mds(0, 2) == 2);
+            ALPAKA_CHECK(*success, mds(1, 0) == 3);
+            ALPAKA_CHECK(*success, mds(1, 1) == 4);
+            ALPAKA_CHECK(*success, mds(1, 2) == 5);
+
+            auto elem_1_2 = alpaka::experimental::submdspan(mds, 1, 2);
+            ALPAKA_CHECK(*success, elem_1_2() == 5);
+
+            auto row0 = alpaka::experimental::submdspan(mds, 0, alpaka::experimental::full_extent);
+            ALPAKA_CHECK(*success, row0(0) == 0);
+            ALPAKA_CHECK(*success, row0(1) == 1);
+            ALPAKA_CHECK(*success, row0(2) == 2);
+
+            auto row1 = alpaka::experimental::submdspan(mds, 1, alpaka::experimental::full_extent);
+            ALPAKA_CHECK(*success, row1(0) == 3);
+            ALPAKA_CHECK(*success, row1(1) == 4);
+            ALPAKA_CHECK(*success, row1(2) == 5);
+
+            auto col0 = alpaka::experimental::submdspan(mds, alpaka::experimental::full_extent, 0);
+            ALPAKA_CHECK(*success, col0(0) == 0);
+            ALPAKA_CHECK(*success, col0(1) == 3);
+
+            auto col1 = alpaka::experimental::submdspan(mds, alpaka::experimental::full_extent, 1);
+            ALPAKA_CHECK(*success, col1(0) == 1);
+            ALPAKA_CHECK(*success, col1(1) == 4);
+
+            auto col2 = alpaka::experimental::submdspan(mds, alpaka::experimental::full_extent, 2);
+            ALPAKA_CHECK(*success, col2(0) == 2);
+            ALPAKA_CHECK(*success, col2(1) == 5);
+
+            auto matrix = alpaka::experimental::submdspan(
+                mds,
+                alpaka::experimental::full_extent,
+                alpaka::experimental::full_extent);
+            ALPAKA_CHECK(*success, matrix(0, 0) == 0);
+            ALPAKA_CHECK(*success, matrix(0, 1) == 1);
+            ALPAKA_CHECK(*success, matrix(0, 2) == 2);
+            ALPAKA_CHECK(*success, matrix(1, 0) == 3);
+            ALPAKA_CHECK(*success, matrix(1, 1) == 4);
+            ALPAKA_CHECK(*success, matrix(1, 2) == 5);
+        }));
+}
+#endif


### PR DESCRIPTION
This PR adds the reference implementation of `std::experimental::mdspan` from Kokkos to alpaka and adds a new API `alpaka::experimental::getMdSpan(TView&)`/`alpaka::experimental::getMdSpanTransposed(TView&)`, which allows to build an mdspan from any view.

Currently, there is only one memory layout supported which is hard coded inside alpaka to support arbitrary pitched allocations, which mdspan does not support with its standard layouts. ~I assume further mdspan functions sensitive to the layout (e.g. slicing) will not work.~ Submdspan works as well.

The additional dependency can be enabled via the cmake option `alpaka_USE_MDSPAN`, which is `OFF` by default. It can be set to `SYSTEM` to look for `mdspan` installed in the system, or to `FETCH` to acquire the Kokkos reference implementation via `FetchContent`.

When mdspan is enabled, it will *not* be installed with alpaka. However, when using an installed version of alpaka, you can get mdspan again via `FetchContent` or from a system installation. The behavior for getting `mdspan` is thus the same whether you use alpaka via `add_subdirectory` or from a system installation.

Fixes: #1482

Open questions:

- [x] ~Are we fine with shipping `std::experimental::mdspan` as part of alpaka?~ We will leave it out to avoid difficulties with installing it alongside alpaka.
- [x] ~If yes, how/where should we ship it? As part of the `include/alpaka` tree? It needs to be installed with alpaka.~
- [x] ~Should we offer a combined API to allocate a buffer and create the mdspan in one go? Should such a call for an ND buffer/mdspan return a ND buffer/mdspan or 1D buffer/ND mdspan. The latter is required for the standard layouts.~ Let's skip this for now.
- [x] ~When we want to have a normal mdspan with the standard layouts, we can only create it from 1D buffers/views. What should we do? Only allow custom layouts in `getMdSpan` for 1D views and have a hard coded pitched layout for ND views?~  Let's skip this for now and be happy that we can get an mdspan, even if we cannot play with layouts yet.