### PR TITLE
Replace ConcurrentExecPool by CallbackThread in all queues

### DIFF
--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -81,11 +81,6 @@ namespace alpaka
             m_spDevCpuImpl->registerQueue(spQueue);
         }
 
-        auto registerCleanup(cpu::detail::DevCpuImpl::CleanerFunctor c) const -> void
-        {
-            m_spDevCpuImpl->registerCleanup(c);
-        }
-
         [[nodiscard]] auto getNativeHandle() const noexcept
         {
             return 0;

--- a/include/alpaka/dev/common/QueueRegistry.hpp
+++ b/include/alpaka/dev/common/QueueRegistry.hpp
@@ -11,51 +11,47 @@
 #include <memory>
 #include <mutex>
 
-namespace alpaka
+namespace alpaka::detail
 {
-    namespace detail
+    //! The CPU device implementation.
+    template<typename TQueue>
+    struct QueueRegistry
     {
-        //! The CPU device implementation.
-        template<typename TQueue>
-        class QueueRegistry
+        ALPAKA_FN_HOST auto getAllExistingQueues() const -> std::vector<std::shared_ptr<TQueue>>
         {
-        public:
-            ALPAKA_FN_HOST auto getAllExistingQueues() const -> std::vector<std::shared_ptr<TQueue>>
+            std::vector<std::shared_ptr<TQueue>> vspQueues;
+
+            std::lock_guard<std::mutex> lk(m_Mutex);
+            vspQueues.reserve(std::size(m_queues));
+
+            for(auto it = std::begin(m_queues); it != std::end(m_queues);)
             {
-                std::vector<std::shared_ptr<TQueue>> vspQueues;
-
-                std::lock_guard<std::mutex> lk(m_Mutex);
-                vspQueues.reserve(std::size(m_queues));
-
-                for(auto it = std::begin(m_queues); it != std::end(m_queues);)
+                auto spQueue = it->lock();
+                if(spQueue)
                 {
-                    auto spQueue = it->lock();
-                    if(spQueue)
-                    {
-                        vspQueues.emplace_back(std::move(spQueue));
-                        ++it;
-                    }
-                    else
-                    {
-                        it = m_queues.erase(it);
-                    }
+                    vspQueues.emplace_back(std::move(spQueue));
+                    ++it;
                 }
-                return vspQueues;
+                else
+                {
+                    it = m_queues.erase(it);
+                }
             }
+            return vspQueues;
+        }
 
-            //! Registers the given queue on this device.
-            //! NOTE: Every queue has to be registered for correct functionality of device wait operations!
-            ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<TQueue> const& spQueue) const -> void
-            {
-                std::lock_guard<std::mutex> lk(m_Mutex);
+        //! Registers the given queue on this device.
+        //! NOTE: Every queue has to be registered for correct functionality of device wait operations!
+        ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<TQueue> const& spQueue) const -> void
+        {
+            std::lock_guard<std::mutex> lk(m_Mutex);
 
-                // Register this queue on the device.
-                m_queues.push_back(spQueue);
-            }
+            // Register this queue on the device.
+            m_queues.push_back(spQueue);
+        }
 
-        private:
-            std::mutex mutable m_Mutex;
-            std::deque<std::weak_ptr<TQueue>> mutable m_queues;
-        };
-    } // namespace detail
-} // namespace alpaka
+    private:
+        std::mutex mutable m_Mutex;
+        std::deque<std::weak_ptr<TQueue>> mutable m_queues;
+    };
+} // namespace alpaka::detail

--- a/include/alpaka/dev/common/QueueRegistry.hpp
+++ b/include/alpaka/dev/common/QueueRegistry.hpp
@@ -53,42 +53,6 @@ namespace alpaka
                 m_queues.push_back(spQueue);
             }
 
-            using CleanerFunctor = std::function<void()>;
-            static ALPAKA_FN_HOST auto registerCleanup(CleanerFunctor cleaner) -> void
-            {
-                class CleanupList
-                {
-                    std::mutex m_mutex;
-                    std::deque<CleanerFunctor> mutable m_cleanup;
-
-                public:
-                    ~CleanupList()
-                    {
-                        for(auto& c : m_cleanup)
-                        {
-                            c();
-                        }
-                    }
-
-                    void push(CleanerFunctor&& c)
-                    {
-                        std::lock_guard<std::mutex> lk(m_mutex);
-
-                        m_cleanup.emplace_back(std::move(c));
-                    }
-                };
-#if BOOST_COMP_CLANG
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wexit-time-destructors" // running this at exit time is the point
-#endif
-                static CleanupList cleanupList;
-#if BOOST_COMP_CLANG
-#    pragma clang diagnostic pop
-#endif
-
-                cleanupList.push(std::move(cleaner));
-            }
-
         private:
             std::mutex mutable m_Mutex;
             std::deque<std::weak_ptr<TQueue>> mutable m_queues;

