### PR TITLE
fix CUDA memory allocation mapped/async

### DIFF
--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -274,7 +274,7 @@ namespace alpaka
 
                 auto const& dev = getDev(queue);
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
-                void* memPtr;
+                void* memPtr = nullptr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::mallocAsync(
                     &memPtr,
                     static_cast<std::size_t>(width) * sizeof(TElem),
@@ -316,7 +316,7 @@ namespace alpaka
 
                 // Allocate CUDA/HIP page-locked memory on the host, mapped into the CUDA/HIP address space and
                 // accessible to all CUDA/HIP devices.
-                TElem* memPtr;
+                TElem* memPtr = nullptr;
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::hostMalloc(
                     reinterpret_cast<void**>(&memPtr),
                     sizeof(TElem) * static_cast<std::size_t>(getExtentProduct(extent)),


### PR DESCRIPTION
At least some CUDA versions return the unchanged pointer given to CUDA memory allocation if the size to allocate is zero. If the destination pointer is not initialized with `nullptr` and contains random data the random data is returned.
The created alpaka buffer is passing the pointer to the corresponding function to free the memory, in case the pointer is a random address the free is failing with an error written to stderr because alpaka guarding the CUDA call with a check which is not throwing in case an error happened.

We observed this error with PIConGPU which is using cupla to allocate memory. 