### PR TITLE
Run clang-format

### DIFF
--- a/include/alpaka/workdiv/WorkDivMembers.hpp
+++ b/include/alpaka/workdiv/WorkDivMembers.hpp
@@ -67,7 +67,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC friend constexpr auto operator==(WorkDivMembers const& a, WorkDivMembers const& b) -> bool
         {
             return a.m_gridBlockExtent == b.m_gridBlockExtent && a.m_blockThreadExtent == b.m_blockThreadExtent
-                && a.m_threadElemExtent == b.m_threadElemExtent;
+                   && a.m_threadElemExtent == b.m_threadElemExtent;
         }
 
         ALPAKA_FN_HOST friend auto operator<<(std::ostream& os, WorkDivMembers const& workDiv) -> std::ostream&


### PR DESCRIPTION
We recently merged #1829, which was not properly formatted by clang-format-14. This PR fixes this.