### PR TITLE
rename AccToTagType and TagToAccType

### DIFF
--- a/example/tagSpecialization/src/tagSpecialization.cpp
+++ b/example/tagSpecialization/src/tagSpecialization.cpp
@@ -100,8 +100,8 @@ auto main() -> int
     std::cout << "Using alpaka accelerator: " << alpaka::getAccName<Acc>() << std::endl;
 
     // Call the specialized functions
-    std::cout << host_function_ver1<alpaka::trait::AccToTagType<Acc>>() << std::endl;
-    std::cout << host_function_ver2(alpaka::trait::AccToTagType<Acc>{}) << std::endl;
+    std::cout << host_function_ver1<alpaka::AccToTag<Acc>>() << std::endl;
+    std::cout << host_function_ver2(alpaka::AccToTag<Acc>{}) << std::endl;
 
     // Defines the synchronization behavior of a queue
     using QueueProperty = alpaka::Blocking;

--- a/include/alpaka/acc/Tag.hpp
+++ b/include/alpaka/acc/Tag.hpp
@@ -37,16 +37,22 @@ namespace alpaka
         template<typename TAcc>
         struct AccToTag;
 
-        template<typename TAcc>
-        using AccToTagType = typename AccToTag<TAcc>::type;
-
         template<typename TTag, typename TDim, typename TIdx>
         struct TagToAcc;
-
-        template<typename TTag, typename TDim, typename TIdx>
-        using TagToAccType = typename TagToAcc<TTag, TDim, TIdx>::type;
     } // namespace trait
 
+    /// @brief maps an acc type to a tag type
+    /// @tparam TAcc alpaka acc type
+    template<typename TAcc>
+    using AccToTag = typename trait::AccToTag<TAcc>::type;
+
+    /// @brief maps a tag type to an acc type
+    /// @tparam TTag alpaka tag type
+    /// @tparam TDim dimension of the mapped acc type
+    /// @tparam TIdx index type of the mapped acc type
+    template<typename TTag, typename TDim, typename TIdx>
+    using TagToAcc = typename trait::TagToAcc<TTag, TDim, TIdx>::type;
+
     template<typename TAcc, typename... TTag>
-    inline constexpr bool accMatchesTags = (std::is_same_v<alpaka::trait::AccToTagType<TAcc>, TTag> || ...);
+    inline constexpr bool accMatchesTags = (std::is_same_v<alpaka::AccToTag<TAcc>, TTag> || ...);
 } // namespace alpaka

--- a/test/unit/acc/src/AccTagTest.cpp
+++ b/test/unit/acc/src/AccTagTest.cpp
@@ -57,13 +57,13 @@ TEMPLATE_LIST_TEST_CASE("test all possible acc tag combinations", "[acc][tag]", 
     {
         if constexpr(std::is_same_v<TestTag, ExpectedTag>)
         {
-            STATIC_REQUIRE((std::is_same_v<alpaka::trait::AccToTagType<TestAcc>, ExpectedTag>) );
-            STATIC_REQUIRE((std::is_same_v<alpaka::trait::TagToAccType<TestTag, Dim, Idx>, TestAcc>) );
+            STATIC_REQUIRE((std::is_same_v<alpaka::AccToTag<TestAcc>, ExpectedTag>) );
+            STATIC_REQUIRE((std::is_same_v<alpaka::TagToAcc<TestTag, Dim, Idx>, TestAcc>) );
             STATIC_REQUIRE((alpaka::accMatchesTags<TestAcc, TestTag>) );
         }
         else
         {
-            STATIC_REQUIRE(!(std::is_same_v<alpaka::trait::AccToTagType<TestAcc>, TestTag>) );
+            STATIC_REQUIRE(!(std::is_same_v<alpaka::AccToTag<TestAcc>, TestTag>) );
             STATIC_REQUIRE(!(alpaka::accMatchesTags<TestAcc, TestTag>) );
         }
     }
@@ -137,10 +137,10 @@ TEMPLATE_LIST_TEST_CASE("specialization of functions with tags", "[acc][tag]", T
 
     INFO(
         "Test Acc: " + alpaka::getAccName<TestAcc>() + "\n" + "expect: " + expected_result + "\n"
-        + "is_specialized() returns: " + specialized_function<alpaka::trait::AccToTagType<TestAcc>>() + "\n"
-        + "is_specialized_2() returns: " + specialized_function_2(alpaka::trait::AccToTagType<TestAcc>{}));
-    REQUIRE((specialized_function<alpaka::trait::AccToTagType<TestAcc>>() == expected_result));
-    REQUIRE((specialized_function_2(alpaka::trait::AccToTagType<TestAcc>{}) == expected_result));
+        + "is_specialized() returns: " + specialized_function<alpaka::AccToTag<TestAcc>>() + "\n"
+        + "is_specialized_2() returns: " + specialized_function_2(alpaka::AccToTag<TestAcc>{}));
+    REQUIRE((specialized_function<alpaka::AccToTag<TestAcc>>() == expected_result));
+    REQUIRE((specialized_function_2(alpaka::AccToTag<TestAcc>{}) == expected_result));
 }
 
 struct InitKernel


### PR DESCRIPTION
alpaka::trait::AccToTagType -> alpaka::trait::Tag
alpaka::trait::TagToAccType -> alpaka::trait::Acc

Suggestion of @fwyzard : https://github.com/alpaka-group/alpaka/pull/1804#discussion_r995653153

The PR starts as draft to discuss if we want to rename it.

There is no name collision. I looked a little bit in the code. We use the word `Acc` only in one situations, in examples: `using Acc = alpaka::AccCpuSerial<>`. The word `Tag` is not used anywhere. So I think it's pretty hard to mistake the words `Acc` and `Tag`.
