### PR TITLE
Rework `BOOST_COMP_HIP` and `BOOST_LANG_HIP`

### DIFF
--- a/include/alpaka/core/BoostPredef.hpp
+++ b/include/alpaka/core/BoostPredef.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2023 Benjamin Worpitz, Matthias Werner, Jan Stephan
+/* Copyright 2023 Benjamin Worpitz, Matthias Werner, René Widera, Sergei Bastrakov, Jeffrey Kelling,
+ *                Bernhard Manfred Gruber, Jan Stephan
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -12,18 +13,16 @@
 #endif
 
 //---------------------------------------HIP-----------------------------------
-// __HIPCC__ is defined by hipcc (if either __CUDACC__ is defined)
+// __HIP__ is defined by both hip-clang and vanilla clang in HIP mode.
 // https://github.com/ROCm-Developer-Tools/HIP/blob/master/docs/markdown/hip_porting_guide.md#compiler-defines-summary
 #if !defined(BOOST_LANG_HIP)
-#    if defined(__HIPCC__) && (defined(__CUDACC__) || defined(__HIP__))
-#        include <hip/hip_runtime.h>
-// HIP defines "abort()" as "{asm("trap;");}", which breaks some kernels
-#        undef abort
+#    if defined(__HIP__)
+/* BOOST_LANG_CUDA is enabled when either __CUDACC__ (nvcc) or __CUDA__ (clang) are defined. This occurs when
+   nvcc / clang encounter a CUDA source file. Since there are no HIP source files we treat every source file
+   as HIP when we are using a HIP-capable compiler. */
+#        include <hip/hip_version.h>
+// HIP doesn't give us a patch level for the last entry, just a gitdate
 #        define BOOST_LANG_HIP BOOST_VERSION_NUMBER(HIP_VERSION_MAJOR, HIP_VERSION_MINOR, 0)
-#        if defined(BOOST_LANG_CUDA) && BOOST_LANG_CUDA
-#            undef BOOST_LANG_CUDA
-#            define BOOST_LANG_CUDA BOOST_VERSION_NUMBER_NOT_AVAILABLE
-#        endif
 #    else
 #        define BOOST_LANG_HIP BOOST_VERSION_NUMBER_NOT_AVAILABLE
 #    endif
@@ -40,10 +39,12 @@
 #    endif
 #endif
 
-// hip compiler detection
+// HIP compiler detection
 #if !defined(BOOST_COMP_HIP)
-#    if defined(__HIP__)
-#        define BOOST_COMP_HIP BOOST_VERSION_NUMBER_AVAILABLE
+#    if defined(__HIP__) // Defined by hip-clang and vanilla clang in HIP mode.
+#        include <hip/hip_version.h>
+// HIP doesn't give us a patch level for the last entry, just a gitdate
+#        define BOOST_COMP_HIP BOOST_VERSION_NUMBER(HIP_VERSION_MAJOR, HIP_VERSION_MINOR, 0)
 #    else
 #        define BOOST_COMP_HIP BOOST_VERSION_NUMBER_NOT_AVAILABLE
 #    endif

--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -12,6 +12,11 @@
 #    include <intrin.h>
 #endif
 
+#if BOOST_LANG_HIP
+// HIP defines some keywords like __forceinline__ in header files.
+#    include <hip/hip_runtime.h>
+#endif
+
 //! All functions that can be used on an accelerator have to be attributed with ALPAKA_FN_ACC or ALPAKA_FN_HOST_ACC.
 //!
 //! \code{.cpp}


### PR DESCRIPTION
Currently `BOOST_COMP_HIP` can only detect whether we are compiling with clang targeting HIP. This PR adds a version detection so we can have checks like these:

```c++
#if BOOST_COMP_HIP >= BOOST_VERSION_NUMBER(5, 5, 0)
```