### PR TITLE
fix callback thread and unit tests

### DIFF
--- a/include/alpaka/core/CallbackThread.hpp
+++ b/include/alpaka/core/CallbackThread.hpp
@@ -61,13 +61,15 @@ namespace alpaka::core
                 m_tasks.emplace(std::move(task));
                 if(!m_thread.joinable())
                     startWorkerThread();
+                m_cond.notify_one();
             }
-            m_cond.notify_one();
+
             return f;
         }
 
-        [[nodiscard]] auto empty() const
+        [[nodiscard]] auto empty()
         {
+            std::unique_lock<std::mutex> lock{m_mutex};
             return m_tasksInProgress == 0;
         }
 

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRt.hpp
@@ -108,7 +108,7 @@ namespace alpaka
             {
                 return m_spQueueImpl->getNativeHandle();
             }
-            auto getCallbackThread() -> core::CallbackThread&
+            auto getCallbackThread() const -> core::CallbackThread&
             {
                 return m_spQueueImpl->m_callbackThread;
             }
@@ -146,7 +146,7 @@ namespace alpaka
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
                     ret = TApi::streamQuery(queue.getNativeHandle()),
                     TApi::errorNotReady);
-                return (ret == TApi::success);
+                return (ret == TApi::success) && queue.getCallbackThread().empty();
             }
         };
 

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -94,6 +94,7 @@ TEMPLATE_LIST_TEST_CASE(
         alpaka::wait(f.m_queue);
     }
 
+    alpaka::empty(f.m_queue);
     CHECK(callbackFinished.load() == true);
 
     // The blocking queue must be empty because we wait for the non-blocking queue and the blocking on is synchronized


### PR DESCRIPTION
 I did some changes on top of #1870 which workaround all thread sanitizer errors for the callback tests.
To validate these in the CI I opened this PR.

- [ ] includes #1989