### PR TITLE
Update CI NVHPC versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,10 +258,13 @@ jobs:
           env: {CXX: icpx,    CC: icx,                                 ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_CI_BOOST_BRANCH: boost-1.75.0, ALPAKA_CI_CMAKE_VER: 3.22.3, OMP_NUM_THREADS: 4, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "ubuntu:20.04", CMAKE_CXX_FLAGS: "-fiopenmp -fopenmp-targets=spir64 -Wno-source-uses-openmp", alpaka_ACC_ANY_BT_OMP5_ENABLE: ON, alpaka_OFFLOAD_MAX_BLOCK_SIZE: 1, OMP_TARGET_OFFLOAD: "DISABLED", alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF}
 
         ## NVHPC
-        - name: linux_nvhpc-21.9_release_oacc_multicore
+        - name: linux_nvhpc-22.9_release_oacc_multicore
         # # gcc is used to compile the dependencies, NVHPC will be used to compile alpaka
+        # have to build with -O2 (hence CMAKE_BUILD_TYPE=RelWithDebInfo) at
+        # most since at least 22.3: Loop in Vec::operator+(..) is wrongly
+        # eliminated by optimizer at -O3 in matMulTest
           os: ubuntu-20.04
-          env: {CXX: g++,   CC: gcc,    ALPAKA_CI_GCC_VER: 9, CMAKE_CXX_COMPILER: nvc++,     CMAKE_C_COMPILER: nvc,    ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release,   ALPAKA_CI_BOOST_BRANCH: boost-1.74.0, ALPAKA_CI_CMAKE_VER: 3.18.6, OMP_NUM_THREADS: 4, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "nvcr.io/nvidia/nvhpc:21.9-devel-cuda11.4-ubuntu20.04", ALPAKA_CI_ANALYSIS: OFF, alpaka_DEBUG: 0, alpaka_ACC_ANY_BT_OACC_ENABLE: ON, alpaka_OFFLOAD_MAX_BLOCK_SIZE: 1, alpaka_DEBUG_OFFLOAD_ASSUME_HOST: ON, CMAKE_CXX_FLAGS: "-acc -ta=multicore", alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF, alpaka_CHECK_HEADERS: ON}
+          env: {CXX: g++,   CC: gcc,    ALPAKA_CI_GCC_VER: 9, CMAKE_CXX_COMPILER: nvc++,     CMAKE_C_COMPILER: nvc,    ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: RelWithDebInfo,   ALPAKA_CI_BOOST_BRANCH: boost-1.74.0, ALPAKA_CI_CMAKE_VER: 3.18.6, OMP_NUM_THREADS: 4, ALPAKA_CI_DOCKER_BASE_IMAGE_NAME: "nvcr.io/nvidia/nvhpc:22.9-devel-cuda11.7-ubuntu20.04", ALPAKA_CI_ANALYSIS: OFF, alpaka_DEBUG: 0, alpaka_ACC_ANY_BT_OACC_ENABLE: ON, alpaka_OFFLOAD_MAX_BLOCK_SIZE: 1, alpaka_DEBUG_OFFLOAD_ASSUME_HOST: ON, CMAKE_CXX_FLAGS: "-acc -ta=multicore --diag_suppress=186", alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF, alpaka_CHECK_HEADERS: ON}
 
     steps:
     - name: check filter

--- a/include/alpaka/acc/AccOacc.hpp
+++ b/include/alpaka/acc/AccOacc.hpp
@@ -50,7 +50,7 @@ namespace alpaka
     // define max gang/worker num because there is no standart way in OpenACC to
     // get this information
 #    ifndef ALPAKA_OACC_MAX_GANG_NUM
-    constexpr size_t oaccMaxGangNum = std::numeric_limits<unsigned int>::max();
+    constexpr size_t oaccMaxGangNum = 1;
 #    else
     constexpr size_t oaccMaxGangNum = ALPAKA_OACC_MAX_GANG_NUM;
 #    endif
