### PR TITLE
add math::log2 and math::log10

### DIFF
--- a/include/alpaka/math/MathGenericSycl.hpp
+++ b/include/alpaka/math/MathGenericSycl.hpp
@@ -127,6 +127,16 @@ namespace alpaka::math
     {
     };
 
+    //! The SYCL log2.
+    class Log2GenericSycl : public concepts::Implements<alpaka::math::ConceptMathLog2, Log2GenericSycl>
+    {
+    };
+
+    //! The SYCL log10.
+    class Log10GenericSycl : public concepts::Implements<alpaka::math::ConceptMathLog10, Log10GenericSycl>
+    {
+    };
+
     //! The SYCL max.
     class MaxGenericSycl : public concepts::Implements<alpaka::math::ConceptMathMax, MaxGenericSycl>
     {
@@ -216,6 +226,8 @@ namespace alpaka::math
         , public IsinfGenericSycl
         , public IsnanGenericSycl
         , public LogGenericSycl
+        , public Log2GenericSycl
+        , public Log10GenericSycl
         , public MaxGenericSycl
         , public MinGenericSycl
         , public PowGenericSycl
@@ -479,6 +491,26 @@ namespace alpaka::math::trait
         auto operator()(math::LogGenericSycl const&, TArg const& arg)
         {
             return sycl::log(arg);
+        }
+    };
+
+    //! The SYCL log2 trait specialization.
+    template<typename TArg>
+    struct Log2<math::Log2GenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    {
+        auto operator()(math::Log2GenericSycl const&, TArg const& arg)
+        {
+            return sycl::log2(arg);
+        }
+    };
+
+    //! The SYCL log10 trait specialization.
+    template<typename TArg>
+    struct Log10<math::Log10GenericSycl, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
+    {
+        auto operator()(math::Log10GenericSycl const&, TArg const& arg)
+        {
+            return sycl::log10(arg);
         }
     };
 

--- a/include/alpaka/math/MathStdLib.hpp
+++ b/include/alpaka/math/MathStdLib.hpp
@@ -120,6 +120,16 @@ namespace alpaka::math
     {
     };
 
+    //! The standard library log2, implementation covered by the general template.
+    class Log2StdLib : public concepts::Implements<ConceptMathLog2, Log2StdLib>
+    {
+    };
+
+    //! The standard library log10, implementation covered by the general template.
+    class Log10StdLib : public concepts::Implements<ConceptMathLog10, Log10StdLib>
+    {
+    };
+
     //! The standard library max.
     class MaxStdLib : public concepts::Implements<ConceptMathMax, MaxStdLib>
     {
@@ -206,6 +216,8 @@ namespace alpaka::math
         , public FloorStdLib
         , public FmodStdLib
         , public LogStdLib
+        , public Log2StdLib
+        , public Log10StdLib
         , public MaxStdLib
         , public MinStdLib
         , public PowStdLib

--- a/include/alpaka/math/Traits.hpp
+++ b/include/alpaka/math/Traits.hpp
@@ -216,6 +216,14 @@ namespace alpaka::math
     {
     };
 
+    struct ConceptMathLog2
+    {
+    };
+
+    struct ConceptMathLog10
+    {
+    };
+
     struct ConceptMathMax
     {
     };
@@ -556,6 +564,32 @@ namespace alpaka::math
                 // backend and we could not find log(TArg) in the namespace of your type.
                 using std::log;
                 return log(arg);
+            }
+        };
+
+        //! The bas 2 log trait.
+        template<typename T, typename TArg, typename TSfinae = void>
+        struct Log2
+        {
+            ALPAKA_FN_HOST_ACC auto operator()(T const& /* ctx */, TArg const& arg)
+            {
+                // This is an ADL call. If you get a compile error here then your type is not supported by the
+                // backend and we could not find log2(TArg) in the namespace of your type.
+                using std::log2;
+                return log2(arg);
+            }
+        };
+
+        //! The base 10 log trait.
+        template<typename T, typename TArg, typename TSfinae = void>
+        struct Log10
+        {
+            ALPAKA_FN_HOST_ACC auto operator()(T const& /* ctx */, TArg const& arg)
+            {
+                // This is an ADL call. If you get a compile error here then your type is not supported by the
+                // backend and we could not find log10(TArg) in the namespace of your type.
+                using std::log10;
+                return log10(arg);
             }
         };
 
