### PR TITLE
Remove the functions to pin/unpin an existing buffer

### DIFF
--- a/docs/source/dev/details.rst
+++ b/docs/source/dev/details.rst
@@ -25,7 +25,7 @@ They allow arbitrary types as parameters, as long as they model the required con
 C++ provides a language inherent object oriented abstraction allowing to check that parameters to a function comply with the concept they are required to model.
 By defining interface classes, which model the *alpaka* concepts, the user would be able to inherit his extension classes from the interfaces he wants to model and implement the abstract virtual methods the interfaces define.
 The *alpaka* functions in turn would use the corresponding interface types as their parameter types.
-For example, the ``Buffer`` concept requires methods for getting the pitch or changing the memory pinning state.
+For example, the ``Buffer`` concept requires methods for getting the pitch or accessing the underlying memory.
 With this intrusive object oriented design pattern the ``BufCpu`` or ``BufCudaRt`` classes would have to inherit from an ``IBuffer`` interface and implement the abstract methods it declares.
 An example of this basic pattern is shown in the following source snippet:
 
@@ -34,16 +34,14 @@ An example of this basic pattern is shown in the following source snippet:
    struct IBuffer
    {
      virtual std::size_t getPitch() const = 0;
-     virtual void pin() = 0;
-     virtual void unpin() = 0;
+     virtual std::byte * data() = 0;
      ...
    };
 
    struct BufCpu : public IBuffer
    {
      virtual std::size_t getPitch() const override { ... }
-     virtual void pin() override { ... }
-     virtual void unpin() override { ... }
+     virtual std::byte * data() override { ... }
      ...
    };
 

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -60,7 +60,6 @@ namespace alpaka
                 , m_extentElements(getExtentVecEnd<TDim>(extent))
                 , m_pMem(pMem)
                 , m_deleter(std::move(deleter))
-                , m_bPinned(false)
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
@@ -83,19 +82,6 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                // Unpin this memory if it is currently pinned.
-                if(m_bPinned)
-                {
-                    try
-                    {
-                        unpin(*this); // May throw std::runtime_error
-                    }
-                    catch(std::runtime_error const& err)
-                    {
-                        std::cerr << "Caught runtime error while unpinning in ~BufCpuImpl(): " << err.what()
-                                  << std::endl;
-                    }
-                }
                 // NOTE: m_pMem is allowed to be a nullptr here.
                 m_deleter(m_pMem);
             }
@@ -105,7 +91,6 @@ namespace alpaka
             Vec<TDim, TIdx> const m_extentElements;
             TElem* const m_pMem;
             std::function<void(TElem*)> m_deleter;
-            bool m_bPinned;
         };
     } // namespace detail
 