@@ -121,8 +121,8 @@ namespace alpaka
                 auto const gridBlockCountMax(alpaka::core::clipCast<TIdx>(oaccMaxGangNum));
 
                 return {// m_multiProcessorCount
-                        static_cast<TIdx>(gridBlockCountMax),
-                        // m_gridBlockExtentMax
+                        static_cast<TIdx>(gridBlockCountMax), // TODO: standardize a way to return "unknown"
+                                                              // m_gridBlockExtentMax
                         Vec<TDim, TIdx>::all(std::numeric_limits<TIdx>::max()),
                         // m_gridBlockCountMax
                         std::numeric_limits<TIdx>::max(),

--- a/include/alpaka/test/acc/TestAccs.hpp
+++ b/include/alpaka/test/acc/TestAccs.hpp
@@ -75,6 +75,7 @@ namespace alpaka::test
         using AccCpuOmp2ThreadsIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_ANY_BT_OMP5_ENABLED) && !defined(TEST_UNIT_KERNEL_KERNEL_STD_FUNCTION)                         \
+    && !(BOOST_COMP_PGI && (defined TEST_UNIT_FENCE))                                                                 \
     && !(                                                                                                             \
         BOOST_COMP_GNUC                                                                                               \
         && (((BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(11, 0, 0)) /* tests excluded because of GCC10 Oacc / Omp5 target \
@@ -96,7 +97,7 @@ namespace alpaka::test
 #if defined(ALPAKA_ACC_ANY_BT_OACC_ENABLED) && !(defined(TEST_UNIT_KERNEL_KERNEL_STD_FUNCTION))                       \
     && !(                                                                                                             \
         defined(TEST_UNIT_TIME) /*no clock in OpenACC*/                                                               \
-        || defined(TEST_UNIT_BLOCK_SYNC) /*TODO: maybe atomics not working*/)                                         \
+        || defined(TEST_UNIT_FENCE) /*no mem fence in OpenACC*/)                                                      \
     && !(                                                                                                             \
         BOOST_COMP_GNUC                                                                                               \
         && (((BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(11, 0, 0)) /* tests excluded because of GCC10 Oacc / Omp5 target \

--- a/script/gitlabci/job_base.yml
+++ b/script/gitlabci/job_base.yml
@@ -82,7 +82,7 @@
     - cuda
     - intel
 
-.base_oacc_nvhpc:
+.base_nvhpc:
   image: nvcr.io/nvidia/nvhpc:${ALPAKA_CI_NVHPC_VER}-devel-cuda${ALPAKA_CI_CUDA_VERSION}-ubuntu${ALPAKA_CI_UBUNTU_VER}
   extends: .base
   variables:
@@ -100,10 +100,23 @@
     alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: "OFF"
     alpaka_ACC_GPU_CUDA_ENABLE: "OFF"
     alpaka_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: "OFF"
-    alpaka_ACC_ANY_BT_OACC_ENABLE: "ON"
     alpaka_OFFLOAD_MAX_BLOCK_SIZE: 256
     alpaka_DEBUG_OFFLOAD_ASSUME_HOST: "OFF"
+  tags:
+    - cuda
+    - intel
+
+.base_oacc_nvhpc:
+  extends: .base_nvhpc
+  variables:
+    alpaka_ACC_ANY_BT_OACC_ENABLE: "ON"
     CMAKE_CXX_FLAGS: "-acc -ta=tesla"
+
+.base_omp5_nvhpc:
+  extends: .base_nvhpc
+  variables:
+    alpaka_ACC_ANY_BT_OMP5_ENABLE: "ON"
+    CMAKE_CXX_FLAGS: "-ta=tesla --diag_suppress=186 -Wc,--pending_instantiations=256"
   tags:
     - cuda
     - intel

--- a/script/gitlabci/job_cuda11.5.yml
+++ b/script/gitlabci/job_cuda11.5.yml
@@ -44,17 +44,3 @@ linux_nvcc-11.5_gcc-10_debug:
   stage: stageRun1
 
 # clang not included because of an CUDA 11.5 bug: https://github.com/alpaka-group/alpaka/issues/1625
-
-# nvhpc
-linux_nvhpc-21.11_cuda-11.5_oacc:
-  extends: .base_oacc_nvhpc
-  variables:
-    ALPAKA_CI_UBUNTU_VER: "20.04"
-    ALPAKA_CI_CUDA_VERSION: "11.5"
-    ALPAKA_CI_NVHPC_VER: "21.11"
-    CMAKE_BUILD_TYPE: ""
-    ALPAKA_BOOST_VERSION: 1.74.0
-    ALPAKA_CI_CMAKE_VER: 3.19.8
-    alpaka_CHECK_HEADERS: "ON"
-  stage: stageRun0
-  

--- a/script/gitlabci/job_cuda11.6.yml
+++ b/script/gitlabci/job_cuda11.6.yml
@@ -113,3 +113,28 @@ linux_nvcc-11.6_clang-13_release:
     CMAKE_CUDA_COMPILER: nvcc
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF" # bug, see: https://github.com/NVIDIA/cuda-samples/issues/102
   stage: stageRun1
+
+# nvhpc
+linux_nvhpc-22.3_cuda-11.6_oacc:
+  extends: .base_oacc_nvhpc
+  variables:
+    ALPAKA_CI_UBUNTU_VER: "20.04"
+    ALPAKA_CI_CUDA_VERSION: "11.6"
+    ALPAKA_CI_NVHPC_VER: "22.3"
+    CMAKE_BUILD_TYPE: ""
+    ALPAKA_BOOST_VERSION: 1.74.0
+    ALPAKA_CI_CMAKE_VER: 3.19.8
+    alpaka_CHECK_HEADERS: "ON"
+  stage: stageRun0
+
+linux_nvhpc-22.3_cuda-11.6_omp5:
+  extends: .base_omp5_nvhpc
+  variables:
+    ALPAKA_CI_UBUNTU_VER: "20.04"
+    ALPAKA_CI_CUDA_VERSION: "11.6"
+    ALPAKA_CI_NVHPC_VER: "22.3"
+    CMAKE_BUILD_TYPE: ""
+    ALPAKA_BOOST_VERSION: 1.74.0
+    ALPAKA_CI_CMAKE_VER: 3.19.8
+    alpaka_CHECK_HEADERS: "ON"
+  stage: stageRun0

--- a/test/unit/block/sync/src/BlockSync.cpp
+++ b/test/unit/block/sync/src/BlockSync.cpp
@@ -17,7 +17,10 @@
 class BlockSyncTestKernel
 {
 public:
-    static const std::uint8_t gridThreadExtentPerDim = 4u;
+    static constexpr std::uint8_t gridThreadExtentPerDim()
+    {
+        return 4u;
+    }
 
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
@@ -75,7 +78,7 @@ TEMPLATE_LIST_TEST_CASE("synchronize", "[blockSync]", alpaka::test::TestAccs)
     using Idx = alpaka::Idx<Acc>;
 
     alpaka::test::KernelExecutionFixture<Acc> fixture(
-        alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(BlockSyncTestKernel::gridThreadExtentPerDim)));
+        alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(BlockSyncTestKernel::gridThreadExtentPerDim())));
 
     BlockSyncTestKernel kernel;
 

--- a/test/unit/mem/fence/CMakeLists.txt
+++ b/test/unit/mem/fence/CMakeLists.txt
@@ -8,20 +8,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-if(NOT alpaka_ACC_ANY_BT_OACC_ENABLE) # Fences are not supported for OpenACC
-        set(_TARGET_NAME "FenceTest")
+set(_TARGET_NAME "FenceTest")
 
-        append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
+append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 
-        alpaka_add_executable(
-                ${_TARGET_NAME}
-                ${_FILES_SOURCE})
+alpaka_add_executable(
+        ${_TARGET_NAME}
+        ${_FILES_SOURCE})
 
-        target_link_libraries(
-                ${_TARGET_NAME}
-                PRIVATE common)
+target_link_libraries(
+        ${_TARGET_NAME}
+        PRIVATE common)
 
-        set_target_properties(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
+set_target_properties(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
+target_compile_definitions(${_TARGET_NAME} PRIVATE "-DTEST_UNIT_FENCE")
 
-        add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME} ${_alpaka_TEST_OPTIONS})
-endif()
+add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME} ${_alpaka_TEST_OPTIONS})


### PR DESCRIPTION
Also:
* Add OMP5 on CUDA-GPU check using NVHPC 22.3 (22.9 segfaults compiling this).
* Make `GetDevProps<AccOacc>` and `GetDevProps<AccOmp5>` report `m_multiprocessorCount = 1` for compatibility.