### PR TITLE
delete copy, assign, move and move assign operator for accelerators

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -90,6 +90,11 @@ namespace alpaka
         template<typename TDim2, typename TIdx2, typename TKernelFnObj, typename... TArgs>
         friend class ::alpaka::TaskKernelCpuFibers;
 
+        AccCpuFibers(AccCpuFibers const&) = delete;
+        AccCpuFibers(AccCpuFibers&&) = delete;
+        auto operator=(AccCpuFibers const&) -> AccCpuFibers& = delete;
+        auto operator=(AccCpuFibers&&) -> AccCpuFibers& = delete;
+
     private:
         template<typename TWorkDiv>
         ALPAKA_FN_HOST AccCpuFibers(TWorkDiv const& workDiv, std::size_t const& blockSharedMemDynSizeBytes)

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -91,6 +91,11 @@ namespace alpaka
         template<typename TDim2, typename TIdx2, typename TKernelFnObj, typename... TArgs>
         friend class ::alpaka::TaskKernelCpuOmp2Blocks;
 
+        AccCpuOmp2Blocks(AccCpuOmp2Blocks const&) = delete;
+        AccCpuOmp2Blocks(AccCpuOmp2Blocks&&) = delete;
+        auto operator=(AccCpuOmp2Blocks const&) -> AccCpuOmp2Blocks& = delete;
+        auto operator=(AccCpuOmp2Blocks&&) -> AccCpuOmp2Blocks& = delete;
+
     private:
         template<typename TWorkDiv>
         ALPAKA_FN_HOST AccCpuOmp2Blocks(TWorkDiv const& workDiv, std::size_t const& blockSharedMemDynSizeBytes)

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -92,6 +92,11 @@ namespace alpaka
         template<typename TDim2, typename TIdx2, typename TKernelFnObj, typename... TArgs>
         friend class ::alpaka::TaskKernelCpuOmp2Threads;
 
+        AccCpuOmp2Threads(AccCpuOmp2Threads const&) = delete;
+        AccCpuOmp2Threads(AccCpuOmp2Threads&&) = delete;
+        auto operator=(AccCpuOmp2Threads const&) -> AccCpuOmp2Threads& = delete;
+        auto operator=(AccCpuOmp2Threads&&) -> AccCpuOmp2Threads& = delete;
+
     private:
         template<typename TWorkDiv>
         ALPAKA_FN_HOST AccCpuOmp2Threads(TWorkDiv const& workDiv, std::size_t const& blockSharedMemDynSizeBytes)

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -85,6 +85,11 @@ namespace alpaka
         template<typename TDim2, typename TIdx2, typename TKernelFnObj, typename... TArgs>
         friend class ::alpaka::TaskKernelCpuSerial;
 
+        AccCpuSerial(AccCpuSerial const&) = delete;
+        AccCpuSerial(AccCpuSerial&&) = delete;
+        auto operator=(AccCpuSerial const&) -> AccCpuSerial& = delete;
+        auto operator=(AccCpuSerial&&) -> AccCpuSerial& = delete;
+
     private:
         template<typename TWorkDiv>
         ALPAKA_FN_HOST AccCpuSerial(TWorkDiv const& workDiv, size_t const& blockSharedMemDynSizeBytes)

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -82,6 +82,11 @@ namespace alpaka
         template<typename TDim2, typename TIdx2, typename TKernelFnObj, typename... TArgs>
         friend class ::alpaka::TaskKernelCpuTbbBlocks;
 
+        AccCpuTbbBlocks(AccCpuTbbBlocks const&) = delete;
+        AccCpuTbbBlocks(AccCpuTbbBlocks&&) = delete;
+        auto operator=(AccCpuTbbBlocks const&) -> AccCpuTbbBlocks& = delete;
+        auto operator=(AccCpuTbbBlocks&&) -> AccCpuTbbBlocks& = delete;
+
     private:
         template<typename TWorkDiv>
         ALPAKA_FN_HOST AccCpuTbbBlocks(TWorkDiv const& workDiv, std::size_t const& blockSharedMemDynSizeBytes)

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -87,6 +87,11 @@ namespace alpaka
         template<typename TDim2, typename TIdx2, typename TKernelFnObj, typename... TArgs>
         friend class ::alpaka::TaskKernelCpuThreads;
 
