### PR TITLE
documentation: QueueCpuOmp2Collective

### DIFF
--- a/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
+++ b/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
@@ -73,9 +73,12 @@ namespace alpaka
     // to the user workflows.
     //
     // Within a OpenMP parallel region kernel will be performed collectively.
-    // All other operations will be performed from one thread (it is not defined which thread).
+    // All other operations will be performed from one thread (it is not defined which thread) and there will be no
+    // implicit synchronization between other operations within the parallel OpenMP parallel region. Operations
+    // executed within a OpenMP parallel region will be executed after already queued tasks before the parallel region
+    // was created.
     //
-    // Outside of a OpenMP parallel region the queue behaves like QueueCpuBlocking.
+    // Outside of an OpenMP parallel region the queue behaves like QueueCpuBlocking.
     class QueueCpuOmp2Collective final
         : public concepts::Implements<ConceptCurrentThreadWaitFor, QueueCpuOmp2Collective>
     {


### PR DESCRIPTION
This PR is a replacement of https://github.com/alpaka-group/alpaka/pull/2023

Improve the documentation of the QueueCpuOmp2Collective to reflect the special synchronization behaviors.