### PR TITLE
HIP <=5.3 avoid compiler error

### DIFF
--- a/script/job_generator/requirements.txt
+++ b/script/job_generator/requirements.txt
@@ -1,5 +1,5 @@
 alpaka-job-coverage >= 1.2.1
 allpairspy == 2.5.0
-typeguard
+typeguard < 3.0.0
 pyaml
 types-PyYAML

--- a/test/common/devCompileOptions.cmake
+++ b/test/common/devCompileOptions.cmake
@@ -151,6 +151,13 @@ ELSE()
         ENDIF()
         IF(alpaka_ACC_GPU_HIP_ENABLE)
             LIST(APPEND alpaka_DEV_COMPILE_OPTIONS "-Wno-unused-command-line-argument")
+            IF(HIP_VERSION VERSION_LESS_EQUAL 5.3)
+                # avoid error:
+                #  rocrand/rocrand_common.h:73:6: error: "Disabled inline asm, because
+                #  the build target does not support it." [-Werror,-W#warnings]
+                #  #warning "Disabled inline asm, because the build target does not support it."
+                LIST(APPEND alpaka_DEV_COMPILE_OPTIONS "-Wno-error=#warnings")
+            ENDIF()
         ENDIF()
 
         SET(IS_ICPX OFF)


### PR DESCRIPTION
Avoid compile error for CI tests if the following warning from rocrand is shown:

```
rocrand/rocrand_common.h:73:6: error: "Disabled inline asm, because the build target does not support it." [-Werror,-W#warnings]
    #warning "Disabled inline asm, because the build target does not support it."
```

The second commit is fixing issues with the CI job generator and the latest typeguard version.