### PR TITLE
Refactor Philox to expose Counter-based RNG API

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -30,6 +30,7 @@ project("alpakaExamples" LANGUAGES CXX)
 
 add_subdirectory("bufferCopy/")
 add_subdirectory("complex/")
+add_subdirectory("counterBasedRng/")
 add_subdirectory("heatEquation/")
 add_subdirectory("helloWorld/")
 add_subdirectory("helloWorldLambda/")

--- a/example/counterBasedRng/CMakeLists.txt
+++ b/example/counterBasedRng/CMakeLists.txt
@@ -1,0 +1,61 @@
+#
+# Copyright 2022 Benjamin Worpitz, Jan Stephan, Jeffrey Kelling
+#
+# This file exemplifies usage of alpaka.
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED “AS IS” AND ISC DISCLAIMS ALL WARRANTIES WITH
+# REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY
+# SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+# IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+#
+
+################################################################################
+# Required CMake version.
+
+cmake_minimum_required(VERSION 3.18)
+
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+################################################################################
+# Project.
+
+set(_TARGET_NAME counterBasedRng)
+
+project(${_TARGET_NAME} LANGUAGES CXX)
+
+
+#-------------------------------------------------------------------------------
+# Find alpaka.
+
+if(NOT TARGET alpaka::alpaka)
+    option(alpaka_USE_SOURCE_TREE "Use alpaka's source tree instead of an alpaka installation" OFF)
+
+    if(alpaka_USE_SOURCE_TREE)
+        # Don't build the examples recursively
+        set(alpaka_BUILD_EXAMPLES OFF)
+        add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." "${CMAKE_BINARY_DIR}/alpaka")
+    else()
+        find_package(alpaka REQUIRED)
+    endif()
+endif()
+
+#-------------------------------------------------------------------------------
+# Add executable.
+
+alpaka_add_executable(
+    ${_TARGET_NAME}
+    src/counterBasedRng.cpp)
+target_link_libraries(
+    ${_TARGET_NAME}
+    PUBLIC alpaka::alpaka)
+
+set_target_properties(${_TARGET_NAME} PROPERTIES FOLDER example)
+
+add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/example/counterBasedRng/src/counterBasedRng.cpp
+++ b/example/counterBasedRng/src/counterBasedRng.cpp
@@ -1,0 +1,258 @@
+/* Copyright 2022 Jeffrey Kelling
+ *
+ * This file exemplifies usage of alpaka.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS” AND ISC DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+ * IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/example/ExampleDefaultAcc.hpp>
+#include <alpaka/rand/RandPhiloxStateless.hpp>
+
+#include <chrono>
+#include <iostream>
+#include <random>
+#include <typeinfo>
+
+//! A kernel that fills an array with pseudo-random numbers.
+class CounterBasedRngKernel
+{
+public:
+    template<class TAcc>
+    using Vec = alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>>;
+    template<class TAcc>
+    using Gen = typename alpaka::rand::PhiloxStateless4x32x10Vector<TAcc>;
+    template<class TAcc>
+    using Key = typename Gen<TAcc>::Key;
+    template<class TAcc>
+    using Counter = typename Gen<TAcc>::Counter;
+
+private:
+    template<unsigned int I>
+    struct ElemLoop
+    {
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<typename TAcc, typename TElem>
+        static ALPAKA_FN_ACC auto elemLoop(
+            TAcc const& acc,
+            alpaka::experimental::
+                BufferAccessor<TAcc, TElem, alpaka::Dim<TAcc>::value, alpaka::experimental::WriteAccess> dst,
+            Key<TAcc> const& key,
+            Vec<TAcc> const& threadElemExtent,
+            Vec<TAcc>& threadFirstElemIdx) -> void
+        {
+            auto const threadLastElemIdx = threadFirstElemIdx[I] + threadElemExtent[I];
+            auto const threadLastElemIdxClipped
+                = (dst.extents[I] > threadLastElemIdx) ? threadLastElemIdx : dst.extents[I];
+
+            constexpr auto Dim = alpaka::Dim<TAcc>::value;
+
+            const auto firstElem = threadFirstElemIdx[I];
+            if constexpr(I < Dim - 1)
+            {
+                for(; threadFirstElemIdx[I] < threadLastElemIdxClipped; ++threadFirstElemIdx[I])
+                {
+                    ElemLoop<I + 1>::elemLoop(acc, dst, key, threadElemExtent, threadFirstElemIdx);
+                }
+            }
+            else
+            {
+                Counter<TAcc> c = {0, 0, 0, 0};
+                for(unsigned int i = 0; i < Dim; ++i)
+                    c[i] = threadFirstElemIdx[i];
+
+                for(; threadFirstElemIdx[Dim - 1] < threadLastElemIdxClipped; ++threadFirstElemIdx[Dim - 1])
+                {
+                    c[Dim - 1] = threadFirstElemIdx[Dim - 1];
+                    const auto random = Gen<TAcc>::generate(c, key);
+                    // to make use of the whole random vector we would need to ensure numElement[0] % 4 == 0
+                    dst[threadFirstElemIdx] = TElem(random[0]);
+                }
+            }
+            threadFirstElemIdx[I] = firstElem;
+        }
+    };
+
+public:
+    //! The kernel entry point.
+    //!
+    //! \tparam TAcc The accelerator environment to be executed on.
+    //! \tparam TElem The matrix element type.
+    //! \param acc The accelerator to be executed on.
+    //! \param dst destimation matrix.
+    //! \param extent The matrix dimension in elements.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAcc, typename TElem>
+    ALPAKA_FN_ACC auto operator()(
+        TAcc const& acc,
+        alpaka::experimental::BufferAccessor<TAcc, TElem, alpaka::Dim<TAcc>::value, alpaka::experimental::WriteAccess>
+            dst,
+        Key<TAcc> const& key) const -> void
+    {
+        constexpr auto Dim = alpaka::Dim<TAcc>::value;
+        static_assert(Dim <= 4, "The CounterBasedRngKernel expects at most 4-dimensional indices!");
+
+        Vec<TAcc> const gridThreadIdx(alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc));
+        Vec<TAcc> const threadElemExtent(alpaka::getWorkDiv<alpaka::Thread, alpaka::Elems>(acc));
+        Vec<TAcc> threadFirstElemIdx(gridThreadIdx * threadElemExtent);
+
+        ElemLoop<0>::elemLoop(acc, dst, key, threadElemExtent, threadFirstElemIdx);
+    }
+};
+
+auto main() -> int
+{
+// Fallback for the CI with disabled sequential backend
+#if defined(ALPAKA_CI) && !defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
+    return EXIT_SUCCESS;
+#else
+
+    // Define the index domain
+    using Dim = alpaka::DimInt<3u>;
+    using Idx = std::size_t;
+
+    // Define the accelerator
+    //
+    // It is possible to choose from a set of accelerators:
+    // - AccGpuCudaRt
+    // - AccGpuHipRt
+    // - AccCpuThreads
+    // - AccCpuFibers
+    // - AccCpuOmp2Threads
+    // - AccCpuOmp2Blocks
+    // - AccOmp5
+    // - AccCpuTbbBlocks
+    // - AccCpuSerial
+    // using Acc = alpaka::AccCpuSerial<Dim, Idx>;
+    using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
+    std::cout << "Using alpaka accelerator: " << alpaka::getAccName<Acc>() << std::endl;
+
+    using AccHost = alpaka::AccCpuSerial<Dim, Idx>;
+    // Get the host device for allocating memory on the host.
+    using DevHost = alpaka::DevCpu;
+
+    // Defines the synchronization behavior of a queue
+    //
+    // choose between Blocking and NonBlocking
+    using QueueProperty = alpaka::Blocking;
+    using QueueAcc = alpaka::Queue<Acc, QueueProperty>;
+    using QueueHost = alpaka::Queue<AccHost, QueueProperty>;
+
+    // Select a device
+    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const devHost = alpaka::getDevByIdx<AccHost>(0u);
+
+    // Create a queue on the device
+    QueueAcc queueAcc(devAcc);
+    QueueHost queueHost(devHost);
+
+    // Define the work division
+    alpaka::Vec<Dim, Idx> const extent = {16, 16, 16 * 8};
+    alpaka::Vec<Dim, Idx> const elementsPerThread = {1, 1, 1};
+    alpaka::Vec<Dim, Idx> const elementsPerThreadHost = {1, 1, 8};
+
+    // Let alpaka calculate good block and grid sizes given our full problem extent
+    alpaka::WorkDivMembers<Dim, Idx> const workDivAcc(alpaka::getValidWorkDiv<Acc>(
+        devAcc,
+        extent,
+        elementsPerThread,
+        false,
+        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted));
+    alpaka::WorkDivMembers<Dim, Idx> const workDivHost(alpaka::getValidWorkDiv<AccHost>(
+        devHost,
+        extent,
+        elementsPerThreadHost,
+        false,
+        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted));
+
+    // Define the buffer element type
+    using Data = std::uint32_t;
+
+    // Allocate 3 host memory buffers
+    using BufHost = alpaka::Buf<DevHost, Data, Dim, Idx>;
+    BufHost bufHost(alpaka::allocBuf<Data, Idx>(devHost, extent));
+    BufHost bufHostDev(alpaka::allocBuf<Data, Idx>(devHost, extent));
+
+    // Initialize the host input vectors A and B
+    Data* const pBufHost(alpaka::getPtrNative(bufHost));
+    Data* const pBufHostDev(alpaka::getPtrNative(bufHostDev));
+
+    std::random_device rd{};
+    CounterBasedRngKernel::Key<AccHost> key = {rd(), rd()};
+
+    // Allocate buffer on the accelerator
+    using BufAcc = alpaka::Buf<Acc, Data, Dim, Idx>;
+    BufAcc bufAcc(alpaka::allocBuf<Data, Idx>(devAcc, extent));
+
+    // Create the kernel execution task.
+    auto const taskKernelAcc = alpaka::createTaskKernel<Acc>(
+        workDivAcc,
+        CounterBasedRngKernel(),
+        alpaka::experimental::writeAccess(bufAcc),
+        key);
+    auto const taskKernelHost = alpaka::createTaskKernel<AccHost>(
+        workDivHost,
+        CounterBasedRngKernel(),
+        alpaka::experimental::writeAccess(bufHost),
+        key);
+
+    // Enqueue the kernel execution task
+    alpaka::enqueue(queueHost, taskKernelHost);
+    alpaka::enqueue(queueAcc, taskKernelAcc);
+
+    // Copy the result from the device
+    alpaka::memcpy(queueAcc, bufHostDev, bufAcc);
+    const auto numElements = extent.prod();
+    // alpaka::memcpy(queueAcc,
+    //     alpaka::createView(devHost, pBufHostDev, alpaka::Vec<alpaka::DimInt<1u>, Idx>(numElements)),
+    //     alpaka::createView(devAcc, alpaka::getPtrNative(bufAcc),
+    //         alpaka::Vec<alpaka::DimInt<1u>, Idx>(numElements)));
+
+    // wait in case we are using an asynchronous queue to time actual kernel runtime
+    alpaka::wait(queueHost);
+    alpaka::wait(queueAcc);
+
+    int falseResults = 0;
+    const int MAX_PRINT_FALSE_RESULTS = extent[2] * 2;
+
+    auto aHost = alpaka::experimental::readAccess(bufHost);
+    auto aAcc = alpaka::experimental::readAccess(bufHostDev);
+    for(Idx z = 0; z < aHost.extents[0]; ++z)
+        for(Idx y = 0; y < aHost.extents[1]; ++y)
+            for(Idx x = 0; x < aHost.extents[2]; ++x)
+            {
+                Data const& valHost(aHost(z, y, x));
+                Data const& valAcc(aAcc(z, y, x));
+                if(valHost != valAcc)
+                {
+                    if(falseResults < MAX_PRINT_FALSE_RESULTS)
+                        std::cerr << "host[" << z << ", " << y << ", " << x << "] = " << valHost << " != acc[" << z
+                                  << ", " << y << ", " << x << "] = " << valAcc << std::endl;
+                    ++falseResults;
+                }
+            }
+
+    if(falseResults == 0)
+    {
+        std::cout << "Execution results correct!" << std::endl;
+        return EXIT_SUCCESS;
+    }
+    else
+    {
+        std::cout << "Found " << falseResults << " false results, printed no more than " << MAX_PRINT_FALSE_RESULTS
+                  << "\n"
+                  << "Execution results incorrect!" << std::endl;
+        return EXIT_FAILURE;
+    }
+#endif
+}

--- a/example/counterBasedRng/src/counterBasedRng.cpp
+++ b/example/counterBasedRng/src/counterBasedRng.cpp
@@ -213,17 +213,13 @@ auto main() -> int
     // Copy the result from the device
     alpaka::memcpy(queueAcc, bufHostDev, bufAcc);
     const auto numElements = extent.prod();
-    // alpaka::memcpy(queueAcc,
-    //     alpaka::createView(devHost, pBufHostDev, alpaka::Vec<alpaka::DimInt<1u>, Idx>(numElements)),
-    //     alpaka::createView(devAcc, alpaka::getPtrNative(bufAcc),
-    //         alpaka::Vec<alpaka::DimInt<1u>, Idx>(numElements)));
 
     // wait in case we are using an asynchronous queue to time actual kernel runtime
     alpaka::wait(queueHost);
     alpaka::wait(queueAcc);
 
     int falseResults = 0;
-    const int MAX_PRINT_FALSE_RESULTS = extent[2] * 2;
+    const int maxPrintFalseResults = extent[2] * 2;
 
     auto aHost = alpaka::experimental::readAccess(bufHost);
     auto aAcc = alpaka::experimental::readAccess(bufHostDev);
@@ -235,7 +231,7 @@ auto main() -> int
                 Data const& valAcc(aAcc(z, y, x));
                 if(valHost != valAcc)
                 {
-                    if(falseResults < MAX_PRINT_FALSE_RESULTS)
+                    if(falseResults < maxPrintFalseResults)
                         std::cerr << "host[" << z << ", " << y << ", " << x << "] = " << valHost << " != acc[" << z
                                   << ", " << y << ", " << x << "] = " << valAcc << std::endl;
                     ++falseResults;
@@ -249,7 +245,7 @@ auto main() -> int
     }
     else
     {
-        std::cout << "Found " << falseResults << " false results, printed no more than " << MAX_PRINT_FALSE_RESULTS
+        std::cout << "Found " << falseResults << " false results, printed no more than " << maxPrintFalseResults
                   << "\n"
                   << "Execution results incorrect!" << std::endl;
         return EXIT_FAILURE;

--- a/include/alpaka/meta/CudaVectorArrayWrapper.hpp
+++ b/include/alpaka/meta/CudaVectorArrayWrapper.hpp
@@ -139,6 +139,27 @@ namespace alpaka::meta
             this->z = *it++;
             this->w = *it++;
         }
+        template<class Other>
+        ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CudaVectorArrayWrapper(const Other& o)
+        {
+            static_assert(std::tuple_size<Other>::value == size, "Can only convert between vectors of same size.");
+            static_assert(
+                std::is_same<typename Other::value_type, value_type>::value,
+                "Can only convert between vectors of same element type.");
+            this->x = o[0];
+            this->y = o[1];
+            this->z = o[2];
+            this->w = o[3];
+        }
+        operator std::array<value_type, size>() const
+        {
+            std::array<value_type, size> ret;
+            ret[0] = this->x;
+            ret[1] = this->y;
+            ret[2] = this->z;
+            ret[3] = this->w;
+        }
+
         ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr value_type& operator[](int const k) noexcept
         {
             assert(k >= 0 && k < 4);
@@ -164,6 +185,25 @@ namespace alpaka::meta
             this->y = *it++;
             this->z = *it++;
         }
+        template<class Other>
+        ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CudaVectorArrayWrapper(const Other& o)
+        {
+            static_assert(std::tuple_size<Other>::value == size, "Can only convert between vectors of same size.");
+            static_assert(
+                std::is_same<typename Other::value_type, value_type>::value,
+                "Can only convert between vectors of same element type.");
+            this->x = o[0];
+            this->y = o[1];
+            this->z = o[2];
+        }
+        operator std::array<value_type, size>() const
+        {
+            std::array<value_type, size> ret;
+            ret[0] = this->x;
+            ret[1] = this->y;
+            ret[2] = this->z;
+        }
+
         ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr value_type& operator[](int const k) noexcept
         {
             assert(k >= 0 && k < 3);
@@ -188,6 +228,23 @@ namespace alpaka::meta
             this->x = *it++;
             this->y = *it++;
         }
+        template<class Other>
+        ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CudaVectorArrayWrapper(const Other& o)
+        {
+            static_assert(std::tuple_size<Other>::value == size, "Can only convert between vectors of same size.");
+            static_assert(
+                std::is_same<typename Other::value_type, value_type>::value,
+                "Can only convert between vectors of same element type.");
+            this->x = o[0];
+            this->y = o[1];
+        }
+        operator std::array<value_type, size>() const
+        {
+            std::array<value_type, size> ret;
+            ret[0] = this->x;
+            ret[1] = this->y;
+        }
+
         ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr value_type& operator[](int const k) noexcept
         {
             assert(k >= 0 && k < 2);
@@ -211,6 +268,21 @@ namespace alpaka::meta
             auto it = std::begin(init);
             this->x = *it;
         }
+        template<class Other>
+        ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CudaVectorArrayWrapper(const Other& o)
+        {
+            static_assert(std::tuple_size<Other>::value == size, "Can only convert between vectors of same size.");
+            static_assert(
+                std::is_same<typename Other::value_type, value_type>::value,
+                "Can only convert between vectors of same element type.");
+            this->x = o[0];
+        }
+        operator std::array<value_type, size>() const
+        {
+            std::array<value_type, size> ret;
+            ret[0] = this->x;
+        }
+
         ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr value_type& operator[]([[maybe_unused]] int const k) noexcept
         {
             assert(k == 0);

--- a/include/alpaka/meta/CudaVectorArrayWrapper.hpp
+++ b/include/alpaka/meta/CudaVectorArrayWrapper.hpp
@@ -142,22 +142,23 @@ namespace alpaka::meta
         template<class Other>
         ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE CudaVectorArrayWrapper(const Other& o)
         {
-            static_assert(std::tuple_size<Other>::value == size, "Can only convert between vectors of same size.");
+            static_assert(std::tuple_size_v<Other> == size, "Can only convert between vectors of same size.");
             static_assert(
-                std::is_same<typename Other::value_type, value_type>::value,
+                std::is_same_v<typename Other::value_type, value_type>,
                 "Can only convert between vectors of same element type.");
             this->x = o[0];
             this->y = o[1];
             this->z = o[2];
             this->w = o[3];
         }
-        operator std::array<value_type, size>() const
+        ALPAKA_FN_HOST_ACC constexpr operator std::array<value_type, size>() const
         {
             std::array<value_type, size> ret;
             ret[0] = this->x;
             ret[1] = this->y;
             ret[2] = this->z;
             ret[3] = this->w;
+            return ret;
         }
 
         ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr value_type& operator[](int const k) noexcept
@@ -196,12 +197,13 @@ namespace alpaka::meta
             this->y = o[1];
             this->z = o[2];
         }
-        operator std::array<value_type, size>() const
+        ALPAKA_FN_HOST_ACC constexpr operator std::array<value_type, size>() const
         {
             std::array<value_type, size> ret;
             ret[0] = this->x;
             ret[1] = this->y;
             ret[2] = this->z;
+            return ret;
         }
 
         ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr value_type& operator[](int const k) noexcept
@@ -238,11 +240,12 @@ namespace alpaka::meta
             this->x = o[0];
             this->y = o[1];
         }
-        operator std::array<value_type, size>() const
+        ALPAKA_FN_HOST_ACC constexpr operator std::array<value_type, size>() const
         {
             std::array<value_type, size> ret;
             ret[0] = this->x;
             ret[1] = this->y;
+            return ret;
         }
 
         ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr value_type& operator[](int const k) noexcept
@@ -277,10 +280,11 @@ namespace alpaka::meta
                 "Can only convert between vectors of same element type.");
             this->x = o[0];
         }
-        operator std::array<value_type, size>() const
+        ALPAKA_FN_HOST_ACC constexpr operator std::array<value_type, size>() const
         {
             std::array<value_type, size> ret;
             ret[0] = this->x;
+            return ret;
         }
 
         ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE constexpr value_type& operator[]([[maybe_unused]] int const k) noexcept

--- a/include/alpaka/rand/Philox/PhiloxBaseCommon.hpp
+++ b/include/alpaka/rand/Philox/PhiloxBaseCommon.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Jiri Vyskocil, Bernhard Manfred Gruber
+/* Copyright 2022 Jiri Vyskocil, Bernhard Manfred Gruber, Jeffrey Kelling
  *
  * This file is part of alpaka.
  *
@@ -9,32 +9,16 @@
 
 #pragma once
 
-#include <alpaka/rand/Philox/MultiplyAndSplit64to32.hpp>
-#include <alpaka/rand/Philox/PhiloxConstants.hpp>
+#include <alpaka/rand/Philox/PhiloxStateless.hpp>
 
 #include <utility>
 
 
 namespace alpaka::rand::engine
 {
-    /** Philox algorithm parameters
-     *
-     * @tparam TCounterSize number of elements in the counter
-     * @tparam TWidth width of one counter element (in bits)
-     * @tparam TRounds number of S-box rounds
-     */
-    template<unsigned TCounterSize, unsigned TWidth, unsigned TRounds>
-    struct PhiloxParams
-    {
-        static unsigned constexpr counterSize = TCounterSize;
-        static unsigned constexpr width = TWidth;
-        static unsigned constexpr rounds = TRounds;
-    };
-
     /** Common class for Philox family engines
      *
-     * Checks the validity of passed-in parameters and calls the \a TBackend methods to perform N rounds of the
-     * Philox shuffle.
+     * Relies on `PhiloxStateless` to provide the PRNG and adds state to handling the counting.
      *
      * @tparam TBackend device-dependent backend, specifies the array types
      * @tparam TParams Philox algorithm parameters \sa PhiloxParams
@@ -49,58 +33,13 @@ namespace alpaka::rand::engine
     template<typename TBackend, typename TParams, typename TImpl>
     class PhiloxBaseCommon
         : public TBackend
-        , public PhiloxConstants<TParams>
+        , public PhiloxStateless<TBackend, TParams>
     {
-        static constexpr unsigned numRounds()
-        {
-            return TParams::rounds;
-        }
-        static constexpr unsigned vectorSize()
-        {
-            return TParams::counterSize;
-        }
-        static constexpr unsigned numberWidth()
-        {
-            return TParams::width;
-        }
-
-        static_assert(numRounds() > 0, "Number of Philox rounds must be > 0.");
-        static_assert(vectorSize() % 2 == 0, "Philox counter size must be an even number.");
-        static_assert(vectorSize() <= 16, "Philox SP network is not specified for sizes > 16.");
-        static_assert(numberWidth() % 8 == 0, "Philox number width in bits must be a multiple of 8.");
-
-        // static_assert(TWidth == 32 || TWidth == 64, "Philox implemented only for 32 and 64 bit numbers.");
-        static_assert(numberWidth() == 32, "Philox implemented only for 32 bit numbers.");
-
     public:
-        using Counter = typename TBackend::Counter;
-        using Key = typename TBackend::Key;
+        using Counter = typename PhiloxStateless<TBackend, TParams>::Counter;
+        using Key = typename PhiloxStateless<TBackend, TParams>::Key;
 
     protected:
-        /** Single round of the Philox shuffle
-         *
-         * @param counter state of the counter
-         * @param key value of the key
-         * @return shuffled counter
-         */
-        ALPAKA_FN_HOST_ACC auto singleRound(Counter const& counter, Key const& key)
-        {
-            std::uint32_t H0, L0, H1, L1;
-            multiplyAndSplit64to32(counter[0], this->MULTIPLITER_4x32_0(), H0, L0);
-            multiplyAndSplit64to32(counter[2], this->MULTIPLITER_4x32_1(), H1, L1);
-            return Counter{H1 ^ counter[1] ^ key[0], L1, H0 ^ counter[3] ^ key[1], L0};
-        }
-
-        /** Bump the \a key by the Weyl sequence step parameter
-         *
-         * @param key the key to be bumped
-         * @return the bumped key
-         */
-        ALPAKA_FN_HOST_ACC auto bumpKey(Key const& key)
-        {
-            return Key{key[0] + this->WEYL_32_0(), key[1] + this->WEYL_32_1()};
-        }
-
         /** Advance the \a counter to the next state
          *
          * Increments the passed-in \a counter by one with a 128-bit carry.
@@ -153,28 +92,6 @@ namespace alpaka::rand::engine
             Counter temp = counter;
             counter[2] += low32Bits(subsequence);
             counter[3] += high32Bits(subsequence) + (counter[2] < temp[2] ? 1 : 0);
-        }
-
-        /** Performs N rounds of the Philox shuffle
-         *
-         * @param counter_in initial state of the counter
-         * @param key_in initial state of the key
-         * @return result of the PRNG shuffle; has the same size as the counter
-         */
-        ALPAKA_FN_HOST_ACC auto nRounds(Counter const& counter_in, Key const& key_in) -> Counter
-        {
-            Key key{key_in};
-            Counter counter = singleRound(counter_in, key);
-
-            // TODO: Consider unrolling the loop for performance
-            for(unsigned int n = 0; n < numRounds(); ++n)
-            {
-                key = bumpKey(key);
-                counter = singleRound(counter, key);
-            }
-            // TODO: Should the key be returned as well??? i.e. should the original key be bumped?
-
-            return counter;
         }
     };
 } // namespace alpaka::rand::engine

