### PR TITLE
gitlab CI run more jobs as compile only

### DIFF
--- a/script/gitlabci/job_cuda10.0.yml
+++ b/script/gitlabci/job_cuda10.0.yml
@@ -1,4 +1,4 @@
-linux_clang-9_cuda-10.0_debug:
+linux_clang-9_cuda-10.0_debug_compile_only:
   extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -10,9 +10,8 @@ linux_clang-9_cuda-10.0_debug:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageCompile0
 
-linux_clang-10_cuda-10.0_release:
+linux_clang-10_cuda-10.0_release_compile_only:
   extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -23,7 +22,6 @@ linux_clang-10_cuda-10.0_release:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageCompile1
 
 linux_clang-11_cuda-10.0_release:
   extends: .base_cuda_clang
@@ -36,10 +34,9 @@ linux_clang-11_cuda-10.0_release:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageRun0
 
-linux_clang-14_cuda-10.0_debug:
-  extends: .base_cuda_clang
+linux_clang-14_cuda-10.0_debug_compile_only:
+  extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "10.0"
@@ -50,4 +47,3 @@ linux_clang-14_cuda-10.0_debug:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageRun1

--- a/script/gitlabci/job_cuda10.1.yml
+++ b/script/gitlabci/job_cuda10.1.yml
@@ -1,4 +1,4 @@
-linux_clang-9_cuda-10.1_debug:
+linux_clang-9_cuda-10.1_debug_compile_only:
   extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -10,9 +10,8 @@ linux_clang-9_cuda-10.1_debug:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageCompile0
 
-linux_clang-10_cuda-10.1_release:
+linux_clang-10_cuda-10.1_release_compile_only:
   extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -24,7 +23,6 @@ linux_clang-10_cuda-10.1_release:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageCompile1
 
 linux_clang-11_cuda-10.1_debug:
   extends: .base_cuda_clang
@@ -38,7 +36,6 @@ linux_clang-11_cuda-10.1_debug:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageRun1
 
 linux_clang-14_cuda-10.1_release:
   extends: .base_cuda_clang
@@ -51,4 +48,3 @@ linux_clang-14_cuda-10.1_release:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageRun0

--- a/script/gitlabci/job_cuda10.2.yml
+++ b/script/gitlabci/job_cuda10.2.yml
@@ -1,5 +1,5 @@
-linux_clang-11_cuda-10.2_release:
-  extends: .base_cuda_clang
+linux_clang-11_cuda-10.2_release_compile_only:
+  extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "10.2"
@@ -10,7 +10,6 @@ linux_clang-11_cuda-10.2_release:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageRun0
 
 linux_clang-14_cuda-10.2_debug:
   extends: .base_cuda_clang
@@ -25,4 +24,3 @@ linux_clang-14_cuda-10.2_debug:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageRun0

--- a/script/gitlabci/job_cuda11.0.yml
+++ b/script/gitlabci/job_cuda11.0.yml
@@ -1,5 +1,5 @@
 # nvcc + g++
-linux_nvcc-11.0_gcc-7_debug_separable_compilation:
+linux_nvcc-11.0_gcc-7_debug_separable_compilation_compile_only:
   extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -9,9 +9,8 @@ linux_nvcc-11.0_gcc-7_debug_separable_compilation:
     ALPAKA_BOOST_VERSION: 1.74.0
     ALPAKA_CI_CMAKE_VER: 3.18.6
     CUDA_SEPARABLE_COMPILATION: "ON"
-  stage: stageCompile0
 
-linux_nvcc-11.0_gcc-7_release_extended_lambda_off:
+linux_nvcc-11.0_gcc-7_release_extended_lambda_off_compile_only:
   extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -22,9 +21,8 @@ linux_nvcc-11.0_gcc-7_release_extended_lambda_off:
     ALPAKA_CI_CMAKE_VER: 3.20.6
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     alpaka_CUDA_EXPT_EXTENDED_LAMBDA: "OFF"
-  stage: stageCompile1
 
-linux_nvcc-11.0_gcc-7_debug:
+linux_nvcc-11.0_gcc-7_debug_compile_only:
   extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -34,9 +32,8 @@ linux_nvcc-11.0_gcc-7_debug:
     ALPAKA_BOOST_VERSION: 1.75.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_ARCHITECTURES: "61;80"
