### PR TITLE
Implement trait constants

### DIFF
--- a/include/alpaka/acc/Traits.hpp
+++ b/include/alpaka/acc/Traits.hpp
@@ -29,6 +29,11 @@ namespace alpaka
     struct ConceptAcc
     {
     };
+
+    //! True if TAcc is an accelerator, i.e. if it implements the ConceptAcc concept.
+    template<typename TAcc>
+    inline constexpr bool isAccelerator = concepts::ImplementsConcept<ConceptAcc, TAcc>::value;
+
     //! The accelerator traits.
     namespace trait
     {

--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -58,6 +58,10 @@ namespace alpaka
 
     struct ConceptDev;
 
+    //! True if TDev is a device, i.e. if it implements the ConceptDev concept.
+    template<typename TDev>
+    inline constexpr bool isDevice = concepts::ImplementsConcept<ConceptDev, TDev>::value;
+
     //! \return The device this object is bound to.
     template<typename T>
     ALPAKA_FN_HOST auto getDev(T const& t)

--- a/include/alpaka/pltf/Traits.hpp
+++ b/include/alpaka/pltf/Traits.hpp
@@ -23,6 +23,10 @@ namespace alpaka
     {
     };
 
+    //! True if TPltf is a platform, i.e. if it implements the ConceptPltf concept.
+    template<typename TPltf>
+    inline constexpr bool isPlatform = concepts::ImplementsConcept<ConceptPltf, TPltf>::value;
+
     //! The platform traits.
     namespace trait
     {

--- a/include/alpaka/queue/Traits.hpp
+++ b/include/alpaka/queue/Traits.hpp
@@ -20,6 +20,10 @@ namespace alpaka
 {
     struct ConceptQueue;
 
+    //! True if TQueue is a queue, i.e. if it implements the ConceptQueue concept.
+    template<typename TQueue>
+    inline constexpr bool isQueue = concepts::ImplementsConcept<ConceptQueue, TQueue>::value;
+
     //! The queue traits.
     namespace trait
     {


### PR DESCRIPTION
Implement the constpextr template variables
  - `alpaka::isAccelerator<T>`
  - `alpaka::isDevice<T>`
  - `alpaka::isPlatform<T`>
  - `alpaka::isQueue<T>`

that evaluate to `true` if the given type implements the corresponding concept.