### PR TITLE
Update documentation for kernel arguments

### DIFF
--- a/docs/source/advanced/rationale.rst
+++ b/docs/source/advanced/rationale.rst
@@ -212,13 +212,14 @@ Requirements
 - User kernels should be implemented independent of the accelerator.
 - A user kernel has to have access to accelerator methods (synchronization within blocks, index retrieval, ...).
 - For usage with CUDA, the kernel methods have to be attributed with ``__device__ __host__``.
-- The user kernel has to fulfill std::is_trivially_copyable because only such objects can be copied into CUDA device memory.
+- The user kernel has to fulfill ``std::is_trivially_copyable`` because only such objects can be copied into CUDA device memory.
   A trivially copyable class is a class that
   #. Has no non-trivial copy constructors(this also requires no virtual functions or virtual bases)
   #. Has no non-trivial move constructors
   #. Has no non-trivial copy assignment operators
   #. Has no non-trivial move assignment operators
   #. Has a trivial destructor
+- For the same reason all kernel parameters have to fulfill ``std::is_trivially_copyable``, too.
 
 Implementation Variants
 +++++++++++++++++++++++

--- a/docs/source/basic/library.rst
+++ b/docs/source/basic/library.rst
@@ -80,8 +80,9 @@ A kernel is a special function object which has to conform to the following requ
 * it has to fulfill the ``std::is_trivially_copyable`` trait (has to be copyable via memcpy)
 * the ``operator()`` is the kernel entry point
   * it has to be an accelerator executable function
-  * it has to return ``void``.
-  * its first argument has to be the accelerator (templated for arbitrary accelerator back-ends).
+  * it has to return ``void``
+  * its first argument has to be the accelerator (templated for arbitrary accelerator back-ends)
+  * all other arguments must fulfill ``std::is_trivially_copyable``
 
 The following code snippet shows a basic example of a kernel function object.
 
@@ -152,9 +153,9 @@ atomic functions instead.
 The ``alpaka::mem_fence`` function can be used inside an alpaka kernel to issue a memory fence instruction. This
 guarantees the following **for the local thread**  and regardless of global or shared memory:
 
-  * All loads that occur before the fence will happen before all loads occuring after the fence, i.e. no *LoadLoad*
+  * All loads that occur before the fence will happen before all loads occurring after the fence, i.e. no *LoadLoad*
     reordering.
-  * All stores that occur before the fence will happen before all stores occuring after the fence, i.e. no *StoreStore*
+  * All stores that occur before the fence will happen before all stores occurring after the fence, i.e. no *StoreStore*
     reordering.
   * The order of stores will be visible to other threads inside the scope (but not necessarily their results).
 


### PR DESCRIPTION
This PR is a documentation update.

* It is now documented that kernel arguments must fulfill `std::is_trivially_copyable`.
* Fixed a few typos.

Fixes #772.