### PR TITLE
Fix missing `final` keyword for accelerator inheritance

### DIFF
--- a/include/alpaka/acc/AccCpuSyclIntel.hpp
+++ b/include/alpaka/acc/AccCpuSyclIntel.hpp
@@ -36,7 +36,7 @@ namespace alpaka::experimental
     //!
     //! This accelerator allows parallel kernel execution on a oneAPI-capable Intel CPU target device.
     template<typename TDim, typename TIdx>
-    class AccCpuSyclIntel
+    class AccCpuSyclIntel final
         : public AccGenericSycl<TDim, TIdx>
         , public concepts::Implements<ConceptAcc, AccCpuSyclIntel<TDim, TIdx>>
     {

--- a/include/alpaka/acc/AccFpgaSyclIntel.hpp
+++ b/include/alpaka/acc/AccFpgaSyclIntel.hpp
@@ -35,7 +35,7 @@ namespace alpaka::experimental
     //!
     //! This accelerator allows parallel kernel execution on a oneAPI-capable Intel FPGA target device.
     template<typename TDim, typename TIdx>
-    class AccFpgaSyclIntel
+    class AccFpgaSyclIntel final
         : public AccGenericSycl<TDim, TIdx>
         , public concepts::Implements<ConceptAcc, AccFpgaSyclIntel<TDim, TIdx>>
     {

--- a/include/alpaka/acc/AccFpgaSyclXilinx.hpp
+++ b/include/alpaka/acc/AccFpgaSyclXilinx.hpp
@@ -35,7 +35,7 @@ namespace alpaka::experimental
     //!
     //! This accelerator allows parallel kernel execution on a SYCL-capable Xilinx FPGA target device.
     template<typename TDim, typename TIdx>
-    class AccFpgaSyclXilinx
+    class AccFpgaSyclXilinx final
         : public AccGenericSycl<TDim, TIdx>
         , public concepts::Implements<ConceptAcc, AccFpgaSyclXilinx<TDim, TIdx>>
     {

--- a/include/alpaka/acc/AccGpuSyclIntel.hpp
+++ b/include/alpaka/acc/AccGpuSyclIntel.hpp
@@ -35,7 +35,7 @@ namespace alpaka::experimental
     //!
     //! This accelerator allows parallel kernel execution on a oneAPI-capable Intel GPU target device.
     template<typename TDim, typename TIdx>
-    class AccGpuSyclIntel
+    class AccGpuSyclIntel final
         : public AccGenericSycl<TDim, TIdx>
         , public concepts::Implements<ConceptAcc, AccGpuSyclIntel<TDim, TIdx>>
     {

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -54,7 +54,7 @@ namespace alpaka
         typename TApi,
         typename TDim,
         typename TIdx>
-    class AccGpuUniformCudaHipRt :
+    class AccGpuUniformCudaHipRt final :
         public WorkDivUniformCudaHipBuiltIn<TDim, TIdx>,
         public gb::IdxGbUniformCudaHipBuiltIn<TDim, TIdx>,
         public bt::IdxBtUniformCudaHipBuiltIn<TDim, TIdx>,


### PR DESCRIPTION
Most of the accelerators a marked with the keyword `final`, therefore it is not possible to inherit from these accelerators.

This PR adds the final keyword to all accelerators to avoid different behavior depending on the accelerator.