### PR TITLE
Use `hipLaunchHostFunc` with HIP 5.4.0 and later

### DIFF
--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -263,8 +263,14 @@ namespace alpaka
 
         static inline Error_t launchHostFunc(Stream_t stream, HostFn_t fn, void* userData)
         {
+            // hipLaunchHostFunc is implemented only in ROCm 5.4.0 and later.
+#    if BOOST_LANG_HIP >= BOOST_VERSION_NUMBER(5, 4, 0)
+            // Wrap the host function using the proper calling convention.
+            return ::hipLaunchHostFunc(stream, HostFnAdaptor::hostFunction, new HostFnAdaptor{fn, userData});
+#    else
             // Emulate hipLaunchHostFunc using hipStreamAddCallback with a callback adaptor.
             return ::hipStreamAddCallback(stream, HostFnAdaptor::streamCallback, new HostFnAdaptor{fn, userData}, 0);
+#    endif
         }
 
         static inline Error_t malloc(void** devPtr, size_t size)


### PR DESCRIPTION
HIP 5.2.0 [introduced](https://docs.amd.com/en-US/bundle/ROCm-Release-Notes-v5.2/page/What%E2%80%99s_New_in_This_Release.html#d678e602) `hipLaunchHostFunc` as the equivalent to `cudaLaunchHostFunc`.

However, while `hip_runtime_api.h` does define it starting from ROCm 5.2.0, `libamdhip64.so` implements it only starting from ROCm 5.4.0 .