### PR TITLE
fix icpx error implicit conversion

### DIFF
--- a/include/alpaka/rand/RandDefault.hpp
+++ b/include/alpaka/rand/RandDefault.hpp
@@ -137,7 +137,8 @@ namespace alpaka::rand
             template<typename TEngine>
             ALPAKA_FN_HOST_ACC auto operator()(TEngine& engine) -> T
             {
-                constexpr T sigma = 1., mu = 0.;
+                constexpr auto sigma = T{1};
+                constexpr auto mu = T{0};
                 if(math::isnan(*m_acc, m_cache))
                 {
                     UniformReal<T> uni;

--- a/test/integ/axpy/src/axpy.cpp
+++ b/test/integ/axpy/src/axpy.cpp
@@ -124,7 +124,7 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
     std::random_device rd{};
     auto const seed = rd();
     std::default_random_engine eng{seed};
-    std::uniform_real_distribution<Val> dist(0.0, 1.0);
+    std::uniform_real_distribution<Val> dist(Val{0}, Val{1});
     std::cout << "using seed: " << seed << "\n";
     // Initialize the host input vectors
     for(Idx i(0); i < numElements; ++i)

--- a/test/unit/math/src/DataGen.hpp
+++ b/test/unit/math/src/DataGen.hpp
@@ -67,7 +67,7 @@ namespace alpaka
                 {
                     auto getMax()
                     {
-                        return Complex<TData>{10.0, 10.0};
+                        return Complex<TData>{TData{10}, TData{10}};
                     }
 
                     auto getLowest()
@@ -140,13 +140,13 @@ namespace alpaka
                             args(0).arg[k] = max;
                             for(size_t i = 1; i < TArgs::capacity; ++i)
                             {
-                                args(i).arg[k] = rngWrapper.getNumber(dist, eng) + static_cast<TData>(1);
+                                args(i).arg[k] = rngWrapper.getNumber(dist, eng) + TData{1};
                             }
                             break;
 
                         case Range::PositiveAndZero:
                             matchedSwitch = true;
-                            args(0).arg[k] = 0.0;
+                            args(0).arg[k] = TData{0};
                             args(1).arg[k] = max;
                             for(size_t i = 2; i < TArgs::capacity; ++i)
                             {
@@ -174,7 +174,7 @@ namespace alpaka
 
                         case Range::Unrestricted:
                             matchedSwitch = true;
-                            args(0).arg[k] = 0.0;
+                            args(0).arg[k] = TData{0};
                             args(1).arg[k] = max;
                             args(2).arg[k] = low;
                             for(size_t i = 3; i < TArgs::capacity; ++i)
@@ -188,7 +188,7 @@ namespace alpaka
 
                         case Range::Anything:
                             matchedSwitch = true;
-                            args(0).arg[k] = 0.0;
+                            args(0).arg[k] = TData{0};
                             args(1).arg[k] = std::numeric_limits<TData>::quiet_NaN();
                             args(2).arg[k] = std::numeric_limits<TData>::signaling_NaN();
                             args(3).arg[k] = std::numeric_limits<TData>::infinity();

--- a/test/unit/math/src/FloatEqualExactTest.cpp
+++ b/test/unit/math/src/FloatEqualExactTest.cpp
@@ -43,7 +43,7 @@ TEMPLATE_LIST_TEST_CASE("floatEqualExactTest", "[math]", alpaka::test::TestAccs)
     // In case REQUIRE were ever somehow modified to silence the warning by itself.
     bool testValue = false;
 
-    float floatValue = -1.0;
+    float floatValue = -1.0f;
     testValue = alpaka::math::floatEqualExactNoWarning(floatValue, -1.0f);
     REQUIRE(testValue);
 

--- a/test/unit/math/src/sincos.cpp
+++ b/test/unit/math/src/sincos.cpp
@@ -32,8 +32,8 @@ public:
         // (PTX kernel (float) was just empty)
         FP check_sin = alpaka::math::sin(acc, arg);
         FP check_cos = alpaka::math::cos(acc, arg);
-        FP result_sin = 0.;
-        FP result_cos = 0.;
+        auto result_sin = FP{0};
+        auto result_cos = FP{0};
         alpaka::math::sincos(acc, arg, result_sin, result_cos);
         using alpaka::test::unit::math::almost_equal;
         ALPAKA_CHECK(


### PR DESCRIPTION
```
test/integ/axpy/src/axpy.cpp:127:46: error: implicit conversion between floating point types of different sizes [-Werror,-Wimplicit-float-size-conversion]
8627
    std::uniform_real_distribution<Val> dist(0.0, 1.0);
8628
                                        ~~~~ ^~~
```