--- a/include/alpaka/rand/Philox/PhiloxBaseCudaArray.hpp
+++ b/include/alpaka/rand/Philox/PhiloxBaseCudaArray.hpp
@@ -51,9 +51,8 @@ namespace alpaka::rand::engine
     /** Philox backend using array-like interface to CUDA uintN types for the storage of Key and Counter
      *
      * @tparam TParams Philox algorithm parameters \sa PhiloxParams
-     * @tparam TImpl engine type implementation (CRTP)
      */
-    template<typename TParams, typename TImpl>
+    template<typename TParams>
     class PhiloxBaseCudaArray
     {
         static_assert(TParams::counterSize == 4, "GPU Philox implemented only for counters of width == 4");

--- a/include/alpaka/rand/Philox/PhiloxBaseStdArray.hpp
+++ b/include/alpaka/rand/Philox/PhiloxBaseStdArray.hpp
@@ -17,9 +17,8 @@ namespace alpaka::rand::engine
     /** Philox backend using std::array for Key and Counter storage
      *
      * @tparam TParams Philox algorithm parameters \sa PhiloxParams
-     * @tparam TImpl engine type implementation (CRTP)
      */
-    template<typename TParams, typename TImpl>
+    template<typename TParams>
     class PhiloxBaseStdArray
     {
     public:

--- a/include/alpaka/rand/Philox/PhiloxBaseTraits.hpp
+++ b/include/alpaka/rand/Philox/PhiloxBaseTraits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Jiri Vyskocil, Bernhard Manfred Gruber
+/* Copyright 2022 Jiri Vyskocil, Bernhard Manfred Gruber, Jeffrey Kelling
  *
  * This file is part of alpaka.
  *
@@ -11,6 +11,8 @@
 
 #include <alpaka/rand/Philox/PhiloxBaseCommon.hpp>
 #include <alpaka/rand/Philox/PhiloxBaseStdArray.hpp>
+#include <alpaka/rand/Philox/PhiloxStateless.hpp>
+#include <alpaka/rand/Philox/PhiloxStatelessKeyedBase.hpp>
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 #    include <alpaka/acc/AccGpuUniformCudaHipRt.hpp>
 #    include <alpaka/rand/Philox/PhiloxBaseCudaArray.hpp>
@@ -42,18 +44,16 @@ namespace alpaka::rand::engine::trait
      *
      * @tparam TAcc the accelerator as defined in alpaka/acc
      * @tparam TParams Philox algorithm parameters
-     * @tparam TImpl engine type implementation (CRTP)
      * @tparam TSfinae internal parameter to stop substitution search and provide the default
      */
-    template<typename TAcc, typename TParams, typename TImpl, typename TSfinae = void>
-    struct PhiloxBaseTraits
+    template<typename TAcc, typename TParams, typename TSfinae = void>
+    struct PhiloxStatelessBaseTraits
     {
         // template <typename Acc, typename TParams, typename TImpl>
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-        using Backend
-            = std::conditional_t<isGPU<TAcc>, PhiloxBaseCudaArray<TParams, TImpl>, PhiloxBaseStdArray<TParams, TImpl>>;
+        using Backend = std::conditional_t<isGPU<TAcc>, PhiloxBaseCudaArray<TParams>, PhiloxBaseStdArray<TParams>>;
 #else
-        using Backend = PhiloxBaseStdArray<TParams, TImpl>;
+        using Backend = PhiloxBaseStdArray<TParams>;
 #endif
         using Counter = typename Backend::Counter; ///< Counter array type
         using Key = typename Backend::Key; ///< Key array type
@@ -61,7 +61,42 @@ namespace alpaka::rand::engine::trait
         using ResultContainer =
             typename Backend::template ResultContainer<TDistributionResultScalar>; ///< Distribution
                                                                                    ///< container type
+        /// Base type to be inherited from by stateless keyed engine
+        using Base = PhiloxStateless<Backend, TParams>;
+    };
 
-        using Base = PhiloxBaseCommon<Backend, TParams, TImpl>; ///< Base type to be inherited from
+    /** Selection of default backend
+     *
+     * Selects the data backend based on the accelerator device type. As of now, different backends operate
+     * on different array types.
+     *
+     * @tparam TAcc the accelerator as defined in alpaka/acc
+     * @tparam TParams Philox algorithm parameters
+     * @tparam TSfinae internal parameter to stop substitution search and provide the default
+     */
+    template<typename TAcc, typename TParams, typename TSfinae = void>
+    struct PhiloxStatelessKeyedBaseTraits : public PhiloxStatelessBaseTraits<TAcc, TParams>
+    {
+        using Backend = typename PhiloxStatelessBaseTraits<TAcc, TParams>::Backend;
+        /// Base type to be inherited from by counting engines
+        using Base = PhiloxStatelessKeyedBase<Backend, TParams>;
+    };
+
+    /** Selection of default backend
+     *
+     * Selects the data backend based on the accelerator device type. As of now, different backends operate
+     * on different array types.
+     *
+     * @tparam TAcc the accelerator as defined in alpaka/acc
+     * @tparam TParams Philox algorithm parameters
+     * @tparam TImpl engine type implementation (CRTP)
+     * @tparam TSfinae internal parameter to stop substitution search and provide the default
+     */
+    template<typename TAcc, typename TParams, typename TImpl, typename TSfinae = void>
+    struct PhiloxBaseTraits : public PhiloxStatelessBaseTraits<TAcc, TParams>
+    {
+        using Backend = typename PhiloxStatelessBaseTraits<TAcc, TParams>::Backend;
+        /// Base type to be inherited from by counting engines
+        using Base = PhiloxBaseCommon<Backend, TParams, TImpl>;
     };
 } // namespace alpaka::rand::engine::trait

--- a/include/alpaka/rand/Philox/PhiloxStateless.hpp
+++ b/include/alpaka/rand/Philox/PhiloxStateless.hpp
@@ -1,0 +1,129 @@
+/* Copyright 2022 Jiri Vyskocil, Bernhard Manfred Gruber, Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/rand/Philox/MultiplyAndSplit64to32.hpp>
+#include <alpaka/rand/Philox/PhiloxConstants.hpp>
+
+#include <utility>
+
+
+namespace alpaka::rand::engine
+{
+    /** Philox algorithm parameters
+     *
+     * @tparam TCounterSize number of elements in the counter
+     * @tparam TWidth width of one counter element (in bits)
+     * @tparam TRounds number of S-box rounds
+     */
+    template<unsigned TCounterSize, unsigned TWidth, unsigned TRounds>
+    struct PhiloxParams
+    {
+        static constexpr unsigned counterSize = TCounterSize;
+        static constexpr unsigned width = TWidth;
+        static constexpr unsigned rounds = TRounds;
+    };
+
+    /** Class basic Philox family counter-based PRNG
+     *
+     * Checks the validity of passed-in parameters and calls the \a TBackend methods to perform N rounds of the
+     * Philox shuffle.
+     *
+     * @tparam TBackend device-dependent backend, specifies the array types
+     * @tparam TParams Philox algorithm parameters \sa PhiloxParams
+     */
+    template<typename TBackend, typename TParams>
+    class PhiloxStateless : public PhiloxConstants<TParams>
+    {
+        static constexpr unsigned numRounds()
+        {
+            return TParams::rounds;
+        }
+        static constexpr unsigned vectorSize()
+        {
+            return TParams::counterSize;
+        }
+        static constexpr unsigned numberWidth()
+        {
+            return TParams::width;
+        }
+
+        static_assert(numRounds() > 0, "Number of Philox rounds must be > 0.");
+        static_assert(vectorSize() % 2 == 0, "Philox counter size must be an even number.");
+        static_assert(vectorSize() <= 16, "Philox SP network is not specified for sizes > 16.");
+        static_assert(numberWidth() % 8 == 0, "Philox number width in bits must be a multiple of 8.");
+
+        // static_assert(TWidth == 32 || TWidth == 64, "Philox implemented only for 32 and 64 bit numbers.");
+        static_assert(numberWidth() == 32, "Philox implemented only for 32 bit numbers.");
+
+    public:
+        using Counter = typename TBackend::Counter;
+        using Key = typename TBackend::Key;
+        using Constants = PhiloxConstants<TParams>;
+
+    protected:
+        /** Single round of the Philox shuffle
+         *
+         * @param counter state of the counter
+         * @param key value of the key
+         * @return shuffled counter
+         */
+        static ALPAKA_FN_HOST_ACC auto singleRound(Counter const& counter, Key const& key)
+        {
+            std::uint32_t H0, L0, H1, L1;
+            multiplyAndSplit64to32(counter[0], Constants::MULTIPLITER_4x32_0(), H0, L0);
+            multiplyAndSplit64to32(counter[2], Constants::MULTIPLITER_4x32_1(), H1, L1);
+            return Counter{H1 ^ counter[1] ^ key[0], L1, H0 ^ counter[3] ^ key[1], L0};
+        }
+
+        /** Bump the \a key by the Weyl sequence step parameter
+         *
+         * @param key the key to be bumped
+         * @return the bumped key
+         */
+        static ALPAKA_FN_HOST_ACC auto bumpKey(Key const& key)
+        {
+            return Key{key[0] + Constants::WEYL_32_0(), key[1] + Constants::WEYL_32_1()};
+        }
+
+        /** Performs N rounds of the Philox shuffle
+         *
+         * @param counter_in initial state of the counter
+         * @param key_in initial state of the key
+         * @return result of the PRNG shuffle; has the same size as the counter
+         */
+        static ALPAKA_FN_HOST_ACC auto nRounds(Counter const& counter_in, Key const& key_in) -> Counter
+        {
+            Key key{key_in};
+            Counter counter = singleRound(counter_in, key);
+
+            // TODO: Consider unrolling the loop for performance
+            for(unsigned int n = 0; n < numRounds(); ++n)
+            {
+                key = bumpKey(key);
+                counter = singleRound(counter, key);
+            }
+
+            return counter;
+        }
+
+    public:
+        /** Generates a random number (\p TCounterSize x32-bit)
+         *
+         * @param counter initial state of the counter
+         * @param key initial state of the key
+         * @return result of the PRNG shuffle; has the same size as the counter
+         */
+        static ALPAKA_FN_HOST_ACC auto generate(Counter const& counter, Key const& key) -> Counter
+        {
+            return nRounds(counter, key);
+        }
+    };
+} // namespace alpaka::rand::engine