-  stage: stageCompile0
 
-linux_nvcc-11.0_gcc-8_release:
+linux_nvcc-11.0_gcc-8_release_compile_only:
   extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -45,7 +42,6 @@ linux_nvcc-11.0_gcc-8_release:
     CMAKE_BUILD_TYPE: Release
     ALPAKA_BOOST_VERSION: 1.77.0
     ALPAKA_CI_CMAKE_VER: 3.18.6
-  stage: stageCompile1
 
 linux_nvcc-11.0_gcc-9_release:
   extends: .base_cuda_gcc
@@ -55,10 +51,9 @@ linux_nvcc-11.0_gcc-9_release:
     ALPAKA_CI_GCC_VER: 9
     ALPAKA_BOOST_VERSION: 1.75.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
-  stage: stageRun0
 
 # nvcc + clang
-linux_nvcc-11.0_clang-8_release:
+linux_nvcc-11.0_clang-8_release_compile_only:
   extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -68,9 +63,8 @@ linux_nvcc-11.0_clang-8_release:
     ALPAKA_BOOST_VERSION: 1.74.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_COMPILER: nvcc
-  stage: stageCompile0
 
-linux_nvcc-11.0_clang-9_debug:
+linux_nvcc-11.0_clang-9_debug_compile_only:
   extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -80,11 +74,10 @@ linux_nvcc-11.0_clang-9_debug:
     ALPAKA_BOOST_VERSION: 1.74.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_COMPILER: nvcc
-  stage: stageCompile1
 
 # clang++ as CUDA compiler
-linux_clang-12_cuda-11.0_release:
-  extends: .base_cuda_clang
+linux_clang-12_cuda-11.0_release_compile_only:
+  extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "11.0"
@@ -94,7 +87,6 @@ linux_clang-12_cuda-11.0_release:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageRun0
 
 linux_clang-14_cuda-11.0_debug:
   extends: .base_cuda_clang
@@ -108,4 +100,3 @@ linux_clang-14_cuda-11.0_debug:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageRun1

--- a/script/gitlabci/job_cuda11.1.yml
+++ b/script/gitlabci/job_cuda11.1.yml
@@ -1,5 +1,5 @@
 # nvcc + g++
-linux_nvcc-11.1_gcc-7_debug:
+linux_nvcc-11.1_gcc-7_debug_compile_only:
   extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -9,9 +9,8 @@ linux_nvcc-11.1_gcc-7_debug:
     ALPAKA_BOOST_VERSION: 1.75.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_ARCHITECTURES: "61;80"
-  stage: stageCompile0
 
-linux_nvcc-11.1_gcc-8_release:
+linux_nvcc-11.1_gcc-8_release_compile_only:
   extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -19,7 +18,6 @@ linux_nvcc-11.1_gcc-8_release:
     ALPAKA_CI_GCC_VER: 8
     ALPAKA_BOOST_VERSION: 1.77.0
     ALPAKA_CI_CMAKE_VER: 3.18.6
-  stage: stageCompile1
 
 linux_nvcc-11.1_gcc-9_release:
   extends: .base_cuda_gcc
@@ -29,12 +27,11 @@ linux_nvcc-11.1_gcc-9_release:
     ALPAKA_CI_GCC_VER: 9
     ALPAKA_BOOST_VERSION: 1.77.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
-  stage: stageRun1
 
 # gcc 10 not included because of an GCC 10.3 bug: https://github.com/alpaka-group/alpaka/issues/1297
 
 # nvcc + clang
-linux_nvcc-11.1_clang-8_release:
+linux_nvcc-11.1_clang-8_release_compile_only:
   extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -43,9 +40,8 @@ linux_nvcc-11.1_clang-8_release:
     ALPAKA_BOOST_VERSION: 1.74.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_COMPILER: nvcc
-  stage: stageCompile0
 
-linux_nvcc-11.1_clang-9_debug:
+linux_nvcc-11.1_clang-9_debug_compile_only:
   extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -55,7 +51,6 @@ linux_nvcc-11.1_clang-9_debug:
     ALPAKA_BOOST_VERSION: 1.77.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_COMPILER: nvcc
-  stage: stageCompile1
 
 linux_nvcc-11.1_clang-10_release:
   extends: .base_cuda_clang