--- a/include/alpaka/event/EventGenericThreads.hpp
+++ b/include/alpaka/event/EventGenericThreads.hpp
@@ -144,8 +144,8 @@ namespace alpaka
                 auto const enqueueCount = spEventImpl->m_enqueueCount;
 
                 // Enqueue a task that only resets the events flag if it is completed.
-                spEventImpl->m_future = queueImpl.m_workerThread->enqueueTask(
-                    [spEventImpl, enqueueCount]()
+                spEventImpl->m_future = queueImpl.m_workerThread.submit(
+                    [spEventImpl, enqueueCount]() mutable
                     {
                         std::unique_lock<std::mutex> lk2(spEventImpl->m_mutex);
 
@@ -154,6 +154,8 @@ namespace alpaka
                         {
                             spEventImpl->m_LastReadyEnqueueCount = spEventImpl->m_enqueueCount;
                         }
+                        spEventImpl
+                            .reset(); // avoid keeping the event alive as part of the background thread task's future
                     });
             }
         };
@@ -297,11 +299,13 @@ namespace alpaka
                     auto const enqueueCount = spEventImpl->m_enqueueCount;
 
                     // Enqueue a task that waits for the given event.
-                    queueImpl.m_workerThread->enqueueTask(
-                        [spEventImpl, enqueueCount]()
+                    queueImpl.m_workerThread.submit(
+                        [spEventImpl, enqueueCount]() mutable
                         {
                             std::unique_lock<std::mutex> lk2(spEventImpl->m_mutex);
                             spEventImpl->wait(enqueueCount, lk2);
+                            spEventImpl.reset(); // avoid keeping the event alive as part of the background thread
+                                                 // task's future
                         });
                 }
             }

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRt.hpp
@@ -63,10 +63,10 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                // In case the device is still doing work in the queue when cuda/hip-StreamDestroy() is called, the
-                // function will return immediately and the resources associated with queue will be released
-                // automatically once the device has completed all work in queue.
-                // -> No need to synchronize here.
+                // Make sure all pending async work is finished before destroying the stream to guarantee determinism.
+                // This would not be necessary for plain CUDA/HIP operations, but we can have host functions in the
+                // stream, which reference this queue instance and its CallbackThread. Make sure they are done.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::streamSynchronize(m_UniformCudaHipQueue));
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::streamDestroy(m_UniformCudaHipQueue));
             }
 
