### PR TITLE
Make SYCL runtime objects `static`.

### DIFF
--- a/include/alpaka/pltf/PltfCpuSyclIntel.hpp
+++ b/include/alpaka/pltf/PltfCpuSyclIntel.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Jan Stephan
+/* Copyright 2023 Jan Stephan
  *
  * This file is part of Alpaka.
  *
@@ -45,13 +45,7 @@ namespace alpaka::experimental
     } // namespace detail
 
     //! The SYCL device manager.
-    class PltfCpuSyclIntel : public PltfGenericSycl
-    {
-    public:
-        PltfCpuSyclIntel() = delete;
-
-        using selector = detail::IntelCpuSelector;
-    };
+    using PltfCpuSyclIntel = PltfGenericSycl<detail::IntelCpuSelector>;
 } // namespace alpaka::experimental
 
 namespace alpaka::trait

--- a/include/alpaka/pltf/PltfFpgaSyclIntel.hpp
+++ b/include/alpaka/pltf/PltfFpgaSyclIntel.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Jan Stephan
+/* Copyright 2023 Jan Stephan
  *
  * This file is part of Alpaka.
  *
@@ -18,22 +18,14 @@
 #    include <CL/sycl.hpp>
 #    include <sycl/ext/intel/fpga_extensions.hpp>
 
-#    include <string>
-
 namespace alpaka::experimental
 {
     //! The SYCL device manager.
-    class PltfFpgaSyclIntel : public PltfGenericSycl
-    {
-    public:
-        PltfFpgaSyclIntel() = delete;
-
 #    ifdef ALPAKA_FPGA_EMULATION
-        using selector = sycl::ext::intel::fpga_emulator_selector;
+    using PltfFpgaSyclIntel = PltfGenericSycl<sycl::ext::intel::fpga_emulator_selector>;
 #    else
-        using selector = sycl::ext::intel::fpga_selector;
+    using PltfFpgaSyclIntel = PltfGenericSycl<sycl::ext::intel::fpga_selector>;
 #    endif
-    };
 } // namespace alpaka::experimental
 
 namespace alpaka::trait

--- a/include/alpaka/pltf/PltfFpgaSyclXilinx.hpp
+++ b/include/alpaka/pltf/PltfFpgaSyclXilinx.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Jan Stephan
+/* Copyright 2023 Jan Stephan
  *
  * This file is part of Alpaka.
  *
@@ -45,13 +45,7 @@ namespace alpaka::experimental
     } // namespace detail
 
     //! The SYCL device manager.
-    class PltfFpgaSyclXilinx : public PltfGenericSycl
-    {
-    public:
-        PltfFpgaSyclXilinx() = delete;
-
-        using selector = detail::XilinxFpgaSelector;
-    };
+    using PltfFgpaSyclIntel = PltfGenericSycl<detail::XilinxFpgaSelector>;
 } // namespace alpaka::experimental
 
 namespace alpaka::trait

--- a/include/alpaka/pltf/PltfGpuSyclIntel.hpp
+++ b/include/alpaka/pltf/PltfGpuSyclIntel.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Jan Stephan
+/* Copyright 2023 Jan Stephan
  *
  * This file is part of Alpaka.
  *
@@ -24,13 +24,13 @@ namespace alpaka::experimental
 {
     namespace detail
     {
-        // Prevent clang from annoying us with warnings about emitting too many vtables. These are discarded by
-        // the linker anyway.
+        // Prevent clang from annoying us with warnings about emitting too many vtables. These are discarded by the
+        // linker anyway.
 #    if BOOST_COMP_CLANG
 #        pragma clang diagnostic push
 #        pragma clang diagnostic ignored "-Wweak-vtables"
-        struct IntelGpuSelector : sycl::device_selector
 #    endif
+        struct IntelGpuSelector : sycl::device_selector
         {
             auto operator()(sycl::device const& dev) const -> int override
             {
@@ -46,13 +46,7 @@ namespace alpaka::experimental
     } // namespace detail
 
     //! The SYCL device manager.
-    class PltfGpuSyclIntel : public PltfGenericSycl
-    {
-    public:
-        PltfGpuSyclIntel() = delete;
-
-        using selector = detail::IntelGpuSelector;
-    };
+    using PltfGpuSyclIntel = PltfGenericSycl<detail::IntelGpuSelector>;
 } // namespace alpaka::experimental
 
 namespace alpaka::trait


### PR DESCRIPTION
This is a supporting effort for #1845. The alpaka SYCL platforms are now specialized using the SYCL device selector. Each specialization will contain (as `static` members) the corresponding `sycl::platform, sycl::context, std::vector<sycl::device>`.

CC @fwyzard @Parsifal-2045 @AuroraPerego