--- a/include/alpaka/rand/Philox/PhiloxStateless.hpp
+++ b/include/alpaka/rand/Philox/PhiloxStateless.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <alpaka/core/Unroll.hpp>
 #include <alpaka/rand/Philox/MultiplyAndSplit64to32.hpp>
 #include <alpaka/rand/Philox/PhiloxConstants.hpp>
 
@@ -60,7 +61,6 @@ namespace alpaka::rand::engine
         static_assert(vectorSize() <= 16, "Philox SP network is not specified for sizes > 16.");
         static_assert(numberWidth() % 8 == 0, "Philox number width in bits must be a multiple of 8.");
 
-        // static_assert(TWidth == 32 || TWidth == 64, "Philox implemented only for 32 and 64 bit numbers.");
         static_assert(numberWidth() == 32, "Philox implemented only for 32 bit numbers.");
 
     public:
@@ -104,7 +104,7 @@ namespace alpaka::rand::engine
             Key key{key_in};
             Counter counter = singleRound(counter_in, key);
 
-            // TODO: Consider unrolling the loop for performance
+            ALPAKA_UNROLL(numRounds())
             for(unsigned int n = 0; n < numRounds(); ++n)
             {
                 key = bumpKey(key);

--- a/include/alpaka/rand/Philox/PhiloxStatelessKeyedBase.hpp
+++ b/include/alpaka/rand/Philox/PhiloxStatelessKeyedBase.hpp
@@ -30,7 +30,7 @@ namespace alpaka::rand::engine
 
         const Key m_key;
 
-        PhiloxStatelessKeyedBase(Key&& key) : m_key(key)
+        PhiloxStatelessKeyedBase(Key&& key) : m_key(std::move(key))
         {
         }
 

--- a/include/alpaka/rand/Philox/PhiloxStatelessKeyedBase.hpp
+++ b/include/alpaka/rand/Philox/PhiloxStatelessKeyedBase.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2022 Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/rand/Philox/PhiloxStateless.hpp>
+
+namespace alpaka::rand::engine
+{
+    /** Common class for Philox family engines
+     *
+     * Checks the validity of passed-in parameters and calls the \a TBackend methods to perform N rounds of the
+     * Philox shuffle.
+     *
+     * @tparam TBackend device-dependent backend, specifies the array types
+     * @tparam TParams Philox algorithm parameters \sa PhiloxParams
+     */
+    template<typename TBackend, typename TParams>
+    struct PhiloxStatelessKeyedBase : public PhiloxStateless<TBackend, TParams>
+    {
+    public:
+        using Counter = typename PhiloxStateless<TBackend, TParams>::Counter;
+        using Key = typename PhiloxStateless<TBackend, TParams>::Key;
+
+        const Key m_key;
+
+        PhiloxStatelessKeyedBase(Key&& key) : m_key(key)
+        {
+        }
+
+        ALPAKA_FN_HOST_ACC auto operator()(Counter const& counter) const
+        {
+            return this->generate(counter, m_key);
+        }
+    };
+} // namespace alpaka::rand::engine

--- a/include/alpaka/rand/Philox/PhiloxStatelessVector.hpp
+++ b/include/alpaka/rand/Philox/PhiloxStatelessVector.hpp
@@ -1,0 +1,32 @@
+/* Copyright 2022 Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/rand/Philox/PhiloxBaseTraits.hpp>
+
+#include <utility>
+
+
+namespace alpaka::rand::engine
+{
+    /** Philox-stateless engine generating a vector of numbers
+     *
+     * This engine's operator() will return a vector of numbers corresponding to the full size of its counter.
+     * This is a convenience vs. memory size tradeoff since the user has to deal with the output array
+     * themselves, but the internal state comprises only of a single counter and a key.
+     *
+     * @tparam TAcc Accelerator type as defined in alpaka/acc
+     * @tparam TParams Basic parameters for the Philox algorithm
+     */
+    template<typename TAcc, typename TParams>
+    class PhiloxStatelessVector : public trait::PhiloxStatelessBaseTraits<TAcc, TParams>::Base
+    {
+    };
+} // namespace alpaka::rand::engine

