### PR TITLE
fix warning calling `__host__` from `__host__ __device__` function

### DIFF
--- a/include/alpaka/mem/view/Accessor.hpp
+++ b/include/alpaka/mem/view/Accessor.hpp
@@ -58,7 +58,7 @@ namespace alpaka::experimental
         struct BuildAccessor
         {
             template<typename... TAccessModes, typename TMemoryObjectForwardRef>
-            ALPAKA_FN_HOST_ACC static auto buildAccessor(TMemoryObjectForwardRef&&)
+            ALPAKA_FN_HOST static auto buildAccessor(TMemoryObjectForwardRef&&)
             {
                 static_assert(
                     meta::DependentFalseType<TMemoryObject>::value,
@@ -104,7 +104,7 @@ namespace alpaka::experimental
         typename... TAccessModes,
         typename TMemoryObject,
         typename = std::enable_if_t<!internal::IsAccessor<std::decay_t<TMemoryObject>>::value>>
-    ALPAKA_FN_HOST_ACC auto accessWith(TMemoryObject&& memoryObject)
+    ALPAKA_FN_HOST auto accessWith(TMemoryObject&& memoryObject)
     {
         return trait::BuildAccessor<std::decay_t<TMemoryObject>>::template buildAccessor<TAccessModes...>(
             memoryObject);
@@ -119,7 +119,7 @@ namespace alpaka::experimental
         typename TBufferIdx,
         std::size_t TDim,
         typename... TPrevAccessModes>
-    ALPAKA_FN_HOST_ACC auto accessWith(
+    ALPAKA_FN_HOST auto accessWith(
         Accessor<TMemoryHandle, TElem, TBufferIdx, TDim, std::tuple<TPrevAccessModes...>> const& acc)
     {
         static_assert(
@@ -131,28 +131,28 @@ namespace alpaka::experimental
     //! Constrains an existing accessor to the specified access modes.
     // constraining accessor to the same access mode again just passes through
     template<typename TNewAccessMode, typename TMemoryHandle, typename TElem, typename TBufferIdx, std::size_t TDim>
-    ALPAKA_FN_HOST_ACC auto accessWith(Accessor<TMemoryHandle, TElem, TBufferIdx, TDim, TNewAccessMode> const& acc)
+    ALPAKA_FN_HOST auto accessWith(Accessor<TMemoryHandle, TElem, TBufferIdx, TDim, TNewAccessMode> const& acc)
     {
         return acc;
     }
 
     //! Creates a read-write accessor for the given memory object (view, buffer, ...) or accessor.
     template<typename TMemoryObjectOrAccessor>
-    ALPAKA_FN_HOST_ACC auto access(TMemoryObjectOrAccessor&& viewOrAccessor)
+    ALPAKA_FN_HOST auto access(TMemoryObjectOrAccessor&& viewOrAccessor)
     {
         return accessWith<ReadWriteAccess>(std::forward<TMemoryObjectOrAccessor>(viewOrAccessor));
     }
 
     //! Creates a read-only accessor for the given memory object (view, buffer, ...) or accessor.
     template<typename TMemoryObjectOrAccessor>
-    ALPAKA_FN_HOST_ACC auto readAccess(TMemoryObjectOrAccessor&& viewOrAccessor)
+    ALPAKA_FN_HOST auto readAccess(TMemoryObjectOrAccessor&& viewOrAccessor)
     {
         return accessWith<ReadAccess>(std::forward<TMemoryObjectOrAccessor>(viewOrAccessor));
     }
 
     //! Creates a write-only accessor for the given memory object (view, buffer, ...) or accessor.
     template<typename TMemoryObjectOrAccessor>
-    ALPAKA_FN_HOST_ACC auto writeAccess(TMemoryObjectOrAccessor&& viewOrAccessor)
+    ALPAKA_FN_HOST auto writeAccess(TMemoryObjectOrAccessor&& viewOrAccessor)
     {
         return accessWith<WriteAccess>(std::forward<TMemoryObjectOrAccessor>(viewOrAccessor));
     }

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -138,9 +138,8 @@ namespace alpaka
 
     //! \return The pitch in bytes. This is the distance in bytes between two consecutive elements in the given
     //! dimension.
-    ALPAKA_NO_HOST_ACC_WARNING
     template<std::size_t Tidx, typename TView>
-    ALPAKA_FN_HOST_ACC auto getPitchBytes(TView const& view) -> Idx<TView>
+    ALPAKA_FN_HOST auto getPitchBytes(TView const& view) -> Idx<TView>
     {
         return trait::GetPitchBytes<DimInt<Tidx>, TView>::getPitchBytes(view);
     }
@@ -358,9 +357,8 @@ namespace alpaka
         template<std::size_t Tidx>
         struct CreatePitchBytes
         {
-            ALPAKA_NO_HOST_ACC_WARNING
             template<typename TView>
-            ALPAKA_FN_HOST_ACC static auto create(TView const& view) -> Idx<TView>
+            ALPAKA_FN_HOST static auto create(TView const& view) -> Idx<TView>
             {
                 return getPitchBytes<Tidx>(view);
             }

--- a/include/alpaka/mem/view/ViewAccessor.hpp
+++ b/include/alpaka/mem/view/ViewAccessor.hpp
@@ -221,13 +221,12 @@ namespace alpaka::experimental
                 using type = std::tuple<TAccessMode1, TAccessMode2, TAccessModes...>;
             };
 
-            ALPAKA_NO_HOST_ACC_WARNING
             template<
                 typename... TAccessModes,
                 typename TViewForwardRef,
                 std::size_t... TPitchIs,
                 std::size_t... TExtentIs>
-            ALPAKA_FN_HOST_ACC auto buildViewAccessor(
+            ALPAKA_FN_HOST auto buildViewAccessor(
                 TViewForwardRef&& view,
                 std::index_sequence<TPitchIs...>,
                 std::index_sequence<TExtentIs...>)
@@ -259,7 +258,7 @@ namespace alpaka::experimental
         struct BuildAccessor<TView, std::enable_if_t<internal::IsView<TView>::value>>
         {
             template<typename... TAccessModes, typename TViewForwardRef>
-            ALPAKA_FN_HOST_ACC static auto buildAccessor(TViewForwardRef&& view)
+            ALPAKA_FN_HOST static auto buildAccessor(TViewForwardRef&& view)
             {
                 using Dim = Dim<std::decay_t<TView>>;
                 return internal::buildViewAccessor<TAccessModes...>(

--- a/include/alpaka/mem/view/ViewConst.hpp
+++ b/include/alpaka/mem/view/ViewConst.hpp
@@ -31,11 +31,11 @@ namespace alpaka
             "This is not implemented"); // It might even be dangerous for ViewConst to store a reference to the wrapped
                                         // view, as this decouples the wrapped view's lifetime.
 
-        ALPAKA_FN_HOST_ACC ViewConst(TView const& view) : m_view(view)
+        ALPAKA_FN_HOST ViewConst(TView const& view) : m_view(view)
         {
         }
 
-        ALPAKA_FN_HOST_ACC ViewConst(TView&& view) : m_view(std::move(view))
+        ALPAKA_FN_HOST ViewConst(TView&& view) : m_view(std::move(view))
         {
         }
 
@@ -76,7 +76,7 @@ namespace alpaka
         template<typename I, typename TView>
         struct GetExtent<I, ViewConst<TView>>
         {
-            ALPAKA_FN_HOST_ACC static auto getExtent(ViewConst<TView> const& view)
+            ALPAKA_FN_HOST static auto getExtent(ViewConst<TView> const& view)
             {
                 return alpaka::getExtent<I::value>(view.m_view);
             }
@@ -88,7 +88,7 @@ namespace alpaka
             using TElem = typename ElemType<TView>::type;
 
             // const qualify the element type of the inner view
-            ALPAKA_FN_HOST_ACC static auto getPtrNative(ViewConst<TView> const& view) -> TElem const*
+            ALPAKA_FN_HOST static auto getPtrNative(ViewConst<TView> const& view) -> TElem const*
             {
                 return alpaka::getPtrNative(view.m_view);
             }
@@ -97,7 +97,7 @@ namespace alpaka
         template<typename I, typename TView>
         struct GetPitchBytes<I, ViewConst<TView>>
         {
-            ALPAKA_FN_HOST_ACC static auto getPitchBytes(ViewConst<TView> const& view)
+            ALPAKA_FN_HOST static auto getPitchBytes(ViewConst<TView> const& view)
             {
                 return alpaka::getPitchBytes<I::value>(view.m_view);
             }
@@ -106,7 +106,7 @@ namespace alpaka
         template<typename I, typename TView>
         struct GetOffset<I, ViewConst<TView>>
         {
-            ALPAKA_FN_HOST_ACC static auto getOffset(ViewConst<TView> const& view)
+            ALPAKA_FN_HOST static auto getOffset(ViewConst<TView> const& view)
             {
                 return alpaka::getOffset<I::value>(view.m_view);
             }

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -113,8 +113,7 @@ namespace alpaka
             ViewPlainPtr<TDev, TElem, TDim, TIdx>,
             std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
         {
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC
+            ALPAKA_FN_HOST
             static auto getExtent(ViewPlainPtr<TDev, TElem, TDim, TIdx> const& extent) -> TIdx
             {
                 return extent.m_extentElements[TIdxIntegralConst::value];
@@ -294,8 +293,7 @@ namespace alpaka
         template<typename TIdxIntegralConst, typename TDev, typename TElem, typename TDim, typename TIdx>
         struct GetOffset<TIdxIntegralConst, ViewPlainPtr<TDev, TElem, TDim, TIdx>>
         {
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC
+            ALPAKA_FN_HOST
             static auto getOffset(ViewPlainPtr<TDev, TElem, TDim, TIdx> const&) -> TIdx
             {
                 return 0u;


### PR DESCRIPTION
Host-only objects were annotated with the host device function specifier. Therefore warnings were shown e.g.

```
alpaka/include/alpaka/mem/view/ViewConst.hpp(93): warning #20011-D: calling a __host__ function(
"const    ::std::remove_volatile< ::alpaka::trait::ElemType<T1, void> ::type> ::type * 
alpaka::getPtrNative< ::alpaka::BufUniformCudaHipRt< ::alpaka::ApiCudaRt, float,     ::std::integral_constant<unsigned long, (unsigned long)1ul> ,
 long> > (const T1 &)") 
from a __host__ __device__ 
function("alpaka::trait::GetPtrNative< ::alpaka::ViewConst< ::alpaka::BufUniformCudaHipRt< 
::alpaka::ApiCudaRt, float,     ::std::integral_constant<unsigned long, (unsigned long)1ul> , long> > , void> ::getPtrNative") is not allowed
```

Remove the usage of `ALPAKA_NO_HOST_ACC_WARNING` this is a workaround that should only be used if there is no other way to fix these warnings.

Warnings were shown with nvcc, I do know why the CI is passing with these warnings.
```
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2022 NVIDIA Corporation
Built on Tue_Mar__8_18:18:20_PST_2022
Cuda compilation tools, release 11.6, V11.6.124
Build cuda_11.6.r11.6/compiler.31057947_0
```