### PR TITLE
Skip zero dimensional accelerators (continued)

### DIFF
--- a/include/alpaka/test/acc/TestAccs.hpp
+++ b/include/alpaka/test/acc/TestAccs.hpp
@@ -145,11 +145,6 @@ namespace alpaka::test
 
     namespace detail
     {
-        //! A std::tuple holding non-zero dimensions.
-        //!
-        //! NonZeroTestDims = std::tuple<Dim1, Dim2, Dim3, ... DimN>
-        using NonZeroTestDims = meta::Filter<TestDims, meta::NonZero>;
-
         //! A std::tuple holding multiple std::tuple consisting of a dimension and a idx type.
         //!
         //! TestDimIdxTuples =

--- a/include/alpaka/test/dim/TestDims.hpp
+++ b/include/alpaka/test/dim/TestDims.hpp
@@ -6,6 +6,8 @@
 
 #include "alpaka/core/BoostPredef.hpp"
 #include "alpaka/dim/DimIntegralConst.hpp"
+#include "alpaka/meta/Filter.hpp"
+#include "alpaka/meta/NonZero.hpp"
 
 #include <tuple>
 
@@ -23,4 +25,10 @@ namespace alpaka::test
         DimInt<4u>
 #endif
         >;
+
+    //! A std::tuple holding non-zero dimensions.
+    //!
+    //! NonZeroTestDims = std::tuple<Dim1, Dim2, ... DimN>
+    using NonZeroTestDims = meta::Filter<TestDims, meta::NonZero>;
+
 } // namespace alpaka::test

--- a/test/unit/idx/src/MapIdxPitchBytes.cpp
+++ b/test/unit/idx/src/MapIdxPitchBytes.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Jeffrey Kelling, Bernhard Manfred Gruber, Jan Stephan
+/* Copyright 2022 Jeffrey Kelling, Bernhard Manfred Gruber, Jan Stephan, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -14,7 +14,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-TEMPLATE_LIST_TEST_CASE("mapIdxPitchBytes", "[idx]", alpaka::test::TestDims)
+TEMPLATE_LIST_TEST_CASE("mapIdxPitchBytes", "[idx]", alpaka::test::NonZeroTestDims)
 {
     using Dim = TestType;
     using Idx = std::size_t;


### PR DESCRIPTION
Follow up to #1979:
  - make `NonZeroTestDims` available along with `TestDims`
  - fix the `mapIdxPitchBytes` test