### PR TITLE
Silence clang-16 warnings about unsafe buffer usage.

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -484,7 +484,7 @@ if(alpaka_ACC_GPU_HIP_ENABLE)
 
     # supported HIP version range
     set(_alpaka_HIP_MIN_VER 5.0)
-    set(_alpaka_HIP_MAX_VER 5.3)
+    set(_alpaka_HIP_MAX_VER 5.5)
     find_package(hip "${_alpaka_HIP_MAX_VER}")
     if(NOT TARGET hip)
         message(STATUS "Could not find HIP v${_alpaka_HIP_MAX_VER}. Now searching for HIP v${_alpaka_HIP_MIN_VER}")
@@ -529,7 +529,6 @@ if(alpaka_ACC_GPU_HIP_ENABLE)
             alpaka_set_compiler_options(HOST_DEVICE target alpaka -save-temps)
         endif()
     endif()
-
 endif() # HIP
 
 #-------------------------------------------------------------------------------

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -244,10 +244,10 @@ namespace alpaka
                 using Allocator = AllocCpuAligned<std::integral_constant<std::size_t, alignment>>;
                 static_assert(std::is_empty_v<Allocator>, "AllocCpuAligned is expected to be stateless");
                 auto* memPtr = alpaka::malloc<TElem>(Allocator{}, static_cast<std::size_t>(getExtentProduct(extent)));
-                auto deleter = [queue = std::move(queue)](TElem* ptr) mutable
+                auto deleter = [l_queue = std::move(queue)](TElem* ptr) mutable
                 {
                     alpaka::enqueue(
-                        queue,
+                        l_queue,
                         [ptr]()
                         {
                             // free the memory

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -34,6 +34,19 @@ endif()
 
 target_link_libraries(${_COMMON_TARGET_NAME} INTERFACE alpaka::alpaka)
 
+# Prevent "unsafe buffer usage" warnings from clang >= 16
+if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "16.0.0") OR
+   (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "2023.2.0"))
+    
+    target_compile_options(${_COMMON_TARGET_NAME} INTERFACE "-Wno-unsafe-buffer-usage")
+
+    # We have no way to determine if we are using amdclang++. So we will just decide this by checking for the HIP back-end.
+    if(alpaka_ACC_GPU_HIP_ENABLE)
+        # amdclang++-5.5 pretends to be clang-16 but doesn't know all warnings.
+        target_compile_options(${_COMMON_TARGET_NAME} INTERFACE "-Wno-unknown-warning-option") 
+    endif()
+endif()
+
 # Prevent warnings from shady code inside Catch2
 get_target_property(alpaka_CATCH2_INCLUDE_DIRS Catch2::Catch2 INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(${_COMMON_TARGET_NAME} SYSTEM INTERFACE ${alpaka_CATCH2_INCLUDE_DIRS})


### PR DESCRIPTION
As requested by @bernhardmgruber in #1984.