### PR TITLE
CI: test ROCm 5.2.3

### DIFF
--- a/script/gitlabci/job_hip5.2.yml
+++ b/script/gitlabci/job_hip5.2.yml
@@ -8,7 +8,7 @@ linux_hip5.2_clang_debug_hip_only:
     CMAKE_BUILD_TYPE: Debug
     ALPAKA_BOOST_VERSION: 1.78.0
     ALPAKA_CI_CMAKE_VER: 3.22.4
-  stage: stageRun0
+  stage: stageCompile0
 
 linux_hip5.2_clang_release_hip_only:
   extends: .base_hip
@@ -19,4 +19,15 @@ linux_hip5.2_clang_release_hip_only:
     CMAKE_BUILD_TYPE: Release
     ALPAKA_BOOST_VERSION: 1.79.0
     ALPAKA_CI_CMAKE_VER: 3.23.1
-  stage: stageCompile0 
+  stage: stageCompile0
+
+linux_hip5.2.3_clang_debug_hip_only:
+  extends: .base_hip
+  variables:
+    ALPAKA_CI_HIP_VERSION: "5.2.3"
+    ALPAKA_CI_CLANG_VER: 14
+    ALPAKA_CI_STDLIB: libstdc++
+    CMAKE_BUILD_TYPE: Debug
+    ALPAKA_BOOST_VERSION: 1.78.0
+    ALPAKA_CI_CMAKE_VER: 3.22.4
+  stage: stageRun0


### PR DESCRIPTION
- switch ROCm 5.2.0 test to compile only
- test runtime and compile usage of ROCm 5.2.3