+        AccCpuThreads(AccCpuThreads const&) = delete;
+        AccCpuThreads(AccCpuThreads&&) = delete;
+        auto operator=(AccCpuThreads const&) -> AccCpuThreads& = delete;
+        auto operator=(AccCpuThreads&&) -> AccCpuThreads& = delete;
+
     private:
         template<typename TWorkDiv>
         ALPAKA_FN_HOST AccCpuThreads(TWorkDiv const& workDiv, std::size_t const& blockSharedMemDynSizeBytes)

--- a/include/alpaka/acc/AccGenericSycl.hpp
+++ b/include/alpaka/acc/AccGenericSycl.hpp
@@ -65,6 +65,11 @@ namespace alpaka::experimental
         , public warp::WarpGenericSycl<TDim>
     {
     public:
+        AccGenericSycl(AccGenericSycl const&) = delete;
+        AccGenericSycl(AccGenericSycl&&) = delete;
+        auto operator=(AccGenericSycl const&) -> AccGenericSycl& = delete;
+        auto operator=(AccGenericSycl&&) -> AccGenericSycl& = delete;
+
 #    ifdef ALPAKA_SYCL_IOSTREAM_ENABLED
         AccGenericSycl(
             Vec<TDim, TIdx> const& threadElemExtent,

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -80,6 +80,11 @@ namespace alpaka
             "Index type is not supported, consider using int or a larger type.");
 
     public:
+        AccGpuUniformCudaHipRt(AccGpuUniformCudaHipRt const&) = delete;
+        AccGpuUniformCudaHipRt(AccGpuUniformCudaHipRt&&) = delete;
+        auto operator=(AccGpuUniformCudaHipRt const&) -> AccGpuUniformCudaHipRt& = delete;
+        auto operator=(AccGpuUniformCudaHipRt&&) -> AccGpuUniformCudaHipRt& = delete;
+
         ALPAKA_FN_HOST_ACC AccGpuUniformCudaHipRt(Vec<TDim, TIdx> const& threadElemExtent)
             : WorkDivUniformCudaHipBuiltIn<TDim, TIdx>(threadElemExtent)
             , gb::IdxGbUniformCudaHipBuiltIn<TDim, TIdx>()

--- a/include/alpaka/acc/AccOacc.hpp
+++ b/include/alpaka/acc/AccOacc.hpp
@@ -98,6 +98,11 @@ namespace alpaka
         }
 
     public:
+        AccOacc(AccOacc const&) = delete;
+        AccOacc(AccOacc&&) = delete;
+        auto operator=(AccOacc const&) -> AccOacc& = delete;
+        auto operator=(AccOacc&&) -> AccOacc& = delete;
+
         CtxBlockOacc<TDim, TIdx>& m_blockShared;
     };
 

--- a/include/alpaka/acc/AccOmp5.hpp
+++ b/include/alpaka/acc/AccOmp5.hpp
@@ -142,6 +142,11 @@ namespace alpaka
         template<typename TDim2, typename TIdx2, typename TKernelFnObj, typename... TArgs>
         friend class ::alpaka::TaskKernelOmp5;
 
+        AccOmp5(AccOmp5 const&) = delete;
+        AccOmp5(AccOmp5&&) = delete;
+        auto operator=(AccOmp5 const&) -> AccOmp5& = delete;
+        auto operator=(AccOmp5&&) -> AccOmp5& = delete;
+
     private:
         AccOmp5(
             Vec<TDim, TIdx> const& gridBlockExtent,


### PR DESCRIPTION
Some accelerators have an internal state e.g for shared memory or to handle other behaviors. If the accelerator is copied alpaka can end in an undefined behavior that differs for each accelerator.


@jkelling and me found this behavior yesterday and we discussed if it would be valid to copy an accelerator. We came to the conclusion that this is not possible because of internal states. To avoid each accelerator behaving differently all accelerator should be guarded against copy and moving.