@@ -310,152 +295,6 @@ namespace alpaka
         template<>
         struct HasMappedBufSupport<PltfCpu> : public std::true_type
         {
-        };
-
-        //! The BufCpu memory mapping trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Map<BufCpu<TElem, TDim, TIdx>, DevCpu>
-        {
-            ALPAKA_FN_HOST static auto map(BufCpu<TElem, TDim, TIdx>& buf, DevCpu const& dev) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(getDev(buf) != dev)
-                {
-                    throw std::runtime_error("Memory mapping of BufCpu between two devices is not implemented!");
-                }
-                // If it is the same device, nothing has to be mapped.
-            }
-        };
-        //! The BufCpu memory unmapping trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Unmap<BufCpu<TElem, TDim, TIdx>, DevCpu>
-        {
-            ALPAKA_FN_HOST static auto unmap(BufCpu<TElem, TDim, TIdx>& buf, DevCpu const& dev) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(getDev(buf) != dev)
-                {
-                    throw std::runtime_error("Memory unmapping of BufCpu between two devices is not implemented!");
-                }
-                // If it is the same device, nothing has to be mapped.
-            }
-        };
-        //! The BufCpu memory pinning trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Pin<BufCpu<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto pin(BufCpu<TElem, TDim, TIdx>& buf) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(!isPinned(buf))
-                {
-                    if(buf.m_spBufCpuImpl->m_extentElements.prod() != 0)
-                    {
-                        // - cudaHostRegisterDefault:
-                        //   See http://cgi.cs.indiana.edu/~nhusted/dokuwiki/doku.php?id=programming:cudaperformance1
-                        // - cudaHostRegisterPortable:
-                        //   The memory returned by this call will be considered as pinned memory by all CUDA contexts,
-                        //   not just the one that performed the allocation.
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                        {
-                            using TApi = ApiCudaRt;
-                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
-                                TApi::hostRegister(
-                                    const_cast<void*>(reinterpret_cast<void const*>(getPtrNative(buf))),
-                                    getExtentProduct(buf) * sizeof(Elem<BufCpu<TElem, TDim, TIdx>>),
-                                    TApi::hostRegisterDefault),
-                                TApi::errorHostMemoryAlreadyRegistered);
-                        }
-#endif
-#if defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-                        {
-                            using TApi = ApiHipRt;
-                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
-                                TApi::hostRegister(
-                                    const_cast<void*>(reinterpret_cast<void const*>(getPtrNative(buf))),
-                                    getExtentProduct(buf) * sizeof(Elem<BufCpu<TElem, TDim, TIdx>>),
-                                    TApi::hostRegisterDefault),
-                                TApi::errorHostMemoryAlreadyRegistered);
-                        }
-#endif
-                        buf.m_spBufCpuImpl->m_bPinned = true;
-                    }
-                }
-            }
-        };
-        //! The BufCpu memory unpinning trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Unpin<BufCpu<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto unpin(BufCpu<TElem, TDim, TIdx>& buf) -> void
-            {
-                alpaka::unpin(*buf.m_spBufCpuImpl.get());
-            }
-        };
-        //! The BufCpuImpl memory unpinning trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Unpin<alpaka::detail::BufCpuImpl<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto unpin(alpaka::detail::BufCpuImpl<TElem, TDim, TIdx>& bufImpl) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(isPinned(bufImpl))
-                {
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                    {
-                        using TApi = ApiCudaRt;
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
-                            TApi::hostUnregister(const_cast<void*>(reinterpret_cast<void const*>(bufImpl.m_pMem))),
-                            TApi::errorHostMemoryNotRegistered);
-                    }
-#endif
-#if defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-                    {
-                        using TApi = ApiHipRt;
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
-                            TApi::hostUnregister(const_cast<void*>(reinterpret_cast<void const*>(bufImpl.m_pMem))),
-                            TApi::errorHostMemoryNotRegistered);
-                    }
-#endif
-                    bufImpl.m_bPinned = false;
-                }
-            }
-        };
-        //! The BufCpu memory pin state trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct IsPinned<BufCpu<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto isPinned(BufCpu<TElem, TDim, TIdx> const& buf) -> bool
-            {
-                return alpaka::isPinned(*buf.m_spBufCpuImpl.get());
-            }
-        };
-        //! The BufCpuImpl memory pin state trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct IsPinned<alpaka::detail::BufCpuImpl<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto isPinned(
-                [[maybe_unused]] alpaka::detail::BufCpuImpl<TElem, TDim, TIdx> const& bufImpl) -> bool
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-                return bufImpl.m_bPinned;
-            }
-        };
-        //! The BufCpu memory prepareForAsyncCopy trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct PrepareForAsyncCopy<BufCpu<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto prepareForAsyncCopy([[maybe_unused]] BufCpu<TElem, TDim, TIdx>& buf) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-                // to optimize the data transfer performance between a cuda/hip device the cpu buffer has to be pinned,
-                // for exclusive cpu use, no preparing is needed
-                pin(buf);
-            }
         };
 
         //! The BufCpu offset get trait specialization.

--- a/include/alpaka/mem/buf/BufGenericSycl.hpp
+++ b/include/alpaka/mem/buf/BufGenericSycl.hpp
@@ -202,81 +202,6 @@ namespace alpaka::trait
         }
     };
 
