### PR TITLE
GitLab CI: support alpaka-job-coverage 1.3.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,10 +21,10 @@ variables:
 
 generate:
   stage: generator
-  # fixed alpine version, because alpine 3.18 does not provide Python 3.10
-  image: alpine:3.17
+  # update alpine version to use newer python version
+  image: alpine:3.18
   script:
-    - apk update && apk add python3~=3.10 py3-pip
+    - apk update && apk add python3~=3.11 py3-pip
     - pip3 install -r script/job_generator/requirements.txt
     - python3 script/job_generator/job_generator.py ${ALPAKA_GITLAB_CI_GENERATOR_CONTAINER_VERSION} --compile-only -o compile_only.yml
     - python3 script/job_generator/job_generator.py ${ALPAKA_GITLAB_CI_GENERATOR_CONTAINER_VERSION} --runtime-only -o runtime.yml

--- a/script/job_generator/alpaka_filter.py
+++ b/script/job_generator/alpaka_filter.py
@@ -30,7 +30,7 @@ def alpaka_post_filter(row: List) -> bool:
     # disable all clang versions older than 14 as CUDA Compiler
     # https://github.com/alpaka-group/alpaka/issues/1857
     if row_check_backend_version(
-        row, ALPAKA_ACC_GPU_CUDA_ENABLE, "!=", OFF
+        row, ALPAKA_ACC_GPU_CUDA_ENABLE, "!=",OFF_VER
     ) and row_check_name(row, DEVICE_COMPILER, "==", CLANG_CUDA):
         if row_check_version(row, DEVICE_COMPILER, "<", "14"):
             return False

--- a/script/job_generator/generate_job_yaml.py
+++ b/script/job_generator/generate_job_yaml.py
@@ -90,7 +90,7 @@ def job_image(job: Dict[str, Tuple[str, str]], container_version: float) -> str:
 
     if (
         ALPAKA_ACC_GPU_CUDA_ENABLE in job
-        and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] != OFF
+        and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] !=OFF_VER
     ):
         # Cast cuda version shape. E.g. from 11.0 to 110
         container_url += "-cuda" + str(
@@ -101,7 +101,7 @@ def job_image(job: Dict[str, Tuple[str, str]], container_version: float) -> str:
 
     if (
         ALPAKA_ACC_GPU_HIP_ENABLE in job
-        and job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION] != OFF
+        and job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION] !=OFF_VER
     ):
         container_url += "-rocm" + job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION]
 
@@ -203,7 +203,7 @@ def job_variables(job: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
     # compiler)
     if (
         ALPAKA_ACC_GPU_CUDA_ENABLE in job
-        and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] != OFF
+        and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] !=OFF_VER
     ):
         variables[ALPAKA_ACC_GPU_CUDA_ENABLE] = "ON"
         variables["ALPAKA_CI_STDLIB"] = "libstdc++"
@@ -262,12 +262,12 @@ def job_tags(job: Dict[str, Tuple[str, str]]) -> List[str]:
 
     if (
         ALPAKA_ACC_GPU_CUDA_ENABLE in job
-        and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] != OFF
+        and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] !=OFF_VER
     ):
         return ["x86_64", "cuda"]
     if (
         ALPAKA_ACC_GPU_HIP_ENABLE in job
-        and job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION] != OFF
+        and job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION] !=OFF_VER
     ):
         return ["x86_64", "rocm"]
 

--- a/script/job_generator/job_modifier.py
+++ b/script/job_generator/job_modifier.py
@@ -55,7 +55,7 @@ def add_job_parameters(job_matrix: List[Dict[str, Tuple[str, str]]]):
     for job in job_matrix:
         if (
             ALPAKA_ACC_GPU_CUDA_ENABLE in job
-            and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] != OFF
+            and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] !=OFF_VER
         ):
             v = version.parse(job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION])
             if not v.major in latest_CUDA_SDK_minor_versions[job[HOST_COMPILER][NAME]]:
@@ -131,7 +131,7 @@ def add_job_parameters(job_matrix: List[Dict[str, Tuple[str, str]]]):
             missing_nvcc_versions.remove(job[DEVICE_COMPILER][VERSION])
         elif (
             ALPAKA_ACC_GPU_CUDA_ENABLE in job
-            and ALPAKA_ACC_GPU_CUDA_ENABLE[VERSION] != OFF
+            and ALPAKA_ACC_GPU_CUDA_ENABLE[VERSION] !=OFF_VER
         ):
             job[SM_LEVEL] = (SM_LEVEL, STANDARD_SM_LEVEL)
         else:

--- a/script/job_generator/requirements.txt
+++ b/script/job_generator/requirements.txt
@@ -1,4 +1,4 @@
-alpaka-job-coverage >= 1.2.1
+alpaka-job-coverage == 1.3.0
 allpairspy == 2.5.0
 typeguard < 3.0.0
 pyaml


### PR DESCRIPTION
Version 1.3.0 fixes a bug at parsing version numbers. Newer python versions becomes more restrictive at parsing version strings. Therefore it was necessary to replace the variable `OFF="off"` with `OFF_VER="0.0.0"` to represent, that a backend is disabled.

Update Python version of the job generator to Python 11. Was not possible because versions bug before.