### PR TITLE
Skip zero dimensional accelerators

### DIFF
--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -171,6 +171,7 @@
 #include "alpaka/meta/IsArrayOrVector.hpp"
 #include "alpaka/meta/IsStrictBase.hpp"
 #include "alpaka/meta/NdLoop.hpp"
+#include "alpaka/meta/NonZero.hpp"
 #include "alpaka/meta/Set.hpp"
 #include "alpaka/meta/Transform.hpp"
 #include "alpaka/meta/TypeListOps.hpp"

--- a/include/alpaka/meta/NonZero.hpp
+++ b/include/alpaka/meta/NonZero.hpp
@@ -1,0 +1,27 @@
+/* Copyright 2023 Andrea Bocci
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace alpaka::meta
+{
+    namespace detail
+    {
+        template<typename T>
+        struct NonZeroImpl : std::false_type
+        {
+        };
+
+        template<typename T, T TValue>
+        struct NonZeroImpl<std::integral_constant<T, TValue>> : std::bool_constant<TValue != static_cast<T>(0)>
+        {
+        };
+    } // namespace detail
+
+    template<typename T>
+    using NonZero = typename detail::NonZeroImpl<T>;
+
+} // namespace alpaka::meta

--- a/include/alpaka/test/acc/TestAccs.hpp
+++ b/include/alpaka/test/acc/TestAccs.hpp
@@ -145,6 +145,11 @@ namespace alpaka::test
 
     namespace detail
     {
+        //! A std::tuple holding non-zero dimensions.
+        //!
+        //! NonZeroTestDims = std::tuple<Dim1, Dim2, Dim3, ... DimN>
+        using NonZeroTestDims = meta::Filter<TestDims, meta::NonZero>;
+
         //! A std::tuple holding multiple std::tuple consisting of a dimension and a idx type.
         //!
         //! TestDimIdxTuples =
@@ -154,7 +159,7 @@ namespace alpaka::test
         //!         tuple<Dim3,Idx1>,
         //!         ...,
         //!         tuple<DimN,IdxN>>
-        using TestDimIdxTuples = meta::CartesianProduct<std::tuple, TestDims, TestIdxs>;
+        using TestDimIdxTuples = meta::CartesianProduct<std::tuple, NonZeroTestDims, TestIdxs>;
 
         template<typename TList>
         using ApplyEnabledAccs = meta::Apply<TList, EnabledAccs>;

--- a/include/alpaka/test/dim/TestDims.hpp
+++ b/include/alpaka/test/dim/TestDims.hpp
@@ -17,7 +17,7 @@ namespace alpaka::test
         DimInt<1u>,
         DimInt<2u>,
         DimInt<3u>
-    // The CUDA & HIP accelerators do not currently support 4D buffers and 4D acceleration.
+    // CUDA, HIP and SYCL accelerators do not support 4D buffers and 4D acceleration.
 #if !defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !defined(ALPAKA_ACC_SYCL_ENABLED)
         ,
         DimInt<4u>


### PR DESCRIPTION
Add a meta type to select non-zero integral constants.
Do not run tests on 0-dimensional accelerators, which breaks the compilation of some SYCL accelerators.