### PR TITLE
fix test CollectiveQueue

### DIFF
--- a/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
+++ b/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
@@ -73,9 +73,12 @@ namespace alpaka
     // to the user workflows.
     //
     // Within a OpenMP parallel region kernel will be performed collectively.
-    // All other operations will be performed from one thread (it is not defined which thread).
+    // All other operations will be performed from one thread (it is not defined which thread) and there will be no
+    // implicit synchronization between other operations within the parallel OpenMP parallel region. Operations
+    // executed within a OpenMP parallel region will be executed after already queued tasks before the parallel region
+    // was created.
     //
-    // Outside of a OpenMP parallel region the queue behaves like QueueCpuBlocking.
+    // Outside of an OpenMP parallel region the queue behaves like QueueCpuBlocking.
     class QueueCpuOmp2Collective final
         : public concepts::Implements<ConceptCurrentThreadWaitFor, QueueCpuOmp2Collective>
     {

--- a/test/unit/queue/src/CollectiveQueue.cpp
+++ b/test/unit/queue/src/CollectiveQueue.cpp
@@ -106,9 +106,8 @@ TEST_CASE("TestCollectiveMemcpy", "[queue]")
         auto dst = alpaka::createView(dev, results.data() + threadId, Vec(static_cast<Idx>(1u)), Vec(sizeof(int)));
         auto src = alpaka::createView(dev, &threadId, Vec(static_cast<Idx>(1u)), Vec(sizeof(int)));
 
-        // avoid that the first thread is executing the copy (can not be guaranteed)
-        size_t sleep_ms = (results.size() - static_cast<uint32_t>(threadId)) * 100u;
-        std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
+        // avoid that the first thread is executing the memcpy before all other threads wrote their changes
+        alpaka::wait(queue);
 
         // only one thread will perform this memcpy
         alpaka::memcpy(queue, dst, src, Vec(static_cast<Idx>(1u)));


### PR DESCRIPTION
Better documentation of the QueueCpuOmp2Collective to reflect the special synchronization behaviours.
Fix the test CollectiveQueue, the data race was mentioned in the comments only handeled via a sleep which was shown as warning in the thread sanitizer.