--- a/include/alpaka/rand/RandPhiloxStateless.hpp
+++ b/include/alpaka/rand/RandPhiloxStateless.hpp
@@ -1,0 +1,39 @@
+/* Copyright 2022 Jeffrey Kelling
+ *
+ * This file is part of alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <alpaka/rand/Philox/PhiloxStateless.hpp>
+#include <alpaka/rand/Philox/PhiloxStatelessVector.hpp>
+#include <alpaka/rand/Traits.hpp>
+
+namespace alpaka::rand
+{
+    /** Most common Philox engine variant, stateless, outputs a 4-vector of floats
+     *
+     * This is a variant of the Philox engine generator which outputs a vector containing 4 floats. The counter
+     * size is \f$4 \times 32 = 128\f$ bits. Since the engine returns the whole generated vector, it is up to the
+     * user to extract individual floats as they need. The benefit is smaller state size since the state does not
+     * contain the intermediate results. The total size of the state is 192 bits = 24 bytes.
+     *
+     * Ref.: J. K. Salmon, M. A. Moraes, R. O. Dror and D. E. Shaw, "Parallel random numbers: As easy as 1, 2, 3,"
+     * SC '11: Proceedings of 2011 International Conference for High Performance Computing, Networking, Storage and
+     * Analysis, 2011, pp. 1-12, doi: 10.1145/2063384.2063405.
+     *
+     * @tparam TAcc Accelerator type as defined in alpaka/acc
+     */
+    template<typename TAcc>
+    class PhiloxStateless4x32x10Vector
+        : public alpaka::rand::engine::PhiloxStatelessVector<TAcc, engine::PhiloxParams<4, 32, 10>>
+        , public concepts::Implements<ConceptRand, PhiloxStateless4x32x10Vector<TAcc>>
+    {
+    public:
+        using EngineParams = engine::PhiloxParams<4, 32, 10>;
+    };
+} // namespace alpaka::rand


