### PR TITLE
 Create a patch if clang-format CI fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,14 @@ jobs:
       with:
         clangFormatVersion: 14
         exclude: './thirdParty'
+        inplace: True
+    - run: |
+        git diff --exit-code > format.patch
+    - uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: format.patch
+        path: format.patch
 
   ci:
     needs: clang-format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
         exclude: './thirdParty'
 
   ci:
+    needs: clang-format
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     env: ${{ matrix.env }}

--- a/docs/source/dev/ci.rst
+++ b/docs/source/dev/ci.rst
@@ -8,6 +8,14 @@ GitHub Actions
 
 The configuration of ``GitHub Actions`` can be found in the ``.github/workflows/`` folder. This CI uses unmodified containers from ``Docker Hub`` and sets up the environment during the test job. A caching mechanism speeds up the job times. The scripts for setting up the environment, building alpaka and running test are located in the ``script/`` folder.
 
+clang-format
+++++++++++++
+
+The first CI job run is clang-format, which will verify the formatting of your changeset.
+Only of this check passes, will the remainder of the GitHub CI continue.
+In case of a formatting failure, a patch file is attached as an artifact to the GitHub action run.
+You can apply this patch file to your changeset to fix the formatting.
+
 GitLab CI
 ---------
 


### PR DESCRIPTION
I was annoyed today that I did not have clang-format X.Y installed on my notebook when preparing a PR for LLAMA. So I just made the CI not only check clang-format but also commit the changes. Then I could easily pull and squash the formatting changes into my commits.

~So, here is the same for alpaka.~

Edit: So here is something similar. The clang-format CI will create a patch file and upload it as an artifact.