-    //! The BufGenericSycl SYCL device memory mapping trait specialization.
-    template<typename TElem, typename TDim, typename TIdx, typename TPltf>
-    struct Map<
-        experimental::BufGenericSycl<TElem, TDim, TIdx, experimental::DevGenericSycl<TPltf>>,
-        experimental::DevGenericSycl<TPltf>>
-    {
-        static_assert(!sizeof(TElem), "Memory mapping is not supported by the SYCL back-end");
-
-        static auto map(
-            experimental::BufGenericSycl<TElem, TDim, TIdx, experimental::DevGenericSycl<TPltf>> const&,
-            experimental::DevGenericSycl<TPltf> const&) -> void
-        {
-        }
-    };
-
-    //! The BufGenericSycl SYCL device memory unmapping trait specialization.
-    template<typename TElem, typename TDim, typename TIdx, typename TPltf>
-    struct Unmap<
-        experimental::BufGenericSycl<TElem, TDim, TIdx, experimental::DevGenericSycl<TPltf>>,
-        experimental::DevGenericSycl<TPltf>>
-    {
-        static_assert(!sizeof(TElem), "Memory mapping is not supported by the SYCL back-end");
-
-        static auto unmap(
-            experimental::BufGenericSycl<TElem, TDim, TIdx, experimental::DevGenericSycl<TPltf>> const&,
-            experimental::DevGenericSycl<TPltf> const&) -> void
-        {
-        }
-    };
-
-    //! The BufGenericSycl memory pinning trait specialization.
-    template<typename TElem, typename TDim, typename TIdx, typename TDev>
-    struct Pin<experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>>
-    {
-        static_assert(!sizeof(TElem), "Memory pinning is not supported by the SYCL back-end");
-
-        static auto pin(experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>&) -> void
-        {
-        }
-    };
-
-    //! The BufGenericSycl memory unpinning trait specialization.
-    template<typename TElem, typename TDim, typename TIdx, typename TDev>
-    struct Unpin<experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>>
-    {
-        static_assert(!sizeof(TElem), "Memory pinning is not supported by the SYCL back-end");
-
-        static auto unpin(experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>&) -> void
-        {
-        }
-    };
-
-    //! The BufGenericSycl memory pin state trait specialization.
-    template<typename TElem, typename TDim, typename TIdx, typename TDev>
-    struct IsPinned<experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>>
-    {
-        static_assert(!sizeof(TElem), "Memory pinning is not supported by the SYCL back-end");
-
-        static auto isPinned(experimental::BufGenericSycl<TElem, TDim, TIdx, TDev> const&) -> bool
-        {
-            return false;
-        }
-    };
-
-    //! The BufGenericSycl memory prepareForAsyncCopy trait specialization.
-    template<typename TElem, typename TDim, typename TIdx, typename TDev>
-    struct PrepareForAsyncCopy<experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>>
-    {
-        static auto prepareForAsyncCopy(experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>&) -> void
-        {
-            ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-            // Everything in SYCL is async by default.
-        }
-    };
-
     //! The BufGenericSycl offset get trait specialization.
     template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx, typename TDev>
     struct GetOffset<TIdxIntegralConst, experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>>
@@ -292,28 +217,6 @@ namespace alpaka::trait
     struct IdxType<experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>>
     {
         using type = TIdx;
-    };
-
-    //! The BufCpu SYCL device memory mapping trait specialization.
-    template<typename TElem, typename TDim, typename TIdx, typename TPltf>
-    struct Map<BufCpu<TElem, TDim, TIdx>, experimental::DevGenericSycl<TPltf>>
-    {
-        static_assert(!sizeof(TElem), "Memory mapping is not supported by the SYCL back-end");
-
-        static auto map(BufCpu<TElem, TDim, TIdx>&, experimental::DevGenericSycl<TPltf> const&) -> void
-        {
-        }
-    };
-
-    //! The BufGenericSycl device memory unmapping trait specialization.
-    template<typename TElem, typename TDim, typename TIdx, typename TPltf>
-    struct Unmap<BufCpu<TElem, TDim, TIdx>, experimental::DevGenericSycl<TPltf>>
-    {
-        static_assert(!sizeof(TElem), "Memory mapping is not supported by the SYCL back-end");
-
-        static auto unmap(BufCpu<TElem, TDim, TIdx>&, experimental::DevGenericSycl<TPltf> const&) -> void
-        {
-        }
     };
 
     //! The BufCpu pointer on SYCL device get trait specialization.

--- a/include/alpaka/mem/buf/BufOacc.hpp
+++ b/include/alpaka/mem/buf/BufOacc.hpp
@@ -244,84 +244,6 @@ namespace alpaka
             }
         };
 