@@ -66,10 +61,9 @@ linux_nvcc-11.1_clang-10_release:
     ALPAKA_BOOST_VERSION: 1.75.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
     CMAKE_CUDA_COMPILER: nvcc
-  stage: stageRun1
 
 # clang++ as CUDA compiler
-linux_clang-14_cuda-11.1_release:
+linux_clang-14_cuda-11.1_release_compile_only:
   extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -80,4 +74,3 @@ linux_clang-14_cuda-11.1_release:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageCompile0

--- a/script/gitlabci/job_cuda11.2.yml
+++ b/script/gitlabci/job_cuda11.2.yml
@@ -1,5 +1,5 @@
 # nvcc + g++
-linux_nvcc-11.2_gcc-7_debug:
+linux_nvcc-11.2_gcc-7_debug_compile_only:
   extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -9,9 +9,8 @@ linux_nvcc-11.2_gcc-7_debug:
     ALPAKA_BOOST_VERSION: 1.75.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_ARCHITECTURES: "61;80"
-  stage: stageCompile0
 
-linux_nvcc-11.2_gcc-8_release:
+linux_nvcc-11.2_gcc-8_release_compile_only:
   extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -19,7 +18,6 @@ linux_nvcc-11.2_gcc-8_release:
     ALPAKA_CI_GCC_VER: 8
     ALPAKA_BOOST_VERSION: 1.76.0
     ALPAKA_CI_CMAKE_VER: 3.18.6
-  stage: stageCompile1
 
 linux_nvcc-11.2_gcc-9_release:
   extends: .base_cuda_gcc
@@ -29,12 +27,11 @@ linux_nvcc-11.2_gcc-9_release:
     ALPAKA_CI_GCC_VER: 9
     ALPAKA_BOOST_VERSION: 1.74.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
-  stage: stageRun1
 
 # gcc 10 not included because of an GCC 10.3 bug: https://github.com/alpaka-group/alpaka/issues/1297
 
 # nvcc + clang
-linux_nvcc-11.2_clang-8_release:
+linux_nvcc-11.2_clang-8_release_compile_only:
   extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -43,9 +40,8 @@ linux_nvcc-11.2_clang-8_release:
     ALPAKA_BOOST_VERSION: 1.74.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_COMPILER: nvcc
-  stage: stageCompile0
 
-linux_nvcc-11.2_clang-9_debug:
+linux_nvcc-11.2_clang-9_debug_compile_only:
   extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -55,7 +51,6 @@ linux_nvcc-11.2_clang-9_debug:
     ALPAKA_BOOST_VERSION: 1.77.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_COMPILER: nvcc
-  stage: stageCompile1
 
 linux_nvcc-11.2_clang-10_release:
   extends: .base_cuda_clang
@@ -66,10 +61,9 @@ linux_nvcc-11.2_clang-10_release:
     ALPAKA_BOOST_VERSION: 1.75.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
     CMAKE_CUDA_COMPILER: nvcc
-  stage: stageRun1
 
 # clang++ as CUDA compiler
-linux_clang-14_cuda-11.2_debug:
+linux_clang-14_cuda-11.2_debug_compile_only:
   extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -81,4 +75,3 @@ linux_clang-14_cuda-11.2_debug:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageCompile1

--- a/script/gitlabci/job_cuda11.3.yml
+++ b/script/gitlabci/job_cuda11.3.yml
@@ -1,5 +1,5 @@
 # nvcc + g++
-linux_nvcc-11.3_gcc-7_debug:
+linux_nvcc-11.3_gcc-7_debug_compile_only:
   extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -9,9 +9,8 @@ linux_nvcc-11.3_gcc-7_debug:
     ALPAKA_BOOST_VERSION: 1.76.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_ARCHITECTURES: "61;86"
-  stage: stageCompile0
 
-linux_nvcc-11.3_gcc-8_release:
+linux_nvcc-11.3_gcc-8_release_compile_only:
   extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -19,7 +18,6 @@ linux_nvcc-11.3_gcc-8_release:
     ALPAKA_CI_GCC_VER: 8
     ALPAKA_BOOST_VERSION: 1.74.0
     ALPAKA_CI_CMAKE_VER: 3.18.6
-  stage: stageCompile1
 
 linux_nvcc-11.3_gcc-9_release:
   extends: .base_cuda_gcc