### PR DESCRIPTION
This PR refactors alpaka's Philox RNG implementation to expose the counter-based core RNG to the user without overhead.

## Rationale

The current alpaka RNG API is inspired by `<random>` and thereby follows the pattern of classical sequence-based RNGs. The Philox RNG is a counter-based RNG, i.e. it actually is a block cipher that encrypts a value (sequence index/counter) to produce a random number. Thereby, the counter-based RNG can generate any random number from its range for a given seed (key) arbitrarily without following any sequence.

The current API exposes a classical sequence RNG implemented based on the counter-based one by maintaining a counter for each thread while using the grid-thread-index as an offset (value in another word of the global counter) to select independent sequences. The API forces the user to keep an instance of counter state in order to use the RNG. This API limits applications in two ways:
1. There is an overhead for maintaining the counter-state in situations where the index is naturally generated from the simulation step and element each time a random number is needed.
   1. The counter is bundled with the globally-shared key. In many setups having only one global instance of the key/seed, instead of a copy per thread should be more efficient.
2. Relying on the counter will, for the same seed, produce different random numbers depending on `workDiv`, which prohibits reproducibility across platforms. A way to get reproducible runs is to derive the counter/index from the simulation step and element (e.g. time-step and updated cell or particle, this must be some parameter of the simulation continuously progressing, not based on the simulation state.)

## Solution in this PR

1. Split the Philox class hierarchy into the bare counter-based-RNG implementation and the current API and add a new user-facing generator wit default params `PhiloxStateless4x32x10Vector`.
2. Functions related to the core implementation are not using any data members of the Philox classes, hence they are made static.
3. Add a cast operator from `CudaVectorArrayWrapper` to `std::array` in order to allow for seamless transfer of keys and counter offsets between different backends.
4. Add example `counterBasedRng` which fill a multi-dimensional arrays with random numbers in a way yielding the identical results for any backend. This for illustration and constitutes a test by comparing results from one active parallel backend to some form the sequential backend.

## Review

* Please have a look at the proposed API in this PR. I am using this implementation in a current project and thus would appreciate if changes were not too breaking...
* @j-stephan @psychocoderHPC @bernhardmgruber 