### PR TITLE
show better error message if kernel argument is not trivially copyable

### DIFF
--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -222,6 +222,8 @@ namespace alpaka
         inline void assertKernelArgIsTriviallyCopyable()
         {
             static_assert(
+                // it's implementation defined whether the closure type of a lambda is trivially copyable. But they
+                // should be at least empty then (stateless).
                 std::is_empty_v<T> || std::is_trivially_copyable_v<T>,
                 "The kernel argument T must be trivially copyable!");
         }

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -215,15 +215,26 @@ namespace alpaka
                 static_assert(std::is_same_v<Result, void>, "The TKernelFnObj is required to return void!");
             }
         };
+
+        // asserts that T is trivially copyable. We put this in a separate function so we can see which T would fail
+        // the test, when called from a fold expression.
+        template<typename T>
+        inline void assertKernelArgIsTriviallyCopyable()
+        {
+            static_assert(
+                std::is_empty<T> || std::is_trivially_copyable_v<T>,
+                "The kernel argument T must be trivially copyable!");
+        }
+
     } // namespace detail
 
-    //! Creates a kernel execution task.
-    //!
-    //! \tparam TAcc The accelerator type.
-    //! \param workDiv The index domain work division.
-    //! \param kernelFnObj The kernel function object which should be executed.
-    //! \param args,... The kernel invocation arguments.
-    //! \return The kernel execution task.
+//! Creates a kernel execution task.
+//!
+//! \tparam TAcc The accelerator type.
+//! \param workDiv The index domain work division.
+//! \param kernelFnObj The kernel function object which should be executed.
+//! \param args,... The kernel invocation arguments.
+//! \return The kernel execution task.
 #if BOOST_COMP_CLANG
 #    pragma clang diagnostic pop
 #endif
@@ -241,9 +252,7 @@ namespace alpaka
 #else
         static_assert(std::is_trivially_copyable_v<TKernelFnObj>, "Kernels must be trivially copyable!");
 #endif
-        static_assert(
-            (std::is_trivially_copyable_v<std::decay_t<TArgs>> && ...),
-            "Kernel arguments must be trivially copyable!");
+        (detail::assertKernelArgIsTriviallyCopyable<std::decay_t<TArgs>>(), ...);
         static_assert(
             Dim<std::decay_t<TWorkDiv>>::value == Dim<TAcc>::value,
             "The dimensions of TAcc and TWorkDiv have to be identical!");
@@ -266,13 +275,13 @@ namespace alpaka
 #    pragma clang diagnostic ignored                                                                                  \
         "-Wdocumentation" // clang does not support the syntax for variadic template arguments "args,..."
 #endif
-    //! Executes the given kernel in the given queue.
-    //!
-    //! \tparam TAcc The accelerator type.
-    //! \param queue The queue to enqueue the view copy task into.
-    //! \param workDiv The index domain work division.
-    //! \param kernelFnObj The kernel function object which should be executed.
-    //! \param args,... The kernel invocation arguments.
+//! Executes the given kernel in the given queue.
+//!
+//! \tparam TAcc The accelerator type.
+//! \param queue The queue to enqueue the view copy task into.
+//! \param workDiv The index domain work division.
+//! \param kernelFnObj The kernel function object which should be executed.
+//! \param args,... The kernel invocation arguments.
 #if BOOST_COMP_CLANG
 #    pragma clang diagnostic pop
 #endif

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -222,7 +222,7 @@ namespace alpaka
         inline void assertKernelArgIsTriviallyCopyable()
         {
             static_assert(
-                std::is_empty<T> || std::is_trivially_copyable_v<T>,
+                std::is_empty_v<T> || std::is_trivially_copyable_v<T>,
                 "The kernel argument T must be trivially copyable!");
         }
 


### PR DESCRIPTION
fix #1992

Currently, alpaka is checking all kernel arguments with the fold expression that all arguments are trivially copyable. The problem is if one argument is not trivially copyable the user does not know which.

By checking each argument separately and providing the index to the validator class the user gets the information on which argument produces issues.
This simplifies the debugging a lot.