@@ -29,7 +27,6 @@ linux_nvcc-11.3_gcc-9_release:
     ALPAKA_CI_GCC_VER: 9
     ALPAKA_BOOST_VERSION: 1.75.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
-  stage: stageRun1
 
 # gcc 10 not included because of an GCC 10.3 bug: https://github.com/alpaka-group/alpaka/issues/1297
 

--- a/script/gitlabci/job_cuda11.4.yml
+++ b/script/gitlabci/job_cuda11.4.yml
@@ -1,5 +1,5 @@
 # nvcc + g++
-linux_nvcc-11.4_gcc-7_debug:
+linux_nvcc-11.4_gcc-7_debug_compile_only:
   extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -9,9 +9,8 @@ linux_nvcc-11.4_gcc-7_debug:
     ALPAKA_BOOST_VERSION: 1.75.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_ARCHITECTURES: "61;86"
-  stage: stageCompile0
   
-linux_nvcc-11.4_gcc-8_release:
+linux_nvcc-11.4_gcc-8_release_compile_only:
   extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
@@ -19,7 +18,6 @@ linux_nvcc-11.4_gcc-8_release:
     ALPAKA_CI_GCC_VER: 8
     ALPAKA_BOOST_VERSION: 1.74.0
     ALPAKA_CI_CMAKE_VER: 3.18.6
-  stage: stageCompile1
   
 linux_nvcc-11.4_gcc-9_release:
   extends: .base_cuda_gcc
@@ -29,7 +27,6 @@ linux_nvcc-11.4_gcc-9_release:
     ALPAKA_CI_GCC_VER: 9
     ALPAKA_BOOST_VERSION: 1.74.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
-  stage: stageRun0
   
 # gcc 10 not included because of an GCC 10.3 bug: https://github.com/alpaka-group/alpaka/issues/1297
 
@@ -48,4 +45,3 @@ linux_clang-14_cuda-11.4_release:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageRun1

--- a/script/gitlabci/job_cuda11.5.yml
+++ b/script/gitlabci/job_cuda11.5.yml
@@ -1,6 +1,6 @@
 # nvcc + g++
-linux_nvcc-11.5_gcc-7_debug:
-  extends: .base_cuda_gcc
+linux_nvcc-11.5_gcc-7_debug_compile_only:
+  extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "11.5"
@@ -9,20 +9,18 @@ linux_nvcc-11.5_gcc-7_debug:
     ALPAKA_BOOST_VERSION: 1.75.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_ARCHITECTURES: "61;86"
-  stage: stageRun0
 
-linux_nvcc-11.5_gcc-8_release:
-  extends: .base_cuda_gcc
+linux_nvcc-11.5_gcc-8_release_compile_only:
+  extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "11.5"
     ALPAKA_CI_GCC_VER: 8
     ALPAKA_BOOST_VERSION: 1.77.0
     ALPAKA_CI_CMAKE_VER: 3.18.6
-  stage: stageRun1
 
-linux_nvcc-11.5_gcc-9_release:
-  extends: .base_cuda_gcc
+linux_nvcc-11.5_gcc-9_release_compile_only:
+  extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "11.5"
@@ -30,10 +28,9 @@ linux_nvcc-11.5_gcc-9_release:
     ALPAKA_CI_GCC_VER: 9
     ALPAKA_BOOST_VERSION: 1.76.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
-  stage: stageRun0
 
-linux_nvcc-11.5_gcc-10_debug:
-  extends: .base_cuda_gcc
+linux_nvcc-11.5_gcc-10_debug_compile_only:
+  extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "11.5"
@@ -41,7 +38,6 @@ linux_nvcc-11.5_gcc-10_debug:
     CMAKE_BUILD_TYPE: Debug
     ALPAKA_BOOST_VERSION: 1.76.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
-  stage: stageRun1
 
 # nvcc + clang not included because of an CUDA 11.5 bug: https://github.com/alpaka-group/alpaka/issues/1625
 
@@ -57,7 +53,6 @@ linux_clang-14_cuda-11.5_release:
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     CMAKE_CUDA_COMPILER: clang++
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF"
-  stage: stageRun1
 
 # nvhpc
 linux_nvhpc-21.11_cuda-11.5_oacc:
