### PR TITLE
Remove experimental namespace from SYCL

### DIFF
--- a/include/alpaka/acc/AccCpuSyclIntel.hpp
+++ b/include/alpaka/acc/AccCpuSyclIntel.hpp
@@ -25,7 +25,7 @@
 #    include <string>
 #    include <utility>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The Intel CPU SYCL accelerator.
     //!
@@ -38,34 +38,34 @@ namespace alpaka::experimental
     public:
         using AccGenericSycl<TDim, TIdx>::AccGenericSycl;
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The Intel CPU SYCL accelerator name trait specialization.
     template<typename TDim, typename TIdx>
-    struct GetAccName<experimental::AccCpuSyclIntel<TDim, TIdx>>
+    struct GetAccName<AccCpuSyclIntel<TDim, TIdx>>
     {
         static auto getAccName() -> std::string
         {
-            return "experimental::AccCpuSyclIntel<" + std::to_string(TDim::value) + "," + core::demangled<TIdx> + ">";
+            return "AccCpuSyclIntel<" + std::to_string(TDim::value) + "," + core::demangled<TIdx> + ">";
         }
     };
 
     //! The Intel CPU SYCL accelerator device type trait specialization.
     template<typename TDim, typename TIdx>
-    struct DevType<experimental::AccCpuSyclIntel<TDim, TIdx>>
+    struct DevType<AccCpuSyclIntel<TDim, TIdx>>
     {
-        using type = experimental::DevCpuSyclIntel;
+        using type = DevCpuSyclIntel;
     };
 
     //! The Intel CPU SYCL accelerator execution task type trait specialization.
     template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-    struct CreateTaskKernel<experimental::AccCpuSyclIntel<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+    struct CreateTaskKernel<AccCpuSyclIntel<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
     {
         static auto createTaskKernel(TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
         {
-            return experimental::TaskKernelCpuSyclIntel<TDim, TIdx, TKernelFnObj, TArgs...>{
+            return TaskKernelCpuSyclIntel<TDim, TIdx, TKernelFnObj, TArgs...>{
                 workDiv,
                 kernelFnObj,
                 std::forward<TArgs>(args)...};
@@ -74,13 +74,13 @@ namespace alpaka::trait
 
     //! The Intel CPU SYCL execution task platform type trait specialization.
     template<typename TDim, typename TIdx>
-    struct PltfType<experimental::AccCpuSyclIntel<TDim, TIdx>>
+    struct PltfType<AccCpuSyclIntel<TDim, TIdx>>
     {
-        using type = experimental::PltfCpuSyclIntel;
+        using type = PltfCpuSyclIntel;
     };
 
     template<typename TDim, typename TIdx>
-    struct AccToTag<alpaka::experimental::AccCpuSyclIntel<TDim, TIdx>>
+    struct AccToTag<alpaka::AccCpuSyclIntel<TDim, TIdx>>
     {
         using type = alpaka::TagCpuSyclIntel;
     };
@@ -88,7 +88,7 @@ namespace alpaka::trait
     template<typename TDim, typename TIdx>
     struct TagToAcc<alpaka::TagCpuSyclIntel, TDim, TIdx>
     {
-        using type = alpaka::experimental::AccCpuSyclIntel<TDim, TIdx>;
+        using type = alpaka::AccCpuSyclIntel<TDim, TIdx>;
     };
 } // namespace alpaka::trait
 

--- a/include/alpaka/acc/AccFpgaSyclIntel.hpp
+++ b/include/alpaka/acc/AccFpgaSyclIntel.hpp
@@ -24,7 +24,7 @@
 #    include <string>
 #    include <utility>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The Intel FPGA SYCL accelerator.
     //!
@@ -37,34 +37,34 @@ namespace alpaka::experimental
     public:
         using AccGenericSycl<TDim, TIdx>::AccGenericSycl;
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The Intel FPGA SYCL accelerator name trait specialization.
     template<typename TDim, typename TIdx>
-    struct GetAccName<experimental::AccFpgaSyclIntel<TDim, TIdx>>
+    struct GetAccName<AccFpgaSyclIntel<TDim, TIdx>>
     {
         ALPAKA_FN_HOST static auto getAccName() -> std::string
         {
-            return "experimental::AccFpgaSyclIntel<" + std::to_string(TDim::value) + "," + core::demangled<TIdx> + ">";
+            return "AccFpgaSyclIntel<" + std::to_string(TDim::value) + "," + core::demangled<TIdx> + ">";
         }
     };
 
     //! The Intel FPGA SYCL accelerator device type trait specialization.
     template<typename TDim, typename TIdx>
-    struct DevType<experimental::AccFpgaSyclIntel<TDim, TIdx>>
+    struct DevType<AccFpgaSyclIntel<TDim, TIdx>>
     {
-        using type = experimental::DevFpgaSyclIntel;
+        using type = DevFpgaSyclIntel;
     };
 
     //! The Intel FPGA SYCL accelerator execution task type trait specialization.
     template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-    struct CreateTaskKernel<experimental::AccFpgaSyclIntel<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+    struct CreateTaskKernel<AccFpgaSyclIntel<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
     {
         static auto createTaskKernel(TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
         {
-            return experimental::TaskKernelFpgaSyclIntel<TDim, TIdx, TKernelFnObj, TArgs...>{
+            return TaskKernelFpgaSyclIntel<TDim, TIdx, TKernelFnObj, TArgs...>{
                 workDiv,
                 kernelFnObj,
                 std::forward<TArgs>(args)...};
@@ -73,13 +73,13 @@ namespace alpaka::trait
 
     //! The Intel FPGA SYCL execution task platform type trait specialization.
     template<typename TDim, typename TIdx>
-    struct PltfType<experimental::AccFpgaSyclIntel<TDim, TIdx>>
+    struct PltfType<AccFpgaSyclIntel<TDim, TIdx>>
     {
-        using type = experimental::PltfFpgaSyclIntel;
+        using type = PltfFpgaSyclIntel;
     };
 
     template<typename TDim, typename TIdx>
-    struct AccToTag<alpaka::experimental::AccFpgaSyclIntel<TDim, TIdx>>
+    struct AccToTag<alpaka::AccFpgaSyclIntel<TDim, TIdx>>
     {
         using type = alpaka::TagFpgaSyclIntel;
     };
@@ -87,7 +87,7 @@ namespace alpaka::trait
     template<typename TDim, typename TIdx>
     struct TagToAcc<alpaka::TagFpgaSyclIntel, TDim, TIdx>
     {
-        using type = alpaka::experimental::AccFpgaSyclIntel<TDim, TIdx>;
+        using type = alpaka::AccFpgaSyclIntel<TDim, TIdx>;
     };
 } // namespace alpaka::trait
 

--- a/include/alpaka/acc/AccFpgaSyclXilinx.hpp
+++ b/include/alpaka/acc/AccFpgaSyclXilinx.hpp
@@ -24,7 +24,7 @@
 #    include <string>
 #    include <utility>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The Xilinx FPGA SYCL accelerator.
     //!
@@ -37,35 +37,34 @@ namespace alpaka::experimental
     public:
         using AccGenericSycl<TDim, TIdx>::AccGenericSycl;
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The Xilinx FPGA SYCL accelerator name trait specialization.
     template<typename TDim, typename TIdx>
-    struct GetAccName<experimental::AccFpgaSyclXilinx<TDim, TIdx>>
+    struct GetAccName<AccFpgaSyclXilinx<TDim, TIdx>>
     {
         static auto getAccName() -> std::string
         {
-            return "experimental::AccFpgaSyclXilinx<" + std::to_string(TDim::value) + ","
-                   + core::demangled<TIdx> + ">";
+            return "AccFpgaSyclXilinx<" + std::to_string(TDim::value) + "," + core::demangled<TIdx> + ">";
         }
     };
 
     //! The Xilinx FPGA SYCL accelerator device type trait specialization.
     template<typename TDim, typename TIdx>
-    struct DevType<experimental::AccFpgaSyclXilinx<TDim, TIdx>>
+    struct DevType<AccFpgaSyclXilinx<TDim, TIdx>>
     {
-        using type = experimental::DevFpgaSyclXilinx;
+        using type = DevFpgaSyclXilinx;
     };
 
     //! The Xilinx FPGA SYCL accelerator execution task type trait specialization.
     template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-    struct CreateTaskKernel<experimental::AccFpgaSyclXilinx<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+    struct CreateTaskKernel<AccFpgaSyclXilinx<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
     {
         static auto createTaskKernel(TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
         {
-            return experimental::TaskKernelFpgaSyclXilinx<TDim, TIdx, TKernelFnObj, TArgs...>{
+            return TaskKernelFpgaSyclXilinx<TDim, TIdx, TKernelFnObj, TArgs...>{
                 workDiv,
                 kernelFnObj,
                 std::forward<TArgs>(args)...};
@@ -74,13 +73,13 @@ namespace alpaka::trait
 
     //! The Xilinx FPGA SYCL execution task platform type trait specialization.
     template<typename TDim, typename TIdx>
-    struct PltfType<experimental::AccFpgaSyclXilinx<TDim, TIdx>>
+    struct PltfType<AccFpgaSyclXilinx<TDim, TIdx>>
     {
-        using type = experimental::PltfFpgaSyclXilinx;
+        using type = PltfFpgaSyclXilinx;
     };
 
     template<typename TDim, typename TIdx>
-    struct AccToTag<alpaka::experimental::AccFpgaSyclXilinx<TDim, TIdx>>
+    struct AccToTag<alpaka::AccFpgaSyclXilinx<TDim, TIdx>>
     {
         using type = alpaka::TagFpgaSyclXilinx;
     };
@@ -88,7 +87,7 @@ namespace alpaka::trait
     template<typename TDim, typename TIdx>
     struct TagToAcc<alpaka::TagFpgaSyclXilinx, TDim, TIdx>
     {
-        using type = alpaka::experimental::AccFpgaSyclXilinx<TDim, TIdx>;
+        using type = alpaka::AccFpgaSyclXilinx<TDim, TIdx>;
     };
 } // namespace alpaka::trait
 

--- a/include/alpaka/acc/AccGenericSycl.hpp
+++ b/include/alpaka/acc/AccGenericSycl.hpp
@@ -40,7 +40,7 @@
 #    include <string>
 #    include <type_traits>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The SYCL accelerator.
     //!
@@ -113,15 +113,13 @@ namespace alpaka::experimental
         }
 #    endif
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The SYCL accelerator type trait specialization.
     template<template<typename, typename> typename TAcc, typename TDim, typename TIdx>
-    struct AccType<
-        TAcc<TDim, TIdx>,
-        std::enable_if_t<std::is_base_of_v<experimental::AccGenericSycl<TDim, TIdx>, TAcc<TDim, TIdx>>>>
+    struct AccType<TAcc<TDim, TIdx>, std::enable_if_t<std::is_base_of_v<AccGenericSycl<TDim, TIdx>, TAcc<TDim, TIdx>>>>
     {
         using type = TAcc<TDim, TIdx>;
     };
@@ -130,7 +128,7 @@ namespace alpaka::trait
     template<template<typename, typename> typename TAcc, typename TDim, typename TIdx>
     struct GetAccDevProps<
         TAcc<TDim, TIdx>,
-        std::enable_if_t<std::is_base_of_v<experimental::AccGenericSycl<TDim, TIdx>, TAcc<TDim, TIdx>>>>
+        std::enable_if_t<std::is_base_of_v<AccGenericSycl<TDim, TIdx>, TAcc<TDim, TIdx>>>>
     {
         static auto getAccDevProps(typename DevType<TAcc<TDim, TIdx>>::type const& dev) -> AccDevProps<TDim, TIdx>
         {
@@ -164,18 +162,14 @@ namespace alpaka::trait
 
     //! The SYCL accelerator dimension getter trait specialization.
     template<template<typename, typename> typename TAcc, typename TDim, typename TIdx>
-    struct DimType<
-        TAcc<TDim, TIdx>,
-        std::enable_if_t<std::is_base_of_v<experimental::AccGenericSycl<TDim, TIdx>, TAcc<TDim, TIdx>>>>
+    struct DimType<TAcc<TDim, TIdx>, std::enable_if_t<std::is_base_of_v<AccGenericSycl<TDim, TIdx>, TAcc<TDim, TIdx>>>>
     {
         using type = TDim;
     };
 
     //! The SYCL accelerator idx type trait specialization.
     template<template<typename, typename> typename TAcc, typename TDim, typename TIdx>
-    struct IdxType<
-        TAcc<TDim, TIdx>,
-        std::enable_if_t<std::is_base_of_v<experimental::AccGenericSycl<TDim, TIdx>, TAcc<TDim, TIdx>>>>
+    struct IdxType<TAcc<TDim, TIdx>, std::enable_if_t<std::is_base_of_v<AccGenericSycl<TDim, TIdx>, TAcc<TDim, TIdx>>>>
     {
         using type = TIdx;
     };

--- a/include/alpaka/acc/AccGpuSyclIntel.hpp
+++ b/include/alpaka/acc/AccGpuSyclIntel.hpp
@@ -24,7 +24,7 @@
 #    include <string>
 #    include <utility>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The Intel GPU SYCL accelerator.
     //!
@@ -37,34 +37,34 @@ namespace alpaka::experimental
     public:
         using AccGenericSycl<TDim, TIdx>::AccGenericSycl;
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The Intel GPU SYCL accelerator name trait specialization.
     template<typename TDim, typename TIdx>
-    struct GetAccName<experimental::AccGpuSyclIntel<TDim, TIdx>>
+    struct GetAccName<AccGpuSyclIntel<TDim, TIdx>>
     {
         static auto getAccName() -> std::string
         {
-            return "experimental::AccGpuSyclIntel<" + std::to_string(TDim::value) + "," + core::demangled<TIdx> + ">";
+            return "AccGpuSyclIntel<" + std::to_string(TDim::value) + "," + core::demangled<TIdx> + ">";
         }
     };
 
     //! The Intel GPU SYCL accelerator device type trait specialization.
     template<typename TDim, typename TIdx>
-    struct DevType<experimental::AccGpuSyclIntel<TDim, TIdx>>
+    struct DevType<AccGpuSyclIntel<TDim, TIdx>>
     {
-        using type = experimental::DevGpuSyclIntel;
+        using type = DevGpuSyclIntel;
     };
 
     //! The Intel GPU SYCL accelerator execution task type trait specialization.
     template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-    struct CreateTaskKernel<experimental::AccGpuSyclIntel<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+    struct CreateTaskKernel<AccGpuSyclIntel<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
     {
         static auto createTaskKernel(TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
         {
-            return experimental::TaskKernelGpuSyclIntel<TDim, TIdx, TKernelFnObj, TArgs...>{
+            return TaskKernelGpuSyclIntel<TDim, TIdx, TKernelFnObj, TArgs...>{
                 workDiv,
                 kernelFnObj,
                 std::forward<TArgs>(args)...};
@@ -73,13 +73,13 @@ namespace alpaka::trait
 
     //! The Intel GPU SYCL execution task platform type trait specialization.
     template<typename TDim, typename TIdx>
-    struct PltfType<experimental::AccGpuSyclIntel<TDim, TIdx>>
+    struct PltfType<AccGpuSyclIntel<TDim, TIdx>>
     {
-        using type = experimental::PltfGpuSyclIntel;
+        using type = PltfGpuSyclIntel;
     };
 
     template<typename TDim, typename TIdx>
-    struct AccToTag<alpaka::experimental::AccGpuSyclIntel<TDim, TIdx>>
+    struct AccToTag<alpaka::AccGpuSyclIntel<TDim, TIdx>>
     {
         using type = alpaka::TagGpuSyclIntel;
     };
@@ -87,7 +87,7 @@ namespace alpaka::trait
     template<typename TDim, typename TIdx>
     struct TagToAcc<alpaka::TagGpuSyclIntel, TDim, TIdx>
     {
-        using type = alpaka::experimental::AccGpuSyclIntel<TDim, TIdx>;
+        using type = alpaka::AccGpuSyclIntel<TDim, TIdx>;
     };
 } // namespace alpaka::trait
 

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynGenericSycl.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynGenericSycl.hpp
@@ -13,7 +13,7 @@
 
 #    include <cstddef>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The SYCL block shared memory allocator.
     class BlockSharedMemDynGenericSycl
@@ -30,14 +30,14 @@ namespace alpaka::experimental
 
         sycl::accessor<std::byte, 1, sycl::access::mode::read_write, sycl::access::target::local> m_accessor;
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     template<typename T>
-    struct GetDynSharedMem<T, experimental::BlockSharedMemDynGenericSycl>
+    struct GetDynSharedMem<T, BlockSharedMemDynGenericSycl>
     {
-        static auto getMem(experimental::BlockSharedMemDynGenericSycl const& shared) -> T*
+        static auto getMem(BlockSharedMemDynGenericSycl const& shared) -> T*
         {
             auto void_ptr = sycl::multi_ptr<void, sycl::access::address_space::local_space>{shared.m_accessor};
             auto t_ptr = static_cast<sycl::multi_ptr<T, sycl::access::address_space::local_space>>(void_ptr);

--- a/include/alpaka/block/shared/st/BlockSharedMemStGenericSycl.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStGenericSycl.hpp
@@ -14,7 +14,7 @@
 
 #    include <cstdint>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The generic SYCL shared memory allocator.
     class BlockSharedMemStGenericSycl
@@ -34,14 +34,14 @@ namespace alpaka::experimental
     private:
         sycl::accessor<std::byte, 1, sycl::access_mode::read_write, sycl::target::local> m_accessor;
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     template<typename T, std::size_t TUniqueId>
-    struct DeclareSharedVar<T, TUniqueId, experimental::BlockSharedMemStGenericSycl>
+    struct DeclareSharedVar<T, TUniqueId, BlockSharedMemStGenericSycl>
     {
-        static auto declareVar(experimental::BlockSharedMemStGenericSycl const& smem) -> T&
+        static auto declareVar(BlockSharedMemStGenericSycl const& smem) -> T&
         {
             auto* data = smem.template getVarPtr<T>(TUniqueId);
 
@@ -56,9 +56,9 @@ namespace alpaka::trait
     };
 
     template<>
-    struct FreeSharedVars<experimental::BlockSharedMemStGenericSycl>
+    struct FreeSharedVars<BlockSharedMemStGenericSycl>
     {
-        static auto freeVars(experimental::BlockSharedMemStGenericSycl const&) -> void
+        static auto freeVars(BlockSharedMemStGenericSycl const&) -> void
         {
             // shared memory block data will be reused
         }

--- a/include/alpaka/block/sync/BlockSyncGenericSycl.hpp
+++ b/include/alpaka/block/sync/BlockSyncGenericSycl.hpp
@@ -10,7 +10,7 @@
 
 #    include <CL/sycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The SYCL block synchronization.
     template<typename TDim>
@@ -25,24 +25,23 @@ namespace alpaka::experimental
 
         sycl::nd_item<TDim::value> my_item;
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     template<typename TDim>
-    struct SyncBlockThreads<experimental::BlockSyncGenericSycl<TDim>>
+    struct SyncBlockThreads<BlockSyncGenericSycl<TDim>>
     {
-        static auto syncBlockThreads(experimental::BlockSyncGenericSycl<TDim> const& blockSync) -> void
+        static auto syncBlockThreads(BlockSyncGenericSycl<TDim> const& blockSync) -> void
         {
             blockSync.my_item.barrier();
         }
     };
 
     template<typename TDim>
-    struct SyncBlockThreadsPredicate<BlockCount, experimental::BlockSyncGenericSycl<TDim>>
+    struct SyncBlockThreadsPredicate<BlockCount, BlockSyncGenericSycl<TDim>>
     {
-        static auto syncBlockThreadsPredicate(experimental::BlockSyncGenericSycl<TDim> const& blockSync, int predicate)
-            -> int
+        static auto syncBlockThreadsPredicate(BlockSyncGenericSycl<TDim> const& blockSync, int predicate) -> int
         {
             auto const group = blockSync.my_item.get_group();
             blockSync.my_item.barrier();
@@ -53,10 +52,9 @@ namespace alpaka::trait
     };
 
     template<typename TDim>
-    struct SyncBlockThreadsPredicate<BlockAnd, experimental::BlockSyncGenericSycl<TDim>>
+    struct SyncBlockThreadsPredicate<BlockAnd, BlockSyncGenericSycl<TDim>>
     {
-        static auto syncBlockThreadsPredicate(experimental::BlockSyncGenericSycl<TDim> const& blockSync, int predicate)
-            -> int
+        static auto syncBlockThreadsPredicate(BlockSyncGenericSycl<TDim> const& blockSync, int predicate) -> int
         {
             auto const group = blockSync.my_item.get_group();
             blockSync.my_item.barrier();
@@ -66,10 +64,9 @@ namespace alpaka::trait
     };
 
     template<typename TDim>
-    struct SyncBlockThreadsPredicate<BlockOr, experimental::BlockSyncGenericSycl<TDim>>
+    struct SyncBlockThreadsPredicate<BlockOr, BlockSyncGenericSycl<TDim>>
     {
-        static auto syncBlockThreadsPredicate(experimental::BlockSyncGenericSycl<TDim> const& blockSync, int predicate)
-            -> int
+        static auto syncBlockThreadsPredicate(BlockSyncGenericSycl<TDim> const& blockSync, int predicate) -> int
         {
             auto const group = blockSync.my_item.get_group();
             blockSync.my_item.barrier();

--- a/include/alpaka/core/Sycl.hpp
+++ b/include/alpaka/core/Sycl.hpp
@@ -24,7 +24,7 @@
 #    include <utility>
 
 // SYCL vector types trait specializations.
-namespace alpaka::experimental
+namespace alpaka
 {
     namespace detail
     {
@@ -129,20 +129,20 @@ namespace alpaka::experimental
               sycl::half16>
     {
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! SYCL's types get trait specialization.
     template<typename T>
-    struct DimType<T, std::enable_if_t<experimental::IsSyclBuiltInType<T>::value>>
+    struct DimType<T, std::enable_if_t<IsSyclBuiltInType<T>::value>>
     {
         using type = std::conditional_t<std::is_scalar_v<T>, DimInt<std::size_t{1}>, DimInt<T::size()>>;
     };
 
     //! The SYCL vectors' elem type trait specialization.
     template<typename T>
-    struct ElemType<T, std::enable_if_t<experimental::IsSyclBuiltInType<T>::value>>
+    struct ElemType<T, std::enable_if_t<IsSyclBuiltInType<T>::value>>
     {
         using type = std::conditional_t<std::is_scalar_v<T>, T, typename T::element_type>;
     };
@@ -152,10 +152,7 @@ namespace alpaka::trait
 {
     //! The SYCL vectors' extent get trait specialization.
     template<typename TExtent>
-    struct GetExtent<
-        DimInt<Dim<TExtent>::value>,
-        TExtent,
-        std::enable_if_t<experimental::IsSyclBuiltInType<TExtent>::value>>
+    struct GetExtent<DimInt<Dim<TExtent>::value>, TExtent, std::enable_if_t<IsSyclBuiltInType<TExtent>::value>>
     {
         static auto getExtent(TExtent const& extent)
         {
@@ -176,7 +173,7 @@ namespace alpaka::trait
         DimInt<Dim<TExtent>::value>,
         TExtent,
         TExtentVal,
-        std::enable_if_t<experimental::IsSyclBuiltInType<TExtent>::value>>
+        std::enable_if_t<IsSyclBuiltInType<TExtent>::value>>
     {
         static auto setExtent(TExtent const& extent, TExtentVal const& extentVal)
         {
@@ -193,10 +190,7 @@ namespace alpaka::trait
 
     //! The SYCL vectors' offset get trait specialization.
     template<typename TOffsets>
-    struct GetOffset<
-        DimInt<Dim<TOffsets>::value>,
-        TOffsets,
-        std::enable_if_t<experimental::IsSyclBuiltInType<TOffsets>::value>>
+    struct GetOffset<DimInt<Dim<TOffsets>::value>, TOffsets, std::enable_if_t<IsSyclBuiltInType<TOffsets>::value>>
     {
         static auto getOffset(TOffsets const& offsets)
         {
@@ -217,7 +211,7 @@ namespace alpaka::trait
         DimInt<Dim<TOffsets>::value>,
         TOffsets,
         TOffset,
-        std::enable_if_t<experimental::IsSyclBuiltInType<TOffsets>::value>>
+        std::enable_if_t<IsSyclBuiltInType<TOffsets>::value>>
     {
         static auto setOffset(TOffsets const& offsets, TOffset const& offset)
         {
@@ -234,7 +228,7 @@ namespace alpaka::trait
 
     //! The SYCL vectors' idx type trait specialization.
     template<typename TIdx>
-    struct IdxType<TIdx, std::enable_if_t<experimental::IsSyclBuiltInType<TIdx>::value>>
+    struct IdxType<TIdx, std::enable_if_t<IsSyclBuiltInType<TIdx>::value>>
     {
         using type = std::size_t;
     };

--- a/include/alpaka/dev/DevCpuSyclIntel.hpp
+++ b/include/alpaka/dev/DevCpuSyclIntel.hpp
@@ -9,9 +9,9 @@
 #    include <alpaka/dev/DevGenericSycl.hpp>
 #    include <alpaka/pltf/PltfCpuSyclIntel.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using DevCpuSyclIntel = DevGenericSycl<PltfCpuSyclIntel>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 #endif

--- a/include/alpaka/dev/DevFpgaSyclIntel.hpp
+++ b/include/alpaka/dev/DevFpgaSyclIntel.hpp
@@ -9,9 +9,9 @@
 #    include <alpaka/dev/DevGenericSycl.hpp>
 #    include <alpaka/pltf/PltfFpgaSyclIntel.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using DevFpgaSyclIntel = DevGenericSycl<PltfFpgaSyclIntel>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 #endif

--- a/include/alpaka/dev/DevFpgaSyclXilinx.hpp
+++ b/include/alpaka/dev/DevFpgaSyclXilinx.hpp
@@ -9,7 +9,7 @@
 #    include <alpaka/dev/DevGenericSycl.hpp>
 #    include <alpaka/pltf/PltfFpgaSyclXilinx.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using DevFpgaSyclXilinx = DevGenericSycl<PltfFpgaSyclXilinx>;
 }

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -29,7 +29,7 @@
 #    include <utility>
 #    include <vector>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     template<typename TElem, typename TDim, typename TIdx, typename TDev>
     class BufGenericSycl;
@@ -132,15 +132,15 @@ namespace alpaka::experimental
 
         std::shared_ptr<detail::DevGenericSyclImpl> m_impl;
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The SYCL device name get trait specialization.
     template<typename TPltf>
-    struct GetName<experimental::DevGenericSycl<TPltf>>
+    struct GetName<DevGenericSycl<TPltf>>
     {
-        static auto getName(experimental::DevGenericSycl<TPltf> const& dev) -> std::string
+        static auto getName(DevGenericSycl<TPltf> const& dev) -> std::string
         {
             auto const device = dev.getNativeHandle().first;
             return device.template get_info<sycl::info::device::name>();
@@ -149,9 +149,9 @@ namespace alpaka::trait
 
     //! The SYCL device available memory get trait specialization.
     template<typename TPltf>
-    struct GetMemBytes<experimental::DevGenericSycl<TPltf>>
+    struct GetMemBytes<DevGenericSycl<TPltf>>
     {
-        static auto getMemBytes(experimental::DevGenericSycl<TPltf> const& dev) -> std::size_t
+        static auto getMemBytes(DevGenericSycl<TPltf> const& dev) -> std::size_t
         {
             auto const device = dev.getNativeHandle().first;
             return device.template get_info<sycl::info::device::global_mem_size>();
@@ -160,9 +160,9 @@ namespace alpaka::trait
 
     //! The SYCL device free memory get trait specialization.
     template<typename TPltf>
-    struct GetFreeMemBytes<experimental::DevGenericSycl<TPltf>>
+    struct GetFreeMemBytes<DevGenericSycl<TPltf>>
     {
-        static auto getFreeMemBytes(experimental::DevGenericSycl<TPltf> const& /* dev */) -> std::size_t
+        static auto getFreeMemBytes(DevGenericSycl<TPltf> const& /* dev */) -> std::size_t
         {
             static_assert(!sizeof(TPltf), "Querying free device memory not supported for SYCL devices.");
             return std::size_t{};
@@ -171,9 +171,9 @@ namespace alpaka::trait
 
     //! The SYCL device warp size get trait specialization.
     template<typename TPltf>
-    struct GetWarpSizes<experimental::DevGenericSycl<TPltf>>
+    struct GetWarpSizes<DevGenericSycl<TPltf>>
     {
-        static auto getWarpSizes(experimental::DevGenericSycl<TPltf> const& dev) -> std::vector<std::size_t>
+        static auto getWarpSizes(DevGenericSycl<TPltf> const& dev) -> std::vector<std::size_t>
         {
             auto const device = dev.getNativeHandle().first;
             return device.template get_info<sycl::info::device::sub_group_sizes>();
@@ -182,9 +182,9 @@ namespace alpaka::trait
 
     //! The SYCL device reset trait specialization.
     template<typename TPltf>
-    struct Reset<experimental::DevGenericSycl<TPltf>>
+    struct Reset<DevGenericSycl<TPltf>>
     {
-        static auto reset(experimental::DevGenericSycl<TPltf> const&) -> void
+        static auto reset(DevGenericSycl<TPltf> const&) -> void
         {
             static_assert(!sizeof(TPltf), "Explicit device reset not supported for SYCL devices");
         }
@@ -192,9 +192,9 @@ namespace alpaka::trait
 
     //! The SYCL device native handle trait specialization.
     template<typename TPltf>
-    struct NativeHandle<experimental::DevGenericSycl<TPltf>>
+    struct NativeHandle<DevGenericSycl<TPltf>>
     {
-        [[nodiscard]] static auto getNativeHandle(experimental::DevGenericSycl<TPltf> const& dev)
+        [[nodiscard]] static auto getNativeHandle(DevGenericSycl<TPltf> const& dev)
         {
             return dev.getNativeHandle();
         }
@@ -202,23 +202,23 @@ namespace alpaka::trait
 
     //! The SYCL device memory buffer type trait specialization.
     template<typename TElem, typename TDim, typename TIdx, typename TPltf>
-    struct BufType<experimental::DevGenericSycl<TPltf>, TElem, TDim, TIdx>
+    struct BufType<DevGenericSycl<TPltf>, TElem, TDim, TIdx>
     {
-        using type = experimental::BufGenericSycl<TElem, TDim, TIdx, experimental::DevGenericSycl<TPltf>>;
+        using type = BufGenericSycl<TElem, TDim, TIdx, DevGenericSycl<TPltf>>;
     };
 
     //! The SYCL device platform type trait specialization.
     template<typename TPltf>
-    struct PltfType<experimental::DevGenericSycl<TPltf>>
+    struct PltfType<DevGenericSycl<TPltf>>
     {
         using type = TPltf;
     };
 
     //! The thread SYCL device wait specialization.
     template<typename TPltf>
-    struct CurrentThreadWaitFor<experimental::DevGenericSycl<TPltf>>
+    struct CurrentThreadWaitFor<DevGenericSycl<TPltf>>
     {
-        static auto currentThreadWaitFor(experimental::DevGenericSycl<TPltf> const& dev) -> void
+        static auto currentThreadWaitFor(DevGenericSycl<TPltf> const& dev) -> void
         {
             dev.m_impl->wait();
         }
@@ -226,16 +226,16 @@ namespace alpaka::trait
 
     //! The SYCL blocking queue trait specialization.
     template<typename TPltf>
-    struct QueueType<experimental::DevGenericSycl<TPltf>, Blocking>
+    struct QueueType<DevGenericSycl<TPltf>, Blocking>
     {
-        using type = experimental::detail::QueueGenericSyclBase<experimental::DevGenericSycl<TPltf>, true>;
+        using type = detail::QueueGenericSyclBase<DevGenericSycl<TPltf>, true>;
     };
 
     //! The SYCL non-blocking queue trait specialization.
     template<typename TPltf>
-    struct QueueType<experimental::DevGenericSycl<TPltf>, NonBlocking>
+    struct QueueType<DevGenericSycl<TPltf>, NonBlocking>
     {
-        using type = experimental::detail::QueueGenericSyclBase<experimental::DevGenericSycl<TPltf>, false>;
+        using type = detail::QueueGenericSyclBase<DevGenericSycl<TPltf>, false>;
     };
 } // namespace alpaka::trait
 

--- a/include/alpaka/dev/DevGpuSyclIntel.hpp
+++ b/include/alpaka/dev/DevGpuSyclIntel.hpp
@@ -9,7 +9,7 @@
 #    include <alpaka/dev/DevGenericSycl.hpp>
 #    include <alpaka/pltf/PltfGpuSyclIntel.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using DevGpuSyclIntel = DevGenericSycl<PltfGpuSyclIntel>;
 }

--- a/include/alpaka/event/EventCpuSyclIntel.hpp
+++ b/include/alpaka/event/EventCpuSyclIntel.hpp
@@ -9,9 +9,9 @@
 #    include <alpaka/dev/DevCpuSyclIntel.hpp>
 #    include <alpaka/event/EventGenericSycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using EventCpuSyclIntel = EventGenericSycl<DevCpuSyclIntel>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 #endif

--- a/include/alpaka/event/EventFpgaSyclIntel.hpp
+++ b/include/alpaka/event/EventFpgaSyclIntel.hpp
@@ -9,9 +9,9 @@
 #    include <alpaka/dev/DevFpgaSyclIntel.hpp>
 #    include <alpaka/event/EventGenericSycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using EventFpgaSyclIntel = EventGenericSycl<DevFpgaSyclIntel>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 #endif

--- a/include/alpaka/event/EventFpgaSyclXilinx.hpp
+++ b/include/alpaka/event/EventFpgaSyclXilinx.hpp
@@ -9,9 +9,9 @@
 #    include <alpaka/dev/DevFpgaSyclXilinx.hpp>
 #    include <alpaka/event/EventGenericSycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using EventFpgaSyclXilinx = EventGenericSycl<DevFpgaSyclXilinx>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 #endif

--- a/include/alpaka/event/EventGenericSycl.hpp
+++ b/include/alpaka/event/EventGenericSycl.hpp
@@ -19,7 +19,7 @@
 #    include <memory>
 #    include <stdexcept>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The SYCL device event.
     template<typename TDev>
@@ -55,15 +55,15 @@ namespace alpaka::experimental
     private:
         sycl::event m_event{};
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The SYCL device event device get trait specialization.
     template<typename TDev>
-    struct GetDev<experimental::EventGenericSycl<TDev>>
+    struct GetDev<EventGenericSycl<TDev>>
     {
-        static auto getDev(experimental::EventGenericSycl<TDev> const& event) -> TDev
+        static auto getDev(EventGenericSycl<TDev> const& event) -> TDev
         {
             return event.m_dev;
         }
@@ -71,9 +71,9 @@ namespace alpaka::trait
 
     //! The SYCL device event test trait specialization.
     template<typename TDev>
-    struct IsComplete<experimental::EventGenericSycl<TDev>>
+    struct IsComplete<EventGenericSycl<TDev>>
     {
-        static auto isComplete(experimental::EventGenericSycl<TDev> const& event)
+        static auto isComplete(EventGenericSycl<TDev> const& event)
         {
             auto const status
                 = event.getNativeHandle().template get_info<sycl::info::event::command_execution_status>();
@@ -83,11 +83,9 @@ namespace alpaka::trait
 
     //! The SYCL queue enqueue trait specialization.
     template<typename TDev>
-    struct Enqueue<experimental::QueueGenericSyclNonBlocking<TDev>, experimental::EventGenericSycl<TDev>>
+    struct Enqueue<QueueGenericSyclNonBlocking<TDev>, EventGenericSycl<TDev>>
     {
-        static auto enqueue(
-            experimental::QueueGenericSyclNonBlocking<TDev>& queue,
-            experimental::EventGenericSycl<TDev>& event)
+        static auto enqueue(QueueGenericSyclNonBlocking<TDev>& queue, EventGenericSycl<TDev>& event)
         {
             event.setEvent(queue.m_impl->get_last_event());
         }
@@ -95,11 +93,9 @@ namespace alpaka::trait
 
     //! The SYCL queue enqueue trait specialization.
     template<typename TDev>
-    struct Enqueue<experimental::QueueGenericSyclBlocking<TDev>, experimental::EventGenericSycl<TDev>>
+    struct Enqueue<QueueGenericSyclBlocking<TDev>, EventGenericSycl<TDev>>
     {
-        static auto enqueue(
-            experimental::QueueGenericSyclBlocking<TDev>& queue,
-            experimental::EventGenericSycl<TDev>& event)
+        static auto enqueue(QueueGenericSyclBlocking<TDev>& queue, EventGenericSycl<TDev>& event)
         {
             event.setEvent(queue.m_impl->get_last_event());
         }
@@ -110,9 +106,9 @@ namespace alpaka::trait
     //! Waits until the event itself and therefore all tasks preceding it in the queue it is enqueued to have been
     //! completed. If the event is not enqueued to a queue the method returns immediately.
     template<typename TDev>
-    struct CurrentThreadWaitFor<experimental::EventGenericSycl<TDev>>
+    struct CurrentThreadWaitFor<EventGenericSycl<TDev>>
     {
-        static auto currentThreadWaitFor(experimental::EventGenericSycl<TDev> const& event)
+        static auto currentThreadWaitFor(EventGenericSycl<TDev> const& event)
         {
             event.getNativeHandle().wait_and_throw();
         }
@@ -120,11 +116,9 @@ namespace alpaka::trait
 
     //! The SYCL queue event wait trait specialization.
     template<typename TDev>
-    struct WaiterWaitFor<experimental::QueueGenericSyclNonBlocking<TDev>, experimental::EventGenericSycl<TDev>>
+    struct WaiterWaitFor<QueueGenericSyclNonBlocking<TDev>, EventGenericSycl<TDev>>
     {
-        static auto waiterWaitFor(
-            experimental::QueueGenericSyclNonBlocking<TDev>& queue,
-            experimental::EventGenericSycl<TDev> const& event)
+        static auto waiterWaitFor(QueueGenericSyclNonBlocking<TDev>& queue, EventGenericSycl<TDev> const& event)
         {
             queue.m_impl->register_dependency(event.getNativeHandle());
         }
@@ -132,11 +126,9 @@ namespace alpaka::trait
 
     //! The SYCL queue event wait trait specialization.
     template<typename TDev>
-    struct WaiterWaitFor<experimental::QueueGenericSyclBlocking<TDev>, experimental::EventGenericSycl<TDev>>
+    struct WaiterWaitFor<QueueGenericSyclBlocking<TDev>, EventGenericSycl<TDev>>
     {
-        static auto waiterWaitFor(
-            experimental::QueueGenericSyclBlocking<TDev>& queue,
-            experimental::EventGenericSycl<TDev> const& event)
+        static auto waiterWaitFor(QueueGenericSyclBlocking<TDev>& queue, EventGenericSycl<TDev> const& event)
         {
             queue.m_impl->register_dependency(event.getNativeHandle());
         }
@@ -147,19 +139,19 @@ namespace alpaka::trait
     //! Any future work submitted in any queue of this device will wait for event to complete before beginning
     //! execution.
     template<typename TDev>
-    struct WaiterWaitFor<TDev, experimental::EventGenericSycl<TDev>>
+    struct WaiterWaitFor<TDev, EventGenericSycl<TDev>>
     {
-        static auto waiterWaitFor(TDev& dev, experimental::EventGenericSycl<TDev> const& event)
+        static auto waiterWaitFor(TDev& dev, EventGenericSycl<TDev> const& event)
         {
             dev.m_impl->register_dependency(event.getNativeHandle());
         }
     };
 
     //! The SYCL device event native handle trait specialization.
-    template<TDev>
-    struct NativeHandle<experimental::EventGenericSycl<TDev>>
+    template<typename TDev>
+    struct NativeHandle<EventGenericSycl<TDev>>
     {
-        [[nodiscard]] static auto getNativeHandle(experimental::EventGenericSycl<TDev> const& event)
+        [[nodiscard]] static auto getNativeHandle(EventGenericSycl<TDev> const& event)
         {
             return event.getNativeHandle();
         }

--- a/include/alpaka/event/EventGpuSyclIntel.hpp
+++ b/include/alpaka/event/EventGpuSyclIntel.hpp
@@ -9,9 +9,9 @@
 #    include <alpaka/dev/DevGpuSyclIntel.hpp>
 #    include <alpaka/event/EventGenericSycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using EventGpuSyclIntel = EventGenericSycl<DevGpuSyclIntel>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 #endif

--- a/include/alpaka/example/ExampleDefaultAcc.hpp
+++ b/include/alpaka/example/ExampleDefaultAcc.hpp
@@ -32,14 +32,14 @@ namespace alpaka
     using ExampleDefaultAcc = alpaka::AccCpuSerial<TDim, TIdx>;
 #elif defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_BACKEND_ONEAPI)
 #    if defined(ALPAKA_SYCL_ONEAPI_CPU)
-    using ExampleDefaultAcc = alpaka::experimental::AccCpuSyclIntel<TDim, TIdx>;
+    using ExampleDefaultAcc = alpaka::AccCpuSyclIntel<TDim, TIdx>;
 #    elif defined(ALPAKA_SYCL_ONEAPI_FPGA)
-    using ExampleDefaultAcc = alpaka::experimental::AccFpgaSyclIntel<TDim, TIdx>;
+    using ExampleDefaultAcc = alpaka::AccFpgaSyclIntel<TDim, TIdx>;
 #    elif defined(ALPAKA_SYCL_ONEAPI_GPU)
-    using ExampleDefaultAcc = alpaka::experimental::AccGpuSyclIntel<TDim, TIdx>;
+    using ExampleDefaultAcc = alpaka::AccGpuSyclIntel<TDim, TIdx>;
 #    endif
 #elif defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_BACKEND_XILINX)
-    using ExampleDefaultAcc = alpaka::experimental::AccFpgaSyclXilinx<TDim, TIdx>;
+    using ExampleDefaultAcc = alpaka::AccFpgaSyclXilinx<TDim, TIdx>;
 #else
     class ExampleDefaultAcc;
 #    warning "No supported backend selected."

--- a/include/alpaka/idx/bt/IdxBtGenericSycl.hpp
+++ b/include/alpaka/idx/bt/IdxBtGenericSycl.hpp
@@ -14,7 +14,7 @@
 
 #    include <CL/sycl.hpp>
 
-namespace alpaka::experimental::bt
+namespace alpaka::bt
 {
     //! The SYCL accelerator ND index provider.
     template<typename TDim, typename TIdx>
@@ -29,25 +29,24 @@ namespace alpaka::experimental::bt
 
         sycl::nd_item<TDim::value> my_item;
     };
-} // namespace alpaka::experimental::bt
+} // namespace alpaka::bt
 
 namespace alpaka::trait
 {
     //! The SYCL accelerator index dimension get trait specialization.
     template<typename TDim, typename TIdx>
-    struct DimType<experimental::bt::IdxBtGenericSycl<TDim, TIdx>>
+    struct DimType<bt::IdxBtGenericSycl<TDim, TIdx>>
     {
         using type = TDim;
     };
 
     //! The SYCL accelerator block thread index get trait specialization.
     template<typename TDim, typename TIdx>
-    struct GetIdx<experimental::bt::IdxBtGenericSycl<TDim, TIdx>, origin::Block, unit::Threads>
+    struct GetIdx<bt::IdxBtGenericSycl<TDim, TIdx>, origin::Block, unit::Threads>
     {
         //! \return The index of the current thread in the block.
         template<typename TWorkDiv>
-        static auto getIdx(experimental::bt::IdxBtGenericSycl<TDim, TIdx> const& idx, TWorkDiv const&)
-            -> Vec<TDim, TIdx>
+        static auto getIdx(bt::IdxBtGenericSycl<TDim, TIdx> const& idx, TWorkDiv const&) -> Vec<TDim, TIdx>
         {
             if constexpr(TDim::value == 1)
                 return Vec<TDim, TIdx>{static_cast<TIdx>(idx.my_item.get_local_id(0))};
@@ -69,7 +68,7 @@ namespace alpaka::trait
 
     //! The SYCL accelerator block thread index idx type trait specialization.
     template<typename TDim, typename TIdx>
-    struct IdxType<experimental::bt::IdxBtGenericSycl<TDim, TIdx>>
+    struct IdxType<bt::IdxBtGenericSycl<TDim, TIdx>>
     {
         using type = TIdx;
     };

--- a/include/alpaka/idx/gb/IdxGbGenericSycl.hpp
+++ b/include/alpaka/idx/gb/IdxGbGenericSycl.hpp
@@ -14,7 +14,7 @@
 
 #    include <CL/sycl.hpp>
 
-namespace alpaka::experimental::gb
+namespace alpaka::gb
 {
     //! The SYCL accelerator ND index provider.
     template<typename TDim, typename TIdx>
@@ -29,24 +29,24 @@ namespace alpaka::experimental::gb
 
         sycl::nd_item<TDim::value> my_item;
     };
-} // namespace alpaka::experimental::gb
+} // namespace alpaka::gb
 
 namespace alpaka::trait
 {
     //! The SYCL accelerator index dimension get trait specialization.
     template<typename TDim, typename TIdx>
-    struct DimType<experimental::gb::IdxGbGenericSycl<TDim, TIdx>>
+    struct DimType<gb::IdxGbGenericSycl<TDim, TIdx>>
     {
         using type = TDim;
     };
 
     //! The SYCL accelerator grid block index get trait specialization.
     template<typename TDim, typename TIdx>
-    struct GetIdx<experimental::gb::IdxGbGenericSycl<TDim, TIdx>, origin::Grid, unit::Blocks>
+    struct GetIdx<gb::IdxGbGenericSycl<TDim, TIdx>, origin::Grid, unit::Blocks>
     {
         //! \return The index of the current block in the grid.
         template<typename TWorkDiv>
-        static auto getIdx(experimental::gb::IdxGbGenericSycl<TDim, TIdx> const& idx, TWorkDiv const&)
+        static auto getIdx(gb::IdxGbGenericSycl<TDim, TIdx> const& idx, TWorkDiv const&)
         {
             if constexpr(TDim::value == 1)
                 return Vec<TDim, TIdx>(static_cast<TIdx>(idx.my_item.get_group(0)));
@@ -68,7 +68,7 @@ namespace alpaka::trait
 
     //! The SYCL accelerator grid block index idx type trait specialization.
     template<typename TDim, typename TIdx>
-    struct IdxType<experimental::gb::IdxGbGenericSycl<TDim, TIdx>>
+    struct IdxType<gb::IdxGbGenericSycl<TDim, TIdx>>
     {
         using type = TIdx;
     };

--- a/include/alpaka/intrinsic/IntrinsicGenericSycl.hpp
+++ b/include/alpaka/intrinsic/IntrinsicGenericSycl.hpp
@@ -13,40 +13,40 @@
 
 #    include <cstdint>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The SYCL intrinsic.
     class IntrinsicGenericSycl : public concepts::Implements<ConceptIntrinsic, IntrinsicGenericSycl>
     {
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     template<>
-    struct Popcount<experimental::IntrinsicGenericSycl>
+    struct Popcount<IntrinsicGenericSycl>
     {
-        static auto popcount(experimental::IntrinsicGenericSycl const&, std::uint32_t value) -> std::int32_t
+        static auto popcount(IntrinsicGenericSycl const&, std::uint32_t value) -> std::int32_t
         {
             return static_cast<std::int32_t>(sycl::popcount(value));
         }
 
-        static auto popcount(experimental::IntrinsicGenericSycl const&, std::uint64_t value) -> std::int32_t
+        static auto popcount(IntrinsicGenericSycl const&, std::uint64_t value) -> std::int32_t
         {
             return static_cast<std::int32_t>(sycl::popcount(value));
         }
     };
 
     template<>
-    struct Ffs<experimental::IntrinsicGenericSycl>
+    struct Ffs<IntrinsicGenericSycl>
     {
-        static auto ffs(experimental::IntrinsicGenericSycl const&, std::int32_t value) -> std::int32_t
+        static auto ffs(IntrinsicGenericSycl const&, std::int32_t value) -> std::int32_t
         {
             // There is no FFS operation in SYCL but we can emulate it using popcount.
             return (value == 0) ? 0 : sycl::popcount(value ^ ~(-value));
         }
 
-        static auto ffs(experimental::IntrinsicGenericSycl const&, std::int64_t value) -> std::int32_t
+        static auto ffs(IntrinsicGenericSycl const&, std::int64_t value) -> std::int32_t
         {
             // There is no FFS operation in SYCL but we can emulate it using popcount.
             return (value == 0l) ? 0 : static_cast<std::int32_t>(sycl::popcount(value ^ ~(-value)));

--- a/include/alpaka/kernel/TaskKernelCpuSyclIntel.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSyclIntel.hpp
@@ -8,7 +8,7 @@
 
 #    include <alpaka/kernel/TaskKernelGenericSycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     template<typename TDim, typename TIdx>
     class AccCpuSyclIntel;
@@ -16,6 +16,6 @@ namespace alpaka::experimental
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     using TaskKernelCpuSyclIntel
         = TaskKernelGenericSycl<AccCpuSyclIntel<TDim, TIdx>, TDim, TIdx, TKernelFnObj, TArgs...>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 #endif

--- a/include/alpaka/kernel/TaskKernelFpgaSyclIntel.hpp
+++ b/include/alpaka/kernel/TaskKernelFpgaSyclIntel.hpp
@@ -9,7 +9,7 @@
 
 #    include <alpaka/kernel/TaskKernelGenericSycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     template<typename TDim, typename TIdx>
     class AccFpgaSyclIntel;
@@ -17,6 +17,6 @@ namespace alpaka::experimental
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     using TaskKernelFpgaSyclIntel
         = TaskKernelGenericSycl<AccFpgaSyclIntel<TDim, TIdx>, TDim, TIdx, TKernelFnObj, TArgs...>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 #endif

--- a/include/alpaka/kernel/TaskKernelFpgaSyclXilinx.hpp
+++ b/include/alpaka/kernel/TaskKernelFpgaSyclXilinx.hpp
@@ -9,7 +9,7 @@
 
 #    include <alpaka/kernel/TaskKernelGenericSycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     template<typename TDim, typename TIdx>
     class AccFpgaSyclXilinx;
@@ -17,6 +17,6 @@ namespace alpaka::experimental
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     using TaskKernelFpgaSyclXilinx
         = TaskKernelGenericSycl<AccFpgaSyclXilinx<TDim, TIdx>, TDim, TIdx, TKernelFnObj, TArgs...>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 #endif

--- a/include/alpaka/kernel/TaskKernelGenericSycl.hpp
+++ b/include/alpaka/kernel/TaskKernelGenericSycl.hpp
@@ -30,7 +30,7 @@
 #    include <type_traits>
 #    include <utility>
 
-namespace alpaka::experimental::detail
+namespace alpaka::detail
 {
     template<typename TAcc, typename TKernelFnObj, typename... TArgs>
     struct kernel
@@ -48,7 +48,9 @@ namespace alpaka::experimental::detail
     template<typename TElem, typename TIdx, std::size_t TDim, typename TAccessModes>
     inline auto require(
         sycl::handler& cgh,
-        Accessor<detail::SyclAccessor<TElem, DimInt<TDim>::value, TAccessModes>, TElem, TIdx, TDim, TAccessModes> acc,
+        experimental::
+            Accessor<detail::SyclAccessor<TElem, DimInt<TDim>::value, TAccessModes>, TElem, TIdx, TDim, TAccessModes>
+                acc,
         special)
     {
         cgh.require(acc.m_accessor);
@@ -64,9 +66,9 @@ namespace alpaka::experimental::detail
     {
         core::apply([&](auto&&... ps) { (require(cgh, std::forward<decltype(ps)>(ps), special{}), ...); }, args);
     }
-} // namespace alpaka::experimental::detail
+} // namespace alpaka::detail
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The SYCL accelerator execution task.
     template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
@@ -207,41 +209,41 @@ namespace alpaka::experimental
         TKernelFnObj m_kernelFnObj;
         core::Tuple<std::decay_t<TArgs>...> m_args;
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The SYCL execution task accelerator type trait specialization.
     template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
-    struct AccType<experimental::TaskKernelGenericSycl<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
+    struct AccType<TaskKernelGenericSycl<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
     {
         using type = TAcc;
     };
 
     //! The SYCL execution task device type trait specialization.
     template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
-    struct DevType<experimental::TaskKernelGenericSycl<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
+    struct DevType<TaskKernelGenericSycl<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
     {
         using type = typename DevType<TAcc>::type;
     };
 
     //! The SYCL execution task platform type trait specialization.
     template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
-    struct PltfType<experimental::TaskKernelGenericSycl<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
+    struct PltfType<TaskKernelGenericSycl<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
     {
         using type = typename PltfType<TAcc>::type;
     };
 
     //! The SYCL execution task dimension getter trait specialization.
     template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
-    struct DimType<experimental::TaskKernelGenericSycl<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
+    struct DimType<TaskKernelGenericSycl<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
     {
         using type = TDim;
     };
 
     //! The SYCL execution task idx type trait specialization.
     template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
-    struct IdxType<experimental::TaskKernelGenericSycl<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
+    struct IdxType<TaskKernelGenericSycl<TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
     {
         using type = TIdx;
     };

--- a/include/alpaka/kernel/TaskKernelGpuSyclIntel.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuSyclIntel.hpp
@@ -9,7 +9,7 @@
 
 #    include <alpaka/kernel/TaskKernelGenericSycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     template<typename TDim, typename TIdx>
     class AccGpuSyclIntel;
@@ -17,6 +17,6 @@ namespace alpaka::experimental
     template<typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
     using TaskKernelGpuSyclIntel
         = TaskKernelGenericSycl<AccGpuSyclIntel<TDim, TIdx>, TDim, TIdx, TKernelFnObj, TArgs...>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 #endif

--- a/include/alpaka/math/MathGenericSycl.hpp
+++ b/include/alpaka/math/MathGenericSycl.hpp
@@ -15,7 +15,7 @@
 #    include <type_traits>
 
 //! The mathematical operation specifics.
-namespace alpaka::experimental::math
+namespace alpaka::math
 {
     //! The SYCL abs.
     class AbsGenericSycl : public concepts::Implements<alpaka::math::ConceptMathAbs, AbsGenericSycl>
@@ -231,15 +231,15 @@ namespace alpaka::experimental::math
         , public TruncGenericSycl
     {
     };
-} // namespace alpaka::experimental::math
+} // namespace alpaka::math
 
 namespace alpaka::math::trait
 {
     //! The SYCL abs trait specialization.
     template<typename TArg>
-    struct Abs<experimental::math::AbsGenericSycl, TArg, std::enable_if_t<std::is_arithmetic_v<TArg>>>
+    struct Abs<math::AbsGenericSycl, TArg, std::enable_if_t<std::is_arithmetic_v<TArg>>>
     {
-        auto operator()(experimental::math::AbsGenericSycl const&, TArg const& arg)
+        auto operator()(math::AbsGenericSycl const&, TArg const& arg)
         {
             if constexpr(std::is_integral_v<TArg>)
                 return sycl::abs(arg);
@@ -252,9 +252,9 @@ namespace alpaka::math::trait
 
     //! The SYCL acos trait specialization.
     template<typename TArg>
-    struct Acos<experimental::math::AcosGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Acos<math::AcosGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::AcosGenericSycl const&, TArg const& arg)
+        auto operator()(math::AcosGenericSycl const&, TArg const& arg)
         {
             return sycl::acos(arg);
         }
@@ -262,9 +262,9 @@ namespace alpaka::math::trait
 
     //! The SYCL acosh trait specialization.
     template<typename TArg>
-    struct Acosh<experimental::math::AcoshGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Acosh<math::AcoshGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::AcoshGenericSycl const&, TArg const& arg)
+        auto operator()(math::AcoshGenericSycl const&, TArg const& arg)
         {
             return sycl::acosh(arg);
         }
@@ -272,9 +272,9 @@ namespace alpaka::math::trait
 
     //! The SYCL arg trait specialization.
     template<typename TArgument>
-    struct Arg<experimental::math::ArgGenericSycl, TArgument, std::enable_if_t<std::is_arithmetic_v<TArgument>>>
+    struct Arg<math::ArgGenericSycl, TArgument, std::enable_if_t<std::is_arithmetic_v<TArgument>>>
     {
-        auto operator()(experimental::math::ArgGenericSycl const&, TArgument const& argument)
+        auto operator()(math::ArgGenericSycl const&, TArgument const& argument)
         {
             if constexpr(std::is_integral_v<TArgument>)
                 return sycl::atan2(0.0, static_cast<double>(argument));
@@ -287,9 +287,9 @@ namespace alpaka::math::trait
 
     //! The SYCL asin trait specialization.
     template<typename TArg>
-    struct Asin<experimental::math::AsinGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Asin<math::AsinGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::AsinGenericSycl const&, TArg const& arg)
+        auto operator()(math::AsinGenericSycl const&, TArg const& arg)
         {
             return sycl::asin(arg);
         }
@@ -297,9 +297,9 @@ namespace alpaka::math::trait
 
     //! The SYCL asinh trait specialization.
     template<typename TArg>
-    struct Asinh<experimental::math::AsinhGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Asinh<math::AsinhGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::AsinhGenericSycl const&, TArg const& arg)
+        auto operator()(math::AsinhGenericSycl const&, TArg const& arg)
         {
             return sycl::asinh(arg);
         }
@@ -307,9 +307,9 @@ namespace alpaka::math::trait
 
     //! The SYCL atan trait specialization.
     template<typename TArg>
-    struct Atan<experimental::math::AtanGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Atan<math::AtanGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::AtanGenericSycl const&, TArg const& arg)
+        auto operator()(math::AtanGenericSycl const&, TArg const& arg)
         {
             return sycl::atan(arg);
         }
@@ -317,9 +317,9 @@ namespace alpaka::math::trait
 
     //! The SYCL atanh trait specialization.
     template<typename TArg>
-    struct Atanh<experimental::math::AtanhGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Atanh<math::AtanhGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::AtanhGenericSycl const&, TArg const& arg)
+        auto operator()(math::AtanhGenericSycl const&, TArg const& arg)
         {
             return sycl::atanh(arg);
         }
@@ -328,12 +328,12 @@ namespace alpaka::math::trait
     //! The SYCL atan2 trait specialization.
     template<typename Ty, typename Tx>
     struct Atan2<
-        experimental::math::Atan2GenericSycl,
+        math::Atan2GenericSycl,
         Ty,
         Tx,
         std::enable_if_t<std::is_floating_point_v<Ty> && std::is_floating_point_v<Tx>>>
     {
-        auto operator()(experimental::math::Atan2GenericSycl const&, Ty const& y, Tx const& x)
+        auto operator()(math::Atan2GenericSycl const&, Ty const& y, Tx const& x)
         {
             return sycl::atan2(y, x);
         }
@@ -341,9 +341,9 @@ namespace alpaka::math::trait
 
     //! The SYCL cbrt trait specialization.
     template<typename TArg>
-    struct Cbrt<experimental::math::CbrtGenericSycl, TArg, std::enable_if_t<std::is_arithmetic_v<TArg>>>
+    struct Cbrt<math::CbrtGenericSycl, TArg, std::enable_if_t<std::is_arithmetic_v<TArg>>>
     {
-        auto operator()(experimental::math::CbrtGenericSycl const&, TArg const& arg)
+        auto operator()(math::CbrtGenericSycl const&, TArg const& arg)
         {
             if constexpr(std::is_integral_v<TArg>)
                 return sycl::cbrt(static_cast<double>(arg)); // Mirror CUDA back-end and use double for ints
@@ -356,9 +356,9 @@ namespace alpaka::math::trait
 
     //! The SYCL ceil trait specialization.
     template<typename TArg>
-    struct Ceil<experimental::math::CeilGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Ceil<math::CeilGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::CeilGenericSycl const&, TArg const& arg)
+        auto operator()(math::CeilGenericSycl const&, TArg const& arg)
         {
             return sycl::ceil(arg);
         }
@@ -366,9 +366,9 @@ namespace alpaka::math::trait
 
     //! The SYCL conj trait specialization.
     template<typename TArg>
-    struct Conj<experimental::math::ConjGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Conj<math::ConjGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::ConjGenericSycl const&, TArg const& arg)
+        auto operator()(math::ConjGenericSycl const&, TArg const& arg)
         {
             return Complex<TArg>{arg, TArg{0.0}};
         }
@@ -376,9 +376,9 @@ namespace alpaka::math::trait
 
     //! The SYCL cos trait specialization.
     template<typename TArg>
-    struct Cos<experimental::math::CosGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Cos<math::CosGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::CosGenericSycl const&, TArg const& arg)
+        auto operator()(math::CosGenericSycl const&, TArg const& arg)
         {
             return sycl::cos(arg);
         }
@@ -386,9 +386,9 @@ namespace alpaka::math::trait
 
     //! The SYCL cos trait specialization.
     template<typename TArg>
-    struct Cosh<experimental::math::CoshGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Cosh<math::CoshGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::CoshGenericSycl const&, TArg const& arg)
+        auto operator()(math::CoshGenericSycl const&, TArg const& arg)
         {
             return sycl::cosh(arg);
         }
@@ -396,9 +396,9 @@ namespace alpaka::math::trait
 
     //! The SYCL erf trait specialization.
     template<typename TArg>
-    struct Erf<experimental::math::ErfGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Erf<math::ErfGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::ErfGenericSycl const&, TArg const& arg)
+        auto operator()(math::ErfGenericSycl const&, TArg const& arg)
         {
             return sycl::erf(arg);
         }
@@ -406,9 +406,9 @@ namespace alpaka::math::trait
 
     //! The SYCL exp trait specialization.
     template<typename TArg>
-    struct Exp<experimental::math::ExpGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Exp<math::ExpGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::ExpGenericSycl const&, TArg const& arg)
+        auto operator()(math::ExpGenericSycl const&, TArg const& arg)
         {
             return sycl::exp(arg);
         }
@@ -416,9 +416,9 @@ namespace alpaka::math::trait
 
     //! The SYCL floor trait specialization.
     template<typename TArg>
-    struct Floor<experimental::math::FloorGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Floor<math::FloorGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::FloorGenericSycl const&, TArg const& arg)
+        auto operator()(math::FloorGenericSycl const&, TArg const& arg)
         {
             return sycl::floor(arg);
         }
@@ -427,12 +427,12 @@ namespace alpaka::math::trait
     //! The SYCL fmod trait specialization.
     template<typename Tx, typename Ty>
     struct Fmod<
-        experimental::math::FmodGenericSycl,
+        math::FmodGenericSycl,
         Tx,
         Ty,
         std::enable_if_t<std::is_floating_point_v<Tx> && std::is_floating_point_v<Ty>>>
     {
-        auto operator()(experimental::math::FmodGenericSycl const&, Tx const& x, Ty const& y)
+        auto operator()(math::FmodGenericSycl const&, Tx const& x, Ty const& y)
         {
             return sycl::fmod(x, y);
         }
@@ -440,9 +440,9 @@ namespace alpaka::math::trait
 
     //! The SYCL isfinite trait specialization.
     template<typename TArg>
-    struct Isfinite<experimental::math::IsfiniteGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Isfinite<math::IsfiniteGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::IsfiniteGenericSycl const&, TArg const& arg)
+        auto operator()(math::IsfiniteGenericSycl const&, TArg const& arg)
         {
             return sycl::isfinite(arg);
         }
@@ -450,9 +450,9 @@ namespace alpaka::math::trait
 
     //! The SYCL isinf trait specialization.
     template<typename TArg>
-    struct Isinf<experimental::math::IsinfGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Isinf<math::IsinfGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::IsinfGenericSycl const&, TArg const& arg)
+        auto operator()(math::IsinfGenericSycl const&, TArg const& arg)
         {
             return sycl::isinf(arg);
         }
@@ -460,9 +460,9 @@ namespace alpaka::math::trait
 
     //! The SYCL isnan trait specialization.
     template<typename TArg>
-    struct Isnan<experimental::math::IsnanGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Isnan<math::IsnanGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::IsnanGenericSycl const&, TArg const& arg)
+        auto operator()(math::IsnanGenericSycl const&, TArg const& arg)
         {
             return sycl::isnan(arg);
         }
@@ -470,9 +470,9 @@ namespace alpaka::math::trait
 
     //! The SYCL log trait specialization.
     template<typename TArg>
-    struct Log<experimental::math::LogGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Log<math::LogGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::LogGenericSycl const&, TArg const& arg)
+        auto operator()(math::LogGenericSycl const&, TArg const& arg)
         {
             return sycl::log(arg);
         }
@@ -480,13 +480,9 @@ namespace alpaka::math::trait
 
     //! The SYCL max trait specialization.
     template<typename Tx, typename Ty>
-    struct Max<
-        experimental::math::MaxGenericSycl,
-        Tx,
-        Ty,
-        std::enable_if_t<std::is_arithmetic_v<Tx> && std::is_arithmetic_v<Ty>>>
+    struct Max<math::MaxGenericSycl, Tx, Ty, std::enable_if_t<std::is_arithmetic_v<Tx> && std::is_arithmetic_v<Ty>>>
     {
-        auto operator()(experimental::math::MaxGenericSycl const&, Tx const& x, Ty const& y)
+        auto operator()(math::MaxGenericSycl const&, Tx const& x, Ty const& y)
         {
             if constexpr(std::is_integral_v<Tx> && std::is_integral_v<Ty>)
                 return sycl::max(x, y);
@@ -503,13 +499,9 @@ namespace alpaka::math::trait
 
     //! The SYCL min trait specialization.
     template<typename Tx, typename Ty>
-    struct Min<
-        experimental::math::MinGenericSycl,
-        Tx,
-        Ty,
-        std::enable_if_t<std::is_arithmetic_v<Tx> && std::is_arithmetic_v<Ty>>>
+    struct Min<math::MinGenericSycl, Tx, Ty, std::enable_if_t<std::is_arithmetic_v<Tx> && std::is_arithmetic_v<Ty>>>
     {
-        auto operator()(experimental::math::MinGenericSycl const&, Tx const& x, Ty const& y)
+        auto operator()(math::MinGenericSycl const&, Tx const& x, Ty const& y)
         {
             if constexpr(std::is_integral_v<Tx> && std::is_integral_v<Ty>)
                 return sycl::min(x, y);
@@ -527,12 +519,12 @@ namespace alpaka::math::trait
     //! The SYCL pow trait specialization.
     template<typename TBase, typename TExp>
     struct Pow<
-        experimental::math::PowGenericSycl,
+        math::PowGenericSycl,
         TBase,
         TExp,
         std::enable_if_t<std::is_floating_point_v<TBase> && std::is_floating_point_v<TExp>>>
     {
-        auto operator()(experimental::math::PowGenericSycl const&, TBase const& base, TExp const& exp)
+        auto operator()(math::PowGenericSycl const&, TBase const& base, TExp const& exp)
         {
             return sycl::pow(base, exp);
         }
@@ -541,12 +533,12 @@ namespace alpaka::math::trait
     //! The SYCL remainder trait specialization.
     template<typename Tx, typename Ty>
     struct Remainder<
-        experimental::math::RemainderGenericSycl,
+        math::RemainderGenericSycl,
         Tx,
         Ty,
         std::enable_if_t<std::is_floating_point_v<Tx> && std::is_floating_point_v<Ty>>>
     {
-        auto operator()(experimental::math::RemainderGenericSycl const&, Tx const& x, Ty const& y)
+        auto operator()(math::RemainderGenericSycl const&, Tx const& x, Ty const& y)
         {
             return sycl::remainder(x, y);
         }
@@ -554,9 +546,9 @@ namespace alpaka::math::trait
 
     //! The SYCL round trait specialization.
     template<typename TArg>
-    struct Round<experimental::math::RoundGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Round<math::RoundGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::RoundGenericSycl const&, TArg const& arg)
+        auto operator()(math::RoundGenericSycl const&, TArg const& arg)
         {
             return sycl::round(arg);
         }
@@ -564,9 +556,9 @@ namespace alpaka::math::trait
 
     //! The SYCL lround trait specialization.
     template<typename TArg>
-    struct Lround<experimental::math::RoundGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Lround<math::RoundGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::RoundGenericSycl const&, TArg const& arg)
+        auto operator()(math::RoundGenericSycl const&, TArg const& arg)
         {
             return static_cast<long>(sycl::round(arg));
         }
@@ -574,9 +566,9 @@ namespace alpaka::math::trait
 
     //! The SYCL llround trait specialization.
     template<typename TArg>
-    struct Llround<experimental::math::RoundGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Llround<math::RoundGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::RoundGenericSycl const&, TArg const& arg)
+        auto operator()(math::RoundGenericSycl const&, TArg const& arg)
         {
             return static_cast<long long>(sycl::round(arg));
         }
@@ -584,9 +576,9 @@ namespace alpaka::math::trait
 
     //! The SYCL rsqrt trait specialization.
     template<typename TArg>
-    struct Rsqrt<experimental::math::RsqrtGenericSycl, TArg, std::enable_if_t<std::is_arithmetic_v<TArg>>>
+    struct Rsqrt<math::RsqrtGenericSycl, TArg, std::enable_if_t<std::is_arithmetic_v<TArg>>>
     {
-        auto operator()(experimental::math::RsqrtGenericSycl const&, TArg const& arg)
+        auto operator()(math::RsqrtGenericSycl const&, TArg const& arg)
         {
             if(std::is_floating_point_v<TArg>)
                 return sycl::rsqrt(arg);
@@ -599,9 +591,9 @@ namespace alpaka::math::trait
 
     //! The SYCL sin trait specialization.
     template<typename TArg>
-    struct Sin<experimental::math::SinGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Sin<math::SinGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::SinGenericSycl const&, TArg const& arg)
+        auto operator()(math::SinGenericSycl const&, TArg const& arg)
         {
             return sycl::sin(arg);
         }
@@ -609,9 +601,9 @@ namespace alpaka::math::trait
 
     //! The SYCL sinh trait specialization.
     template<typename TArg>
-    struct Sinh<experimental::math::SinhGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Sinh<math::SinhGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::SinhGenericSycl const&, TArg const& arg)
+        auto operator()(math::SinhGenericSycl const&, TArg const& arg)
         {
             return sycl::sinh(arg);
         }
@@ -619,13 +611,9 @@ namespace alpaka::math::trait
 
     //! The SYCL sincos trait specialization.
     template<typename TArg>
-    struct SinCos<experimental::math::SinCosGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct SinCos<math::SinCosGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(
-            experimental::math::SinCosGenericSycl const&,
-            TArg const& arg,
-            TArg& result_sin,
-            TArg& result_cos) -> void
+        auto operator()(math::SinCosGenericSycl const&, TArg const& arg, TArg& result_sin, TArg& result_cos) -> void
         {
             result_sin = sycl::sincos(arg, &result_cos);
         }
@@ -633,9 +621,9 @@ namespace alpaka::math::trait
 
     //! The SYCL sqrt trait specialization.
     template<typename TArg>
-    struct Sqrt<experimental::math::SqrtGenericSycl, TArg, std::enable_if_t<std::is_arithmetic_v<TArg>>>
+    struct Sqrt<math::SqrtGenericSycl, TArg, std::enable_if_t<std::is_arithmetic_v<TArg>>>
     {
-        auto operator()(experimental::math::SqrtGenericSycl const&, TArg const& arg)
+        auto operator()(math::SqrtGenericSycl const&, TArg const& arg)
         {
             if constexpr(std::is_floating_point_v<TArg>)
                 return sycl::sqrt(arg);
@@ -646,9 +634,9 @@ namespace alpaka::math::trait
 
     //! The SYCL tan trait specialization.
     template<typename TArg>
-    struct Tan<experimental::math::TanGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Tan<math::TanGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::TanGenericSycl const&, TArg const& arg)
+        auto operator()(math::TanGenericSycl const&, TArg const& arg)
         {
             return sycl::tan(arg);
         }
@@ -656,9 +644,9 @@ namespace alpaka::math::trait
 
     //! The SYCL tanh trait specialization.
     template<typename TArg>
-    struct Tanh<experimental::math::TanhGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Tanh<math::TanhGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::TanhGenericSycl const&, TArg const& arg)
+        auto operator()(math::TanhGenericSycl const&, TArg const& arg)
         {
             return sycl::tanh(arg);
         }
@@ -666,9 +654,9 @@ namespace alpaka::math::trait
 
     //! The SYCL trunc trait specialization.
     template<typename TArg>
-    struct Trunc<experimental::math::TruncGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    struct Trunc<math::TruncGenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
     {
-        auto operator()(experimental::math::TruncGenericSycl const&, TArg const& arg)
+        auto operator()(math::TruncGenericSycl const&, TArg const& arg)
         {
             return sycl::trunc(arg);
         }

--- a/include/alpaka/mem/buf/BufCpuSyclIntel.hpp
+++ b/include/alpaka/mem/buf/BufCpuSyclIntel.hpp
@@ -9,7 +9,7 @@
 #    include <alpaka/dev/DevCpuSyclIntel.hpp>
 #    include <alpaka/mem/buf/BufGenericSycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     template<typename TElem, typename TDim, typename TIdx>
     using BufCpuSyclIntel = BufGenericSycl<TElem, TDim, TIdx, DevCpuSyclIntel>;

--- a/include/alpaka/mem/buf/BufFpgaSyclIntel.hpp
+++ b/include/alpaka/mem/buf/BufFpgaSyclIntel.hpp
@@ -10,7 +10,7 @@
 #    include <alpaka/dev/DevFpgaSyclIntel.hpp>
 #    include <alpaka/mem/buf/BufGenericSycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     template<typename TElem, typename TDim, typename TIdx>
     using BufFpgaSyclIntel = BufGenericSycl<TElem, TDim, TIdx, DevFpgaSyclIntel>;

--- a/include/alpaka/mem/buf/BufFpgaSyclXilinx.hpp
+++ b/include/alpaka/mem/buf/BufFpgaSyclXilinx.hpp
@@ -10,11 +10,11 @@
 #    include <alpaka/dev/DevFpgaSyclXilinx.hpp>
 #    include <alpaka/mem/buf/BufGenericSycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The SYCL memory buffer.
     template<typename TElem, typename TDim, typename TIdx>
     using BufFpgaSyclXilinx = BufGenericSycl<TElem, TDim, TIdx, DevFpgaSyclXilinx>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 #endif

--- a/include/alpaka/mem/buf/BufGenericSycl.hpp
+++ b/include/alpaka/mem/buf/BufGenericSycl.hpp
@@ -21,7 +21,7 @@
 #    include <memory>
 #    include <type_traits>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The SYCL memory buffer.
     template<typename TElem, typename TDim, typename TIdx, typename TDev>
@@ -57,22 +57,22 @@ namespace alpaka::experimental
         Vec<TDim, TIdx> m_extentElements;
         sycl::buffer<TElem, TDim::value> m_buffer;
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The BufGenericSycl device type trait specialization.
     template<typename TElem, typename TDim, typename TIdx, typename TDev>
-    struct DevType<experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>>
+    struct DevType<BufGenericSycl<TElem, TDim, TIdx, TDev>>
     {
         using type = TDev;
     };
 
     //! The BufGenericSycl device get trait specialization.
     template<typename TElem, typename TDim, typename TIdx, typename TDev>
-    struct GetDev<experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>>
+    struct GetDev<BufGenericSycl<TElem, TDim, TIdx, TDev>>
     {
-        static auto getDev(experimental::BufGenericSycl<TElem, TDim, TIdx, TDev> const& buf)
+        static auto getDev(BufGenericSycl<TElem, TDim, TIdx, TDev> const& buf)
         {
             return buf.m_dev;
         }
@@ -80,25 +80,25 @@ namespace alpaka::trait
 
     //! The BufGenericSycl dimension getter trait specialization.
     template<typename TElem, typename TDim, typename TIdx, typename TDev>
-    struct DimType<experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>>
+    struct DimType<BufGenericSycl<TElem, TDim, TIdx, TDev>>
     {
         using type = TDim;
     };
 
     //! The BufGenericSycl memory element type get trait specialization.
     template<typename TElem, typename TDim, typename TIdx, typename TDev>
-    struct ElemType<experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>>
+    struct ElemType<BufGenericSycl<TElem, TDim, TIdx, TDev>>
     {
         using type = TElem;
     };
 
     //! The BufGenericSycl extent get trait specialization.
     template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx, typename TDev>
-    struct GetExtent<TIdxIntegralConst, experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>>
+    struct GetExtent<TIdxIntegralConst, BufGenericSycl<TElem, TDim, TIdx, TDev>>
     {
         static_assert(TDim::value > TIdxIntegralConst::value, "Requested dimension out of bounds");
 
-        static auto getExtent(experimental::BufGenericSycl<TElem, TDim, TIdx, TDev> const& buf) -> TIdx
+        static auto getExtent(BufGenericSycl<TElem, TDim, TIdx, TDev> const& buf) -> TIdx
         {
             return buf.m_extentElements[TIdxIntegralConst::value];
         }
@@ -106,18 +106,18 @@ namespace alpaka::trait
 
     //! The BufGenericSycl native pointer get trait specialization.
     template<typename TElem, typename TDim, typename TIdx, typename TDev>
-    struct GetPtrNative<experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>>
+    struct GetPtrNative<BufGenericSycl<TElem, TDim, TIdx, TDev>>
     {
         static_assert(
             !sizeof(TElem),
             "Accessing device-side pointers on the host is not supported by the SYCL back-end");
 
-        static auto getPtrNative(experimental::BufGenericSycl<TElem, TDim, TIdx, TDev> const&) -> TElem const*
+        static auto getPtrNative(BufGenericSycl<TElem, TDim, TIdx, TDev> const&) -> TElem const*
         {
             return nullptr;
         }
 
-        static auto getPtrNative(experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>&) -> TElem*
+        static auto getPtrNative(BufGenericSycl<TElem, TDim, TIdx, TDev>&) -> TElem*
         {
             return nullptr;
         }
@@ -125,19 +125,18 @@ namespace alpaka::trait
 
     //! The BufGenericSycl pointer on device get trait specialization.
     template<typename TElem, typename TDim, typename TIdx, typename TDev>
-    struct GetPtrDev<experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>, TDev>
+    struct GetPtrDev<BufGenericSycl<TElem, TDim, TIdx, TDev>, TDev>
     {
         static_assert(
             !sizeof(TElem),
             "Accessing device-side pointers on the host is not supported by the SYCL back-end");
 
-        static auto getPtrDev(experimental::BufGenericSycl<TElem, TDim, TIdx, TDev> const&, TDev const&)
-            -> TElem const*
+        static auto getPtrDev(BufGenericSycl<TElem, TDim, TIdx, TDev> const&, TDev const&) -> TElem const*
         {
             return nullptr;
         }
 
-        static auto getPtrDev(experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>&, TDev const&) -> TElem*
+        static auto getPtrDev(BufGenericSycl<TElem, TDim, TIdx, TDev>&, TDev const&) -> TElem*
         {
             return nullptr;
         }
@@ -145,11 +144,11 @@ namespace alpaka::trait
 
     //! The SYCL memory allocation trait specialization.
     template<typename TElem, typename TDim, typename TIdx, typename TPltf>
-    struct BufAlloc<TElem, TDim, TIdx, experimental::DevGenericSycl<TPltf>>
+    struct BufAlloc<TElem, TDim, TIdx, DevGenericSycl<TPltf>>
     {
         template<typename TExtent>
-        static auto allocBuf(experimental::DevGenericSycl<TPltf> const& dev, TExtent const& ext)
-            -> experimental::BufGenericSycl<TElem, TDim, TIdx, experimental::DevGenericSycl<TPltf>>
+        static auto allocBuf(DevGenericSycl<TPltf> const& dev, TExtent const& ext)
+            -> BufGenericSycl<TElem, TDim, TIdx, DevGenericSycl<TPltf>>
         {
             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
@@ -199,9 +198,9 @@ namespace alpaka::trait
 
     //! The BufGenericSycl offset get trait specialization.
     template<typename TIdxIntegralConst, typename TElem, typename TDim, typename TIdx, typename TDev>
-    struct GetOffset<TIdxIntegralConst, experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>>
+    struct GetOffset<TIdxIntegralConst, BufGenericSycl<TElem, TDim, TIdx, TDev>>
     {
-        static auto getOffset(experimental::BufGenericSycl<TElem, TDim, TIdx, TDev> const&) -> TIdx
+        static auto getOffset(BufGenericSycl<TElem, TDim, TIdx, TDev> const&) -> TIdx
         {
             return 0u;
         }
@@ -209,24 +208,23 @@ namespace alpaka::trait
 
     //! The BufGenericSycl idx type trait specialization.
     template<typename TElem, typename TDim, typename TIdx, typename TDev>
-    struct IdxType<experimental::BufGenericSycl<TElem, TDim, TIdx, TDev>>
+    struct IdxType<BufGenericSycl<TElem, TDim, TIdx, TDev>>
     {
         using type = TIdx;
     };
 
     //! The BufCpu pointer on SYCL device get trait specialization.
     template<typename TElem, typename TDim, typename TIdx, typename TPltf>
-    struct GetPtrDev<BufCpu<TElem, TDim, TIdx>, experimental::DevGenericSycl<TPltf>>
+    struct GetPtrDev<BufCpu<TElem, TDim, TIdx>, DevGenericSycl<TPltf>>
     {
         static_assert(!sizeof(TElem), "Accessing host pointers on the device is not supported by the SYCL back-end");
 
-        static auto getPtrDev(BufCpu<TElem, TDim, TIdx> const&, experimental::DevGenericSycl<TPltf> const&)
-            -> TElem const*
+        static auto getPtrDev(BufCpu<TElem, TDim, TIdx> const&, DevGenericSycl<TPltf> const&) -> TElem const*
         {
             return nullptr;
         }
 
-        static auto getPtrDev(BufCpu<TElem, TDim, TIdx>&, experimental::DevGenericSycl<TPltf> const&) -> TElem*
+        static auto getPtrDev(BufCpu<TElem, TDim, TIdx>&, DevGenericSycl<TPltf> const&) -> TElem*
         {
             return nullptr;
         }

--- a/include/alpaka/mem/buf/BufGpuSyclIntel.hpp
+++ b/include/alpaka/mem/buf/BufGpuSyclIntel.hpp
@@ -10,7 +10,7 @@
 #    include <alpaka/dev/DevGpuSyclIntel.hpp>
 #    include <alpaka/mem/buf/BufGenericSycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     template<typename TElem, typename TDim, typename TIdx>
     using BufGpuSyclIntel = BufGenericSycl<TElem, TDim, TIdx, DevGpuSyclIntel>;

--- a/include/alpaka/mem/buf/sycl/Accessor.hpp
+++ b/include/alpaka/mem/buf/sycl/Accessor.hpp
@@ -15,7 +15,7 @@
 #    include <cstddef>
 #    include <utility>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     template<typename TElem, typename TDim, typename TIdx, typename TDev>
     class BufGenericSycl;
@@ -26,10 +26,10 @@ namespace alpaka::experimental
         inline constexpr auto sycl_access_mode = sycl::access_mode::read_write;
 
         template<>
-        inline constexpr auto sycl_access_mode<ReadAccess> = sycl::access_mode::read;
+        inline constexpr auto sycl_access_mode<experimental::ReadAccess> = sycl::access_mode::read;
 
         template<>
-        inline constexpr auto sycl_access_mode<WriteAccess> = sycl::access_mode::write;
+        inline constexpr auto sycl_access_mode<experimental::WriteAccess> = sycl::access_mode::write;
 
         template<typename TElem, int TDim, typename... TAlpakaAccessModes>
         using SyclAccessor = sycl::accessor<
@@ -41,7 +41,8 @@ namespace alpaka::experimental
     } // namespace detail
 
     template<typename TElem, typename TIdx, typename TAccessModes>
-    struct Accessor<detail::SyclAccessor<TElem, 1, TAccessModes>, TElem, TIdx, std::size_t{1}, TAccessModes>
+    struct experimental::
+        Accessor<detail::SyclAccessor<TElem, 1, TAccessModes>, TElem, TIdx, std::size_t{1}, TAccessModes>
     {
         static constexpr auto sycl_access_mode = detail::sycl_access_mode<TAccessModes>;
         using SyclAccessor = detail::SyclAccessor<TElem, 1, TAccessModes>;
@@ -78,7 +79,8 @@ namespace alpaka::experimental
     };
 
     template<typename TElem, typename TIdx, std::size_t TDim, typename TAccessModes>
-    struct Accessor<detail::SyclAccessor<TElem, DimInt<TDim>::value, TAccessModes>, TElem, TIdx, TDim, TAccessModes>
+    struct experimental::
+        Accessor<detail::SyclAccessor<TElem, DimInt<TDim>::value, TAccessModes>, TElem, TIdx, TDim, TAccessModes>
     {
         static constexpr auto sycl_access_mode = detail::sycl_access_mode<TAccessModes>;
         using SyclAccessor = detail::SyclAccessor<TElem, DimInt<TDim>::value, TAccessModes>;
@@ -111,7 +113,7 @@ namespace alpaka::experimental
         VecType extents;
     };
 
-    namespace trait
+    namespace experimental::trait
     {
         namespace internal
         {
@@ -127,13 +129,13 @@ namespace alpaka::experimental
             template<typename... TAccessModes>
             static auto buildAccessor(BufGenericSycl<TElem, TDim, TIdx, TDev>& buffer)
             {
-                using SyclAccessor = experimental::detail::SyclAccessor<TElem, TDim::value, TAccessModes...>;
+                using SyclAccessor = detail::SyclAccessor<TElem, TDim::value, TAccessModes...>;
                 return Accessor<SyclAccessor, TElem, TIdx, TDim::value, TAccessModes...>{
                     SyclAccessor{buffer.m_buffer},
                     buffer.m_extentElements};
             }
         };
-    } // namespace trait
-} // namespace alpaka::experimental
+    } // namespace experimental::trait
+} // namespace alpaka
 
 #endif

--- a/include/alpaka/mem/buf/sycl/Common.hpp
+++ b/include/alpaka/mem/buf/sycl/Common.hpp
@@ -14,7 +14,7 @@
 
 #    include <cstddef>
 
-namespace alpaka::experimental::detail
+namespace alpaka::detail
 {
     template<typename TExtent>
     inline auto make_sycl_range(TExtent const& ext, std::size_t multiplier = 1)
@@ -43,6 +43,6 @@ namespace alpaka::experimental::detail
         else
             return sycl::id<3>{getOffsetX(view), getOffsetY(view), getOffsetZ(view)};
     }
-} // namespace alpaka::experimental::detail
+} // namespace alpaka::detail
 
 #endif

--- a/include/alpaka/mem/buf/sycl/Copy.hpp
+++ b/include/alpaka/mem/buf/sycl/Copy.hpp
@@ -22,7 +22,7 @@
 #    include <memory>
 #    include <type_traits>
 
-namespace alpaka::experimental::detail
+namespace alpaka::detail
 {
     template<typename TElem, std::size_t TDim>
     using SrcAccessor = sycl::
@@ -61,14 +61,14 @@ namespace alpaka::experimental::detail
         TDst m_dst;
         static constexpr auto is_sycl_task = true;
     };
-} // namespace alpaka::experimental::detail
+} // namespace alpaka::detail
 
 // Trait specializations for CreateTaskMemcpy.
 namespace alpaka::trait
 {
     //! The SYCL host-to-device memory copy trait specialization.
     template<typename TDim, typename TPltf>
-    struct CreateTaskMemcpy<TDim, experimental::DevGenericSycl<TPltf>, DevCpu>
+    struct CreateTaskMemcpy<TDim, DevGenericSycl<TPltf>, DevCpu>
     {
         template<typename TExtent, typename TViewSrc, typename TViewDstFwd>
         static auto createTaskMemcpy(TViewDstFwd&& viewDst, TViewSrc const& viewSrc, TExtent const& ext)
@@ -78,12 +78,12 @@ namespace alpaka::trait
             constexpr auto copy_dim = static_cast<int>(Dim<TExtent>::value);
             using ElemType = Elem<std::remove_const_t<TViewSrc>>;
             using SrcType = ElemType const*;
-            using DstType = alpaka::experimental::detail::DstAccessor<ElemType, copy_dim>;
+            using DstType = alpaka::detail::DstAccessor<ElemType, copy_dim>;
 
-            auto const range = experimental::detail::make_sycl_range(ext);
-            auto const offset = experimental::detail::make_sycl_offset(viewDst);
+            auto const range = detail::make_sycl_range(ext);
+            auto const offset = detail::make_sycl_offset(viewDst);
 
-            return experimental::detail::TaskCopySycl<SrcType, DstType, experimental::detail::Direction::h2d>{
+            return detail::TaskCopySycl<SrcType, DstType, detail::Direction::h2d>{
                 getPtrNative(viewSrc),
                 DstType{viewDst.m_buffer, range, offset}};
         }
@@ -91,7 +91,7 @@ namespace alpaka::trait
 
     //! The SYCL device-to-host memory copy trait specialization.
     template<typename TDim, typename TPltf>
-    struct CreateTaskMemcpy<TDim, DevCpu, experimental::DevGenericSycl<TPltf>>
+    struct CreateTaskMemcpy<TDim, DevCpu, DevGenericSycl<TPltf>>
     {
         template<typename TExtent, typename TViewSrc, typename TViewDstFwd>
         static auto createTaskMemcpy(TViewDstFwd&& viewDst, TViewSrc const& viewSrc, TExtent const& ext)
@@ -100,15 +100,15 @@ namespace alpaka::trait
 
             constexpr auto copy_dim = static_cast<int>(Dim<TExtent>::value);
             using ElemType = Elem<std::remove_const_t<TViewSrc>>;
-            using SrcType = alpaka::experimental::detail::SrcAccessor<ElemType, copy_dim>;
+            using SrcType = alpaka::detail::SrcAccessor<ElemType, copy_dim>;
             using DstType = ElemType*;
 
-            auto const range = experimental::detail::make_sycl_range(ext);
-            auto const offset = experimental::detail::make_sycl_offset(viewSrc);
+            auto const range = detail::make_sycl_range(ext);
+            auto const offset = detail::make_sycl_offset(viewSrc);
 
             auto view_src = const_cast<TViewSrc&>(viewSrc);
 
-            return experimental::detail::TaskCopySycl<SrcType, DstType, experimental::detail::Direction::d2h>{
+            return detail::TaskCopySycl<SrcType, DstType, detail::Direction::d2h>{
                 SrcType{view_src.m_buffer, range, offset},
                 getPtrNative(viewDst)};
         }
@@ -116,7 +116,7 @@ namespace alpaka::trait
 
     //! The SYCL device-to-device memory copy trait specialization.
     template<typename TDim, typename TPltfDst, typename TPltfSrc>
-    struct CreateTaskMemcpy<TDim, experimental::DevGenericSycl<TPltfDst>, experimental::DevGenericSycl<TPltfSrc>>
+    struct CreateTaskMemcpy<TDim, DevGenericSycl<TPltfDst>, DevGenericSycl<TPltfSrc>>
     {
         template<typename TExtent, typename TViewSrc, typename TViewDstFwd>
         static auto createTaskMemcpy(TViewDstFwd&& viewDst, TViewSrc const& viewSrc, TExtent const& ext)
@@ -125,16 +125,16 @@ namespace alpaka::trait
 
             constexpr auto copy_dim = static_cast<int>(Dim<TExtent>::value);
             using ElemType = Elem<std::remove_const_t<TViewSrc>>;
-            using SrcType = alpaka::experimental::detail::SrcAccessor<ElemType, copy_dim>;
-            using DstType = alpaka::experimental::detail::DstAccessor<ElemType, copy_dim>;
+            using SrcType = alpaka::detail::SrcAccessor<ElemType, copy_dim>;
+            using DstType = alpaka::detail::DstAccessor<ElemType, copy_dim>;
 
-            auto const range = experimental::detail::make_sycl_range(ext);
-            auto const offset_src = experimental::detail::make_sycl_offset(viewSrc);
-            auto const offset_dst = experimental::detail::make_sycl_offset(viewDst);
+            auto const range = detail::make_sycl_range(ext);
+            auto const offset_src = detail::make_sycl_offset(viewSrc);
+            auto const offset_dst = detail::make_sycl_offset(viewDst);
 
             auto view_src = const_cast<TViewSrc&>(viewSrc);
 
-            return experimental::detail::TaskCopySycl<SrcType, DstType, experimental::detail::Direction::d2d>{
+            return detail::TaskCopySycl<SrcType, DstType, detail::Direction::d2d>{
                 SrcType{view_src.m_buffer, range, offset_src},
                 DstType{viewDst.m_buffer, range, offset_dst}};
         }

--- a/include/alpaka/mem/buf/sycl/Set.hpp
+++ b/include/alpaka/mem/buf/sycl/Set.hpp
@@ -24,41 +24,40 @@
 
 namespace alpaka
 {
-    namespace experimental
+
+    namespace detail
     {
-        namespace detail
+        template<std::size_t TDim>
+        using Accessor = sycl::accessor<
+            std::byte,
+            TDim,
+            sycl::access_mode::write,
+            sycl::target::global_buffer,
+            sycl::access::placeholder::true_t>;
+
+        //! The SYCL memory set trait.
+        template<typename TAccessor>
+        struct TaskSetSycl
         {
-            template<std::size_t TDim>
-            using Accessor = sycl::accessor<
-                std::byte,
-                TDim,
-                sycl::access_mode::write,
-                sycl::target::global_buffer,
-                sycl::access::placeholder::true_t>;
-
-            //! The SYCL memory set trait.
-            template<typename TAccessor>
-            struct TaskSetSycl
+            auto operator()(sycl::handler& cgh) const -> void
             {
-                auto operator()(sycl::handler& cgh) const -> void
-                {
-                    cgh.require(m_accessor);
-                    cgh.fill(m_accessor, m_value);
-                }
+                cgh.require(m_accessor);
+                cgh.fill(m_accessor, m_value);
+            }
 
-                TAccessor m_accessor;
-                std::byte m_value;
-                // Distinguish from non-alpaka types (= host tasks)
-                static constexpr auto is_sycl_task = true;
-            };
-        } // namespace detail
-    } // namespace experimental
+            TAccessor m_accessor;
+            std::byte m_value;
+            // Distinguish from non-alpaka types (= host tasks)
+            static constexpr auto is_sycl_task = true;
+        };
+    } // namespace detail
+
 
     namespace trait
     {
         //! The SYCL device memory set trait specialization.
         template<typename TDim, typename TPltf>
-        struct CreateTaskMemset<TDim, experimental::DevGenericSycl<TPltf>>
+        struct CreateTaskMemset<TDim, DevGenericSycl<TPltf>>
         {
             template<typename TExtent, typename TViewFwd>
             static auto createTaskMemset(TViewFwd&& view, std::uint8_t const& byte, TExtent const& ext)
@@ -68,14 +67,14 @@ namespace alpaka
                 constexpr auto set_dim = static_cast<int>(Dim<TExtent>::value);
                 using TView = std::remove_reference_t<TViewFwd>;
                 using ElemType = Elem<TView>;
-                using DstType = alpaka::experimental::detail::Accessor<set_dim>;
+                using DstType = alpaka::detail::Accessor<set_dim>;
 
                 // Reinterpret as byte buffer
                 auto buf = view.m_buffer.template reinterpret<std::byte>();
                 auto const byte_val = static_cast<std::byte>(byte);
 
-                auto const range = experimental::detail::make_sycl_range(ext, sizeof(ElemType));
-                return experimental::detail::TaskSetSycl<DstType>{DstType{buf, range}, byte_val};
+                auto const range = detail::make_sycl_range(ext, sizeof(ElemType));
+                return detail::TaskSetSycl<DstType>{DstType{buf, range}, byte_val};
             }
         };
     } // namespace trait

--- a/include/alpaka/mem/fence/MemFenceGenericSycl.hpp
+++ b/include/alpaka/mem/fence/MemFenceGenericSycl.hpp
@@ -10,7 +10,7 @@
 
 #    include <CL/sycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     namespace detail
     {
@@ -49,17 +49,17 @@ namespace alpaka::experimental
         sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::target::global_buffer> m_global_dummy;
         sycl::accessor<int, 1, sycl::access_mode::read_write, sycl::target::local> m_local_dummy;
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     template<typename TMemScope>
-    struct MemFence<experimental::MemFenceGenericSycl, TMemScope>
+    struct MemFence<MemFenceGenericSycl, TMemScope>
     {
-        static auto mem_fence(experimental::MemFenceGenericSycl const& fence, TMemScope const&)
+        static auto mem_fence(MemFenceGenericSycl const& fence, TMemScope const&)
         {
-            static constexpr auto scope = experimental::detail::SyclFenceProps<TMemScope>::scope;
-            static constexpr auto space = experimental::detail::SyclFenceProps<TMemScope>::space;
+            static constexpr auto scope = detail::SyclFenceProps<TMemScope>::scope;
+            static constexpr auto space = detail::SyclFenceProps<TMemScope>::space;
 
             // atomic_ref is already part of the SYCL spec but oneAPI has not caught up yet.
             auto dummy

--- a/include/alpaka/mem/fence/MemFenceGenericSycl.hpp
+++ b/include/alpaka/mem/fence/MemFenceGenericSycl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Jan Stephan
+/* Copyright 2022 Jan Stephan, Luca Ferragina
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -60,15 +60,10 @@ namespace alpaka::trait
         {
             static constexpr auto scope = detail::SyclFenceProps<TMemScope>::scope;
             static constexpr auto space = detail::SyclFenceProps<TMemScope>::space;
-
-            // atomic_ref is already part of the SYCL spec but oneAPI has not caught up yet.
             auto dummy
                 = (scope == sycl::memory_scope::work_group)
-                      ? sycl::ext::oneapi::
-                          atomic_ref<int, sycl::ext::oneapi::memory_order::relaxed, scope, space>{fence.m_local_dummy
-                                                                                                      [0]}
-                      : sycl::ext::oneapi::atomic_ref<int, sycl::ext::oneapi::memory_order::relaxed, scope, space>{
-                          fence.m_global_dummy[0]};
+                      ? sycl::atomic_ref<int, sycl::memory_order::relaxed, scope, space>{fence.m_local_dummy[0]}
+                      : sycl::atomic_ref<int, sycl::memory_order::relaxed, scope, space>{fence.m_global_dummy[0]};
             auto const dummy_val = dummy.load();
             sycl::atomic_fence(sycl::memory_order::acq_rel, scope);
             dummy.store(dummy_val);

--- a/include/alpaka/pltf/PltfCpuSyclIntel.hpp
+++ b/include/alpaka/pltf/PltfCpuSyclIntel.hpp
@@ -14,7 +14,7 @@
 
 #    include <string>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     namespace detail
     {
@@ -41,15 +41,15 @@ namespace alpaka::experimental
 
     //! The SYCL device manager.
     using PltfCpuSyclIntel = PltfGenericSycl<detail::IntelCpuSelector>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The SYCL device manager device type trait specialization.
     template<>
-    struct DevType<experimental::PltfCpuSyclIntel>
+    struct DevType<PltfCpuSyclIntel>
     {
-        using type = experimental::DevGenericSycl<experimental::PltfCpuSyclIntel>; // = DevCpuSyclIntel
+        using type = DevGenericSycl<PltfCpuSyclIntel>; // = DevCpuSyclIntel
     };
 } // namespace alpaka::trait
 

--- a/include/alpaka/pltf/PltfFpgaSyclIntel.hpp
+++ b/include/alpaka/pltf/PltfFpgaSyclIntel.hpp
@@ -13,7 +13,7 @@
 #    include <CL/sycl.hpp>
 #    include <sycl/ext/intel/fpga_extensions.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The SYCL device manager.
 #    ifdef ALPAKA_FPGA_EMULATION
@@ -21,15 +21,15 @@ namespace alpaka::experimental
 #    else
     using PltfFpgaSyclIntel = PltfGenericSycl<sycl::ext::intel::fpga_selector>;
 #    endif
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The SYCL device manager device type trait specialization.
     template<>
-    struct DevType<experimental::PltfFpgaSyclIntel>
+    struct DevType<PltfFpgaSyclIntel>
     {
-        using type = experimental::DevGenericSycl<experimental::PltfFpgaSyclIntel>; // = DevFpgaSyclIntel
+        using type = DevGenericSycl<PltfFpgaSyclIntel>; // = DevFpgaSyclIntel
     };
 } // namespace alpaka::trait
 

--- a/include/alpaka/pltf/PltfFpgaSyclXilinx.hpp
+++ b/include/alpaka/pltf/PltfFpgaSyclXilinx.hpp
@@ -14,7 +14,7 @@
 
 #    include <string>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     namespace detail
     {
@@ -41,15 +41,15 @@ namespace alpaka::experimental
 
     //! The SYCL device manager.
     using PltfFgpaSyclIntel = PltfGenericSycl<detail::XilinxFpgaSelector>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The SYCL device manager device type trait specialization.
     template<>
-    struct DevType<experimental::PltfFpgaSyclXilinx>
+    struct DevType<PltfFpgaSyclXilinx>
     {
-        using type = experimental::DevGenericSycl<experimental::PltfFpgaSyclXilinx>; // = DevFpgaSyclXilinx
+        using type = DevGenericSycl<PltfFpgaSyclXilinx>; // = DevFpgaSyclXilinx
     };
 } // namespace alpaka::trait
 

--- a/include/alpaka/pltf/PltfGenericSycl.hpp
+++ b/include/alpaka/pltf/PltfGenericSycl.hpp
@@ -24,7 +24,7 @@
 #    include <stdexcept>
 #    include <vector>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The SYCL device manager.
     template<typename TSelector>
@@ -127,31 +127,31 @@ namespace alpaka::experimental
 #        pragma clang diagnostic pop
 #    endif
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The SYCL platform device count get trait specialization.
     template<typename TSelector>
-    struct GetDevCount<alpaka::experimental::PltfGenericSycl<TSelector>>
+    struct GetDevCount<alpaka::PltfGenericSycl<TSelector>>
     {
         static auto getDevCount() -> std::size_t
         {
             ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-            return alpaka::experimental::PltfGenericSycl<TSelector>::syclDevices().size();
+            return alpaka::PltfGenericSycl<TSelector>::syclDevices().size();
         }
     };
 
     //! The SYCL platform device get trait specialization.
     template<typename TSelector>
-    struct GetDevByIdx<alpaka::experimental::PltfGenericSycl<TSelector>>
+    struct GetDevByIdx<alpaka::PltfGenericSycl<TSelector>>
     {
         static auto getDevByIdx(std::size_t const& devIdx)
         {
             ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-            using SyclPltf = alpaka::experimental::PltfGenericSycl<TSelector>;
+            using SyclPltf = alpaka::PltfGenericSycl<TSelector>;
 
             auto const dev_num = getDevCount<SyclPltf>();
 

--- a/include/alpaka/pltf/PltfGpuSyclIntel.hpp
+++ b/include/alpaka/pltf/PltfGpuSyclIntel.hpp
@@ -15,7 +15,7 @@
 
 #    include <string>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     namespace detail
     {
@@ -42,15 +42,15 @@ namespace alpaka::experimental
 
     //! The SYCL device manager.
     using PltfGpuSyclIntel = PltfGenericSycl<detail::IntelGpuSelector>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The SYCL device manager device type trait specialization.
     template<>
-    struct DevType<experimental::PltfGpuSyclIntel>
+    struct DevType<PltfGpuSyclIntel>
     {
-        using type = experimental::DevGenericSycl<experimental::PltfGpuSyclIntel>; // = DevGpuSyclIntel
+        using type = DevGenericSycl<PltfGpuSyclIntel>; // = DevGpuSyclIntel
     };
 } // namespace alpaka::trait
 

--- a/include/alpaka/queue/QueueCpuSyclIntelBlocking.hpp
+++ b/include/alpaka/queue/QueueCpuSyclIntelBlocking.hpp
@@ -9,7 +9,7 @@
 #    include <alpaka/dev/DevCpuSyclIntel.hpp>
 #    include <alpaka/queue/QueueGenericSyclBlocking.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using QueueCpuSyclIntelBlocking = QueueGenericSyclBlocking<DevCpuSyclIntel>;
 }

--- a/include/alpaka/queue/QueueCpuSyclIntelNonBlocking.hpp
+++ b/include/alpaka/queue/QueueCpuSyclIntelNonBlocking.hpp
@@ -9,7 +9,7 @@
 #    include <alpaka/dev/DevCpuSyclIntel.hpp>
 #    include <alpaka/queue/QueueGenericSyclNonBlocking.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using QueueCpuSyclIntelNonBlocking = QueueGenericSyclNonBlocking<DevCpuSyclIntel>;
 }

--- a/include/alpaka/queue/QueueFpgaSyclIntelBlocking.hpp
+++ b/include/alpaka/queue/QueueFpgaSyclIntelBlocking.hpp
@@ -10,7 +10,7 @@
 #    include <alpaka/dev/DevFpgaSyclIntel.hpp>
 #    include <alpaka/queue/QueueGenericSyclBlocking.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using QueueFpgaSyclIntelBlocking = QueueGenericSyclBlocking<DevFpgaSyclIntel>;
 }

--- a/include/alpaka/queue/QueueFpgaSyclIntelNonBlocking.hpp
+++ b/include/alpaka/queue/QueueFpgaSyclIntelNonBlocking.hpp
@@ -9,7 +9,7 @@
 #    include <alpaka/dev/DevFpgaSyclIntel.hpp>
 #    include <alpaka/queue/QueueGenericSyclNonBlocking.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using QueueFpgaSyclIntelNonBlocking = QueueGenericSyclNonBlocking<DevFpgaSyclIntel>;
 }

--- a/include/alpaka/queue/QueueFpgaSyclXilinxBlocking.hpp
+++ b/include/alpaka/queue/QueueFpgaSyclXilinxBlocking.hpp
@@ -9,7 +9,7 @@
 #    include <alpaka/dev/DevFpgaSyclXilinx.hpp>
 #    include <alpaka/queue/QueueGenericSyclBlocking.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using QueueFpgaSyclXilinxBlocking = QueueGenericSyclBlocking<DevFpgaSyclXilinx>;
 }

--- a/include/alpaka/queue/QueueFpgaSyclXilinxNonBlocking.hpp
+++ b/include/alpaka/queue/QueueFpgaSyclXilinxNonBlocking.hpp
@@ -9,7 +9,7 @@
 #    include <alpaka/dev/DevFpgaSyclXilinx.hpp>
 #    include <alpaka/queue/QueueGenericSyclNonBlocking.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using QueueFpgaSyclXilinxNonBlocking = QueueGenericSyclNonBlocking<DevFpgaSyclXilinx>;
 }

--- a/include/alpaka/queue/QueueGenericSyclBlocking.hpp
+++ b/include/alpaka/queue/QueueGenericSyclBlocking.hpp
@@ -11,10 +11,10 @@
 #    include <memory>
 #    include <utility>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     template<typename TDev>
     using QueueGenericSyclBlocking = detail::QueueGenericSyclBase<TDev, true>;
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 #endif

--- a/include/alpaka/queue/QueueGenericSyclNonBlocking.hpp
+++ b/include/alpaka/queue/QueueGenericSyclNonBlocking.hpp
@@ -11,7 +11,7 @@
 #    include <memory>
 #    include <utility>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     template<typename TDev>
     using QueueGenericSyclNonBlocking = detail::QueueGenericSyclBase<TDev, false>;

--- a/include/alpaka/queue/QueueGpuSyclIntelBlocking.hpp
+++ b/include/alpaka/queue/QueueGpuSyclIntelBlocking.hpp
@@ -9,7 +9,7 @@
 #    include <alpaka/dev/DevGpuSyclIntel.hpp>
 #    include <alpaka/queue/QueueGenericSyclBlocking.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using QueueGpuSyclIntelBlocking = QueueGenericSyclBlocking<DevGpuSyclIntel>;
 }

--- a/include/alpaka/queue/QueueGpuSyclIntelNonBlocking.hpp
+++ b/include/alpaka/queue/QueueGpuSyclIntelNonBlocking.hpp
@@ -9,7 +9,7 @@
 #    include <alpaka/dev/DevGpuSyclIntel.hpp>
 #    include <alpaka/queue/QueueGenericSyclNonBlocking.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     using QueueGpuSyclIntelNonBlocking = QueueGenericSyclNonBlocking<DevGpuSyclIntel>;
 }

--- a/include/alpaka/queue/sycl/QueueGenericSyclBase.hpp
+++ b/include/alpaka/queue/sycl/QueueGenericSyclBase.hpp
@@ -22,7 +22,7 @@
 #    include <utility>
 #    include <vector>
 
-namespace alpaka::experimental::detail
+namespace alpaka::detail
 {
     template<typename T, typename = void>
     inline constexpr auto is_sycl_task = false;
@@ -191,9 +191,9 @@ namespace alpaka::experimental::detail
         TDev m_dev;
         std::shared_ptr<detail::QueueGenericSyclImpl> m_impl;
     };
-} // namespace alpaka::experimental::detail
+} // namespace alpaka::detail
 
-namespace alpaka::experimental
+namespace alpaka
 {
     template<typename TDev>
     class EventGenericSycl;
@@ -203,16 +203,16 @@ namespace alpaka::trait
 {
     //! The SYCL blocking queue device type trait specialization.
     template<typename TDev, bool TBlocking>
-    struct DevType<experimental::detail::QueueGenericSyclBase<TDev, TBlocking>>
+    struct DevType<detail::QueueGenericSyclBase<TDev, TBlocking>>
     {
         using type = TDev;
     };
 
     //! The SYCL blocking queue device get trait specialization.
     template<typename TDev, bool TBlocking>
-    struct GetDev<experimental::detail::QueueGenericSyclBase<TDev, TBlocking>>
+    struct GetDev<detail::QueueGenericSyclBase<TDev, TBlocking>>
     {
-        static auto getDev(experimental::detail::QueueGenericSyclBase<TDev, TBlocking> const& queue)
+        static auto getDev(detail::QueueGenericSyclBase<TDev, TBlocking> const& queue)
         {
             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
             return queue.m_dev;
@@ -221,17 +221,16 @@ namespace alpaka::trait
 
     //! The SYCL blocking queue event type trait specialization.
     template<typename TDev, bool TBlocking>
-    struct EventType<experimental::detail::QueueGenericSyclBase<TDev, TBlocking>>
+    struct EventType<detail::QueueGenericSyclBase<TDev, TBlocking>>
     {
-        using type = experimental::EventGenericSycl<TDev>;
+        using type = EventGenericSycl<TDev>;
     };
 
     //! The SYCL blocking queue enqueue trait specialization.
     template<typename TDev, bool TBlocking, typename TTask>
-    struct Enqueue<experimental::detail::QueueGenericSyclBase<TDev, TBlocking>, TTask>
+    struct Enqueue<detail::QueueGenericSyclBase<TDev, TBlocking>, TTask>
     {
-        static auto enqueue(experimental::detail::QueueGenericSyclBase<TDev, TBlocking>& queue, TTask const& task)
-            -> void
+        static auto enqueue(detail::QueueGenericSyclBase<TDev, TBlocking>& queue, TTask const& task) -> void
         {
             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
             queue.m_impl->template enqueue<TBlocking>(task);
@@ -240,9 +239,9 @@ namespace alpaka::trait
 
     //! The SYCL blocking queue test trait specialization.
     template<typename TDev, bool TBlocking>
-    struct Empty<experimental::detail::QueueGenericSyclBase<TDev, TBlocking>>
+    struct Empty<detail::QueueGenericSyclBase<TDev, TBlocking>>
     {
-        static auto empty(experimental::detail::QueueGenericSyclBase<TDev, TBlocking> const& queue) -> bool
+        static auto empty(detail::QueueGenericSyclBase<TDev, TBlocking> const& queue) -> bool
         {
             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
             return queue.m_impl->empty();
@@ -254,10 +253,9 @@ namespace alpaka::trait
     //! Blocks execution of the calling thread until the queue has finished processing all previously requested
     //! tasks (kernels, data copies, ...)
     template<typename TDev, bool TBlocking>
-    struct CurrentThreadWaitFor<experimental::detail::QueueGenericSyclBase<TDev, TBlocking>>
+    struct CurrentThreadWaitFor<detail::QueueGenericSyclBase<TDev, TBlocking>>
     {
-        static auto currentThreadWaitFor(experimental::detail::QueueGenericSyclBase<TDev, TBlocking> const& queue)
-            -> void
+        static auto currentThreadWaitFor(detail::QueueGenericSyclBase<TDev, TBlocking> const& queue) -> void
         {
             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
             queue.m_impl->wait();
@@ -266,10 +264,9 @@ namespace alpaka::trait
 
     //! The SYCL queue native handle trait specialization.
     template<typename TDev, bool TBlocking>
-    struct NativeHandle<experimental::detail::QueueGenericSyclBase<TDev, TBlocking>>
+    struct NativeHandle<detail::QueueGenericSyclBase<TDev, TBlocking>>
     {
-        [[nodiscard]] static auto getNativeHandle(
-            experimental::detail::QueueGenericSyclBase<TDev, TBlocking> const& queue)
+        [[nodiscard]] static auto getNativeHandle(detail::QueueGenericSyclBase<TDev, TBlocking> const& queue)
         {
             return queue.getNativeHandle();
         }

--- a/include/alpaka/test/acc/TestAccs.hpp
+++ b/include/alpaka/test/acc/TestAccs.hpp
@@ -123,28 +123,28 @@ namespace alpaka::test
 #endif
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_BACKEND_ONEAPI) && defined(ALPAKA_SYCL_TARGET_CPU)
         template<typename TDim, typename TIdx>
-        using AccCpuSyclIntelIfAvailableElseInt = alpaka::experimental::AccCpuSyclIntel<TDim, TIdx>;
+        using AccCpuSyclIntelIfAvailableElseInt = alpaka::AccCpuSyclIntel<TDim, TIdx>;
 #else
         template<typename TDim, typename TIdx>
         using AccCpuSyclIntelIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_BACKEND_ONEAPI) && defined(ALPAKA_SYCL_TARGET_FPGA)
         template<typename TDim, typename TIdx>
-        using AccFpgaSyclIntelIfAvailableElseInt = alpaka::experimental::AccFpgaSyclIntel<TDim, TIdx>;
+        using AccFpgaSyclIntelIfAvailableElseInt = alpaka::AccFpgaSyclIntel<TDim, TIdx>;
 #else
         template<typename TDim, typename TIdx>
         using AccFpgaSyclIntelIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_BACKEND_XILINX)
         template<typename TDim, typename TIdx>
-        using AccFpgaSyclXilinxIfAvailableElseInt = alpaka::experimental::AccFpgaSyclXilinx<TDim, TIdx>;
+        using AccFpgaSyclXilinxIfAvailableElseInt = alpaka::AccFpgaSyclXilinx<TDim, TIdx>;
 #else
         template<typename TDim, typename TIdx>
         using AccFpgaSyclXilinxIfAvailableElseInt = int;
 #endif
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_BACKEND_ONEAPI) && defined(ALPAKA_SYCL_TARGET_GPU)
         template<typename TDim, typename TIdx>
-        using AccGpuSyclIntelIfAvailableElseInt = alpaka::experimental::AccGpuSyclIntel<TDim, TIdx>;
+        using AccGpuSyclIntelIfAvailableElseInt = alpaka::AccGpuSyclIntel<TDim, TIdx>;
 #else
         template<typename TDim, typename TIdx>
         using AccGpuSyclIntelIfAvailableElseInt = int;

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -724,7 +724,7 @@ namespace alpaka
         class EventHostManualTriggerSycl
         {
         public:
-            EventHostManualTriggerSycl(experimental::DevGenericSycl<TPltf> const&)
+            EventHostManualTriggerSycl(DevGenericSycl<TPltf> const&)
             {
             }
 
@@ -736,15 +736,15 @@ namespace alpaka
         namespace trait
         {
             template<typename TPltf>
-            struct EventHostManualTriggerType<experimental::DevGenericSycl<TPltf>>
+            struct EventHostManualTriggerType<DevGenericSycl<TPltf>>
             {
                 using type = alpaka::test::EventHostManualTriggerSycl<TPltf>;
             };
 
             template<typename TPltf>
-            struct IsEventHostManualTriggerSupported<experimental::DevGenericSycl<TPltf>>
+            struct IsEventHostManualTriggerSupported<DevGenericSycl<TPltf>>
             {
-                ALPAKA_FN_HOST static auto isSupported(experimental::DevGenericSycl<TPltf> const&) -> bool
+                ALPAKA_FN_HOST static auto isSupported(DevGenericSycl<TPltf> const&) -> bool
                 {
                     return false;
                 }
@@ -755,24 +755,20 @@ namespace alpaka
     namespace trait
     {
         template<typename TPltf>
-        struct Enqueue<
-            experimental::QueueGenericSyclBlocking<experimental::DevGenericSycl<TPltf>>,
-            test::EventHostManualTriggerSycl<TPltf>>
+        struct Enqueue<QueueGenericSyclBlocking<DevGenericSycl<TPltf>>, test::EventHostManualTriggerSycl<TPltf>>
         {
             ALPAKA_FN_HOST static auto enqueue(
-                experimental::QueueGenericSyclBlocking<experimental::DevGenericSycl<TPltf>>& queue,
+                QueueGenericSyclBlocking<DevGenericSycl<TPltf>>& queue,
                 test::EventHostManualTriggerSycl<TPltf>& event) -> void
             {
             }
         };
 
         template<typename TPltf>
-        struct Enqueue<
-            experimental::QueueGenericSyclNonBlocking<experimental::DevGenericSycl<TPltf>>,
-            test::EventHostManualTriggerSycl<TPltf>>
+        struct Enqueue<QueueGenericSyclNonBlocking<DevGenericSycl<TPltf>>, test::EventHostManualTriggerSycl<TPltf>>
         {
             ALPAKA_FN_HOST static auto enqueue(
-                experimental::QueueGenericSyclNonBlocking<experimental::DevGenericSycl<TPltf>>& queue,
+                QueueGenericSyclNonBlocking<DevGenericSycl<TPltf>>& queue,
                 test::EventHostManualTriggerSycl<TPltf>& event) -> void
             {
             }

--- a/include/alpaka/test/queue/Queue.hpp
+++ b/include/alpaka/test/queue/Queue.hpp
@@ -108,23 +108,23 @@ namespace alpaka::test
 #        ifdef ALPAKA_SYCL_ONEAPI_CPU
         //! The default queue type trait specialization for the Intel CPU device.
         template<>
-        struct DefaultQueueType<alpaka::experimental::DevCpuSyclIntel>
+        struct DefaultQueueType<alpaka::DevCpuSyclIntel>
         {
 #            if(ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-            using type = alpaka::experimental::QueueCpuSyclIntelBlocking;
+            using type = alpaka::QueueCpuSyclIntelBlocking;
 #            else
-            using type = alpaka::experimental::QueueCpuSyclIntelNonBlocking;
+            using type = alpaka::QueueCpuSyclIntelNonBlocking;
 #            endif
         };
 
         template<>
-        struct IsBlockingQueue<alpaka::experimental::QueueCpuSyclIntelBlocking>
+        struct IsBlockingQueue<alpaka::QueueCpuSyclIntelBlocking>
         {
             static constexpr auto value = true;
         };
 
         template<>
-        struct IsBlockingQueue<alpaka::experimental::QueueCpuSyclIntelNonBlocking>
+        struct IsBlockingQueue<alpaka::QueueCpuSyclIntelNonBlocking>
         {
             static constexpr auto value = false;
         };
@@ -132,23 +132,23 @@ namespace alpaka::test
 #        ifdef ALPAKA_SYCL_ONEAPI_FPGA
         //! The default queue type trait specialization for the Intel SYCL device.
         template<>
-        struct DefaultQueueType<alpaka::experimental::DevFpgaSyclIntel>
+        struct DefaultQueueType<alpaka::DevFpgaSyclIntel>
         {
 #            if(ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-            using type = alpaka::experimental::QueueFpgaSyclIntelBlocking;
+            using type = alpaka::QueueFpgaSyclIntelBlocking;
 #            else
-            using type = alpaka::experimental::QueueFpgaSyclIntelNonBlocking;
+            using type = alpaka::QueueFpgaSyclIntelNonBlocking;
 #            endif
         };
 
         template<>
-        struct IsBlockingQueue<alpaka::experimental::QueueFpgaSyclIntelBlocking>
+        struct IsBlockingQueue<alpaka::QueueFpgaSyclIntelBlocking>
         {
             static constexpr auto value = true;
         };
 
         template<>
-        struct IsBlockingQueue<alpaka::experimental::QueueFpgaSyclIntelNonBlocking>
+        struct IsBlockingQueue<alpaka::QueueFpgaSyclIntelNonBlocking>
         {
             static constexpr auto value = false;
         };
@@ -156,23 +156,23 @@ namespace alpaka::test
 #        ifdef ALPAKA_SYCL_ONEAPI_GPU
         //! The default queue type trait specialization for the Intel CPU device.
         template<>
-        struct DefaultQueueType<alpaka::experimental::DevGpuSyclIntel>
+        struct DefaultQueueType<alpaka::DevGpuSyclIntel>
         {
 #            if(ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-            using type = alpaka::experimental::QueueGpuSyclIntelBlocking;
+            using type = alpaka::QueueGpuSyclIntelBlocking;
 #            else
-            using type = alpaka::experimental::QueueGpuSyclIntelNonBlocking;
+            using type = alpaka::QueueGpuSyclIntelNonBlocking;
 #            endif
         };
 
         template<>
-        struct IsBlockingQueue<alpaka::experimental::QueueGpuSyclIntelBlocking>
+        struct IsBlockingQueue<alpaka::QueueGpuSyclIntelBlocking>
         {
             static constexpr auto value = true;
         };
 
         template<>
-        struct IsBlockingQueue<alpaka::experimental::QueueGpuSyclIntelNonBlocking>
+        struct IsBlockingQueue<alpaka::QueueGpuSyclIntelNonBlocking>
         {
             static constexpr auto value = false;
         };
@@ -181,23 +181,23 @@ namespace alpaka::test
 #    ifdef ALPAKA_SYCL_BACKEND_XILINX
         //! The default queue type trait specialization for the Xilinx SYCL device.
         template<>
-        struct DefaultQueueType<alpaka::experimental::DevFpgaSyclXilinx>
+        struct DefaultQueueType<alpaka::DevFpgaSyclXilinx>
         {
 #        if(ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
-            using type = alpaka::experimental::QueueFpgaSyclXilinxBlocking;
+            using type = alpaka::QueueFpgaSyclXilinxBlocking;
 #        else
-            using type = alpaka::experimental::QueueFpgaSyclXilinxNonBlocking;
+            using type = alpaka::QueueFpgaSyclXilinxNonBlocking;
 #        endif
         };
 
         template<>
-        struct IsBlockingQueue<alpaka::experimental::QueueFpgaSyclXilinxBlocking>
+        struct IsBlockingQueue<alpaka::QueueFpgaSyclXilinxBlocking>
         {
             static constexpr auto value = true;
         };
 
         template<>
-        struct IsBlockingQueue<alpaka::experimental::QueueFpgaSyclXilinxNonBlocking>
+        struct IsBlockingQueue<alpaka::QueueFpgaSyclXilinxNonBlocking>
         {
             static constexpr auto value = false;
         };
@@ -235,24 +235,24 @@ namespace alpaka::test
 #    ifdef ALPAKA_SYCL_BACKEND_ONEAPI
 #        ifdef ALPAKA_SYCL_ONEAPI_CPU
         ,
-        std::tuple<alpaka::experimental::DevCpuSyclIntel, alpaka::experimental::QueueCpuSyclIntelBlocking>,
-        std::tuple<alpaka::experimental::DevCpuSyclIntel, alpaka::experimental::QueueCpuSyclIntelNonBlocking>
+        std::tuple<alpaka::DevCpuSyclIntel, alpaka::QueueCpuSyclIntelBlocking>,
+        std::tuple<alpaka::DevCpuSyclIntel, alpaka::QueueCpuSyclIntelNonBlocking>
 #        endif
 #        ifdef ALPAKA_SYCL_ONEAPI_FPGA
         ,
-        std::tuple<alpaka::experimental::DevFpgaSyclIntel, alpaka::experimental::QueueFpgaSyclIntelBlocking>,
-        std::tuple<alpaka::experimental::DevFpgaSyclIntel, alpaka::experimental::QueueFpgaSyclIntelNonBlocking>
+        std::tuple<alpaka::DevFpgaSyclIntel, alpaka::QueueFpgaSyclIntelBlocking>,
+        std::tuple<alpaka::DevFpgaSyclIntel, alpaka::QueueFpgaSyclIntelNonBlocking>
 #        endif
 #        ifdef ALPAKA_SYCL_ONEAPI_GPU
         ,
-        std::tuple<alpaka::experimental::DevGpuSyclIntel, alpaka::experimental::QueueGpuSyclIntelBlocking>,
-        std::tuple<alpaka::experimental::DevGpuSyclIntel, alpaka::experimental::QueueGpuSyclIntelNonBlocking>
+        std::tuple<alpaka::DevGpuSyclIntel, alpaka::QueueGpuSyclIntelBlocking>,
+        std::tuple<alpaka::DevGpuSyclIntel, alpaka::QueueGpuSyclIntelNonBlocking>
 #        endif
 #    endif
 #    if defined(ALPAKA_SYCL_BACKEND_XILINX)
         ,
-        std::tuple<alpaka::experimental::DevFpgaSyclXilinx, alpaka::experimental::QueueFpgaSyclXilinxBlocking>,
-        std::tuple<alpaka::experimental::DevFpgaSyclXilinx, alpaka::experimental::QueueFpgaSyclXilinxNonBlocking>
+        std::tuple<alpaka::DevFpgaSyclXilinx, alpaka::QueueFpgaSyclXilinxBlocking>,
+        std::tuple<alpaka::DevFpgaSyclXilinx, alpaka::QueueFpgaSyclXilinxNonBlocking>
 #    endif
 #endif
         >;

--- a/include/alpaka/warp/WarpGenericSycl.hpp
+++ b/include/alpaka/warp/WarpGenericSycl.hpp
@@ -12,7 +12,7 @@
 
 #    include <cstdint>
 
-namespace alpaka::experimental::warp
+namespace alpaka::warp
 {
     //! The SYCL warp.
     template<typename TDim>
@@ -25,14 +25,14 @@ namespace alpaka::experimental::warp
 
         sycl::nd_item<TDim::value> m_item;
     };
-} // namespace alpaka::experimental::warp
+} // namespace alpaka::warp
 
 namespace alpaka::warp::trait
 {
     template<typename TDim>
-    struct GetSize<experimental::warp::WarpGenericSycl<TDim>>
+    struct GetSize<warp::WarpGenericSycl<TDim>>
     {
-        static auto getSize(experimental::warp::WarpGenericSycl<TDim> const& warp) -> std::int32_t
+        static auto getSize(warp::WarpGenericSycl<TDim> const& warp) -> std::int32_t
         {
             auto const sub_group = warp.m_item.get_sub_group();
             // SYCL sub-groups are always 1D
@@ -41,9 +41,9 @@ namespace alpaka::warp::trait
     };
 
     template<typename TDim>
-    struct Activemask<experimental::warp::WarpGenericSycl<TDim>>
+    struct Activemask<warp::WarpGenericSycl<TDim>>
     {
-        static auto activemask(experimental::warp::WarpGenericSycl<TDim> const& warp) -> std::uint32_t
+        static auto activemask(warp::WarpGenericSycl<TDim> const& warp) -> std::uint32_t
         {
             // SYCL has no way of querying this. Since sub-group functions have to be executed in convergent code
             // regions anyway we return the full mask.
@@ -53,9 +53,9 @@ namespace alpaka::warp::trait
     };
 
     template<typename TDim>
-    struct All<experimental::warp::WarpGenericSycl<TDim>>
+    struct All<warp::WarpGenericSycl<TDim>>
     {
-        static auto all(experimental::warp::WarpGenericSycl<TDim> const& warp, std::int32_t predicate) -> std::int32_t
+        static auto all(warp::WarpGenericSycl<TDim> const& warp, std::int32_t predicate) -> std::int32_t
         {
             auto const sub_group = warp.m_item.get_sub_group();
             return static_cast<std::int32_t>(sycl::all_of_group(sub_group, static_cast<bool>(predicate)));
@@ -63,9 +63,9 @@ namespace alpaka::warp::trait
     };
 
     template<typename TDim>
-    struct Any<experimental::warp::WarpGenericSycl<TDim>>
+    struct Any<warp::WarpGenericSycl<TDim>>
     {
-        static auto any(experimental::warp::WarpGenericSycl<TDim> const& warp, std::int32_t predicate) -> std::int32_t
+        static auto any(warp::WarpGenericSycl<TDim> const& warp, std::int32_t predicate) -> std::int32_t
         {
             auto const sub_group = warp.m_item.get_sub_group();
             return static_cast<std::int32_t>(sycl::any_of_group(sub_group, static_cast<bool>(predicate)));
@@ -73,9 +73,9 @@ namespace alpaka::warp::trait
     };
 
     template<typename TDim>
-    struct Ballot<experimental::warp::WarpGenericSycl<TDim>>
+    struct Ballot<warp::WarpGenericSycl<TDim>>
     {
-        static auto ballot(experimental::warp::WarpGenericSycl<TDim> const& warp, std::int32_t predicate)
+        static auto ballot(warp::WarpGenericSycl<TDim> const& warp, std::int32_t predicate)
         {
             auto const sub_group = warp.m_item.get_sub_group();
             return sycl::ext::oneapi::group_ballot(sub_group, static_cast<bool>(predicate));
@@ -83,14 +83,10 @@ namespace alpaka::warp::trait
     };
 
     template<typename TDim>
-    struct Shfl<experimental::warp::WarpGenericSycl<TDim>>
+    struct Shfl<warp::WarpGenericSycl<TDim>>
     {
         template<typename T>
-        static auto shfl(
-            experimental::warp::WarpGenericSycl<TDim> const& warp,
-            T value,
-            std::int32_t srcLane,
-            std::int32_t width)
+        static auto shfl(warp::WarpGenericSycl<TDim> const& warp, T value, std::int32_t srcLane, std::int32_t width)
         {
             /* If width < srcLane the sub-group needs to be split into assumed subdivisions. The first item of each
                subdivision has the assumed index 0. The srcLane index is relative to the subdivisions.

--- a/include/alpaka/workdiv/WorkDivGenericSycl.hpp
+++ b/include/alpaka/workdiv/WorkDivGenericSycl.hpp
@@ -12,7 +12,7 @@
 
 #    include <CL/sycl.hpp>
 
-namespace alpaka::experimental
+namespace alpaka
 {
     //! The SYCL accelerator work division.
     template<typename TDim, typename TIdx>
@@ -30,30 +30,30 @@ namespace alpaka::experimental
         Vec<TDim, TIdx> const& m_threadElemExtent;
         sycl::nd_item<TDim::value> my_item;
     };
-} // namespace alpaka::experimental
+} // namespace alpaka
 
 namespace alpaka::trait
 {
     //! The SYCL accelerator work division dimension get trait specialization.
     template<typename TDim, typename TIdx>
-    struct DimType<experimental::WorkDivGenericSycl<TDim, TIdx>>
+    struct DimType<WorkDivGenericSycl<TDim, TIdx>>
     {
         using type = TDim;
     };
 
     //! The SYCL accelerator work division idx type trait specialization.
     template<typename TDim, typename TIdx>
-    struct IdxType<experimental::WorkDivGenericSycl<TDim, TIdx>>
+    struct IdxType<WorkDivGenericSycl<TDim, TIdx>>
     {
         using type = TIdx;
     };
 
     //! The SYCL accelerator work division grid block extent trait specialization.
     template<typename TDim, typename TIdx>
-    struct GetWorkDiv<experimental::WorkDivGenericSycl<TDim, TIdx>, origin::Grid, unit::Blocks>
+    struct GetWorkDiv<WorkDivGenericSycl<TDim, TIdx>, origin::Grid, unit::Blocks>
     {
         //! \return The number of blocks in each dimension of the grid.
-        static auto getWorkDiv(experimental::WorkDivGenericSycl<TDim, TIdx> const& workDiv) -> Vec<TDim, TIdx>
+        static auto getWorkDiv(WorkDivGenericSycl<TDim, TIdx> const& workDiv) -> Vec<TDim, TIdx>
         {
             if constexpr(TDim::value == 1)
                 return Vec<TDim, TIdx>{static_cast<TIdx>(workDiv.my_item.get_group_range(0))};
@@ -75,10 +75,10 @@ namespace alpaka::trait
 
     //! The SYCL accelerator work division block thread extent trait specialization.
     template<typename TDim, typename TIdx>
-    struct GetWorkDiv<experimental::WorkDivGenericSycl<TDim, TIdx>, origin::Block, unit::Threads>
+    struct GetWorkDiv<WorkDivGenericSycl<TDim, TIdx>, origin::Block, unit::Threads>
     {
         //! \return The number of threads in each dimension of a block.
-        static auto getWorkDiv(experimental::WorkDivGenericSycl<TDim, TIdx> const& workDiv) -> Vec<TDim, TIdx>
+        static auto getWorkDiv(WorkDivGenericSycl<TDim, TIdx> const& workDiv) -> Vec<TDim, TIdx>
         {
             if constexpr(TDim::value == 1)
                 return Vec<TDim, TIdx>{static_cast<TIdx>(workDiv.my_item.get_local_range(0))};
@@ -100,10 +100,10 @@ namespace alpaka::trait
 
     //! The SYCL accelerator work division thread element extent trait specialization.
     template<typename TDim, typename TIdx>
-    struct GetWorkDiv<experimental::WorkDivGenericSycl<TDim, TIdx>, origin::Thread, unit::Elems>
+    struct GetWorkDiv<WorkDivGenericSycl<TDim, TIdx>, origin::Thread, unit::Elems>
     {
         //! \return The number of blocks in each dimension of the grid.
-        static auto getWorkDiv(experimental::WorkDivGenericSycl<TDim, TIdx> const& workDiv) -> Vec<TDim, TIdx>
+        static auto getWorkDiv(WorkDivGenericSycl<TDim, TIdx> const& workDiv) -> Vec<TDim, TIdx>
         {
             return workDiv.m_threadElemExtent;
         }


### PR DESCRIPTION
This is a supporting PR for #1845 
It only removes all the experimental namespaces related to SYCL. Memory operations are currently not working (the bufCopy example won't even compile). That is being fixed by the main PR but seems to be related to the importing of mdspan.