### PR TITLE
Update readthedocs config to version 2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,20 +1,25 @@
 # SPDX-License-Identifier: MPL-2.0
 
-# Default [] (epub, pdf, htmlzip)
-# Note: PDF/epub/htmlzip output is not supported when using MkDocs
-formats: []
+version: 2
 
-requirements_file: docs/requirements.txt
+# Note: PDF/epub/htmlzip output is not supported when using MkDocs
+formats:
+  - htmlzip
+  - pdf
+  - epub
 
 build:
-  image: latest
-
-python:
-  version: 3.7
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 sphinx:
   builder: html
-  configuration: conf.py
-  fail_on_warning: true
+  configuration: docs/source/conf.py
+  fail_on_warning: false
+
+python:
+ install:
+ - requirements: docs/requirements.txt
 
 # see: https://docs.readthedocs.io/en/stable/config-file/v2.html#supported-settings


### PR DESCRIPTION
~I have some problems with readthedocs in PR #2005 . Therefore I need to test it in an extra PR.~

Update readthedocs config to version 2. Looks like support for version 1 was removed. 
Update used python version to 3.11