-        //! The BufOacc device memory mapping trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Map<BufOacc<TElem, TDim, TIdx>, DevOacc>
-        {
-            ALPAKA_FN_HOST static auto map(BufOacc<TElem, TDim, TIdx> const& buf, DevOacc const& dev) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(getDev(buf) != dev)
-                {
-                    throw std::runtime_error(
-                        "Mapping memory from one OpenACC device into an other OpenACC device not implemented!");
-                }
-                // If it is already the same device, nothing has to be mapped.
-            }
-        };
-        //! The BufOacc device memory unmapping trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Unmap<BufOacc<TElem, TDim, TIdx>, DevOacc>
-        {
-            ALPAKA_FN_HOST static auto unmap(BufOacc<TElem, TDim, TIdx> const& buf, DevOacc const& dev) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(getDev(buf) != dev)
-                {
-                    throw std::runtime_error("Unmapping memory mapped from one OpenACC device into an other OpenACC "
-                                             "device not implemented!");
-                }
-                // If it is already the same device, nothing has to be unmapped.
-            }
-        };
-        //! The BufOacc memory pinning trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Pin<BufOacc<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto pin(BufOacc<TElem, TDim, TIdx>&) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // No explicit pinning in OpenACC? GPU would be pinned anyway.
-            }
-        };
-        //! The BufOacc memory unpinning trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Unpin<BufOacc<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto unpin(BufOacc<TElem, TDim, TIdx>&) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // No explicit pinning in OpenACC? GPU would be pinned anyway.
-            }
-        };
-        //! The BufOacc memory pin state trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct IsPinned<BufOacc<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto isPinned(BufOacc<TElem, TDim, TIdx> const&) -> bool
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // No explicit pinning in OpenACC? GPU would be pinned anyway.
-                return true;
-            }
-        };
-        //! The BufOacc memory prepareForAsyncCopy trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct PrepareForAsyncCopy<BufOacc<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto prepareForAsyncCopy(BufOacc<TElem, TDim, TIdx>&) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // OpenACC device memory is always ready for async copy
-            }
-        };
-
         //! The BufOacc offset get trait specialization.
         template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
         struct GetOffset<TIdxIntegralConst, BufOacc<TElem, TDim, TIdx>>
@@ -339,40 +261,7 @@ namespace alpaka
             using type = TIdx;
         };
 
-        //! The BufCpu CUDA device memory mapping trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Map<BufCpu<TElem, TDim, TIdx>, DevOacc>
-        {
-            ALPAKA_FN_HOST static auto map(BufCpu<TElem, TDim, TIdx>& buf, DevOacc const& dev) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(getDev(buf) != dev) //! \TODO WTF?
-                {
-                    //   Maps the allocation into the CUDA address space.The device pointer to the memory may be
-                    //   obtained by calling cudaHostGetDevicePointer().
-                    throw std::runtime_error("Mapping host memory to OpenACC device not implemented!");
-                }
-                // If it is already the same device, nothing has to be mapped.
-            }
-        };
-        //! The BufCpu CUDA device memory unmapping trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Unmap<BufCpu<TElem, TDim, TIdx>, DevOacc>
-        {
-            ALPAKA_FN_HOST static auto unmap(BufCpu<TElem, TDim, TIdx>& buf, DevOacc const& dev) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(getDev(buf) != dev) //! \TODO WTF?
-                {
-                    throw std::runtime_error("Mapping host memory to OpenACC device not implemented!");
-                }
-                // If it is already the same device, nothing has to be unmapped.
-            }
-        };
-
-        //! The BufCpu pointer on CUDA device get trait specialization.
+        //! The BufCpu pointer on OpenAcc device get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrDev<BufCpu<TElem, TDim, TIdx>, DevOacc>
         {

--- a/include/alpaka/mem/buf/BufOmp5.hpp
+++ b/include/alpaka/mem/buf/BufOmp5.hpp
@@ -241,84 +241,6 @@ namespace alpaka
             }
         };
 