@@ -70,5 +65,4 @@ linux_nvhpc-21.11_cuda-11.5_oacc:
     ALPAKA_BOOST_VERSION: 1.74.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
     alpaka_CHECK_HEADERS: "ON"
-  stage: stageRun0
   

--- a/script/gitlabci/job_cuda11.6.yml
+++ b/script/gitlabci/job_cuda11.6.yml
@@ -1,6 +1,6 @@
 # nvcc + g++
-linux_nvcc-11.6_gcc-7_debug:
-  extends: .base_cuda_gcc
+linux_nvcc-11.6_gcc-7_debug_compile_only:
+  extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "11.6"
@@ -9,17 +9,15 @@ linux_nvcc-11.6_gcc-7_debug:
     ALPAKA_BOOST_VERSION: 1.75.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_ARCHITECTURES: "61;86"
-  stage: stageRun0
 
-linux_nvcc-11.6_gcc-8_release:
-  extends: .base_cuda_gcc
+linux_nvcc-11.6_gcc-8_release_compile_only:
+  extends: .base_cuda_gcc_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "11.6"
     ALPAKA_CI_GCC_VER: 8
     ALPAKA_BOOST_VERSION: 1.77.0
     ALPAKA_CI_CMAKE_VER: 3.18.6
-  stage: stageRun1
 
 linux_nvcc-11.6_gcc-9_release:
   extends: .base_cuda_gcc
@@ -30,7 +28,6 @@ linux_nvcc-11.6_gcc-9_release:
     ALPAKA_CI_GCC_VER: 9
     ALPAKA_BOOST_VERSION: 1.76.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
-  stage: stageRun0
 
 linux_nvcc-11.6_gcc-10_debug:
   extends: .base_cuda_gcc
@@ -41,11 +38,10 @@ linux_nvcc-11.6_gcc-10_debug:
     CMAKE_BUILD_TYPE: Debug
     ALPAKA_BOOST_VERSION: 1.76.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
-  stage: stageRun1
 
 # nvcc + clang
-linux_nvcc-11.6_clang-8_release:
-  extends: .base_cuda_clang
+linux_nvcc-11.6_clang-8_release_compile_only:
+  extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "11.6"
@@ -53,10 +49,9 @@ linux_nvcc-11.6_clang-8_release:
     ALPAKA_BOOST_VERSION: 1.74.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_COMPILER: nvcc
-  stage: stageRun0
 
-linux_nvcc-11.6_clang-9_debug:
-  extends: .base_cuda_clang
+linux_nvcc-11.6_clang-9_debug_compile_only:
+  extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "11.6"
@@ -65,10 +60,9 @@ linux_nvcc-11.6_clang-9_debug:
     ALPAKA_BOOST_VERSION: 1.77.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
     CMAKE_CUDA_COMPILER: nvcc
-  stage: stageRun1
 
-linux_nvcc-11.6_clang-10_release:
-  extends: .base_cuda_clang
+linux_nvcc-11.6_clang-10_release_compile_only:
+  extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "11.6"
@@ -76,7 +70,6 @@ linux_nvcc-11.6_clang-10_release:
     ALPAKA_BOOST_VERSION: 1.75.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
     CMAKE_CUDA_COMPILER: nvcc
-  stage: stageRun0
 
 linux_nvcc-11.6_clang-11_release:
   extends: .base_cuda_clang
@@ -87,10 +80,9 @@ linux_nvcc-11.6_clang-11_release:
     ALPAKA_BOOST_VERSION: 1.77.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
     CMAKE_CUDA_COMPILER: nvcc
-  stage: stageRun0
 
-linux_nvcc-11.6_clang-12_release:
-  extends: .base_cuda_clang
+linux_nvcc-11.6_clang-12_release_compile_only:
+  extends: .base_cuda_clang_compile_only
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "11.6"
@@ -99,7 +91,6 @@ linux_nvcc-11.6_clang-12_release:
     ALPAKA_BOOST_VERSION: 1.75.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
     CMAKE_CUDA_COMPILER: nvcc
-  stage: stageRun1
 
 linux_nvcc-11.6_clang-13_release:
   extends: .base_cuda_clang
@@ -112,7 +103,6 @@ linux_nvcc-11.6_clang-13_release:
     ALPAKA_CI_CMAKE_VER: 3.19.8
     CMAKE_CUDA_COMPILER: nvcc
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "OFF" # bug, see: https://github.com/NVIDIA/cuda-samples/issues/102
-  stage: stageRun1
 
 # nvhpc
 linux_nvhpc-22.3_cuda-11.6_oacc:
