### PR TITLE
Change separable compilation test from `double` to `float`

### DIFF
--- a/test/integ/separableCompilation/include/mysqrt.hpp
+++ b/test/integ/separableCompilation/include/mysqrt.hpp
@@ -1,7 +1,7 @@
-/* Copyright 2022 Benjamin Worpitz, Luca Ferragina
+/* Copyright 2023 Benjamin Worpitz, Luca Ferragina, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #include <alpaka/alpaka.hpp>
 
-ALPAKA_FN_HOST_ACC ALPAKA_FN_EXTERN auto mysqrt(double x) -> double;
+ALPAKA_FN_HOST_ACC ALPAKA_FN_EXTERN auto mysqrt(float x) noexcept -> float;

--- a/test/integ/separableCompilation/include/mysqrt.hpp
+++ b/test/integ/separableCompilation/include/mysqrt.hpp
@@ -1,7 +1,7 @@
-/* Copyright 2019 Benjamin Worpitz
+/* Copyright 2022 Benjamin Worpitz, Luca Ferragina
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #include <alpaka/alpaka.hpp>
 
-ALPAKA_FN_HOST_ACC auto mysqrt(double x) -> double;
+ALPAKA_FN_HOST_ACC ALPAKA_FN_EXTERN auto mysqrt(double x) -> double;

--- a/test/integ/separableCompilation/src/mysqrt.cpp
+++ b/test/integ/separableCompilation/src/mysqrt.cpp
@@ -1,27 +1,49 @@
-/* Copyright 2019 Benjamin Worpitz
+/* Copyright 2023 Benjamin Worpitz, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #include "mysqrt.hpp"
 
-// a square root calculation using simple operations
-ALPAKA_FN_HOST_ACC auto mysqrt(double x) -> double
+#if defined(__CUDA_ARCH__)
+#    include <cuda_runtime.h>
+#elif defined(__HIP_DEVICE_COMPILE__)
+#    include <hip_runtime.h>
+#elif defined(__SYCL_DEVICE_ONLY__)
+#    include <sycl/sycl.hpp>
+#else
+#    include <cmath>
+#endif
+
+// Computes x * y + z as if to infinite precision and rounded only once to fit the result type.
+inline ALPAKA_FN_HOST_ACC auto myfma(float x, float y, float z) noexcept -> float
+{
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+    return ::fmaf(x, y, z);
+#elif defined(__SYCL_DEVICE_ONLY__)
+    return sycl::fma(x, y, z);
+#else
+    return std::fma(x, y, z);
+#endif
+}
+
+// A square root calculation using simple operations.
+ALPAKA_FN_HOST_ACC auto mysqrt(float x) noexcept -> float
 {
     if(x <= 0)
     {
-        return 0.0;
+        return 0.0f;
     }
 
-    double result = x;
+    float result = x;
 
     for(int i = 0; i < 100; ++i)
     {
         if(result <= 0)
         {
-            result = 0.1;
+            result = 0.1f;
         }
-        double delta = x - (result * result);
-        result = result + 0.5 * delta / result;
+        float delta = myfma(-result, result, x);
+        result = result + 0.5f * delta / result;
     }
     return result;
 }


### PR DESCRIPTION
Using `double` triggers an error with the SYCL backend on some targets where double precision is not supported by the hardware and is emulated in software.

The problems seems to be independent from the use of separable compilation.