-        //! The BufOmp5 device memory mapping trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Map<BufOmp5<TElem, TDim, TIdx>, DevOmp5>
-        {
-            ALPAKA_FN_HOST static auto map(BufOmp5<TElem, TDim, TIdx> const& buf, DevOmp5 const& dev) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(getDev(buf) != dev)
-                {
-                    throw std::runtime_error(
-                        "Mapping memory from one OMP5 device into an other OMP5 device not implemented!");
-                }
-                // If it is already the same device, nothing has to be mapped.
-            }
-        };
-        //! The BufOmp5 device memory unmapping trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Unmap<BufOmp5<TElem, TDim, TIdx>, DevOmp5>
-        {
-            ALPAKA_FN_HOST static auto unmap(BufOmp5<TElem, TDim, TIdx> const& buf, DevOmp5 const& dev) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(getDev(buf) != dev)
-                {
-                    throw std::runtime_error(
-                        "Unmapping memory mapped from one OMP5 device into an other OMP5 device not implemented!");
-                }
-                // If it is already the same device, nothing has to be unmapped.
-            }
-        };
-        //! The BufOmp5 memory pinning trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Pin<BufOmp5<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto pin(BufOmp5<TElem, TDim, TIdx>&) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // No explicit pinning in OMP5? GPU would be pinned anyway.
-            }
-        };
-        //! The BufOmp5 memory unpinning trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Unpin<BufOmp5<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto unpin(BufOmp5<TElem, TDim, TIdx>&) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // No explicit pinning in OMP5? GPU would be pinned anyway.
-            }
-        };
-        //! The BufOmp5 memory pin state trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct IsPinned<BufOmp5<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto isPinned(BufOmp5<TElem, TDim, TIdx> const&) -> bool
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // No explicit pinning in OMP5? GPU would be pinned anyway.
-                return true;
-            }
-        };
-        //! The BufOmp5 memory prepareForAsyncCopy trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct PrepareForAsyncCopy<BufOmp5<TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto prepareForAsyncCopy(BufOmp5<TElem, TDim, TIdx>&) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // OMP5 device memory is always ready for async copy
-            }
-        };
-
         //! The BufOmp5 offset get trait specialization.
         template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
         struct GetOffset<TIdxIntegralConst, BufOmp5<TElem, TDim, TIdx>>
@@ -336,40 +258,7 @@ namespace alpaka
             using type = TIdx;
         };
 
-        //! The BufCpu CUDA device memory mapping trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Map<BufCpu<TElem, TDim, TIdx>, DevOmp5>
-        {
-            ALPAKA_FN_HOST static auto map(BufCpu<TElem, TDim, TIdx>& buf, DevOmp5 const& dev) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(getDev(buf) != dev) //! \TODO WTF?
-                {
-                    //   Maps the allocation into the CUDA address space.The device pointer to the memory may be
-                    //   obtained by calling cudaHostGetDevicePointer().
-                    throw std::runtime_error("Mapping host memory to OMP5 device not implemented!");
-                }
-                // If it is already the same device, nothing has to be mapped.
-            }
-        };
-        //! The BufCpu CUDA device memory unmapping trait specialization.
-        template<typename TElem, typename TDim, typename TIdx>
-        struct Unmap<BufCpu<TElem, TDim, TIdx>, DevOmp5>
-        {
-            ALPAKA_FN_HOST static auto unmap(BufCpu<TElem, TDim, TIdx>& buf, DevOmp5 const& dev) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(getDev(buf) != dev) //! \TODO WTF?
-                {
-                    throw std::runtime_error("Mapping host memory to OMP5 device not implemented!");
-                }
-                // If it is already the same device, nothing has to be unmapped.
-            }
-        };
-
-        //! The BufCpu pointer on CUDA device get trait specialization.
+        //! The BufCpu pointer on OpenMP 5 device get trait specialization.
         template<typename TElem, typename TDim, typename TIdx>
         struct GetPtrDev<BufCpu<TElem, TDim, TIdx>, DevOmp5>
         {

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -333,88 +333,6 @@ namespace alpaka
         {
         };
 
-        //! The BufUniformCudaHipRt CUDA/HIP device memory mapping trait specialization.
-        template<typename TApi, typename TElem, typename TDim, typename TIdx>
-        struct Map<BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>, DevUniformCudaHipRt<TApi>>
-        {
-            ALPAKA_FN_HOST static auto map(
-                BufUniformCudaHipRt<TApi, TElem, TDim, TIdx> const& buf,
-                DevUniformCudaHipRt<TApi> const& dev) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(getDev(buf) != dev)
-                {
-                    throw std::runtime_error(
-                        "Mapping memory from one CUDA/HIP device into an other CUDA/HIP device not implemented!");
-                }
-                // If it is already the same device, nothing has to be mapped.
-            }
-        };
-        //! The BufUniformCudaHipRt CUDA/HIP device memory unmapping trait specialization.
-        template<typename TApi, typename TElem, typename TDim, typename TIdx>
-        struct Unmap<BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>, DevUniformCudaHipRt<TApi>>
-        {
-            ALPAKA_FN_HOST static auto unmap(
-                BufUniformCudaHipRt<TApi, TElem, TDim, TIdx> const& buf,
-                DevUniformCudaHipRt<TApi> const& dev) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(getDev(buf) != dev)
-                {
-                    throw std::runtime_error("Unmapping memory mapped from one CUDA/HIP device into an other CUDA/HIP "
-                                             "device not implemented!");
-                }
-                // If it is already the same device, nothing has to be unmapped.
-            }
-        };
-        //! The BufUniformCudaHipRt memory pinning trait specialization.
-        template<typename TApi, typename TElem, typename TDim, typename TIdx>
-        struct Pin<BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto pin(BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>&) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // CUDA/HIP device memory is always pinned, it can not be swapped out.
-            }
-        };
-        //! The BufUniformCudaHipRt memory unpinning trait specialization.
-        template<typename TApi, typename TElem, typename TDim, typename TIdx>
-        struct Unpin<BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto unpin(BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>&) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // CUDA/HIP device memory is always pinned, it can not be swapped out.
-            }
-        };
-        //! The BufUniformCudaHipRt memory pin state trait specialization.
-        template<typename TApi, typename TElem, typename TDim, typename TIdx>
-        struct IsPinned<BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto isPinned(BufUniformCudaHipRt<TApi, TElem, TDim, TIdx> const&) -> bool
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // CUDA/HIP device memory is always pinned, it can not be swapped out.
-                return true;
-            }
-        };
-        //! The BufUniformCudaHipRt memory prepareForAsyncCopy trait specialization.
-        template<typename TApi, typename TElem, typename TDim, typename TIdx>
-        struct PrepareForAsyncCopy<BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>>
-        {
-            ALPAKA_FN_HOST static auto prepareForAsyncCopy(BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>&) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // CUDA/HIP device memory is always ready for async copy
-            }
-        };
-
         //! The BufUniformCudaHipRt offset get trait specialization.
         template<typename TApi, typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx>
         struct GetOffset<TIdxIntegralConst, BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>>