@@ -125,7 +115,6 @@ linux_nvhpc-22.3_cuda-11.6_oacc:
     ALPAKA_BOOST_VERSION: 1.74.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
     alpaka_CHECK_HEADERS: "ON"
-  stage: stageRun0
 
 linux_nvhpc-22.3_cuda-11.6_omp5:
   extends: .base_omp5_nvhpc
@@ -137,4 +126,3 @@ linux_nvhpc-22.3_cuda-11.6_omp5:
     ALPAKA_BOOST_VERSION: 1.74.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
     alpaka_CHECK_HEADERS: "ON"
-  stage: stageRun0

--- a/script/gitlabci/job_hip4.2.yml
+++ b/script/gitlabci/job_hip4.2.yml
@@ -8,9 +8,8 @@ linux_hip4.2_clang_debug_hip_only:
     CMAKE_BUILD_TYPE: Debug
     ALPAKA_BOOST_VERSION: 1.77.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
-  stage: stageRun0
 
-linux_hip4.2_clang_release_hip_only:
+linux_hip4.2_clang_release_hip_only_compile_only:
   extends: .base_hip_compile_only
   variables:
     ALPAKA_CI_HIP_VERSION: "4.2"
@@ -19,4 +18,3 @@ linux_hip4.2_clang_release_hip_only:
     CMAKE_BUILD_TYPE: Release
     ALPAKA_BOOST_VERSION: 1.74.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
-  stage: stageCompile0

--- a/script/gitlabci/job_hip4.3.yml
+++ b/script/gitlabci/job_hip4.3.yml
@@ -8,9 +8,8 @@ linux_hip4.3_clang_debug_hip_only:
     CMAKE_BUILD_TYPE: Debug
     ALPAKA_BOOST_VERSION: 1.75.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
-  stage: stageRun0
 
-linux_hip4.3_clang_release_hip_only:
+linux_hip4.3_clang_release_hip_only_compile_only:
   extends: .base_hip_compile_only
   variables:
     ALPAKA_CI_HIP_VERSION: "4.3"
@@ -19,4 +18,3 @@ linux_hip4.3_clang_release_hip_only:
     CMAKE_BUILD_TYPE: Release
     ALPAKA_BOOST_VERSION: 1.76.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
-  stage: stageCompile0

--- a/script/gitlabci/job_hip4.5.yml
+++ b/script/gitlabci/job_hip4.5.yml
@@ -8,10 +8,9 @@ linux_hip4.5_clang_debug_hip_only:
     CMAKE_BUILD_TYPE: Debug
     ALPAKA_BOOST_VERSION: 1.77.0
     ALPAKA_CI_CMAKE_VER: 3.19.8
-  stage: stageRun0
 
-linux_hip4.5_clang_release_hip_only:
-  extends: .base_hip
+linux_hip4.5_clang_release_hip_only_compile_only:
+  extends: .base_hip_compile_only
   variables:
     ALPAKA_CI_HIP_VERSION: "4.5"
     ALPAKA_CI_CLANG_VER: 13
@@ -19,4 +18,3 @@ linux_hip4.5_clang_release_hip_only:
     CMAKE_BUILD_TYPE: Release
     ALPAKA_BOOST_VERSION: 1.78.0
     ALPAKA_CI_CMAKE_VER: 3.20.6
-  stage: stageCompile0

--- a/script/gitlabci/job_hip5.0.yml
+++ b/script/gitlabci/job_hip5.0.yml
@@ -8,10 +8,9 @@ linux_hip5.0_clang_debug_hip_only:
     CMAKE_BUILD_TYPE: Debug
     ALPAKA_BOOST_VERSION: 1.77.0
     ALPAKA_CI_CMAKE_VER: 3.21.6
-  stage: stageRun0
 
-linux_hip5.0_clang_release_hip_only:
-  extends: .base_hip
+linux_hip5.0_clang_release_hip_only_compile_only:
+  extends: .base_hip_compile_only
   variables:
     ALPAKA_CI_HIP_VERSION: "5.0"
     ALPAKA_CI_CLANG_VER: 14
