### PR TITLE
Enable NVCC 12.x tests with C++20 in the GitLab CI

### DIFF
--- a/script/job_generator/alpaka_filter.py
+++ b/script/job_generator/alpaka_filter.py
@@ -9,34 +9,6 @@ from typing import List
 from alpaka_job_coverage.globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from alpaka_globals import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
-from alpaka_job_coverage.util import (
-    row_check_name,
-    row_check_version,
-    row_check_backend_version,
-)
-
 
 def alpaka_post_filter(row: List) -> bool:
-    # disable clang as host compiler for nvcc 11.3 until 11.5
-    # https://github.com/alpaka-group/alpaka/issues/1625
-    if row_check_name(row, DEVICE_COMPILER, "==", NVCC) and row_check_name(
-        row, HOST_COMPILER, "==", CLANG
-    ):
-        if row_check_version(row, DEVICE_COMPILER, ">=", "11.3") and row_check_version(
-            row, DEVICE_COMPILER, "<=", "11.5"
-        ):
-            return False
-
-    # disable all clang versions older than 14 as CUDA Compiler
-    # https://github.com/alpaka-group/alpaka/issues/1857
-    if row_check_backend_version(
-        row, ALPAKA_ACC_GPU_CUDA_ENABLE, "!=",OFF_VER
-    ) and row_check_name(row, DEVICE_COMPILER, "==", CLANG_CUDA):
-        if row_check_version(row, DEVICE_COMPILER, "<", "14"):
-            return False
-
-        # a bug in CMAKE 3.18 avoids the correct usage of the variable CMAKE_CUDA_ARCHITECTURE
-        if row_check_version(row, CMAKE, "<", "3.19"):
-            return False
-
     return True

--- a/script/job_generator/generate_job_yaml.py
+++ b/script/job_generator/generate_job_yaml.py
@@ -90,7 +90,7 @@ def job_image(job: Dict[str, Tuple[str, str]], container_version: float) -> str:
 
     if (
         ALPAKA_ACC_GPU_CUDA_ENABLE in job
-        and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] !=OFF_VER
+        and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] != OFF_VER
     ):
         # Cast cuda version shape. E.g. from 11.0 to 110
         container_url += "-cuda" + str(
@@ -101,7 +101,7 @@ def job_image(job: Dict[str, Tuple[str, str]], container_version: float) -> str:
 
     if (
         ALPAKA_ACC_GPU_HIP_ENABLE in job
-        and job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION] !=OFF_VER
+        and job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION] != OFF_VER
     ):
         container_url += "-rocm" + job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION]
 
@@ -203,7 +203,7 @@ def job_variables(job: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
     # compiler)
     if (
         ALPAKA_ACC_GPU_CUDA_ENABLE in job
-        and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] !=OFF_VER
+        and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] != OFF_VER
     ):
         variables[ALPAKA_ACC_GPU_CUDA_ENABLE] = "ON"
         variables["ALPAKA_CI_STDLIB"] = "libstdc++"
@@ -262,12 +262,12 @@ def job_tags(job: Dict[str, Tuple[str, str]]) -> List[str]:
 
     if (
         ALPAKA_ACC_GPU_CUDA_ENABLE in job
-        and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] !=OFF_VER
+        and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] != OFF_VER
     ):
         return ["x86_64", "cuda"]
     if (
         ALPAKA_ACC_GPU_HIP_ENABLE in job
-        and job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION] !=OFF_VER
+        and job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION] != OFF_VER
     ):
         return ["x86_64", "rocm"]
 
@@ -384,7 +384,6 @@ def generate_job_yaml_list(
 def distribute_to_waves(
     job_matrix: List[Dict[str, Dict]], wave_size: Dict[str, int] = {}
 ) -> Dict[str, List[List[Dict[str, Dict]]]]:
-
     sorted_groups = {}
 
     for wave in WAVE_GROUP_NAMES:

--- a/script/job_generator/requirements.txt
+++ b/script/job_generator/requirements.txt
@@ -1,4 +1,4 @@
-alpaka-job-coverage == 1.3.0
+alpaka-job-coverage == 1.3.1
 allpairspy == 2.5.0
 typeguard < 3.0.0
 pyaml


### PR DESCRIPTION
The `alpaka-job-coverage` library disabled accidentally C++ 20 tests for nvcc 12.x. `alpaka-job-coverage` 1.3.1 solves the bug.
Removed some filter rules, which are integrated in `alpaka-job-coverage` 1.3.1 now.

- [x] requires that #1951 is merged