@@ -185,86 +185,43 @@ namespace alpaka
         template<typename TApi, bool TBlocking, typename TTask>
         struct Enqueue<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>, TTask>
         {
-            enum class CallbackState
-            {
-                enqueued,
-                notified,
-                finished,
-            };
+            using QueueImpl = uniform_cuda_hip::detail::QueueUniformCudaHipRtImpl<TApi>;
 
-            struct CallbackSynchronizationData : public std::enable_shared_from_this<CallbackSynchronizationData>
+            struct HostFuncData
             {
-                std::mutex m_mutex;
-                std::condition_variable m_event;
-                CallbackState m_state = CallbackState::enqueued;
+                // We don't need to keep the queue alive, because in it's dtor it will synchronize with the CUDA/HIP
+                // stream and wait until all host functions and the CallbackThread are done. It's actually an error to
+                // copy the queue into the host function. Destroying it here would call CUDA/HIP APIs from the host
+                // function. Passing it further to the Callback thread, would make the Callback thread hold a task
+                // containing the queue with the CallbackThread itself. Destroying the task if no other queue instance
+                // exists will make the CallbackThread join itself and crash.
+                QueueImpl& q;
+                TTask t;
             };
 
             ALPAKA_FN_HOST static void uniformCudaHipRtHostFunc(void* arg)
             {
-                // explicitly copy the shared_ptr so that this method holds the state even when the executing thread
-                // has already finished.
-                auto const spCallbackSynchronizationData
-                    = reinterpret_cast<CallbackSynchronizationData*>(arg)->shared_from_this();
-
-                // Notify the executing thread.
-                {
-                    std::unique_lock<std::mutex> lock(spCallbackSynchronizationData->m_mutex);
-                    spCallbackSynchronizationData->m_state = CallbackState::notified;
-                }
-                spCallbackSynchronizationData->m_event.notify_one();
-
-                // Wait for the executing thread to finish the task if it has not already finished.
-                std::unique_lock<std::mutex> lock(spCallbackSynchronizationData->m_mutex);
-                if(spCallbackSynchronizationData->m_state != CallbackState::finished)
-                {
-                    spCallbackSynchronizationData->m_event.wait(
-                        lock,
-                        [&spCallbackSynchronizationData]()
-                        { return spCallbackSynchronizationData->m_state == CallbackState::finished; });
-                }
-            }
+                auto data = std::unique_ptr<HostFuncData>(reinterpret_cast<HostFuncData*>(arg));
+                auto& queue = data->q;
+                auto f = queue.m_callbackThread.submit(
+                    [data = std::move(data)]() mutable
+                    {
+                        data->t();
+                        data.reset(); // destroy the task
+                    });
+                f.wait();
+            } // destroys the future `f`, destroying the packaged task and the above lambda
 
             ALPAKA_FN_HOST static auto enqueue(
                 uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>& queue,
                 TTask const& task) -> void
             {
-                auto spCallbackSynchronizationData = std::make_shared<CallbackSynchronizationData>();
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::launchHostFunc(
                     queue.getNativeHandle(),
                     uniformCudaHipRtHostFunc,
-                    spCallbackSynchronizationData.get()));
-
-                // We start a new std::thread which stores the task to be executed.
-                // This circumvents the limitation that it is not possible to call CUDA/HIP methods within the CUDA/HIP
-                // callback thread. The CUDA/HIP thread signals the std::thread when it is ready to execute the task.
-                // The CUDA/HIP thread is waiting for the std::thread to signal that it is finished executing the task
-                // before it executes the next task in the queue (CUDA/HIP stream).
-                auto f = queue.getCallbackThread().submit(
-                    [spCallbackSynchronizationData, task]()
-                    {
-                        // If the callback has not yet been called, we wait for it.
-                        {
-                            std::unique_lock<std::mutex> lock(spCallbackSynchronizationData->m_mutex);
-                            if(spCallbackSynchronizationData->m_state != CallbackState::notified)
-                            {
-                                spCallbackSynchronizationData->m_event.wait(
-                                    lock,
-                                    [&spCallbackSynchronizationData]()
-                                    { return spCallbackSynchronizationData->m_state == CallbackState::notified; });
-                            }
-
-                            task();
-
-                            // Notify the waiting CUDA/HIP thread.
-                            spCallbackSynchronizationData->m_state = CallbackState::finished;
-                        }
-                        spCallbackSynchronizationData->m_event.notify_one();
-                    });
-
+                    new HostFuncData{*queue.m_spQueueImpl, task}));
                 if constexpr(TBlocking)
-                {
-                    f.wait();
-                }
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::streamSynchronize(queue.getNativeHandle()));
             }
         };
 

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -8,6 +8,7 @@
 #include <alpaka/test/queue/QueueCpuOmp2Collective.hpp>
 #include <alpaka/test/queue/QueueTestFixture.hpp>
 
+#include <catch2/benchmark/catch_benchmark.hpp>
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
@@ -195,4 +196,21 @@ TEMPLATE_LIST_TEST_CASE("nonBlockingQueueShouldNotRunPastProgramTermination", "[
                 std::cout << "END not-awaited task in Queue '" << name << "'" << std::endl;
             });
     }
+}
+
+TEMPLATE_LIST_TEST_CASE("enqueueBenchmark", "[queue]", alpaka::test::TestQueues)
+{
+    using DevQueue = TestType;
+    using Fixture = alpaka::test::QueueTestFixture<DevQueue>;
+    Fixture f;
+
+    constexpr auto reps = 1000;
+    BENCHMARK("Enqueue " + std::to_string(reps))
+    {
+        std::atomic<int> count = 0;
+        for(int i = 0; i < reps; i++)
+            alpaka::enqueue(f.m_queue, [&]() noexcept { ++count; });
+        alpaka::wait(f.m_queue);
+        return count.load();
+    };
 }


### PR DESCRIPTION
This PR replaces `ConcurrentExecPool` as a background thread inside `QueueGenericThreadsNonBlockingImpl` by the much simpler `CallbackThread`. Furthermore, since it is no longer necessary, the detaching logic in `ConcurrentExecPool` is removed. The implementation for `Enqueue` for `QueueUniformCudaHipRt` is also vastly simplified.

This PR causes one change in behavior: the destructor of a non-blocking queue will now block until all tasks in the queue are completed. This is required to ensure deterministic lifetime and destruction of queues, background threads, tasks, etc. If we are fine with this new behavior, we should also cover it by a unit test.

This changeset fixes several issues reported by TSAN (see #1936), although it does not completely fix all errors. I am suspecting there could be some remaining false positives.

Depends on:

- [x] Merge #1975 first
- [x] Merge #1987 first

When this PR is merged, `ConcurrentExecPool` is only used in one place anymore, as a yielding thread pool for running CPU kernels of the Threads backend. I think we could cut down the class to it's new purpose and potentially optimize performance. 