@@ -19,4 +18,3 @@ linux_hip5.0_clang_release_hip_only:
     CMAKE_BUILD_TYPE: Release
     ALPAKA_BOOST_VERSION: 1.78.0
     ALPAKA_CI_CMAKE_VER: 3.22.3
-  stage: stageRun1

--- a/script/gitlabci/job_hip5.1.yml
+++ b/script/gitlabci/job_hip5.1.yml
@@ -1,6 +1,6 @@
 # HIP
-linux_hip5.1_clang_debug_hip_only:
-  extends: .base_hip
+linux_hip5.1_clang_debug_hip_only_compile_only:
+  extends: .base_hip_compile_only
   variables:
     ALPAKA_CI_HIP_VERSION: "5.1"
     ALPAKA_CI_CLANG_VER: 14
@@ -8,10 +8,9 @@ linux_hip5.1_clang_debug_hip_only:
     CMAKE_BUILD_TYPE: Debug
     ALPAKA_BOOST_VERSION: 1.78.0
     ALPAKA_CI_CMAKE_VER: 3.22.4
-  stage: stageRun0
 
-linux_hip5.1_clang_release_hip_only:
-  extends: .base_hip
+linux_hip5.1_clang_release_hip_only_compile_only:
+  extends: .base_hip_compile_only
   variables:
     ALPAKA_CI_HIP_VERSION: "5.1"
     ALPAKA_CI_CLANG_VER: 14
@@ -19,4 +18,3 @@ linux_hip5.1_clang_release_hip_only:
     CMAKE_BUILD_TYPE: Release
     ALPAKA_BOOST_VERSION: 1.79.0
     ALPAKA_CI_CMAKE_VER: 3.23.1
-  stage: stageRun1 

--- a/script/gitlabci/job_hip5.2.yml
+++ b/script/gitlabci/job_hip5.2.yml
@@ -8,10 +8,9 @@ linux_hip5.2_clang_debug_hip_only:
     CMAKE_BUILD_TYPE: Debug
     ALPAKA_BOOST_VERSION: 1.78.0
     ALPAKA_CI_CMAKE_VER: 3.22.4
-  stage: stageCompile0
 
-linux_hip5.2_clang_release_hip_only:
-  extends: .base_hip
+linux_hip5.2_clang_release_hip_only_compile_only:
+  extends: .base_hip_compile_only
   variables:
     ALPAKA_CI_HIP_VERSION: "5.2"
     ALPAKA_CI_CLANG_VER: 14
@@ -19,10 +18,9 @@ linux_hip5.2_clang_release_hip_only:
     CMAKE_BUILD_TYPE: Release
     ALPAKA_BOOST_VERSION: 1.79.0
     ALPAKA_CI_CMAKE_VER: 3.23.1
-  stage: stageCompile0
 
-linux_hip5.2.3_clang_debug_hip_only:
-  extends: .base_hip
+linux_hip5.2.3_clang_debug_hip_only_compile_only:
+  extends: .base_hip_compile_only
   variables:
     ALPAKA_CI_HIP_VERSION: "5.2.3"
     ALPAKA_CI_CLANG_VER: 14
@@ -30,4 +28,3 @@ linux_hip5.2.3_clang_debug_hip_only:
     CMAKE_BUILD_TYPE: Debug
     ALPAKA_BOOST_VERSION: 1.78.0
     ALPAKA_CI_CMAKE_VER: 3.22.4
-  stage: stageRun0

--- a/script/gitlabci/job_hip5.3.yml
+++ b/script/gitlabci/job_hip5.3.yml
@@ -8,7 +8,7 @@ linux_hip5.3_clang_debug_hip_only:
     CMAKE_BUILD_TYPE: Debug
     ALPAKA_BOOST_VERSION: 1.79.0
     ALPAKA_CI_CMAKE_VER: 3.23.5
-  stage: stageCompile0
+
 
 linux_hip5.3_clang_release_hip_only:
   extends: .base_hip
@@ -19,4 +19,3 @@ linux_hip5.3_clang_release_hip_only:
     CMAKE_BUILD_TYPE: Release
     ALPAKA_BOOST_VERSION: 1.80.0
     ALPAKA_CI_CMAKE_VER: 3.24.3
-  stage: stageRun0


### PR DESCRIPTION
- disable execution of tests for many jobs to speedup the CI (there is no fixed rules which job is compile only)
- remove the stage from the configuration because the job creation tool is ignoreing the stage