### PR TITLE
fix CallBack thread data race

### DIFF
--- a/include/alpaka/core/CallbackThread.hpp
+++ b/include/alpaka/core/CallbackThread.hpp
@@ -61,8 +61,9 @@ namespace alpaka::core
                 m_tasks.emplace(std::move(task));
                 if(!m_thread.joinable())
                     startWorkerThread();
+                m_cond.notify_one();
             }
-            m_cond.notify_one();
+
             return f;
         }
 


### PR DESCRIPTION
fix #1936

Fix the data race shown by thread sanitizer between the notification of the worker thread and the wait execution.


Together with #2011 the issue #1936 is fixed.