### PR TITLE
Make alpaka platforms full objects

### DIFF
--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -22,8 +22,8 @@ General
 
    Spacer 0,5
 
-Accelerator and Device
-----------------------
+Accelerator, Platform and Device
+--------------------------------
 
 Define in-kernel thread indexing type
   .. code-block:: c++
@@ -48,11 +48,11 @@ Define accelerator type (CUDA, OpenMP,etc.)
 	AccCpuSerial
 
 
-Select device for the given accelerator by index
+Create platform and select a device by index
    .. code-block:: c++
 
-      auto const device = getDevByIdx<Acc>(index);
-
+      auto const platform = Pltf<Acc>{};
+      auto const device = getDevByIdx(platform, index);
 
 Queue and Events
 ----------------
@@ -107,7 +107,8 @@ Memory allocation and transfers are symmetric for host and devices, both done vi
 Create a CPU device for memory allocation on the host side
   .. code-block:: c++
 
-     auto const devHost = getDevByIdx<DevCpu>(0u);
+     auto const platformHost = PltfCpu{};
+     auto const devHost = getDevByIdx(platformHost, 0);
 
 Allocate a buffer in host memory
   .. code-block:: c++

--- a/docs/source/basic/library.rst
+++ b/docs/source/basic/library.rst
@@ -264,12 +264,13 @@ The following source code listing shows the execution of a kernel by enqueuing t
    using Queue = alpaka::QueueCpuNonBlocking;
 
    // Select a device to execute on.
-   auto devAcc(alpaka::getDevByIdx<alpaka::PltfCpu>(0));
+   auto platformAcc = alpaka::Pltf<Acc>{};
+   auto devAcc = alpaka::getDevByIdx(platformAcc, 0);
    // Create a queue to enqueue the execution into.
    Queue queue(devAcc);
 
    // Create a 1-dimensional work division with 256 blocks a 16 threads.