@@ -430,49 +348,6 @@ namespace alpaka
         struct IdxType<BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>>
         {
             using type = TIdx;
-        };
-
-        //! The BufCpu CUDA/HIP device memory mapping trait specialization.
-        template<typename TApi, typename TElem, typename TDim, typename TIdx>
-        struct Map<BufCpu<TElem, TDim, TIdx>, DevUniformCudaHipRt<TApi>>
-        {
-            ALPAKA_FN_HOST static auto map(BufCpu<TElem, TDim, TIdx>& buf, DevUniformCudaHipRt<TApi> const& dev)
-                -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                // If it is already the same device, nothing has to be mapped.
-                if(getDev(buf) != dev)
-                {
-                    // cuda/hip-HostRegisterMapped:
-                    //   Maps the allocation into the CUDA/HIP address space.The device pointer to the memory may be
-                    //   obtained by calling cudaHostGetDevicePointer(). This feature is available only on GPUs with
-                    //   compute capability greater than or equal to 1.1.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::hostRegister(
-                        const_cast<void*>(reinterpret_cast<void const*>(getPtrNative(buf))),
-                        getExtentProduct(buf) * sizeof(Elem<BufCpu<TElem, TDim, TIdx>>),
-                        TApi::hostRegisterMapped));
-                }
-            }
-        };
-        //! The BufCpu CUDA/HIP device memory unmapping trait specialization.
-        template<typename TApi, typename TElem, typename TDim, typename TIdx>
-        struct Unmap<BufCpu<TElem, TDim, TIdx>, DevUniformCudaHipRt<TApi>>
-        {
-            ALPAKA_FN_HOST static auto unmap(BufCpu<TElem, TDim, TIdx>& buf, DevUniformCudaHipRt<TApi> const& dev)
-                -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-
-                if(getDev(buf) != dev)
-                {
-                    // Unmaps the memory range whose base address is specified by ptr, and makes it pageable again.
-                    // \FIXME: If the memory has separately been pinned before we destroy the pinning state.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        TApi::hostUnregister(const_cast<void*>(reinterpret_cast<void const*>(getPtrNative(buf)))));
-                }
-                // If it is already the same device, nothing has to be unmapped.
-            }
         };
 
         //! The BufCpu pointer on CUDA/HIP device get trait specialization.

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -48,30 +48,6 @@ namespace alpaka
         struct HasMappedBufSupport : public std::false_type
         {
         };