@@ -1105,6 +1139,42 @@ namespace alpaka::math
     {
         using ImplementationBase = concepts::ImplementationBase<ConceptMathLog, T>;
         return trait::Log<ImplementationBase, TArg>{}(log_ctx, arg);
+    }
+
+    //! Computes the the natural (base 2) logarithm of arg.
+    //!
+    //! Valid real arguments are non-negative. For other values the result
+    //! may depend on the backend and compilation options, will likely
+    //! be NaN.
+    //!
+    //! \tparam T The type of the object specializing Log2.
+    //! \tparam TArg The arg type.
+    //! \param log2_ctx The object specializing Log2.
+    //! \param arg The arg.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename T, typename TArg>
+    ALPAKA_FN_HOST_ACC auto log2(T const& log2_ctx, TArg const& arg)
+    {
+        using ImplementationBase = concepts::ImplementationBase<ConceptMathLog2, T>;
+        return trait::Log2<ImplementationBase, TArg>{}(log2_ctx, arg);
+    }
+
+    //! Computes the the natural (base 10) logarithm of arg.
+    //!
+    //! Valid real arguments are non-negative. For other values the result
+    //! may depend on the backend and compilation options, will likely
+    //! be NaN.
+    //!
+    //! \tparam T The type of the object specializing Log10.
+    //! \tparam TArg The arg type.
+    //! \param log10_ctx The object specializing Log10.
+    //! \param arg The arg.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename T, typename TArg>
+    ALPAKA_FN_HOST_ACC auto log10(T const& log10_ctx, TArg const& arg)
+    {
+        using ImplementationBase = concepts::ImplementationBase<ConceptMathLog10, T>;
+        return trait::Log10<ImplementationBase, TArg>{}(log10_ctx, arg);
     }
 
     //! Returns the larger of two arguments.

--- a/test/unit/math/src/Functor.hpp
+++ b/test/unit/math/src/Functor.hpp
@@ -169,6 +169,15 @@ namespace alpaka
 
                 ALPAKA_TEST_MATH_OP_FUNCTOR(OpLog, Arity::Unary, std::log, alpaka::math::log, Range::PositiveOnly)
 
+                ALPAKA_TEST_MATH_OP_FUNCTOR(OpLog2, Arity::Unary, std::log2, alpaka::math::log2, Range::PositiveOnly)
+
+                ALPAKA_TEST_MATH_OP_FUNCTOR(
+                    OpLog10,
+                    Arity::Unary,
+                    std::log10,
+                    alpaka::math::log10,
+                    Range::PositiveOnly)
+
                 ALPAKA_TEST_MATH_OP_FUNCTOR(
                     OpRound,
                     Arity::Unary,
@@ -287,6 +296,8 @@ namespace alpaka
                     OpExp,
                     OpFloor,
                     OpLog,
+                    OpLog2,
+                    OpLog10,
                     OpRound,
                     OpRsqrt,
                     OpSin,
@@ -363,6 +374,7 @@ namespace alpaka
                     OpCosh,
                     OpExp,
                     OpLog,
+                    OpLog10,
                     OpRsqrt,
                     OpSin,
                     OpSinh,

--- a/test/unit/math/src/mathADL.cpp
+++ b/test/unit/math/src/mathADL.cpp
@@ -38,6 +38,8 @@ namespace custom
         Floor,
         Fmod,
         Log,
+        Log2,
+        Log10,
         Max,
         Min,
         Pow,
@@ -151,6 +153,18 @@ namespace custom
         return Custom::Log | c;
     }
 
+    ALPAKA_FN_HOST_ACC auto log2(Custom c);
+    ALPAKA_FN_HOST_ACC auto log2(Custom c)
+    {
+        return Custom::Log2 | c;
+    }
+
+    ALPAKA_FN_HOST_ACC auto log10(Custom c);
+    ALPAKA_FN_HOST_ACC auto log10(Custom c)
+    {
+        return Custom::Log10 | c;
+    }
+
     ALPAKA_FN_HOST_ACC auto max(Custom a, Custom b);
     ALPAKA_FN_HOST_ACC auto max(Custom a, Custom b)
     {
@@ -251,6 +265,8 @@ struct AdlKernel
         ALPAKA_CHECK(*success, alpaka::math::exp(acc, Custom::Arg1) == (Custom::Exp | Custom::Arg1));
         ALPAKA_CHECK(*success, alpaka::math::floor(acc, Custom::Arg1) == (Custom::Floor | Custom::Arg1));
         ALPAKA_CHECK(*success, alpaka::math::log(acc, Custom::Arg1) == (Custom::Log | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::log2(acc, Custom::Arg1) == (Custom::Log2 | Custom::Arg1));
+        ALPAKA_CHECK(*success, alpaka::math::log10(acc, Custom::Arg1) == (Custom::Log10 | Custom::Arg1));
         ALPAKA_CHECK(*success, alpaka::math::round(acc, Custom::Arg1) == (Custom::Round | Custom::Arg1));
         ALPAKA_CHECK(*success, alpaka::math::lround(acc, Custom::Arg1) == (Custom::Lround | Custom::Arg1));
         ALPAKA_CHECK(*success, alpaka::math::llround(acc, Custom::Arg1) == (Custom::Llround | Custom::Arg1));


### PR DESCRIPTION
fix #2012

Implement supportfor `log2` and `log10` and the coresponding CI tests.