-   auto const workDiv(alpaka::WorkDivMembers<Dim, Idx>(256u, 16u);
+   auto const workDiv = alpaka::WorkDivMembers<Dim, Idx>(256u, 16u);
    // Create an instance of the kernel function object.
    MyKernel kernel;
    // Enqueue the execution task into the queue.

--- a/docs/source/dev/test.rst
+++ b/docs/source/dev/test.rst
@@ -61,7 +61,8 @@ to the backend which is executing the test.
 Since the function that must be tested has a device object as argument, it is necessary to define one:
 
 .. code-block:: c++
-    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const platform = Pltf{};
+    Dev const dev = alpaka::getDevByIdx(platform, 0);
 
 Having all the necessary objects well defined, the function can be called and the result stored in an object:
 

--- a/example/babelstream/src/AlpakaStream.cpp
+++ b/example/babelstream/src/AlpakaStream.cpp
@@ -17,8 +17,8 @@ constexpr auto DOT_NUM_BLOCKS = 256;
 template<typename T>
 AlpakaStream<T>::AlpakaStream(Idx arraySize, Idx deviceIndex)
     : arraySize(arraySize)
-    , devHost(alpaka::getDevByIdx<DevHost>(0u))
-    , devAcc(alpaka::getDevByIdx<Acc>(deviceIndex))
+    , devHost(alpaka::getDevByIdx(platformHost, 0))
+    , devAcc(alpaka::getDevByIdx(platformAcc, deviceIndex))
     , sums(alpaka::allocBuf<T, Idx>(devHost, DOT_NUM_BLOCKS))
     , d_a(alpaka::allocBuf<T, Idx>(devAcc, arraySize))
     , d_b(alpaka::allocBuf<T, Idx>(devAcc, arraySize))
@@ -239,7 +239,8 @@ T AlpakaStream<T>::dot()
 
 void listDevices()
 {
-    auto const count = alpaka::getDevCount<Acc>();
+    auto const platform = alpaka::Pltf<Acc>{};
+    auto const count = alpaka::getDevCount(platform);
     std::cout << "Devices:" << std::endl;
     for(int i = 0; i < count; i++)
         std::cout << i << ": " << getDeviceName(i) << std::endl;
@@ -247,7 +248,8 @@ void listDevices()
 
 std::string getDeviceName(int deviceIndex)
 {
-    return alpaka::getName(alpaka::getDevByIdx<Acc>(deviceIndex));
+    auto const platform = alpaka::Pltf<Acc>{};
+    return alpaka::getName(alpaka::getDevByIdx(platform, deviceIndex));
 }
 
 std::string getDeviceDriver(int device)

--- a/example/babelstream/src/AlpakaStream.h
+++ b/example/babelstream/src/AlpakaStream.h
@@ -38,7 +38,9 @@ struct AlpakaStream : Stream<T>
     virtual void init_arrays(T initA, T initB, T initC) override;
     virtual void read_arrays(std::vector<T>& a, std::vector<T>& b, std::vector<T>& c) override;
 
-    using DevHost = alpaka::DevCpu;
+    using PlatformHost = alpaka::PltfCpu;
+    using DevHost = alpaka::Dev<PlatformHost>;
+    using PlatformAcc = alpaka::Pltf<Acc>;
     using DevAcc = alpaka::Dev<Acc>;
     using BufHost = alpaka::Buf<alpaka::DevCpu, T, Dim, Idx>;
     using BufAcc = alpaka::Buf<Acc, T, Dim, Idx>;
@@ -48,7 +50,9 @@ struct AlpakaStream : Stream<T>
 
 private:
     Idx arraySize;
+    PlatformHost platformHost;
     DevHost devHost;
+    PlatformAcc platformAcc;
     DevAcc devAcc;
     BufHost sums;
     BufAcc d_a;

--- a/example/complex/src/complex.cpp
+++ b/example/complex/src/complex.cpp
@@ -63,7 +63,8 @@ auto main() -> int
     using Queue = alpaka::Queue<Acc, QueueProperty>;
 
     // Select a device
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     // Create a queue on the device
     Queue queue(devAcc);

--- a/example/counterBasedRng/src/counterBasedRng.cpp
+++ b/example/counterBasedRng/src/counterBasedRng.cpp
@@ -124,8 +124,6 @@ auto main() -> int
     std::cout << "Using alpaka accelerator: " << alpaka::getAccName<Acc>() << std::endl;
 
     using AccHost = alpaka::AccCpuSerial<Dim, Idx>;
-    // Get the host device for allocating memory on the host.
-    using DevHost = alpaka::DevCpu;
 
     // Defines the synchronization behavior of a queue
     //
@@ -135,8 +133,10 @@ auto main() -> int
     using QueueHost = alpaka::Queue<AccHost, QueueProperty>;
 
     // Select a device
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
-    auto const devHost = alpaka::getDevByIdx<AccHost>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     // Create a queue on the device
     QueueAcc queueAcc(devAcc);
@@ -165,9 +165,8 @@ auto main() -> int
     using Data = std::uint32_t;
 
     // Allocate 3 host memory buffers
-    using BufHost = alpaka::Buf<DevHost, Data, Dim, Idx>;
-    BufHost bufHost(alpaka::allocBuf<Data, Idx>(devHost, extent));
-    BufHost bufHostDev(alpaka::allocBuf<Data, Idx>(devHost, extent));
+    auto bufHost(alpaka::allocBuf<Data, Idx>(devHost, extent));
+    auto bufHostDev(alpaka::allocBuf<Data, Idx>(devHost, extent));
 
     // Initialize the host input vectors A and B
     Data* const pBufHost(alpaka::getPtrNative(bufHost));

--- a/example/heatEquation/src/heatEquation.cpp
+++ b/example/heatEquation/src/heatEquation.cpp
@@ -95,11 +95,11 @@ auto main() -> int
     using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
     std::cout << "Using alpaka accelerator: " << alpaka::getAccName<Acc>() << std::endl;
 
-    using DevHost = alpaka::DevCpu;
-
     // Select specific devices
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
-    auto const devHost = alpaka::getDevByIdx<DevHost>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     // Get valid workdiv for the given problem
     uint32_t elemPerThread = 1;
@@ -118,11 +118,10 @@ auto main() -> int
     QueueAcc queue{devAcc};
 
     // Initialize host-buffer
-    using BufHost = alpaka::Buf<DevHost, double, Dim, Idx>;
     // This buffer holds the calculated values
-    auto uNextBufHost = BufHost{alpaka::allocBuf<double, Idx>(devHost, extent)};
+    auto uNextBufHost = alpaka::allocBuf<double, Idx>(devHost, extent);
     // This buffer will hold the current values (used for the next step)
-    auto uCurrBufHost = BufHost{alpaka::allocBuf<double, Idx>(devHost, extent)};
+    auto uCurrBufHost = alpaka::allocBuf<double, Idx>(devHost, extent);
 
     double* const pCurrHost = alpaka::getPtrNative(uCurrBufHost);
     double* const pNextHost = alpaka::getPtrNative(uNextBufHost);

--- a/example/helloWorld/src/helloWorld.cpp
+++ b/example/helloWorld/src/helloWorld.cpp
@@ -74,7 +74,7 @@ auto main() -> int
     // - AccCpuSerial
     //
     // Each accelerator has strengths and weaknesses. Therefore,
-    // they need to be choosen carefully depending on the actual
+    // they need to be chosen carefully depending on the actual
     // use case. Furthermore, some accelerators only support a
     // particular workdiv, but workdiv can also be generated
     // automatically.
@@ -93,12 +93,13 @@ auto main() -> int
     // Select a device
     //
     // The accelerator only defines how something should be
-    // parallized, but a device is the real entity which will
-    // run the parallel programm. The device can be choosen
+    // parallelized, but a device is the real entity which will
+    // run the parallel program. The device can be chosen
     // by id (0 to the number of devices minus 1) or you
     // can also retrieve all devices in a vector (getDevs()).
-    // In this example the first devices is choosen.
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    // In this example the first devices is chosen.
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     // Create a queue on the device
     //
@@ -108,7 +109,7 @@ auto main() -> int
     // tasks will be executed. Queues are provided in
     // non-blocking and blocking variants.
     // The example queue is a blocking queue to a cpu device,
-    // but it also exists an non-blocking queue for this
+    // but it also exists as non-blocking queue for this
     // device (QueueCpuNonBlocking).
     Queue queue(devAcc);
 
@@ -165,7 +166,7 @@ auto main() -> int
     // parameters.
     // The kernel execution task is enqueued into an accelerator queue.
     // The queue can be blocking or non-blocking
-    // depending on the choosen queue type (see type definitions above).
+    // depending on the chosen queue type (see type definitions above).
     // Here it is synchronous which means that the kernel is directly executed.
     alpaka::exec<Acc>(
         queue,

--- a/example/helloWorldLambda/src/helloWorldLambda.cpp
+++ b/example/helloWorldLambda/src/helloWorldLambda.cpp
@@ -71,7 +71,8 @@ auto main() -> int
     using Queue = alpaka::Queue<Acc, QueueProperty>;
 
     // Select a device
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     // Create a queue on the device
     Queue queue(devAcc);

--- a/example/kernelSpecialization/src/kernelSpecialization.cpp
+++ b/example/kernelSpecialization/src/kernelSpecialization.cpp
@@ -80,7 +80,8 @@ auto main() -> int
     using Queue = alpaka::Queue<Acc, QueueProperty>;
 
     // Select a device
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     // Create a queue on the device
     Queue queue(devAcc);

--- a/example/monteCarloIntegration/src/monteCarloIntegration.cpp
+++ b/example/monteCarloIntegration/src/monteCarloIntegration.cpp
@@ -81,8 +81,10 @@ auto main() -> int
     using Vec = alpaka::Vec<Dim, Idx>;
     using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
     using Host = alpaka::DevCpu;
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
-    auto const devHost = alpaka::getDevByIdx<Host>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
     using QueueProperty = alpaka::Blocking;
     using QueueAcc = alpaka::Queue<Acc, QueueProperty>;
     QueueAcc queue{devAcc};

--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -98,7 +98,8 @@ auto main() -> int
     using Queue = alpaka::Queue<Acc, QueueProperty>;
 
     // Select a device
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     // Create a queue on the device
     Queue queue(devAcc);

--- a/example/randomCells2D/src/randomCells2D.cpp
+++ b/example/randomCells2D/src/randomCells2D.cpp
@@ -150,8 +150,10 @@ auto main() -> int
     using Vec = alpaka::Vec<Dim, Idx>;
     using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
     using Host = alpaka::DevCpu;
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
-    auto const devHost = alpaka::getDevByIdx<Host>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
     using QueueProperty = alpaka::Blocking;
     using QueueAcc = alpaka::Queue<Acc, QueueProperty>;
     QueueAcc queue{devAcc};

--- a/example/reduce/src/reduce.cpp
+++ b/example/reduce/src/reduce.cpp
@@ -115,8 +115,10 @@ auto main() -> int
     using T = uint32_t;
     static constexpr uint64_t blockSize = getMaxBlockSize<Accelerator, 256>();
 
-    auto devAcc = alpaka::getDevByIdx<Acc>(dev);
-    auto devHost = alpaka::getDevByIdx<Host>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
     QueueAcc queue(devAcc);
 
     // calculate optimal block size (8 times the MP count proved to be

--- a/example/tagSpecialization/src/tagSpecialization.cpp
+++ b/example/tagSpecialization/src/tagSpecialization.cpp
@@ -107,7 +107,8 @@ auto main() -> int
     using QueueProperty = alpaka::Blocking;
     using Queue = alpaka::Queue<Acc, QueueProperty>;
     // Select a device
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     // Create a queue on the device
     Queue queue(devAcc);

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -85,7 +85,8 @@ auto main() -> int
     using QueueAcc = alpaka::Queue<Acc, QueueProperty>;
 
     // Select a device
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const platform = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platform, 0);
 
     // Create a queue on the device
     QueueAcc queue(devAcc);
@@ -108,7 +109,8 @@ auto main() -> int
 
     // Get the host device for allocating memory on the host.
     using DevHost = alpaka::DevCpu;
-    auto const devHost = alpaka::getDevByIdx<DevHost>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
 
     // Allocate 3 host memory buffers
     using BufHost = alpaka::Buf<DevHost, Data, Dim, Idx>;

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -38,7 +38,7 @@ namespace alpaka
         template<typename TPltf, typename TSfinae>
         struct GetDevByIdx;
     }
-    class PltfCpu;
+    struct PltfCpu;
 
     //! The CPU device.
     namespace cpu::detail

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     using QueueUniformCudaHipRtNonBlocking = uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, false>;
 
     template<typename TApi>
-    class PltfUniformCudaHipRt;
+    struct PltfUniformCudaHipRt;
 
     template<typename TApi, typename TElem, typename TDim, typename TIdx>
     class BufUniformCudaHipRt;

--- a/include/alpaka/mem/view/ViewStdArray.hpp
+++ b/include/alpaka/mem/view/ViewStdArray.hpp
@@ -29,7 +29,9 @@ namespace alpaka::trait
     {
         ALPAKA_FN_HOST static auto getDev(std::array<TElem, Tsize> const& /* view */) -> DevCpu
         {
-            return getDevByIdx<PltfCpu>(0u);
+            // Instantiating the CPU platform here is a hack we can do internally, because we know that the CPU
+            // platform does not contain any data. But it generally does not apply.
+            return getDevByIdx(PltfCpu{}, 0u);
         }
     };
 

--- a/include/alpaka/mem/view/ViewStdVector.hpp
+++ b/include/alpaka/mem/view/ViewStdVector.hpp
@@ -29,7 +29,7 @@ namespace alpaka::trait
     {
         ALPAKA_FN_HOST static auto getDev(std::vector<TElem, TAllocator> const& /* view */) -> DevCpu
         {
-            return getDevByIdx<PltfCpu>(0u);
+            return getDevByIdx(PltfCpu{}, 0u);
         }
     };
 

--- a/include/alpaka/pltf/PltfCpu.hpp
+++ b/include/alpaka/pltf/PltfCpu.hpp
@@ -14,10 +14,8 @@
 namespace alpaka
 {
     //! The CPU device platform.
-    class PltfCpu : public concepts::Implements<ConceptPltf, PltfCpu>
+    struct PltfCpu : concepts::Implements<ConceptPltf, PltfCpu>
     {
-    public:
-        ALPAKA_FN_HOST PltfCpu() = delete;
     };
 
     namespace trait
@@ -33,7 +31,7 @@ namespace alpaka
         template<>
         struct GetDevCount<PltfCpu>
         {
-            ALPAKA_FN_HOST static auto getDevCount() -> std::size_t
+            ALPAKA_FN_HOST static auto getDevCount(PltfCpu const&) -> std::size_t
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
@@ -45,11 +43,11 @@ namespace alpaka
         template<>
         struct GetDevByIdx<PltfCpu>
         {
-            ALPAKA_FN_HOST static auto getDevByIdx(std::size_t const& devIdx) -> DevCpu
+            ALPAKA_FN_HOST static auto getDevByIdx(PltfCpu const& platform, std::size_t const& devIdx) -> DevCpu
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                std::size_t const devCount(getDevCount<PltfCpu>());
+                std::size_t const devCount = getDevCount(platform);
                 if(devIdx >= devCount)
                 {
                     std::stringstream ssErr;

--- a/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
+++ b/include/alpaka/pltf/PltfUniformCudaHipRt.hpp
@@ -25,10 +25,8 @@ namespace alpaka
 
     //! The CUDA/HIP RT platform.
     template<typename TApi>
-    class PltfUniformCudaHipRt : public concepts::Implements<ConceptPltf, PltfUniformCudaHipRt<TApi>>
+    struct PltfUniformCudaHipRt : concepts::Implements<ConceptPltf, PltfUniformCudaHipRt<TApi>>
     {
-    public:
-        ALPAKA_FN_HOST PltfUniformCudaHipRt() = delete;
     };
 
     namespace trait
@@ -44,7 +42,7 @@ namespace alpaka
         template<typename TApi>
         struct GetDevCount<PltfUniformCudaHipRt<TApi>>
         {
-            ALPAKA_FN_HOST static auto getDevCount() -> std::size_t
+            ALPAKA_FN_HOST static auto getDevCount(PltfUniformCudaHipRt<TApi> const&) -> std::size_t
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
@@ -61,11 +59,13 @@ namespace alpaka
         template<typename TApi>
         struct GetDevByIdx<PltfUniformCudaHipRt<TApi>>
         {
-            ALPAKA_FN_HOST static auto getDevByIdx(std::size_t const& devIdx) -> DevUniformCudaHipRt<TApi>
+            ALPAKA_FN_HOST static auto getDevByIdx(
+                PltfUniformCudaHipRt<TApi> const& platform,
+                std::size_t const& devIdx) -> DevUniformCudaHipRt<TApi>
             {
                 ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                std::size_t const devCount(getDevCount<PltfUniformCudaHipRt<TApi>>());
+                std::size_t const devCount = getDevCount(platform);
                 if(devIdx >= devCount)
                 {
                     std::stringstream ssErr;

--- a/include/alpaka/pltf/Traits.hpp
+++ b/include/alpaka/pltf/Traits.hpp
@@ -50,29 +50,29 @@ namespace alpaka
 
     //! \return The device identified by its index.
     template<typename TPltf>
-    ALPAKA_FN_HOST auto getDevCount()
+    ALPAKA_FN_HOST auto getDevCount(TPltf const& platform)
     {
-        return trait::GetDevCount<Pltf<TPltf>>::getDevCount();
+        return trait::GetDevCount<TPltf>::getDevCount(platform);
     }
 
     //! \return The device identified by its index.
     template<typename TPltf>
-    ALPAKA_FN_HOST auto getDevByIdx(std::size_t const& devIdx)
+    ALPAKA_FN_HOST auto getDevByIdx(TPltf const& platform, std::size_t const& devIdx) -> Dev<TPltf>
     {
-        return trait::GetDevByIdx<Pltf<TPltf>>::getDevByIdx(devIdx);
+        return trait::GetDevByIdx<TPltf>::getDevByIdx(platform, devIdx);
     }
 
     //! \return All the devices available on this accelerator.
     template<typename TPltf>
-    ALPAKA_FN_HOST auto getDevs() -> std::vector<Dev<Pltf<TPltf>>>
+    ALPAKA_FN_HOST auto getDevs(TPltf const& platform) -> std::vector<Dev<TPltf>>
     {
-        std::vector<Dev<Pltf<TPltf>>> devs;
+        std::vector<Dev<TPltf>> devs;
 
-        std::size_t const devCount(getDevCount<Pltf<TPltf>>());
+        std::size_t const devCount = getDevCount(platform);
         devs.reserve(devCount);
         for(std::size_t devIdx(0); devIdx < devCount; ++devIdx)
         {
-            devs.push_back(getDevByIdx<Pltf<TPltf>>(devIdx));
+            devs.push_back(getDevByIdx(platform, devIdx));
         }
 
         return devs;

--- a/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/include/alpaka/test/KernelExecutionFixture.hpp
@@ -29,14 +29,15 @@ namespace alpaka::test
         using Acc = TAcc;
         using Dim = alpaka::Dim<Acc>;
         using Idx = alpaka::Idx<Acc>;
+        using PlatformAcc = Pltf<Acc>;
         using DevAcc = Dev<Acc>;
         using PltfAcc = Pltf<DevAcc>;
         using QueueAcc = test::DefaultQueue<DevAcc>;
         using WorkDiv = WorkDivMembers<Dim, Idx>;
 
         KernelExecutionFixture(WorkDiv workDiv)
-            : m_devHost(getDevByIdx<PltfCpu>(0u))
-            , m_devAcc(getDevByIdx<PltfAcc>(0u))
+            : m_devHost(getDevByIdx(m_platformHost, 0))
+            , m_devAcc(getDevByIdx(m_platformAcc, 0))
             , m_queue(m_devAcc)
             , m_workDiv(std::move(workDiv))
         {
@@ -45,7 +46,7 @@ namespace alpaka::test
         template<typename TExtent>
         KernelExecutionFixture(TExtent const& extent)
             : KernelExecutionFixture(getValidWorkDiv<Acc>(
-                getDevByIdx<PltfAcc>(0u),
+                getDevByIdx(m_platformAcc, 0),
                 extent,
                 Vec<Dim, Idx>::ones(),
                 false,
@@ -73,7 +74,9 @@ namespace alpaka::test
         }
 
     private:
+        PltfCpu m_platformHost;
         DevCpu m_devHost;
+        PlatformAcc m_platformAcc;
         DevAcc m_devAcc;
         QueueAcc m_queue;
         WorkDiv m_workDiv;

--- a/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/include/alpaka/test/mem/view/ViewTest.hpp
@@ -201,12 +201,10 @@ namespace alpaka::test
     template<typename TView, typename TQueue>
     ALPAKA_FN_HOST auto iotaFillView(TQueue& queue, TView& view) -> void
     {
-        using DevHost = DevCpu;
-        using PltfHost = Pltf<DevHost>;
-
         using Elem = Elem<TView>;
 
-        DevHost const devHost = getDevByIdx<PltfHost>(0);
+        auto const platformHost = alpaka::PltfCpu{};
+        auto const devHost = alpaka::getDevByIdx(platformHost, 0);
 
         auto const extent = getExtentVec(view);
 

--- a/include/alpaka/test/queue/QueueTestFixture.hpp
+++ b/include/alpaka/test/queue/QueueTestFixture.hpp
@@ -14,13 +14,13 @@ namespace alpaka::test
     {
         using Dev = std::tuple_element_t<0, TDevQueue>;
         using Queue = std::tuple_element_t<1, TDevQueue>;
-
         using Pltf = alpaka::Pltf<Dev>;
 
-        QueueTestFixture() : m_dev(getDevByIdx<Pltf>(0u)), m_queue(m_dev)
+        QueueTestFixture() : m_dev(getDevByIdx(m_platform, 0)), m_queue(m_dev)
         {
         }
 
+        Pltf m_platform;
         Dev m_dev;
         Queue m_queue;
     };

--- a/test/integ/axpy/src/axpy.cpp
+++ b/test/integ/axpy/src/axpy.cpp
@@ -78,16 +78,17 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
     using DevAcc = alpaka::Dev<Acc>;
     using PltfAcc = alpaka::Pltf<DevAcc>;
     using QueueAcc = alpaka::test::DefaultQueue<DevAcc>;
-    using PltfHost = alpaka::PltfCpu;
 
     // Create the kernel function object.
     AxpyKernel kernel;
 
     // Get the host device.
-    auto const devHost = alpaka::getDevByIdx<PltfHost>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
 
     // Select a device to execute on.
-    auto const devAcc = alpaka::getDevByIdx<PltfAcc>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     // Get a queue on this device.
     QueueAcc queue(devAcc);

--- a/test/integ/hostOnlyAPI/src/hostOnlyAPI.cpp
+++ b/test/integ/hostOnlyAPI/src/hostOnlyAPI.cpp
@@ -39,7 +39,8 @@ TEMPLATE_LIST_TEST_CASE("hostOnlyAPI", "[hostOnlyAPI]", TestAccs)
     using HostQueue = alpaka::Queue<Host, alpaka::Blocking>;
 
     // CPU host
-    auto const host = alpaka::getDevByIdx<Host>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const host = alpaka::getDevByIdx(platformHost, 0);
     INFO("using alpaka device: " << alpaka::getName(host));
     HostQueue hostQueue(host);
 
@@ -81,7 +82,8 @@ TEMPLATE_LIST_TEST_CASE("hostOnlyAPI", "[hostOnlyAPI]", TestAccs)
     CHECK(expected1 == *alpaka::getPtrNative(h_buffer1));
 
     // GPU device
-    auto const device = alpaka::getDevByIdx<Device>(0u);
+    auto const platformAcc = alpaka::Pltf<TestType>{};
+    auto const device = alpaka::getDevByIdx(platformAcc, 0);
     INFO("using alpaka device: " << alpaka::getName(device));
     DeviceQueue deviceQueue(device);
 

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -274,16 +274,17 @@ TEMPLATE_LIST_TEST_CASE("mandelbrot", "[mandelbrot]", TestAccs)
     using DevAcc = alpaka::Dev<Acc>;
     using PltfAcc = alpaka::Pltf<DevAcc>;
     using QueueAcc = alpaka::test::DefaultQueue<DevAcc>;
-    using PltfHost = alpaka::PltfCpu;
 
     // Create the kernel function object.
     MandelbrotKernel kernel;
 
     // Get the host device.
-    auto const devHost = alpaka::getDevByIdx<PltfHost>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
 
     // Select a device to execute on.
-    auto const devAcc = alpaka::getDevByIdx<PltfAcc>(0u);
+    auto const platformAcc = PltfAcc{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     // Get a queue on this device.
     QueueAcc queue(devAcc);

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -165,21 +165,21 @@ TEMPLATE_LIST_TEST_CASE("matMul", "[matMul]", TestAccs)
     using DevAcc = alpaka::Dev<Acc>;
     using PltfAcc = alpaka::Pltf<DevAcc>;
     using QueueAcc = alpaka::test::DefaultQueue<alpaka::Dev<Acc>>;
-    using PltfHost = alpaka::PltfCpu;
-    using DevHost = alpaka::Dev<PltfHost>;
     using QueueHost = alpaka::QueueCpuNonBlocking;
 
     // Create the kernel function object.
     MatMulKernel kernel;
 
     // Get the host device.
-    DevHost const devHost = alpaka::getDevByIdx<PltfHost>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
 
     // Get a queue on the host device.
     QueueHost queueHost(devHost);
 
     // Select a device to execute on.
-    DevAcc const devAcc = alpaka::getDevByIdx<PltfAcc>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     // Get a queue on the accelerator device.
     QueueAcc queueAcc(devAcc);

--- a/test/integ/separableCompilation/src/main.cpp
+++ b/test/integ/separableCompilation/src/main.cpp
@@ -70,8 +70,6 @@ TEMPLATE_LIST_TEST_CASE("separableCompilation", "[separableCompilation]", TestAc
     using DevAcc = alpaka::Dev<Acc>;
     using PltfAcc = alpaka::Pltf<DevAcc>;
     using QueueAcc = alpaka::test::DefaultQueue<alpaka::Dev<Acc>>;
-    using PltfHost = alpaka::PltfCpu;
-    using DevHost = alpaka::Dev<PltfHost>;
 
     Idx const numElements = 32;
 
@@ -79,10 +77,12 @@ TEMPLATE_LIST_TEST_CASE("separableCompilation", "[separableCompilation]", TestAc
     SqrtKernel kernel;
 
     // Get the host device.
-    DevHost const devHost = alpaka::getDevByIdx<PltfHost>(0);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
 
     // Select a device to execute on.
-    DevAcc const devAcc = alpaka::getDevByIdx<PltfAcc>(0);
+    auto const platformAcc = PltfAcc{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     // Get a queue on this device.
     QueueAcc queueAcc(devAcc);

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -117,7 +117,6 @@ TEMPLATE_LIST_TEST_CASE("sharedMem", "[sharedMem]", TestAccs)
     using TnumUselessWork = std::integral_constant<Idx, 100>;
 
     using DevAcc = alpaka::Dev<Acc>;
-    using PltfAcc = alpaka::Pltf<DevAcc>;
     using QueueAcc = alpaka::test::DefaultQueue<DevAcc>;
 
 
@@ -125,7 +124,8 @@ TEMPLATE_LIST_TEST_CASE("sharedMem", "[sharedMem]", TestAccs)
     SharedMemKernel<TnumUselessWork, Val> kernel;
 
     // Select a device to execute on.
-    auto const devAcc = alpaka::getDevByIdx<PltfAcc>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     // Get a queue on this device.
     QueueAcc queue(devAcc);

--- a/test/integ/zeroDimBuffer/src/zeroDimBuffer.cpp
+++ b/test/integ/zeroDimBuffer/src/zeroDimBuffer.cpp
@@ -38,11 +38,9 @@ using TestAccs = alpaka::test::EnabledAccs<Dim1D, Idx>;
 TEMPLATE_LIST_TEST_CASE("zeroDimBuffer", "[zeroDimBuffer]", TestAccs)
 {
     using DeviceAcc = TestType;
-    using Device = alpaka::Dev<DeviceAcc>;
     using DeviceQueue = alpaka::Queue<DeviceAcc, alpaka::NonBlocking>;
 
     using HostAcc = alpaka::AccCpuSerial<Dim1D, Idx>;
-    using Host = alpaka::DevCpu;
     using HostQueue = alpaka::Queue<HostAcc, alpaka::Blocking>;
 
     // check that a Scalar extent has exactly 1 element
@@ -51,7 +49,8 @@ TEMPLATE_LIST_TEST_CASE("zeroDimBuffer", "[zeroDimBuffer]", TestAccs)
     CHECK(scalar.prod() == 1u);
 
     // CPU host
-    auto const host = alpaka::getDevByIdx<Host>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const host = alpaka::getDevByIdx(platformHost, 0);
     INFO("Using alpaka accelerator: " << alpaka::getAccName<HostAcc>());
     HostQueue hostQueue(host);
 
@@ -93,7 +92,8 @@ TEMPLATE_LIST_TEST_CASE("zeroDimBuffer", "[zeroDimBuffer]", TestAccs)
     CHECK(expected1 == *h_buffer1);
 
     // GPU device
-    auto const device = alpaka::getDevByIdx<Device>(0u);
+    auto const platformAcc = alpaka::Pltf<DeviceAcc>{};
+    auto const device = alpaka::getDevByIdx(platformAcc, 0);
     INFO("Using alpaka accelerator: " << alpaka::getAccName<DeviceAcc>());
     DeviceQueue deviceQueue(device);
 

--- a/test/unit/acc/src/AccDevPropsTest.cpp
+++ b/test/unit/acc/src/AccDevPropsTest.cpp
@@ -12,9 +12,8 @@
 TEMPLATE_LIST_TEST_CASE("getAccDevProps", "[acc]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::Dev<Acc>;
-    using Pltf = alpaka::Pltf<Dev>;
-    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const platform = alpaka::Pltf<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
     auto const devProps = alpaka::getAccDevProps<Acc>(dev);
 
     REQUIRE(devProps.m_gridBlockExtentMax.min() > 0);

--- a/test/unit/acc/src/AccTagTest.cpp
+++ b/test/unit/acc/src/AccTagTest.cpp
@@ -198,11 +198,12 @@ TEMPLATE_LIST_TEST_CASE("kernel specialization with tags", "[acc][tag]", TestAcc
     using TestAcc = TestType;
     using QueueProperty = alpaka::Blocking;
     using Queue = alpaka::Queue<TestAcc, QueueProperty>;
-    auto const devAcc = alpaka::getDevByIdx<TestAcc>(0u);
+    auto const platformAcc = alpaka::Pltf<TestAcc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
     Queue queue(devAcc);
 
-    using PltfHost = alpaka::PltfCpu;
-    auto const devHost = alpaka::getDevByIdx<PltfHost>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
 
     using Vec = alpaka::Vec<alpaka::DimInt<1>, int>;
     Vec extents(Vec::all(1));

--- a/test/unit/block/sharedSharing/src/BlockSharedMemSharing.cpp
+++ b/test/unit/block/sharedSharing/src/BlockSharedMemSharing.cpp
@@ -53,7 +53,8 @@ void BlockSharedMemSharingTest(TKernel kernel)
     using Idx = alpaka::Idx<TAcc>;
     using Vec = alpaka::Vec<Dim, Idx>;
 
-    auto const devAcc = alpaka::getDevByIdx<TAcc>(0u);
+    auto const platformAcc = alpaka::Pltf<TAcc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     auto const accDevProps = alpaka::getAccDevProps<TAcc>(devAcc);
     const Idx gridBlockCount = 2u;
@@ -68,8 +69,8 @@ void BlockSharedMemSharingTest(TKernel kernel)
 
     alpaka::exec<TAcc>(queue, workDiv, kernel, alpaka::getPtrNative(bufAcc));
 
-    using DevHost = alpaka::DevCpu;
-    auto const devHost = alpaka::getDevByIdx<DevHost>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
     auto bufHost = alpaka::allocBuf<std::uint32_t, Idx>(devHost, gridBlockCount);
 
     alpaka::memcpy(queue, bufHost, bufAcc);

--- a/test/unit/dev/src/DevWarpSizeTest.cpp
+++ b/test/unit/dev/src/DevWarpSizeTest.cpp
@@ -13,9 +13,8 @@
 
 TEMPLATE_LIST_TEST_CASE("getWarpSizes", "[dev]", alpaka::test::TestAccs)
 {
-    using Dev = alpaka::Dev<TestType>;
-    using Pltf = alpaka::Pltf<Dev>;
-    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const platform = alpaka::Pltf<TestType>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
     auto const warpExtents = alpaka::getWarpSizes(dev);
     REQUIRE(std::all_of(
         std::cbegin(warpExtents),

--- a/test/unit/idx/src/MapIdxPitchBytes.cpp
+++ b/test/unit/idx/src/MapIdxPitchBytes.cpp
@@ -25,7 +25,8 @@ TEMPLATE_LIST_TEST_CASE("mapIdxPitchBytes", "[idx]", alpaka::test::NonZeroTestDi
 
     using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
     using Elem = std::uint8_t;
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
     auto parentView = alpaka::createView(devAcc, static_cast<Elem*>(nullptr), extentNd);
 
     auto const offset = Vec::all(4u);

--- a/test/unit/math/src/Buffer.hpp
+++ b/test/unit/math/src/Buffer.hpp
@@ -44,6 +44,7 @@ namespace alpaka
                     using PltfAcc = alpaka::Pltf<DevAcc>;
                     using BufAcc = alpaka::Buf<DevAcc, TData, Dim, Idx>;
 
+                    PltfHost platformHost;
                     DevHost devHost;
 
                     BufHost hostBuffer;
@@ -59,7 +60,7 @@ namespace alpaka
 
                     // Constructor needs to initialize all Buffer.
                     Buffer(DevAcc const& devAcc)
-                        : devHost{alpaka::getDevByIdx<PltfHost>(0u)}
+                        : devHost{alpaka::getDevByIdx(platformHost, 0)}
                         , hostBuffer{alpaka::allocMappedBufIfSupported<PltfAcc, TData, Idx>(devHost, Tcapacity)}
                         , devBuffer{alpaka::allocBuf<TData, Idx>(devAcc, Tcapacity)}
                         , pHostBuffer{alpaka::getPtrNative(hostBuffer)}

--- a/test/unit/math/src/TestTemplate.hpp
+++ b/test/unit/math/src/TestTemplate.hpp
@@ -69,11 +69,8 @@ struct TestTemplate
                   << alpaka::core::demangled<TWrappedFunctor> << " seed:" << seed << std::endl;
 
         // SETUP (defines and initialising)
-        // DevAcc and DevHost are defined in Buffer.hpp too.
+        // DevAcc is defined in Buffer.hpp too.
         using DevAcc = alpaka::Dev<TAcc>;
-        using DevHost = alpaka::DevCpu;
-        using PltfAcc = alpaka::Pltf<DevAcc>;
-        using PltfHost = alpaka::Pltf<DevHost>;
 
         using Dim = alpaka::DimInt<1u>;
         using Idx = std::size_t;
@@ -90,8 +87,10 @@ struct TestTemplate
         static constexpr size_t elementsPerThread = 1u;
         static constexpr size_t sizeExtent = 1u;
 
-        DevAcc const devAcc = alpaka::getDevByIdx<PltfAcc>(0u);
-        DevHost const devHost = alpaka::getDevByIdx<PltfHost>(0u);
+        auto const platformAcc = alpaka::Pltf<TAcc>{};
+        auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
+        auto const platformHost = alpaka::PltfCpu{};
+        auto const devHost = alpaka::getDevByIdx(platformHost, 0);
 
         QueueAcc queue{devAcc};
 

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -19,14 +19,14 @@ template<typename TAcc>
 static auto testBufferMutable(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
 {
     using Dev = alpaka::Dev<TAcc>;
-    using Pltf = alpaka::Pltf<Dev>;
     using Queue = alpaka::test::DefaultQueue<Dev>;
 
     using Elem = float;
     using Dim = alpaka::Dim<TAcc>;
     using Idx = alpaka::Idx<TAcc>;
 
-    Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+    auto const platformAcc = alpaka::Pltf<TAcc>{};
+    auto const dev = alpaka::getDevByIdx(platformAcc, 0);
     Queue queue(dev);
 
     // alpaka::malloc
@@ -42,14 +42,14 @@ template<typename TAcc>
 static auto testAsyncBufferMutable(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
 {
     using Dev = alpaka::Dev<TAcc>;
-    using Pltf = alpaka::Pltf<Dev>;
     using Queue = alpaka::test::DefaultQueue<Dev>;
 
     using Elem = float;
     using Dim = alpaka::Dim<TAcc>;
     using Idx = alpaka::Idx<TAcc>;
 
-    Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+    auto const platformAcc = alpaka::Pltf<TAcc>{};
+    auto const dev = alpaka::getDevByIdx(platformAcc, 0);
     Queue queue(dev);
 
     // memory is allocated when the queue reaches this point
@@ -128,14 +128,12 @@ TEMPLATE_LIST_TEST_CASE("memBufAsyncZeroSizeTest", "[memBuf]", alpaka::test::Tes
 template<typename TAcc>
 static auto testBufferImmutable(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
 {
-    using Dev = alpaka::Dev<TAcc>;
-    using Pltf = alpaka::Pltf<Dev>;
-
     using Elem = float;
     using Dim = alpaka::Dim<TAcc>;
     using Idx = alpaka::Idx<TAcc>;
 
-    Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+    auto const platformAcc = alpaka::Pltf<TAcc>{};
+    auto const dev = alpaka::getDevByIdx(platformAcc, 0);
 
     // alpaka::malloc
     auto const buf = alpaka::allocBuf<Elem, Idx>(dev, extent);
@@ -161,14 +159,14 @@ static auto testAsyncBufferImmutable(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<
 {
     {
         using Dev = alpaka::Dev<TAcc>;
-        using Pltf = alpaka::Pltf<Dev>;
         using Queue = alpaka::test::DefaultQueue<Dev>;
 
         using Elem = float;
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
 
-        Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+        auto const platformAcc = alpaka::Pltf<TAcc>{};
+        auto const dev = alpaka::getDevByIdx(platformAcc, 0);
         Queue queue(dev);
 
         // memory is allocated when the queue reaches this point
@@ -216,9 +214,6 @@ static auto testBufferAccessorAdaptor(
     alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent,
     alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& index) -> void
 {
-    using Dev = alpaka::Dev<TAcc>;
-    using Pltf = alpaka::Pltf<Dev>;
-
     using Elem = float;
     using Dim = alpaka::Dim<TAcc>;
     using Idx = alpaka::Idx<TAcc>;
@@ -226,7 +221,8 @@ static auto testBufferAccessorAdaptor(
     // assume dimensionality up to 4
     CHECK(Dim::value <= 4);
 
-    Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+    auto const platformAcc = alpaka::Pltf<TAcc>{};
+    auto const dev = alpaka::getDevByIdx(platformAcc, 0);
 
     // alpaka::malloc
     auto buf = alpaka::allocBuf<Elem, Idx>(dev, extent);
@@ -279,11 +275,12 @@ TEMPLATE_LIST_TEST_CASE("memBufMove", "[memBuf]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
     using Idx = alpaka::Idx<Acc>;
-    using Pltf = alpaka::Pltf<alpaka::Dev<Acc>>;
     using Elem = std::size_t;
 
-    auto const devHost = alpaka::getDevByIdx<alpaka::PltfCpu>(0u);
-    auto const dev = alpaka::getDevByIdx<Pltf>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platformAcc, 0);
     auto queue = alpaka::Queue<Acc, alpaka::Blocking>{dev};
     auto const extent = alpaka::Vec<alpaka::DimInt<0>, Idx>{};
 

--- a/test/unit/mem/copy/src/BufSlicing.cpp
+++ b/test/unit/mem/copy/src/BufSlicing.cpp
@@ -23,7 +23,7 @@ struct TestContainer
     using AccQueueProperty = alpaka::Blocking;
     using DevQueue = alpaka::Queue<TAcc, AccQueueProperty>;
     using DevAcc = alpaka::Dev<TAcc>;
-    using PltfAcc = alpaka::Pltf<DevAcc>;
+    using PltfAcc = alpaka::Pltf<TAcc>;
 
     using DevHost = alpaka::DevCpu;
     using PltfHost = alpaka::Pltf<DevHost>;
@@ -33,14 +33,16 @@ struct TestContainer
 
     using SubView = alpaka::ViewSubView<DevAcc, TData, TDim, TIdx>;
 
+    PltfAcc const platformAcc{};
     DevAcc const devAcc;
+    PltfHost const platformHost{};
     DevHost const devHost;
     DevQueue devQueue;
 
     // Constructor
     TestContainer()
-        : devAcc(alpaka::getDevByIdx<PltfAcc>(0u))
-        , devHost(alpaka::getDevByIdx<PltfHost>(0u))
+        : devAcc(alpaka::getDevByIdx(platformAcc, 0))
+        , devHost(alpaka::getDevByIdx(platformHost, 0u))
         , devQueue(devAcc)
     {
     }

--- a/test/unit/mem/fence/src/FenceTest.cpp
+++ b/test/unit/mem/fence/src/FenceTest.cpp
@@ -180,8 +180,10 @@ TEMPLATE_LIST_TEST_CASE("FenceTest", "[fence]", TestAccs)
         = isSingleThreaded<Acc> ? alpaka::test::KernelExecutionFixture<Acc>{WorkDiv{one, one, two}}
                                 : alpaka::test::KernelExecutionFixture<Acc>{WorkDiv{one, two, one}};
 
-    auto const host = alpaka::getDevByIdx<alpaka::PltfCpu>(0u);
-    auto const dev = alpaka::getDevByIdx<Pltf>(0u);
+    auto const platformHost = alpaka::PltfCpu{};
+    auto const host = alpaka::getDevByIdx(platformHost, 0);
+    auto const platformAcc = Pltf{};
+    auto const dev = alpaka::getDevByIdx(platformAcc, 0);
     auto queue = Queue{dev};
 
     auto const numElements = Idx{2ul};

--- a/test/unit/mem/p2p/src/P2P.cpp
+++ b/test/unit/mem/p2p/src/P2P.cpp
@@ -19,21 +19,21 @@ template<typename TAcc>
 static auto testP2P(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const& extent) -> void
 {
     using Dev = alpaka::Dev<TAcc>;
-    using Pltf = alpaka::Pltf<Dev>;
     using Queue = alpaka::test::DefaultQueue<Dev>;
 
     using Elem = std::uint32_t;
     using Idx = alpaka::Idx<TAcc>;
 
-    if(alpaka::getDevCount<Pltf>() < 2)
+    auto const platformAcc = alpaka::Pltf<TAcc>{};
+    if(alpaka::getDevCount(platformAcc) < 2)
     {
         std::cerr << "No two devices found to test peer-to-peer copy." << std::endl;
         CHECK(true);
         return;
     }
 
-    Dev const dev0 = alpaka::getDevByIdx<Pltf>(0u);
-    Dev const dev1 = alpaka::getDevByIdx<Pltf>(1u);
+    Dev const dev0 = alpaka::getDevByIdx(platformAcc, 0);
+    Dev const dev1 = alpaka::getDevByIdx(platformAcc, 1);
     Queue queue0(dev0);
     Queue queue1(dev1);
 

--- a/test/unit/mem/view/src/Accessor.cpp
+++ b/test/unit/mem/view/src/Accessor.cpp
@@ -23,7 +23,8 @@ TEST_CASE("IsView", "[accessor]")
     using Dev = alpaka::Dev<Acc>;
 
     // buffer
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
     auto buffer = alpaka::allocBuf<int, Size>(devAcc, Size{1});
     STATIC_REQUIRE(IsView<decltype(buffer)>::value);
 
@@ -125,7 +126,8 @@ TEST_CASE("readWrite", "[accessor]")
     using DevAcc = alpaka::Dev<Acc>;
     using Queue = alpaka::Queue<DevAcc, alpaka::Blocking>;
 
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
     auto queue = Queue{devAcc};
     auto buffer = alpaka::allocBuf<float, Size>(devAcc, Size{N});
     auto const workdiv = alpaka::WorkDivMembers<Dim, Size>{
@@ -228,7 +230,8 @@ TEST_CASE("projection", "[accessor]")
     using DevAcc = alpaka::Dev<Acc>;
     using Queue = alpaka::Queue<DevAcc, alpaka::Blocking>;
 
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
     auto queue = Queue{devAcc};
 
     auto srcBuffer = alpaka::allocBuf<int, Size>(devAcc, Size{1});
@@ -254,7 +257,8 @@ TEST_CASE("constraining", "[accessor]")
     using Size = std::size_t;
     using Acc = alpaka::ExampleDefaultAcc<Dim, Size>;
 
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
     auto buffer = alpaka::allocBuf<int, Size>(devAcc, Size{1});
     using MemoryHandle = alpakaex::MemoryHandle<decltype(alpakaex::access(buffer))>;
 
@@ -338,7 +342,8 @@ TEST_CASE("BufferAccessor", "[accessor]")
     using DevAcc = alpaka::Dev<Acc>;
     using Queue = alpaka::Queue<DevAcc, alpaka::Blocking>;
 
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
     auto queue = Queue{devAcc};
     auto buffer = alpaka::allocBuf<int, Size>(devAcc, Size{1});
 

--- a/test/unit/mem/view/src/ViewConst.cpp
+++ b/test/unit/mem/view/src/ViewConst.cpp
@@ -61,14 +61,12 @@ TEMPLATE_LIST_TEST_CASE("viewConstTest", "[memView]", alpaka::test::TestAccs)
 {
     using Elem = float;
     using Acc = TestType;
-
     using Dev = alpaka::Dev<Acc>;
-    using Pltf = alpaka::Pltf<Dev>;
-
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    auto const dev = alpaka::getDevByIdx<Pltf>(0u);
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platformAcc, 0);
 
     auto const extents
         = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();

--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -51,13 +51,12 @@ namespace alpaka::test
     auto testViewPlainPtr() -> void
     {
         using Dev = alpaka::Dev<TAcc>;
-        using Pltf = alpaka::Pltf<Dev>;
-
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
         using View = alpaka::ViewPlainPtr<Dev, TElem, Dim, Idx>;
 
-        Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+        auto const platform = alpaka::Pltf<TAcc>{};
+        auto const dev = alpaka::getDevByIdx(platform, 0);
 
         auto const extentBuf
             = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
@@ -78,13 +77,12 @@ namespace alpaka::test
     auto testViewPlainPtrConst() -> void
     {
         using Dev = alpaka::Dev<TAcc>;
-        using Pltf = alpaka::Pltf<Dev>;
-
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
         using View = alpaka::ViewPlainPtr<Dev, TElem, Dim, Idx>;
 
-        Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+        auto const platform = alpaka::Pltf<TAcc>{};
+        auto const dev = alpaka::getDevByIdx(platform, 0);
 
         auto const extentBuf
             = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
@@ -105,13 +103,12 @@ namespace alpaka::test
     auto testViewPlainPtrOperators() -> void
     {
         using Dev = alpaka::Dev<TAcc>;
-        using Pltf = alpaka::Pltf<Dev>;
-
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
         using View = alpaka::ViewPlainPtr<Dev, TElem, Dim, Idx>;
 
-        Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+        auto const platform = alpaka::Pltf<TAcc>{};
+        auto const dev = alpaka::getDevByIdx(platform, 0);
 
         auto const extentBuf
             = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
@@ -152,7 +149,8 @@ TEMPLATE_LIST_TEST_CASE("viewPlainPtrOperatorTest", "[memView]", alpaka::test::T
 TEMPLATE_TEST_CASE("createView", "[memView]", (std::array<float, 4>), std::vector<float>)
 {
     using Dev = alpaka::DevCpu;
-    auto const dev = alpaka::getDevByIdx<alpaka::PltfCpu>(0u);
+    auto const platform = alpaka::PltfCpu{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
 
     TestType a{1, 2, 3, 4};
 

--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -46,8 +46,9 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAc
 {
     using Acc = TestType;
     using DevAcc = alpaka::Dev<Acc>;
-    using PltfAcc = alpaka::Pltf<DevAcc>;
-    DevAcc devAcc = alpaka::getDevByIdx<PltfAcc>(0u);
+
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     alpaka::Vec<Dim, Idx> const extent(3u, 2u);
 
@@ -57,8 +58,8 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryGlobal", "[viewStaticAccMem]", TestAc
 
     // uninitialized static constant device memory
     {
-        using PltfHost = alpaka::PltfCpu;
-        auto devHost(alpaka::getDevByIdx<PltfHost>(0u));
+        auto const platformHost = alpaka::PltfCpu{};
+        auto const devHost = alpaka::getDevByIdx(platformHost, 0);
 
         using QueueAcc = alpaka::test::DefaultQueue<DevAcc>;
         QueueAcc queueAcc(devAcc);
@@ -87,8 +88,9 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryConstant", "[viewStaticAccMem]", Test
 {
     using Acc = TestType;
     using DevAcc = alpaka::Dev<Acc>;
-    using PltfAcc = alpaka::Pltf<DevAcc>;
-    DevAcc devAcc(alpaka::getDevByIdx<PltfAcc>(0u));
+
+    auto const platformAcc = alpaka::Pltf<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     alpaka::Vec<Dim, Idx> const extent(3u, 2u);
 
@@ -98,8 +100,8 @@ TEMPLATE_LIST_TEST_CASE("staticDeviceMemoryConstant", "[viewStaticAccMem]", Test
 
     // uninitialized static global device memory
     {
-        using PltfHost = alpaka::PltfCpu;
-        auto devHost(alpaka::getDevByIdx<PltfHost>(0u));
+        auto const platformHost = alpaka::PltfCpu{};
+        auto const devHost = alpaka::getDevByIdx(platformHost, 0);
 
         using QueueAcc = alpaka::test::DefaultQueue<DevAcc>;
         QueueAcc queueAcc(devAcc);

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -82,13 +82,12 @@ namespace alpaka::test
     auto testViewSubViewNoOffset() -> void
     {
         using Dev = alpaka::Dev<TAcc>;
-        using Pltf = alpaka::Pltf<Dev>;
-
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
         using View = alpaka::ViewSubView<Dev, TElem, Dim, Idx>;
 
-        Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+        auto const platform = alpaka::Pltf<TAcc>{};
+        auto const dev = alpaka::getDevByIdx(platform, 0);
 
         auto const extentBuf
             = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
@@ -105,13 +104,12 @@ namespace alpaka::test
     auto testViewSubViewOffset() -> void
     {
         using Dev = alpaka::Dev<TAcc>;
-        using Pltf = alpaka::Pltf<Dev>;
-
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
         using View = alpaka::ViewSubView<Dev, TElem, Dim, Idx>;
 
-        Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+        auto const platform = alpaka::Pltf<TAcc>{};
+        auto const dev = alpaka::getDevByIdx(platform, 0);
 
         auto const extentBuf
             = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
@@ -130,13 +128,12 @@ namespace alpaka::test
     auto testViewSubViewOffsetConst() -> void
     {
         using Dev = alpaka::Dev<TAcc>;
-        using Pltf = alpaka::Pltf<Dev>;
-
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
         using View = alpaka::ViewSubView<Dev, TElem, Dim, Idx>;
 
-        Dev const dev = alpaka::getDevByIdx<Pltf>(0u);
+        auto const platform = alpaka::Pltf<TAcc>{};
+        auto const dev = alpaka::getDevByIdx(platform, 0);
 
         auto const extentBuf
             = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();

--- a/test/unit/queue/src/CollectiveQueue.cpp
+++ b/test/unit/queue/src/CollectiveQueue.cpp
@@ -42,7 +42,8 @@ TEST_CASE("queueCollective", "[queue]")
     using Queue = alpaka::QueueCpuOmp2Collective;
     using Pltf = alpaka::Pltf<Dev>;
 
-    auto dev = alpaka::getDevByIdx<Pltf>(0u);
+    auto const platform = Pltf{};
+    auto dev = alpaka::getDevByIdx(platform, 0);
     Queue queue(dev);
 
     std::vector<int> results(4, -1);
@@ -83,7 +84,8 @@ TEST_CASE("TestCollectiveMemcpy", "[queue]")
     using Queue = alpaka::QueueCpuOmp2Collective;
     using Pltf = alpaka::Pltf<Dev>;
 
-    auto dev = alpaka::getDevByIdx<Pltf>(0u);
+    auto const platform = Pltf{};
+    auto dev = alpaka::getDevByIdx(platform, 0);
     Queue queue(dev);
 
     std::vector<int> results(4, -1);

--- a/test/unit/traits/src/NativeHandleTest.cpp
+++ b/test/unit/traits/src/NativeHandleTest.cpp
@@ -12,9 +12,10 @@
 TEMPLATE_LIST_TEST_CASE("NativeHandle", "[handle]", alpaka::test::TestAccs)
 {
     using Dev = alpaka::Dev<TestType>;
-    using Pltf = alpaka::Pltf<Dev>;
-    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
-    auto handle = alpaka::getNativeHandle(dev);
+
+    auto const platformAcc = alpaka::Pltf<TestType>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
+    auto handle = alpaka::getNativeHandle(devAcc);
 
     STATIC_REQUIRE(std::is_same_v<alpaka::NativeHandle<Dev>, decltype(handle)>);
     // The SYCL backend does not use an int as the native handle type

--- a/test/unit/warp/src/Activemask.cpp
+++ b/test/unit/warp/src/Activemask.cpp
@@ -56,12 +56,11 @@ struct ActivemaskMultipleThreadWarpTestKernel
 TEMPLATE_LIST_TEST_CASE("activemask", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::Dev<Acc>;
-    using Pltf = alpaka::Pltf<Dev>;
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const platform = alpaka::Pltf<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
     auto const warpExtents = alpaka::getWarpSizes(dev);
     for(auto const warpExtent : warpExtents)
     {

--- a/test/unit/warp/src/All.cpp
+++ b/test/unit/warp/src/All.cpp
@@ -60,12 +60,11 @@ struct AllMultipleThreadWarpTestKernel
 TEMPLATE_LIST_TEST_CASE("all", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::Dev<Acc>;
-    using Pltf = alpaka::Pltf<Dev>;
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const platform = alpaka::Pltf<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
     auto const warpExtents = alpaka::getWarpSizes(dev);
     for(auto const warpExtent : warpExtents)
     {

--- a/test/unit/warp/src/Any.cpp
+++ b/test/unit/warp/src/Any.cpp
@@ -60,12 +60,11 @@ struct AnyMultipleThreadWarpTestKernel
 TEMPLATE_LIST_TEST_CASE("any", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::Dev<Acc>;
-    using Pltf = alpaka::Pltf<Dev>;
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const platform = alpaka::Pltf<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
     auto const warpExtents = alpaka::getWarpSizes(dev);
     for(auto const warpExtent : warpExtents)
     {

--- a/test/unit/warp/src/Ballot.cpp
+++ b/test/unit/warp/src/Ballot.cpp
@@ -68,12 +68,11 @@ struct BallotMultipleThreadWarpTestKernel
 TEMPLATE_LIST_TEST_CASE("ballot", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::Dev<Acc>;
-    using Pltf = alpaka::Pltf<Dev>;
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const platform = alpaka::Pltf<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
     auto const warpExtents = alpaka::getWarpSizes(dev);
     for(auto const warpExtent : warpExtents)
     {

--- a/test/unit/warp/src/GetSize.cpp
+++ b/test/unit/warp/src/GetSize.cpp
@@ -25,12 +25,11 @@ struct GetSizeTestKernel
 TEMPLATE_LIST_TEST_CASE("getSize", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::Dev<Acc>;
-    using Pltf = alpaka::Pltf<Dev>;
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const platform = alpaka::Pltf<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
     auto const warpSizes = alpaka::getWarpSizes(dev);
     REQUIRE(std::any_of(
         begin(warpSizes),

--- a/test/unit/warp/src/Shfl.cpp
+++ b/test/unit/warp/src/Shfl.cpp
@@ -90,12 +90,11 @@ struct ShflMultipleThreadWarpTestKernel
 TEMPLATE_LIST_TEST_CASE("shfl", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::Dev<Acc>;
-    using Pltf = alpaka::Pltf<Dev>;
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    Dev const dev(alpaka::getDevByIdx<Pltf>(0u));
+    auto const platform = alpaka::Pltf<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
     auto const warpExtents = alpaka::getWarpSizes(dev);
     for(auto const warpExtent : warpExtents)
     {

--- a/test/unit/workDiv/src/WorkDivHelpersTest.cpp
+++ b/test/unit/workDiv/src/WorkDivHelpersTest.cpp
@@ -20,7 +20,8 @@ namespace
         using Dim = alpaka::Dim<TAcc>;
         using Idx = alpaka::Idx<TAcc>;
 
-        auto const dev = alpaka::getDevByIdx<TAcc>(0u);
+        auto const platform = alpaka::Pltf<TAcc>{};
+        auto const dev = alpaka::getDevByIdx(platform, 0);
         auto const gridThreadExtent = alpaka::Vec<Dim, Idx>::all(10);
         auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
         auto const workDiv = alpaka::getValidWorkDiv<TAcc>(
@@ -49,7 +50,8 @@ TEMPLATE_LIST_TEST_CASE("subDivideGridElems.2D.examples", "[workDiv]", alpaka::t
     using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
     if constexpr(Dim::value == 2)
     {
-        auto const dev = alpaka::getDevByIdx<Acc>(0u);
+        auto const platform = alpaka::Pltf<Acc>{};
+        auto const dev = alpaka::getDevByIdx(platform, 0);
         auto props = alpaka::getAccDevProps<Acc>(dev);
         props.m_gridBlockExtentMax = Vec{1024, 1024};
         props.m_gridBlockCountMax = 1024 * 1024;
@@ -118,7 +120,8 @@ TEMPLATE_LIST_TEST_CASE("getValidWorkDiv.1D.withIdx", "[workDiv]", alpaka::test:
     using Vec = alpaka::Vec<Dim, Idx>;
     if constexpr(Dim::value == 1)
     {
-        auto const dev = alpaka::getDevByIdx<Acc>(0u);
+        auto const platform = alpaka::Pltf<Acc>{};
+        auto const dev = alpaka::getDevByIdx(platform, 0);
         // test that we can call getValidWorkDiv with the Idx type directly instead of a Vec
         auto const ref = alpaka::getValidWorkDiv<Acc>(dev, Vec{256}, Vec{13});
         CHECK(alpaka::getValidWorkDiv<Acc>(dev, Idx{256}, Idx{13}) == ref);
@@ -128,10 +131,9 @@ TEMPLATE_LIST_TEST_CASE("getValidWorkDiv.1D.withIdx", "[workDiv]", alpaka::test:
 TEMPLATE_LIST_TEST_CASE("isValidWorkDiv", "[workDiv]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
-    using Dev = alpaka::Dev<Acc>;
-    using Pltf = alpaka::Pltf<Dev>;
 
-    Dev dev = alpaka::getDevByIdx<Pltf>(0u);
+    auto const platform = alpaka::Pltf<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
     auto const workDiv = getWorkDiv<Acc>();
     // Test both overloads
     REQUIRE(alpaka::isValidWorkDiv(alpaka::getAccDevProps<Acc>(dev), workDiv));


### PR DESCRIPTION
Fixes: #1938

For now, I have only converted the `vectorAdd` example. We should discuss how the user-facing API looks now and whether we can improve something here.

Questions:

- [x] Should alpaka have a global singleton for the host CPU platform? Answer: No, this is up to the user. Alpaka should allow for deterministic construction and destruction and therefore not use any globals or `static`s.
- [X] Should alpaka have a global singleton for the host CPU device? We had discussions in the past whether we want to have multiple host CPU devices for multi-processor systems. Answer: No, for the same reason as above.