### PR TITLE
Fix compilation error in allocMappedBuf for SYCL

### DIFF
--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -15,6 +15,7 @@
 #include "alpaka/mem/buf/Traits.hpp"
 #include "alpaka/mem/view/ViewAccessOps.hpp"
 #include "alpaka/meta/DependentFalseType.hpp"
+#include "alpaka/platform/PlatformCpu.hpp"
 #include "alpaka/vec/Vec.hpp"
 
 #include <functional>
@@ -270,8 +271,10 @@ namespace alpaka
         struct BufAllocMapped<PlatformCpu, TElem, TDim, TIdx>
         {
             template<typename TExtent>
-            ALPAKA_FN_HOST static auto allocMappedBuf(DevCpu const& host, TExtent const& extent)
-                -> BufCpu<TElem, TDim, TIdx>
+            ALPAKA_FN_HOST static auto allocMappedBuf(
+                DevCpu const& host,
+                PlatformCpu const& /*platform*/,
+                TExtent const& extent) -> BufCpu<TElem, TDim, TIdx>
             {
                 // Allocate standard host memory.
                 return allocBuf<TElem, TIdx>(host, extent);

--- a/include/alpaka/mem/buf/BufGenericSycl.hpp
+++ b/include/alpaka/mem/buf/BufGenericSycl.hpp
@@ -225,13 +225,14 @@ namespace alpaka::trait
     struct BufAllocMapped
     {
         template<typename TExtent>
-        static auto allocMappedBuf(DevCpu const& host, TExtent const& extent) -> BufCpu<TElem, TDim, TIdx>
+        static auto allocMappedBuf(DevCpu const& host, TPlatform const& platform, TExtent const& extent)
+            -> BufCpu<TElem, TDim, TIdx>
         {
             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
             // Allocate SYCL page-locked memory on the host, mapped into the TPlatform address space and
             // accessible to all devices in the TPlatform.
-            auto ctx = TPlatform::syclContext();
+            auto ctx = platform.syclContext();
             TElem* memPtr = sycl::malloc_host<TElem>(static_cast<std::size_t>(getExtentProduct(extent)), ctx);
             auto deleter = [ctx](TElem* ptr) { sycl::free(ptr, ctx); };
 

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -304,8 +304,10 @@ namespace alpaka
         struct BufAllocMapped<PlatformUniformCudaHipRt<TApi>, TElem, TDim, TIdx>
         {
             template<typename TExtent>
-            ALPAKA_FN_HOST static auto allocMappedBuf(DevCpu const& host, TExtent const& extent)
-                -> BufCpu<TElem, TDim, TIdx>
+            ALPAKA_FN_HOST static auto allocMappedBuf(
+                DevCpu const& host,
+                PlatformUniformCudaHipRt<TApi> const& /*platform*/,
+                TExtent const& extent) -> BufCpu<TElem, TDim, TIdx>
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -133,9 +133,12 @@ namespace alpaka
     //! \param extent The extent of the buffer.
     //! \return The newly allocated buffer.
     template<typename TPlatform, typename TElem, typename TIdx, typename TExtent>
-    ALPAKA_FN_HOST auto allocMappedBuf(DevCpu const& host, TExtent const& extent = TExtent())
+    ALPAKA_FN_HOST auto allocMappedBuf(
+        DevCpu const& host,
+        TPlatform const& platform,
+        TExtent const& extent = TExtent())
     {
-        return trait::BufAllocMapped<TPlatform, TElem, Dim<TExtent>, TIdx>::allocMappedBuf(host, extent);
+        return trait::BufAllocMapped<TPlatform, TElem, Dim<TExtent>, TIdx>::allocMappedBuf(host, platform, extent);
     }
 
     /* TODO: Remove this pragma block once support for clang versions <= 13 is removed. These versions are unable to
@@ -167,11 +170,14 @@ namespace alpaka
     //! \param extent The extent of the buffer.
     //! \return The newly allocated buffer.
     template<typename TPlatform, typename TElem, typename TIdx, typename TExtent>
-    ALPAKA_FN_HOST auto allocMappedBufIfSupported(DevCpu const& host, TExtent const& extent = TExtent())
+    ALPAKA_FN_HOST auto allocMappedBufIfSupported(
+        DevCpu const& host,
+        TPlatform const& platform,
+        TExtent const& extent = TExtent())
     {
         if constexpr(hasMappedBufSupport<TPlatform>)
         {
-            return allocMappedBuf<TPlatform, TElem, TIdx>(host, extent);
+            return allocMappedBuf<TPlatform, TElem, TIdx>(host, platform, extent);
         }
         else
         {

--- a/test/integ/axpy/src/axpy.cpp
+++ b/test/integ/axpy/src/axpy.cpp
@@ -109,9 +109,9 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
               << std::endl;
 
     // Allocate host memory buffers in pinned memory.
-    auto memBufHostX = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, extent);
-    auto memBufHostOrigY = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, extent);
-    auto memBufHostY = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, extent);
+    auto memBufHostX = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extent);
+    auto memBufHostOrigY = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extent);
+    auto memBufHostY = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extent);
     Val* const pBufHostX = alpaka::getPtrNative(memBufHostX);
     Val* const pBufHostOrigY = alpaka::getPtrNative(memBufHostOrigY);
     Val* const pBufHostY = alpaka::getPtrNative(memBufHostY);

--- a/test/integ/hostOnlyAPI/src/hostOnlyAPI.cpp
+++ b/test/integ/hostOnlyAPI/src/hostOnlyAPI.cpp
@@ -35,6 +35,8 @@ TEMPLATE_LIST_TEST_CASE("hostOnlyAPI", "[hostOnlyAPI]", TestAccs)
     using Device = alpaka::Dev<TestType>;
     using DeviceQueue = alpaka::Queue<Device, alpaka::NonBlocking>;
 
+    auto const platformAcc = alpaka::Platform<TestType>{};
+
     using Host = alpaka::DevCpu;
     using HostQueue = alpaka::Queue<Host, alpaka::Blocking>;
 
@@ -45,7 +47,8 @@ TEMPLATE_LIST_TEST_CASE("hostOnlyAPI", "[hostOnlyAPI]", TestAccs)
     HostQueue hostQueue(host);
 
     // host buffer
-    auto h_buffer1 = alpaka::allocMappedBufIfSupported<alpaka::Platform<Device>, int, Idx>(host, Vec1D{Idx{42}});
+    auto h_buffer1
+        = alpaka::allocMappedBufIfSupported<alpaka::Platform<Device>, int, Idx>(host, platformAcc, Vec1D{Idx{42}});
     INFO(
         "host buffer allocated at " << alpaka::getPtrNative(h_buffer1) << " with "
                                     << alpaka::getExtentProduct(h_buffer1) << " element(s)");
@@ -82,7 +85,6 @@ TEMPLATE_LIST_TEST_CASE("hostOnlyAPI", "[hostOnlyAPI]", TestAccs)
     CHECK(expected1 == *alpaka::getPtrNative(h_buffer1));
 
     // GPU device
-    auto const platformAcc = alpaka::Platform<TestType>{};
     auto const device = alpaka::getDevByIdx(platformAcc, 0);
     INFO("using alpaka device: " << alpaka::getName(device));
     DeviceQueue deviceQueue(device);

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -306,7 +306,7 @@ TEMPLATE_LIST_TEST_CASE("mandelbrot", "[mandelbrot]", TestAccs)
               << std::endl;
 
     // allocate host memory, potentially pinned for faster copy to/from the accelerator.
-    auto bufColorHost = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, extent);
+    auto bufColorHost = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extent);
 
     // Allocate the buffer on the accelerator.
     auto bufColorAcc = alpaka::allocBuf<Val, Idx>(devAcc, extent);

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -217,7 +217,7 @@ TEMPLATE_LIST_TEST_CASE("matMul", "[matMul]", TestAccs)
     auto bufBHost = alpaka::createView(devHost, bufBHost1d.data(), extentB);
 
     // Allocate C and set it to zero.
-    auto bufCHost = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, extentC);
+    auto bufCHost = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extentC);
     alpaka::memset(queueHost, bufCHost, 0u);
 
     // Allocate the buffers on the accelerator.

--- a/test/integ/separableCompilation/src/main.cpp
+++ b/test/integ/separableCompilation/src/main.cpp
@@ -103,9 +103,9 @@ TEMPLATE_LIST_TEST_CASE("separableCompilation", "[separableCompilation]", TestAc
               << ", numElements:" << numElements << ")" << std::endl;
 
     // Allocate host memory buffers, potentially pinned for faster copy to/from the accelerator.
-    auto memBufHostA = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, extent);
-    auto memBufHostB = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, extent);
-    auto memBufHostC = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, extent);
+    auto memBufHostA = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extent);
+    auto memBufHostB = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extent);
+    auto memBufHostC = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extent);
 
     // Initialize the host input vectors
     for(Idx i = 0; i < numElements; ++i)

--- a/test/unit/math/src/Buffer.hpp
+++ b/test/unit/math/src/Buffer.hpp
@@ -49,6 +49,7 @@ namespace alpaka
 
                     BufHost hostBuffer;
                     BufAcc devBuffer;
+                    PlatformAcc platformAcc;
 
                     // Native pointer to access buffer.
                     TData* const pHostBuffer;
@@ -61,7 +62,10 @@ namespace alpaka
                     // Constructor needs to initialize all Buffer.
                     Buffer(DevAcc const& devAcc)
                         : devHost{alpaka::getDevByIdx(platformHost, 0)}
-                        , hostBuffer{alpaka::allocMappedBufIfSupported<PlatformAcc, TData, Idx>(devHost, Tcapacity)}
+                        , hostBuffer{alpaka::allocMappedBufIfSupported<PlatformAcc, TData, Idx>(
+                              devHost,
+                              platformAcc,
+                              Tcapacity)}
                         , devBuffer{alpaka::allocBuf<TData, Idx>(devAcc, Tcapacity)}
                         , pHostBuffer{alpaka::getPtrNative(hostBuffer)}
                         , pDevBuffer{alpaka::getPtrNative(devBuffer)}

--- a/test/unit/mem/fence/src/FenceTest.cpp
+++ b/test/unit/mem/fence/src/FenceTest.cpp
@@ -188,7 +188,7 @@ TEMPLATE_LIST_TEST_CASE("FenceTest", "[fence]", TestAccs)
 
     auto const numElements = Idx{2ul};
     auto const extent = alpaka::Vec<Dim, Idx>{numElements};
-    auto vars_host = alpaka::allocMappedBufIfSupported<Platform, int, Idx>(host, extent);
+    auto vars_host = alpaka::allocMappedBufIfSupported<Platform, int, Idx>(host, platformAcc, extent);
     auto vars_dev = alpaka::allocBuf<int, Idx>(dev, extent);
     vars_host[0] = 1;
     vars_host[1] = 2;


### PR DESCRIPTION
In the SYCL version of `allocMappedBuf` there is a call to `TPlatform::syclContext()` that has to be changed to `platform.syclContext()` now that the `Platform` is an object.
Fixes the error: `call to non-static member function without an object argument`.

`allocMappedBuf` has been modified to take also the `Platform` as an optional argument, not used for the other back-ends.