### PR TITLE
Implement ShflUp, ShflDown and ShflXor 

### DIFF
--- a/include/alpaka/warp/WarpSingleThread.hpp
+++ b/include/alpaka/warp/WarpSingleThread.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Sergei Bastrakov, David M. Rogers, Bernhard Manfred Gruber
+/* Copyright 2022 Sergei Bastrakov, David M. Rogers, Bernhard Manfred Gruber, Aurora Perego
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -65,18 +65,52 @@ namespace alpaka::warp
         template<>
         struct Shfl<WarpSingleThread>
         {
+            template<typename T>
             static auto shfl(
                 warp::WarpSingleThread const& /*warp*/,
-                std::int32_t val,
+                T val,
                 std::int32_t /*srcLane*/,
                 std::int32_t /*width*/)
             {
                 return val;
             }
+        };
 
-            static auto shfl(
+        template<>
+        struct ShflUp<WarpSingleThread>
+        {
+            template<typename T>
+            static auto shfl_up(
                 warp::WarpSingleThread const& /*warp*/,
-                float val,
+                T val,
+                std::uint32_t /*srcLane*/,
+                std::int32_t /*width*/)
+            {
+                return val;
+            }
+        };
+
+        template<>
+        struct ShflDown<WarpSingleThread>
+        {
+            template<typename T>
+            static auto shfl_down(
+                warp::WarpSingleThread const& /*warp*/,
+                T val,
+                std::uint32_t /*srcLane*/,
+                std::int32_t /*width*/)
+            {
+                return val;
+            }
+        };
+
+        template<>
+        struct ShflXor<WarpSingleThread>
+        {
+            template<typename T>
+            static auto shfl_xor(
+                warp::WarpSingleThread const& /*warp*/,
+                T val,
                 std::int32_t /*srcLane*/,
                 std::int32_t /*width*/)
             {

--- a/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Sergei Bastrakov, David M. Rogers, Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2022 Sergei Bastrakov, David M. Rogers, Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber, Aurora Perego
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -113,26 +113,12 @@ namespace alpaka::warp
         template<>
         struct Shfl<WarpUniformCudaHipBuiltIn>
         {
-            //-------------------------------------------------------------
+            template<typename T>
             __device__ static auto shfl(
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
-                float val,
+                T val,
                 int srcLane,
-                std::int32_t width) -> float
-            {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                return __shfl_sync(activemask(warp), val, srcLane, width);
-#        else
-                return __shfl(val, srcLane, width);
-#        endif
-            }
-
-            //-------------------------------------------------------------
-            __device__ static auto shfl(
-                [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
-                std::int32_t val,
-                int srcLane,
-                std::int32_t width) -> std::int32_t
+                std::int32_t width) -> T
             {
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                 return __shfl_sync(activemask(warp), val, srcLane, width);
@@ -141,6 +127,61 @@ namespace alpaka::warp
 #        endif
             }
         };
+
+        template<>
+        struct ShflUp<WarpUniformCudaHipBuiltIn>
+        {
+            template<typename T>
+            __device__ static auto shfl_up(
+                [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
+                T val,
+                std::uint32_t offset,
+                std::int32_t width) -> T
+            {
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+                return __shfl_up_sync(activemask(warp), val, offset, width);
+#        else
+                return __shfl_up(val, offset, width);
+#        endif
+            }
+        };
+
+        template<>
+        struct ShflDown<WarpUniformCudaHipBuiltIn>
+        {
+            template<typename T>
+            __device__ static auto shfl_down(
+                [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
+                T val,
+                std::uint32_t offset,
+                std::int32_t width) -> T
+            {
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+                return __shfl_down_sync(activemask(warp), val, offset, width);
+#        else
+                return __shfl_down(val, offset, width);
+#        endif
+            }
+        };
+
+        template<>
+        struct ShflXor<WarpUniformCudaHipBuiltIn>
+        {
+            template<typename T>
+            __device__ static auto shfl_xor(
+                [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
+                T val,
+                std::int32_t mask,
+                std::int32_t width) -> T
+            {
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+                return __shfl_xor_sync(activemask(warp), val, mask, width);
+#        else
+                return __shfl_xor(val, mask, width);
+#        endif
+            }
+        };
+
     } // namespace trait
 #    endif
 } // namespace alpaka::warp

--- a/test/unit/warp/src/ShflDown.cpp
+++ b/test/unit/warp/src/ShflDown.cpp
@@ -1,0 +1,175 @@
+/* Copyright 2023 Aurora Perego
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <alpaka/math/FloatEqualExact.hpp>
+#include <alpaka/test/KernelExecutionFixture.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
+#include <alpaka/test/queue/Queue.hpp>
+#include <alpaka/warp/Traits.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <limits>
+
+#if BOOST_COMP_GNUC
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wstrict-overflow"
+#endif
+
+struct ShflDownSingleThreadWarpTestKernel
+{
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAcc>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
+    {
+        if constexpr(alpaka::Dim<TAcc>::value > 0)
+        {
+            ALPAKA_CHECK(*success, alpaka::warp::getSize(acc) == 1);
+            ALPAKA_CHECK(*success, alpaka::warp::shfl_down(acc, 42, 0) == 42);
+        }
+        else
+        {
+            ALPAKA_CHECK(*success, alpaka::warp::shfl_down(acc, 42, 0, 1) == 42);
+        }
+        ALPAKA_CHECK(*success, alpaka::warp::shfl_down(acc, 12, 0) == 12);
+        float ans = alpaka::warp::shfl_down(acc, 3.3f, 0);
+        ALPAKA_CHECK(*success, alpaka::math::floatEqualExactNoWarning(ans, 3.3f));
+    }
+};
+
+template<std::uint32_t TWarpSize>
+struct ShflDownMultipleThreadWarpTestKernel
+{
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAcc>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
+    {
+        auto const localThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
+        auto const blockExtent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
+        std::int32_t const warpExtent = alpaka::warp::getSize(acc);
+        // Test relies on having a single warp per thread block
+        ALPAKA_CHECK(*success, static_cast<std::int32_t>(blockExtent.prod()) == warpExtent);
+        auto const threadIdxInWarp = std::int32_t(alpaka::mapIdx<1u>(localThreadIdx, blockExtent)[0]);
+
+        ALPAKA_CHECK(*success, warpExtent > 1);
+
+        ALPAKA_CHECK(*success, alpaka::warp::shfl_down(acc, 42, 0) == 42);
+        ALPAKA_CHECK(*success, alpaka::warp::shfl_down(acc, threadIdxInWarp, 0) == threadIdxInWarp);
+        ALPAKA_CHECK(
+            *success,
+            alpaka::warp::shfl_down(acc, threadIdxInWarp, 1)
+                == (threadIdxInWarp + 1 < warpExtent ? threadIdxInWarp + 1 : threadIdxInWarp));
+        auto const epsilon = std::numeric_limits<float>::epsilon();
+
+        // Test various widths
+        for(int width = 1; width < warpExtent; width *= 2)
+        {
+            for(int idx = 0; idx < width; idx++)
+            {
+                int const off = width * (threadIdxInWarp / width);
+                ALPAKA_CHECK(
+                    *success,
+                    alpaka::warp::shfl_down(acc, threadIdxInWarp, static_cast<std::uint32_t>(idx), width)
+                        == ((threadIdxInWarp + idx < (width + off)) ? threadIdxInWarp + idx : threadIdxInWarp));
+                float const ans = alpaka::warp::shfl_down(
+                    acc,
+                    4.0f - float(threadIdxInWarp),
+                    static_cast<std::uint32_t>(idx),
+                    width);
+                float const expect
+                    = ((threadIdxInWarp + idx < (width + off)) ? (4.0f - float(threadIdxInWarp + idx))
+                                                               : (4.0f - float(threadIdxInWarp)));
+                ALPAKA_CHECK(*success, alpaka::math::abs(acc, ans - expect) < epsilon);
+            }
+        }
+
+        // Some threads quit the kernel to test that the warp operations
+        // properly operate on the active threads only
+        if(threadIdxInWarp >= warpExtent / 2)
+            return;
+
+        for(int idx = 0; idx < warpExtent / 2; idx++)
+        {
+            auto const shfl = alpaka::warp::shfl_down(acc, threadIdxInWarp, static_cast<std::uint32_t>(idx));
+            float const ans
+                = alpaka::warp::shfl_down(acc, 4.0f - float(threadIdxInWarp), static_cast<std::uint32_t>(idx));
+            float const expect
+                = ((threadIdxInWarp + idx < warpExtent / 2) ? (4.0f - float(threadIdxInWarp + idx)) : 0);
+            if(threadIdxInWarp + idx < warpExtent / 2)
+            {
+                ALPAKA_CHECK(*success, shfl == threadIdxInWarp + idx);
+                ALPAKA_CHECK(*success, alpaka::math::abs(acc, ans - expect) < epsilon);
+            }
+        }
+    }
+};
+
+template<std::uint32_t TWarpSize, typename TAcc>
+struct alpaka::trait::WarpSize<ShflDownMultipleThreadWarpTestKernel<TWarpSize>, TAcc>
+    : std::integral_constant<std::uint32_t, TWarpSize>
+{
+};
+
+TEMPLATE_LIST_TEST_CASE("shfl_down", "[warp]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+    using Dev = alpaka::Dev<Acc>;
+    using Dim = alpaka::Dim<Acc>;
+    using Idx = alpaka::Idx<Acc>;
+
+    auto const platform = alpaka::Platform<Acc>{};
+    Dev const dev(alpaka::getDevByIdx(platform, 0u));
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
+    {
+        auto const scalar = Dim::value == 0 || warpExtent == 1;
+        if(scalar)
+        {
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+            REQUIRE(fixture(ShflDownSingleThreadWarpTestKernel{}));
+        }
+        else
+        {
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            if(warpExtent == 4)
+            {
+                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<4>{}));
+            }
+            else if(warpExtent == 8)
+            {
+                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<8>{}));
+            }
+            else if(warpExtent == 16)
+            {
+                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<16>{}));
+            }
+            else if(warpExtent == 32)
+            {
+                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<32>{}));
+            }
+            else if(warpExtent == 64)
+            {
+                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<64>{}));
+            }
+        }
+    }
+}
+
+#if BOOST_COMP_GNUC
+#    pragma GCC diagnostic pop
+#endif

--- a/test/unit/warp/src/ShflUp.cpp
+++ b/test/unit/warp/src/ShflUp.cpp
@@ -1,0 +1,167 @@
+/* Copyright 2023 Aurora Perego
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <alpaka/math/FloatEqualExact.hpp>
+#include <alpaka/test/KernelExecutionFixture.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
+#include <alpaka/test/queue/Queue.hpp>
+#include <alpaka/warp/Traits.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <limits>
+
+struct ShflUpSingleThreadWarpTestKernel
+{
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAcc>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
+    {
+        if constexpr(alpaka::Dim<TAcc>::value > 0)
+        {
+            ALPAKA_CHECK(*success, alpaka::warp::getSize(acc) == 1);
+            ALPAKA_CHECK(*success, alpaka::warp::shfl_up(acc, 42, 0) == 42);
+        }
+        else
+        {
+            ALPAKA_CHECK(*success, alpaka::warp::shfl_up(acc, 42, 0, 1) == 42);
+        }
+        ALPAKA_CHECK(*success, alpaka::warp::shfl_up(acc, 12, 0) == 12);
+        float ans = alpaka::warp::shfl_up(acc, 3.3f, 0);
+        ALPAKA_CHECK(*success, alpaka::math::floatEqualExactNoWarning(ans, 3.3f));
+    }
+};
+
+template<std::uint32_t TWarpSize>
+struct ShflUpMultipleThreadWarpTestKernel
+{
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAcc>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
+    {
+        auto const localThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
+        auto const blockExtent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
+        std::int32_t const warpExtent = alpaka::warp::getSize(acc);
+        // Test relies on having a single warp per thread block
+        ALPAKA_CHECK(*success, static_cast<std::int32_t>(blockExtent.prod()) == warpExtent);
+        auto const threadIdxInWarp = std::int32_t(alpaka::mapIdx<1u>(localThreadIdx, blockExtent)[0]);
+
+        ALPAKA_CHECK(*success, warpExtent > 1);
+
+        ALPAKA_CHECK(*success, alpaka::warp::shfl_up(acc, 42, 0) == 42);
+        ALPAKA_CHECK(*success, alpaka::warp::shfl_up(acc, threadIdxInWarp, 0) == threadIdxInWarp);
+        ALPAKA_CHECK(
+            *success,
+            alpaka::warp::shfl_up(acc, threadIdxInWarp, 1)
+                == (threadIdxInWarp - 1 >= 0 ? threadIdxInWarp - 1 : threadIdxInWarp));
+
+        auto const epsilon = std::numeric_limits<float>::epsilon();
+
+        // Test various widths
+        for(int width = 1; width < warpExtent; width *= 2)
+        {
+            for(int idx = 0; idx < width; idx++)
+            {
+                int const off = width * (threadIdxInWarp / width);
+                ALPAKA_CHECK(
+                    *success,
+                    alpaka::warp::shfl_up(acc, threadIdxInWarp, static_cast<std::uint32_t>(idx), width)
+                        == ((threadIdxInWarp - idx >= off) ? threadIdxInWarp - idx : threadIdxInWarp));
+                float const ans = alpaka::warp::shfl_up(
+                    acc,
+                    4.0f - float(threadIdxInWarp),
+                    static_cast<std::uint32_t>(idx),
+                    width);
+                float const expect
+                    = ((threadIdxInWarp - idx >= off) ? (4.0f - float(threadIdxInWarp - idx))
+                                                      : (4.0f - float(threadIdxInWarp)));
+                ALPAKA_CHECK(*success, alpaka::math::abs(acc, ans - expect) < epsilon);
+            }
+        }
+
+        // Some threads quit the kernel to test that the warp operations
+        // properly operate on the active threads only
+        if(threadIdxInWarp >= warpExtent / 2)
+            return;
+
+        for(int idx = 0; idx < warpExtent / 2; idx++)
+        {
+            ALPAKA_CHECK(
+                *success,
+                alpaka::warp::shfl_up(acc, threadIdxInWarp, static_cast<std::uint32_t>(idx))
+                    == ((threadIdxInWarp - idx >= 0) ? (threadIdxInWarp - idx) : threadIdxInWarp));
+            float const ans
+                = alpaka::warp::shfl_up(acc, 4.0f - float(threadIdxInWarp), static_cast<std::uint32_t>(idx));
+            float const expect
+                = ((threadIdxInWarp - idx >= 0) ? (4.0f - float(threadIdxInWarp - idx))
+                                                : (4.0f - float(threadIdxInWarp)));
+            ALPAKA_CHECK(*success, alpaka::math::abs(acc, ans - expect) < epsilon);
+        }
+    }
+};
+
+template<std::uint32_t TWarpSize, typename TAcc>
+struct alpaka::trait::WarpSize<ShflUpMultipleThreadWarpTestKernel<TWarpSize>, TAcc>
+    : std::integral_constant<std::uint32_t, TWarpSize>
+{
+};
+
+TEMPLATE_LIST_TEST_CASE("shfl_up", "[warp]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+    using Dev = alpaka::Dev<Acc>;
+    using Dim = alpaka::Dim<Acc>;
+    using Idx = alpaka::Idx<Acc>;
+
+    auto const platform = alpaka::Platform<Acc>{};
+    Dev const dev(alpaka::getDevByIdx(platform, 0u));
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
+    {
+        auto const scalar = Dim::value == 0 || warpExtent == 1;
+        if(scalar)
+        {
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+            REQUIRE(fixture(ShflUpSingleThreadWarpTestKernel{}));
+        }
+        else
+        {
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            if(warpExtent == 4)
+            {
+                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<4>{}));
+            }
+            else if(warpExtent == 8)
+            {
+                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<8>{}));
+            }
+            else if(warpExtent == 16)
+            {
+                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<16>{}));
+            }
+            else if(warpExtent == 32)
+            {
+                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<32>{}));
+            }
+            else if(warpExtent == 64)
+            {
+                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<64>{}));
+            }
+        }
+    }
+}

--- a/test/unit/warp/src/ShflXor.cpp
+++ b/test/unit/warp/src/ShflXor.cpp
@@ -1,0 +1,152 @@
+/* Copyright 2023 Aurora Perego
+ *
+ * This file is part of Alpaka.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <alpaka/math/FloatEqualExact.hpp>
+#include <alpaka/test/KernelExecutionFixture.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
+#include <alpaka/test/queue/Queue.hpp>
+#include <alpaka/warp/Traits.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+struct ShflXorSingleThreadWarpTestKernel
+{
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAcc>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
+    {
+        if constexpr(alpaka::Dim<TAcc>::value > 0)
+        {
+            ALPAKA_CHECK(*success, alpaka::warp::getSize(acc) == 1);
+            ALPAKA_CHECK(*success, alpaka::warp::shfl_xor(acc, 42, -1) == 42);
+        }
+        else
+        {
+            ALPAKA_CHECK(*success, alpaka::warp::shfl_xor(acc, 42, 0, 1) == 42);
+        }
+        ALPAKA_CHECK(*success, alpaka::warp::shfl_xor(acc, 12, 0) == 12);
+        float ans = alpaka::warp::shfl_xor(acc, 3.3f, 0);
+        ALPAKA_CHECK(*success, alpaka::math::floatEqualExactNoWarning(ans, 3.3f));
+    }
+};
+
+template<std::uint32_t TWarpSize>
+struct ShflXorMultipleThreadWarpTestKernel
+{
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAcc>
+    ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success) const -> void
+    {
+        auto const localThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
+        auto const blockExtent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
+        std::int32_t const warpExtent = alpaka::warp::getSize(acc);
+        // Test relies on having a single warp per thread block
+        ALPAKA_CHECK(*success, static_cast<std::int32_t>(blockExtent.prod()) == warpExtent);
+        auto const threadIdxInWarp = std::int32_t(alpaka::mapIdx<1u>(localThreadIdx, blockExtent)[0]);
+
+        ALPAKA_CHECK(*success, warpExtent > 1);
+
+        ALPAKA_CHECK(*success, alpaka::warp::shfl_xor(acc, 42, 0) == 42);
+        ALPAKA_CHECK(*success, alpaka::warp::shfl_xor(acc, threadIdxInWarp, 0) == threadIdxInWarp);
+        ALPAKA_CHECK(*success, alpaka::warp::shfl_xor(acc, threadIdxInWarp, 1) == (threadIdxInWarp ^ 1));
+        ALPAKA_CHECK(*success, alpaka::warp::shfl_xor(acc, 5, -1) == 5);
+
+        auto const epsilon = std::numeric_limits<float>::epsilon();
+
+        // Test various widths
+        for(int width = 1; width < warpExtent; width *= 2)
+        {
+            for(int idx = 0; idx < width; idx++)
+            {
+                ALPAKA_CHECK(
+                    *success,
+                    alpaka::warp::shfl_xor(acc, threadIdxInWarp, idx, width) == (threadIdxInWarp ^ idx));
+                float const ans = alpaka::warp::shfl_xor(acc, 4.0f - float(threadIdxInWarp), idx, width);
+                float const expect = 4.0f - float(threadIdxInWarp ^ idx);
+                ALPAKA_CHECK(*success, alpaka::math::abs(acc, ans - expect) < epsilon);
+            }
+        }
+
+        // Some threads quit the kernel to test that the warp operations
+        // properly operate on the active threads only
+        if(threadIdxInWarp >= warpExtent / 2)
+            return;
+
+        for(int idx = 0; idx < warpExtent / 2; idx++)
+        {
+            ALPAKA_CHECK(*success, alpaka::warp::shfl_xor(acc, threadIdxInWarp, idx) == (threadIdxInWarp ^ idx));
+            float const ans = alpaka::warp::shfl_xor(acc, 4.0f - float(threadIdxInWarp), idx);
+            float const expect = 4.0f - float(threadIdxInWarp ^ idx);
+            ALPAKA_CHECK(*success, alpaka::math::abs(acc, ans - expect) < epsilon);
+        }
+    }
+};
+
+template<std::uint32_t TWarpSize, typename TAcc>
+struct alpaka::trait::WarpSize<ShflXorMultipleThreadWarpTestKernel<TWarpSize>, TAcc>
+    : std::integral_constant<std::uint32_t, TWarpSize>
+{
+};
+
+TEMPLATE_LIST_TEST_CASE("shfl_xor", "[warp]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+    using Dev = alpaka::Dev<Acc>;
+    using Dim = alpaka::Dim<Acc>;
+    using Idx = alpaka::Idx<Acc>;
+
+    auto const platform = alpaka::Platform<Acc>{};
+    Dev const dev(alpaka::getDevByIdx(platform, 0u));
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
+    {
+        auto const scalar = Dim::value == 0 || warpExtent == 1;
+        if(scalar)
+        {
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+            REQUIRE(fixture(ShflXorSingleThreadWarpTestKernel{}));
+        }
+        else
+        {
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            if(warpExtent == 4)
+            {
+                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<4>{}));
+            }
+            else if(warpExtent == 8)
+            {
+                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<8>{}));
+            }
+            else if(warpExtent == 16)
+            {
+                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<16>{}));
+            }
+            else if(warpExtent == 32)
+            {
+                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<32>{}));
+            }
+            else if(warpExtent == 64)
+            {
+                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<64>{}));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Following the logic of `alpaka::shfl`, I've implemented also the other three methods: `alpaka::shfl_up`, `alpaka::shfl_down`, `alpaka::shfl_xor`.
I've also added the tests for those methods.

I have two comments on that:
- is there a reason for not having templated the `alpaka::shfl` method and having defined two different methods, one for `std::int_32t` and the other one for `float`? (btw I think that also `unsigned`, `long` and `double` should be added if we don't want to template the methods) 
- SYCL doesn't support a sub group (aka warp) size different from the width in those methods. For the moment I added an assert to check that, but maybe we should think of a way to determine the `scrLane` based on the parameters given in input to `alpaka::shfl_up`, `alpaka::shfl_down`, `alpaka::shfl_xor` and then use `alpaka::shfl` when `width != sub_group_size`.

Last thing, when running the tests I noticed that, when selecting the CUDA backend, **sometimes** the kernel is not executed (I put an `assert(false)` in a kernel and all the tests passed without crashing). I don't know why, maybe that could be discussed in a separated issue.