### PR TITLE
[abandoned] Allowing zerocopy: `makeAvailable(queue, dst, srcView)`

### DIFF
--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -167,6 +167,16 @@ Enqueue a memory copy from device to host
 
      memcpy(queue, bufHost, bufDevice, extent);
 
+Makes the memory of bufA available on dev via bufB. A zero-copy can be performed and bufA and bufB may share the memory.
+  .. code-block:: c++
+
+     auto bufB = makeAvailable(queue, dev, bufA);
+
+Makes the memory of bufB available on the device of bufA, as bufA. A zero-copy can be performed and bufA and bufB may share the memory.
+  .. code-block:: c++
+
+     makeAvailable(queue, bufA, bufB);
+
 .. raw:: pdf
 
    PageBreak

--- a/example/randomCells2D/src/randomCells2D.cpp
+++ b/example/randomCells2D/src/randomCells2D.cpp
@@ -165,7 +165,6 @@ auto main() -> int
     using BufAcc = alpaka::Buf<Acc, float, Dim, Idx>;
     using BufHostRand = alpaka::Buf<Host, RandomEngineSingle<Acc>, Dim, Idx>;
     using BufAccRand = alpaka::Buf<Acc, RandomEngineSingle<Acc>, Dim, Idx>;
-    using BufHostRandVec = alpaka::Buf<Host, RandomEngineVector<Acc>, Dim, Idx>;
     using BufAccRandVec = alpaka::Buf<Acc, RandomEngineVector<Acc>, Dim, Idx>;
     using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
 
@@ -195,11 +194,9 @@ auto main() -> int
     BufAcc bufAccV{alpaka::allocBuf<float, Idx>(devAcc, extent)};
     float* const ptrBufAccV{alpaka::getPtrNative(bufAccV)};
 
-    BufHostRand bufHostRandS{alpaka::allocBuf<RandomEngineSingle<Acc>, Idx>(devHost, extent)};
     BufAccRand bufAccRandS{alpaka::allocBuf<RandomEngineSingle<Acc>, Idx>(devAcc, extent)};
     RandomEngineSingle<Acc>* const ptrBufAccRandS{alpaka::getPtrNative(bufAccRandS)};
 
-    BufHostRandVec bufHostRandV{alpaka::allocBuf<RandomEngineVector<Acc>, Idx>(devHost, extent)};
     BufAccRandVec bufAccRandV{alpaka::allocBuf<RandomEngineVector<Acc>, Idx>(devAcc, extent)};
     RandomEngineVector<Acc>* const ptrBufAccRandV{alpaka::getPtrNative(bufAccRandV)};
 

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -191,4 +191,82 @@ namespace alpaka
 
         ALPAKA_UNREACHABLE(allocBuf<TElem, TIdx>(host, extent));
     }
+
+    namespace detail
+    {
+        // TODO(bgruber): very crude
+        template<typename DevDst, typename DevSrc>
+        auto canZeroCopy(DevDst const& devDst, DevSrc const& devSrc) -> bool
+        {
+            if constexpr(std::is_same_v<DevDst, DevSrc>)
+                if(devSrc == devDst)
+                    return true;
+            return false;
+        }
+    } // namespace detail
+
+    //! Makes the content of the source view available on the device associated with the destination queue. If the
+    //! destination shares the same memory space as the source view, no copy is performed and the destination view is
+    //! updated to share the same buffer as the source view. Otherwise, a memcpy is performed from source to
+    //! destination view.
+    template<typename TQueue, typename TViewDst, typename TViewSrc>
+    ALPAKA_FN_HOST void makeAvailable(TQueue& queue, TViewDst& viewDst, TViewSrc const& viewSrc)
+    {
+        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+        if constexpr(std::is_same_v<TViewSrc, TViewDst>) // TODO(bgruber): lift this by converting buffer types
+            if(detail::canZeroCopy(getDev(viewDst), getDev(viewSrc)))
+            {
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
+                std::cout << "zero_memcopy: copy elided\n";
+#endif
+                viewDst = viewSrc;
+                return;
+            }
+
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
+        std::cout << "zero_memcopy: deep copy required\n";
+#endif
+        memcpy(queue, viewDst, viewSrc);
+    }
+
+    //! Makes the content of the source view available on the destination device. If the destination shares the same
+    //! memory space as the source view, no copy is performed and the source view is returned. Otherwise a newly
+    //! allocated buffer is created on the destination device and the content of the source view copied to it.
+    template<
+        typename TQueue,
+        typename TDevDst,
+        typename TViewSrc,
+        std::enable_if_t<isDevice<TDevDst>, int> = 0,
+        typename TViewDst = Buf<TDevDst, Elem<TViewSrc>, Dim<TViewSrc>, Idx<TViewSrc>>>
+    ALPAKA_FN_HOST auto makeAvailable(TQueue& queue, TDevDst const& dstDev, TViewSrc const& viewSrc) -> TViewDst
+    {
+        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+        if constexpr(std::is_same_v<TViewSrc, TViewDst>) // TODO(bgruber): lift this by converting buffer types
+            if(detail::canZeroCopy(dstDev, getDev(viewSrc)))
+            {
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
+                std::cout << "zero_memcopy: shallow copy returned\n";
+#endif
+                return viewSrc;
+            }
+
+        using E = Elem<TViewSrc>;
+        using I = Idx<TViewSrc>;
+        auto const extent = getExtentVec(viewSrc);
+        TViewDst dst = [&]
+        {
+            using TDevQueue = Dev<TQueue>;
+            if constexpr(std::is_same_v<TDevQueue, TDevDst>)
+                if(getDev(queue) == dstDev)
+                    return allocAsyncBufIfSupported<E, I>(queue, extent);
+            return allocBuf<E, I>(dstDev, extent);
+        }();
+        memcpy(queue, dst, viewSrc);
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
+        std::cout << "zero_memcopy: deep copy returned\n";
+#endif
+        return dst;
+    }
 } // namespace alpaka


### PR DESCRIPTION
Adds an overload set `zero_memcpy` that only copies a buffer if the destination device requires the buffer in a different memory space in order to access it. Otherwise, no copy is performed and just the handles are adjusted.

Motivating use case (for me):
Avoid duplicating data if the accelerator device is the same as the host device. This is the case in the standard workflow where we create a buffer on the host, then a buffer on the accelerator device, and then copy from host -> device. If e.g. the TBB or OpenMP backend is active, there is no need for two buffers and an actual memory copy.

This zero copy idea can be extended further to also include various other technologies like CUDA's USM (managed memory), or remove memory access etc. For now, I do not have the time to work out all those details, so I am just proposing a minimal API to accomplish my motivating use case.

Example `randomCells2D` is rewritten to use the new API.

Addresses part of: #28

TODO:

- [x] Unit tests
- [x] Cheatsheet
- [x] Documentation?
- [ ] Should this be an experimental feature? (namespace `alpaka::experimental`)