-
-        //! The memory mapping trait.
-        template<typename TBuf, typename TDev, typename TSfinae = void>
-        struct Map;
-
-        //! The memory unmapping trait.
-        template<typename TBuf, typename TDev, typename TSfinae = void>
-        struct Unmap;
-
-        //! The memory pinning trait.
-        template<typename TBuf, typename TSfinae = void>
-        struct Pin;
-
-        //! The memory unpinning trait.
-        template<typename TBuf, typename TSfinae = void>
-        struct Unpin;
-
-        //! The memory pin state trait.
-        template<typename TBuf, typename TSfinae = void>
-        struct IsPinned;
-
-        //! The memory prepareForAsyncCopy trait.
-        template<typename TBuf, typename TSfinae = void>
-        struct PrepareForAsyncCopy;
     } // namespace trait
 
     //! The memory buffer type trait alias template to remove the ::type.
@@ -214,70 +190,5 @@ namespace alpaka
         }
 
         ALPAKA_UNREACHABLE(allocBuf<TElem, TIdx>(host, extent));
-    }
-
-    //! Maps the buffer into the memory of the given device.
-    //!
-    //! \tparam TBuf The buffer type.
-    //! \tparam TDev The device type.
-    //! \param buf The buffer to map into the device memory.
-    //! \param dev The device to map the buffer into.
-    template<typename TBuf, typename TDev>
-    ALPAKA_FN_HOST auto map(TBuf& buf, TDev const& dev) -> void
-    {
-        return trait::Map<TBuf, TDev>::map(buf, dev);
-    }
-
-    //! Unmaps the buffer from the memory of the given device.
-    //!
-    //! \tparam TBuf The buffer type.
-    //! \tparam TDev The device type.
-    //! \param buf The buffer to unmap from the device memory.
-    //! \param dev The device to unmap the buffer from.
-    template<typename TBuf, typename TDev>
-    ALPAKA_FN_HOST auto unmap(TBuf& buf, TDev const& dev) -> void
-    {
-        return trait::Unmap<TBuf, TDev>::unmap(buf, dev);
-    }
-
-    //! Pins the buffer.
-    //!
-    //! \tparam TBuf The buffer type.
-    //! \param buf The buffer to pin in the device memory.
-    template<typename TBuf>
-    ALPAKA_FN_HOST auto pin(TBuf& buf) -> void
-    {
-        return trait::Pin<TBuf>::pin(buf);
-    }
-
-    //! Unpins the buffer.
-    //!
-    //! \tparam TBuf The buffer type.
-    //! \param buf The buffer to unpin from the device memory.
-    template<typename TBuf>
-    ALPAKA_FN_HOST auto unpin(TBuf& buf) -> void
-    {
-        return trait::Unpin<TBuf>::unpin(buf);
-    }
-
-    //! The pin state of the buffer.
-    //!
-    //! \tparam TBuf The buffer type.
-    //! \param buf The buffer to get the pin state of.
-    template<typename TBuf>
-    ALPAKA_FN_HOST auto isPinned(TBuf const& buf) -> bool
-    {
-        return trait::IsPinned<TBuf>::isPinned(buf);
-    }
-
-    //! Prepares the buffer for non-blocking copy operations, e.g. pinning if
-    //! non-blocking copy between a cpu and a cuda device is wanted
-    //!
-    //! \tparam TBuf The buffer type.
-    //! \param buf The buffer to prepare in the device memory.
-    template<typename TBuf>
-    ALPAKA_FN_HOST auto prepareForAsyncCopy(TBuf& buf) -> void
-    {
-        return trait::PrepareForAsyncCopy<TBuf>::prepareForAsyncCopy(buf);
     }
 } // namespace alpaka


### PR DESCRIPTION
Remove the
  - `alpaka::map()`/`unmap()`
  - `alpaka::pin()`/`unpin()`
  - `alpaka::isPinned()`
  - `alpaka::prepareForAsyncCopy()` free functions working on existing memory buffers.

Host memory buffers pinnd/mapped for a particular accelerator platform can be obtained with:
```c++
allocMappedBuf<TPltf, TElem, TIdx>(host, extent)
```