### PR TITLE
Make the vendor random number generators optional

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -131,6 +131,12 @@ endif()
 
 set(alpaka_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB "47" CACHE STRING "Kibibytes (1024B) of memory to allocate for block shared memory for backends requiring static allocation (includes CPU_B_OMP2_T_SEQ, CPU_B_TBB_T_SEQ, CPU_B_SEQ_T_SEQ, SYCL)")
 
+# Random number generators
+option(alpaka_DISABLE_VENDOR_RNG "Disable the vendor specific random number generators (NVIDIA cuRAND, AMD rocRAND, Intel DPL)" OFF)
+if(alpaka_DISABLE_VENDOR_RNG)
+    target_compile_definitions(alpaka INTERFACE "ALPAKA_DISABLE_VENDOR_RNG")
+endif()
+
 #-------------------------------------------------------------------------------
 # Debug output of common variables.
 if(${alpaka_DEBUG} GREATER 1)
@@ -472,7 +478,10 @@ if(alpaka_ACC_GPU_CUDA_ENABLE)
             endif()
         endif()
 
-        target_link_libraries(alpaka INTERFACE CUDA::cudart CUDA::curand)
+        if(NOT alpaka_DISABLE_VENDOR_RNG)
+            # Use cuRAND random number generators
+            target_link_libraries(alpaka INTERFACE CUDA::cudart CUDA::curand)
+        endif()
     else()
         message(FATAL_ERROR "Optional alpaka dependency CUDA could not be found!")
     endif()
@@ -502,25 +511,27 @@ if(alpaka_ACC_GPU_HIP_ENABLE)
             alpaka_set_compiler_options(DEVICE target alpaka "-ffast-math")
         endif()
 
-        # hiprand requires ROCm implementation of random numbers by rocrand
-        # hip::hiprand is currently not expressing this dependency
-        find_package(rocrand REQUIRED CONFIG
-                HINTS "${HIP_ROOT_DIR}/rocrand"
-                HINTS "/opt/rocm/rocrand")
-        if(rocrand_FOUND)
-            target_link_libraries(alpaka INTERFACE roc::rocrand)
-        else()
-            MESSAGE(FATAL_ERROR "Could not find rocRAND (also searched in: HIP_ROOT_DIR=${HIP_ROOT_DIR}/rocrand).")
-        endif()
+        if(NOT alpaka_DISABLE_VENDOR_RNG)
+            # hiprand requires ROCm implementation of random numbers by rocrand
+            # hip::hiprand is currently not expressing this dependency
+            find_package(rocrand REQUIRED CONFIG
+                    HINTS "${HIP_ROOT_DIR}/rocrand"
+                    HINTS "/opt/rocm/rocrand")
+            if(rocrand_FOUND)
+                target_link_libraries(alpaka INTERFACE roc::rocrand)
+            else()
+                MESSAGE(FATAL_ERROR "Could not find rocRAND (also searched in: HIP_ROOT_DIR=${HIP_ROOT_DIR}/rocrand).")
+            endif()
 
-        # # HIP random numbers
-        find_package(hiprand REQUIRED CONFIG
-                HINTS "${HIP_ROOT_DIR}/hiprand"
-                HINTS "/opt/rocm/hiprand")
-        if(hiprand_FOUND)
-            target_link_libraries(alpaka INTERFACE hip::hiprand)
-        else()
-            MESSAGE(FATAL_ERROR "Could not find hipRAND (also searched in: HIP_ROOT_DIR=${HIP_ROOT_DIR}/hiprand).")
+            # HIP random numbers
+            find_package(hiprand REQUIRED CONFIG
+                    HINTS "${HIP_ROOT_DIR}/hiprand"
+                    HINTS "/opt/rocm/hiprand")
+            if(hiprand_FOUND)
+                target_link_libraries(alpaka INTERFACE hip::hiprand)
+            else()
+                MESSAGE(FATAL_ERROR "Could not find hipRAND (also searched in: HIP_ROOT_DIR=${HIP_ROOT_DIR}/hiprand).")
+            endif()
         endif()
 
         alpaka_set_compiler_options(HOST_DEVICE target alpaka -std=c++${alpaka_CXX_STANDARD})
@@ -639,9 +650,11 @@ if(alpaka_ACC_SYCL_ENABLE)
         message(FATAL_ERROR "alpaka currently does not support SYCL implementations other than oneAPI.")
     endif()
 
-    # Use oneDPL random number generators
-    find_package(oneDPL REQUIRED)
-    target_link_libraries(alpaka INTERFACE oneDPL)
+    if(NOT alpaka_DISABLE_VENDOR_RNG)
+        # Use oneDPL random number generators
+        find_package(oneDPL REQUIRED)
+        target_link_libraries(alpaka INTERFACE oneDPL)
+    endif()
 
     alpaka_set_compiler_options(DEVICE target alpaka "-fsycl-unnamed-lambda") # Compiler default but made explicit here
 endif()

--- a/example/reduce/src/reduce.cpp
+++ b/example/reduce/src/reduce.cpp
@@ -108,8 +108,7 @@ auto reduce(
 
 auto main() -> int
 {
-    // select device and problem size
-    int const dev = 0;
+    // select problem size
     uint64_t n = 1 << 28;
 
     using T = uint32_t;

--- a/include/alpaka/acc/AccGenericSycl.hpp
+++ b/include/alpaka/acc/AccGenericSycl.hpp
@@ -15,6 +15,7 @@
 #include "alpaka/intrinsic/IntrinsicGenericSycl.hpp"
 #include "alpaka/math/MathGenericSycl.hpp"
 #include "alpaka/mem/fence/MemFenceGenericSycl.hpp"
+#include "alpaka/rand/RandDefault.hpp"
 #include "alpaka/rand/RandGenericSycl.hpp"
 #include "alpaka/warp/WarpGenericSycl.hpp"
 #include "alpaka/workdiv/WorkDivGenericSycl.hpp"
@@ -57,7 +58,11 @@ namespace alpaka
         , public BlockSyncGenericSycl<TDim>
         , public IntrinsicGenericSycl
         , public MemFenceGenericSycl
+#    ifdef ALPAKA_DISABLE_VENDOR_RNG
+        , public rand::RandDefault
+#    else
         , public rand::RandGenericSycl<TDim>
+#    endif
         , public warp::WarpGenericSycl<TDim>
     {
         static_assert(TDim::value > 0, "The SYCL accelerator must have a dimension greater than zero.");
@@ -85,7 +90,11 @@ namespace alpaka
             , BlockSyncGenericSycl<TDim>{work_item}
             , IntrinsicGenericSycl{}
             , MemFenceGenericSycl{global_fence_dummy, local_fence_dummy}
+#    ifdef ALPAKA_DISABLE_VENDOR_RNG
+            , rand::RandDefault{}
+#    else
             , rand::RandGenericSycl<TDim>{work_item}
+#    endif
             , warp::WarpGenericSycl<TDim>{work_item}
         {
         }

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -16,6 +16,7 @@
 #include "alpaka/intrinsic/IntrinsicUniformCudaHipBuiltIn.hpp"
 #include "alpaka/math/MathUniformCudaHipBuiltIn.hpp"
 #include "alpaka/mem/fence/MemFenceUniformCudaHipBuiltIn.hpp"
+#include "alpaka/rand/RandDefault.hpp"
 #include "alpaka/rand/RandUniformCudaHipRand.hpp"
 #include "alpaka/warp/WarpUniformCudaHipBuiltIn.hpp"
 #include "alpaka/workdiv/WorkDivUniformCudaHipBuiltIn.hpp"
@@ -45,28 +46,28 @@ namespace alpaka
     //! The GPU CUDA accelerator.
     //!
     //! This accelerator allows parallel kernel execution on devices supporting CUDA.
-    template<
-        typename TApi,
-        typename TDim,
-        typename TIdx>
-    class AccGpuUniformCudaHipRt final :
-        public WorkDivUniformCudaHipBuiltIn<TDim, TIdx>,
-        public gb::IdxGbUniformCudaHipBuiltIn<TDim, TIdx>,
-        public bt::IdxBtUniformCudaHipBuiltIn<TDim, TIdx>,
-        public AtomicHierarchy<
-            AtomicUniformCudaHipBuiltIn, // grid atomics
-            AtomicUniformCudaHipBuiltIn, // block atomics
-            AtomicUniformCudaHipBuiltIn  // thread atomics
-        >,
-        public math::MathUniformCudaHipBuiltIn,
-        public BlockSharedMemDynUniformCudaHipBuiltIn,
-        public BlockSharedMemStUniformCudaHipBuiltIn,
-        public BlockSyncUniformCudaHipBuiltIn,
-        public IntrinsicUniformCudaHipBuiltIn,
-        public MemFenceUniformCudaHipBuiltIn,
-        public rand::RandUniformCudaHipRand<TApi>,
-        public warp::WarpUniformCudaHipBuiltIn,
-        public concepts::Implements<ConceptAcc, AccGpuUniformCudaHipRt<TApi, TDim, TIdx>>
+    template<typename TApi, typename TDim, typename TIdx>
+    class AccGpuUniformCudaHipRt final
+        : public WorkDivUniformCudaHipBuiltIn<TDim, TIdx>
+        , public gb::IdxGbUniformCudaHipBuiltIn<TDim, TIdx>
+        , public bt::IdxBtUniformCudaHipBuiltIn<TDim, TIdx>
+        , public AtomicHierarchy<
+              AtomicUniformCudaHipBuiltIn, // grid atomics
+              AtomicUniformCudaHipBuiltIn, // block atomics
+              AtomicUniformCudaHipBuiltIn> // thread atomics
+        , public math::MathUniformCudaHipBuiltIn
+        , public BlockSharedMemDynUniformCudaHipBuiltIn
+        , public BlockSharedMemStUniformCudaHipBuiltIn
+        , public BlockSyncUniformCudaHipBuiltIn
+        , public IntrinsicUniformCudaHipBuiltIn
+        , public MemFenceUniformCudaHipBuiltIn
+#    ifdef ALPAKA_DISABLE_VENDOR_RNG
+        , public rand::RandDefault
+#    else
+        , public rand::RandUniformCudaHipRand<TApi>
+#    endif
+        , public warp::WarpUniformCudaHipBuiltIn
+        , public concepts::Implements<ConceptAcc, AccGpuUniformCudaHipRt<TApi, TDim, TIdx>>
     {
         static_assert(
             sizeof(TIdx) >= sizeof(int),
@@ -92,7 +93,11 @@ namespace alpaka
             , BlockSharedMemStUniformCudaHipBuiltIn()
             , BlockSyncUniformCudaHipBuiltIn()
             , MemFenceUniformCudaHipBuiltIn()
+#    ifdef ALPAKA_DISABLE_VENDOR_RNG
+            , rand::RandDefault()
+#    else
             , rand::RandUniformCudaHipRand<TApi>()
+#    endif
         {
         }
     };

--- a/include/alpaka/meta/CudaVectorArrayWrapper.hpp
+++ b/include/alpaka/meta/CudaVectorArrayWrapper.hpp
@@ -13,6 +13,14 @@
 
 #if defined(ALPAKA_ACC_GPU_HIP_ENABLED) || defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
 
+#    ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#        include <cuda_runtime.h>
+#    endif
+
+#    ifdef ALPAKA_ACC_GPU_HIP_ENABLED
+#        include <hip/hip_runtime.h>
+#    endif
+
 namespace alpaka::meta
 {
     namespace detail

--- a/include/alpaka/rand/Philox/PhiloxBaseTraits.hpp
+++ b/include/alpaka/rand/Philox/PhiloxBaseTraits.hpp
@@ -4,12 +4,19 @@
 
 #pragma once
 
-#include "alpaka/acc/AccGpuUniformCudaHipRt.hpp"
 #include "alpaka/rand/Philox/PhiloxBaseCommon.hpp"
 #include "alpaka/rand/Philox/PhiloxBaseCudaArray.hpp"
 #include "alpaka/rand/Philox/PhiloxBaseStdArray.hpp"
 #include "alpaka/rand/Philox/PhiloxStateless.hpp"
 #include "alpaka/rand/Philox/PhiloxStatelessKeyedBase.hpp"
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+namespace alpaka
+{
+    template<typename TApi, typename TDim, typename TIdx>
+    class AccGpuUniformCudaHipRt;
+}
+#endif
 
 namespace alpaka::rand::engine::trait
 {

--- a/include/alpaka/rand/RandGenericSycl.hpp
+++ b/include/alpaka/rand/RandGenericSycl.hpp
@@ -9,28 +9,30 @@
 #include "alpaka/dev/DevGenericSycl.hpp"
 #include "alpaka/rand/Traits.hpp"
 
-#ifdef ALPAKA_ACC_SYCL_ENABLED
+#ifndef ALPAKA_DISABLE_VENDOR_RNG
+
+#    ifdef ALPAKA_ACC_SYCL_ENABLED
 
 // Backend specific imports.
-#    include <sycl/sycl.hpp>
-#    if BOOST_COMP_CLANG
-#        pragma clang diagnostic push
-#        pragma clang diagnostic ignored "-Wcast-align"
-#        pragma clang diagnostic ignored "-Wcast-qual"
-#        pragma clang diagnostic ignored "-Wextra-semi"
-#        pragma clang diagnostic ignored "-Wfloat-equal"
-#        pragma clang diagnostic ignored "-Wold-style-cast"
-#        pragma clang diagnostic ignored "-Wreserved-identifier"
-#        pragma clang diagnostic ignored "-Wreserved-macro-identifier"
-#        pragma clang diagnostic ignored "-Wsign-compare"
-#        pragma clang diagnostic ignored "-Wundef"
-#    endif
-#    include <oneapi/dpl/random>
-#    if BOOST_COMP_CLANG
-#        pragma clang diagnostic pop
-#    endif
+#        include <sycl/sycl.hpp>
+#        if BOOST_COMP_CLANG
+#            pragma clang diagnostic push
+#            pragma clang diagnostic ignored "-Wcast-align"
+#            pragma clang diagnostic ignored "-Wcast-qual"
+#            pragma clang diagnostic ignored "-Wextra-semi"
+#            pragma clang diagnostic ignored "-Wfloat-equal"
+#            pragma clang diagnostic ignored "-Wold-style-cast"
+#            pragma clang diagnostic ignored "-Wreserved-identifier"
+#            pragma clang diagnostic ignored "-Wreserved-macro-identifier"
+#            pragma clang diagnostic ignored "-Wsign-compare"
+#            pragma clang diagnostic ignored "-Wundef"
+#        endif
+#        include <oneapi/dpl/random>
+#        if BOOST_COMP_CLANG
+#            pragma clang diagnostic pop
+#        endif
 
-#    include <type_traits>
+#        include <type_traits>
 
 namespace alpaka::rand
 {
@@ -45,7 +47,7 @@ namespace alpaka::rand
         sycl::nd_item<TDim::value> m_item_rand;
     };
 
-#    if !defined(ALPAKA_HOST_ONLY)
+#        if !defined(ALPAKA_HOST_ONLY)
     namespace distribution::sycl_rand
     {
         //! The SYCL random number floating point normal distribution.
@@ -190,7 +192,9 @@ namespace alpaka::rand
             }
         };
     } // namespace engine::trait
-#    endif
+#        endif
 } // namespace alpaka::rand
+
+#    endif
 
 #endif

--- a/include/alpaka/rand/RandUniformCudaHipRand.hpp
+++ b/include/alpaka/rand/RandUniformCudaHipRand.hpp
@@ -13,26 +13,28 @@
 
 #include <type_traits>
 
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#ifndef ALPAKA_DISABLE_VENDOR_RNG
 
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-#        include <curand_kernel.h>
-#    elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-#        if BOOST_COMP_CLANG
-#            pragma clang diagnostic push
-#            pragma clang diagnostic ignored "-Wduplicate-decl-specifier"
-#        endif
+#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-#        if HIP_VERSION >= 50200000
-#            include <hiprand/hiprand_kernel.h>
-#        else
-#            include <hiprand_kernel.h>
-#        endif
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+#            include <curand_kernel.h>
+#        elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+#            if BOOST_COMP_CLANG
+#                pragma clang diagnostic push
+#                pragma clang diagnostic ignored "-Wduplicate-decl-specifier"
+#            endif
 
-#        if BOOST_COMP_CLANG
-#            pragma clang diagnostic pop
+#            if HIP_VERSION >= 50200000
+#                include <hiprand/hiprand_kernel.h>
+#            else
+#                include <hiprand_kernel.h>
+#            endif
+
+#            if BOOST_COMP_CLANG
+#                pragma clang diagnostic pop
+#            endif
 #        endif
-#    endif
 
 namespace alpaka::rand
 {
@@ -42,15 +44,15 @@ namespace alpaka::rand
     {
     };
 
-#    if !defined(ALPAKA_HOST_ONLY)
+#        if !defined(ALPAKA_HOST_ONLY)
 
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
-#            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
-#        endif
+#            if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !BOOST_LANG_CUDA
+#                error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#            endif
 
-#        if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
-#            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
-#        endif
+#            if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && !BOOST_LANG_HIP
+#                error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
+#            endif
 
     namespace distribution::uniform_cuda_hip
     {
@@ -82,11 +84,11 @@ namespace alpaka::rand
                 std::uint32_t const& subsequence = 0,
                 std::uint32_t const& offset = 0)
             {
-#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#            ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                 curand_init(seed, subsequence, offset, &state);
-#        else
+#            else
                 hiprand_init(seed, subsequence, offset, &state);
-#        endif
+#            endif
             }
 
         private:
@@ -97,22 +99,22 @@ namespace alpaka::rand
             template<typename T>
             friend class distribution::uniform_cuda_hip::UniformUint;
 
-#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#            ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
             curandStateXORWOW_t state = curandStateXORWOW_t{};
-#        else
+#            else
             hiprandStateXORWOW_t state = hiprandStateXORWOW_t{};
-#        endif
+#            endif
 
         public:
             // STL UniformRandomBitGenerator concept. This is not strictly necessary as the distributions
             // contained in this file are aware of the API specifics of the CUDA/HIP XORWOW engine and STL
             // distributions might not work on the device, but it servers a compatibility bridge to other
             // potentially compatible alpaka distributions.
-#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#            ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
             using result_type = decltype(curand(&state));
-#        else
+#            else
             using result_type = decltype(hiprand(&state));
-#        endif
+#            endif
             ALPAKA_FN_HOST_ACC constexpr static result_type min()
             {
                 return std::numeric_limits<result_type>::min();
@@ -123,11 +125,11 @@ namespace alpaka::rand
             }
             __device__ result_type operator()()
             {
-#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#            ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                 return curand(&state);
-#        else
+#            else
                 return hiprand(&state);
-#        endif
+#            endif
             }
         };
     } // namespace engine::uniform_cuda_hip
@@ -142,11 +144,11 @@ namespace alpaka::rand
             template<typename TEngine>
             __device__ auto operator()(TEngine& engine) -> float
             {
-#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#            ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                 return curand_normal(&engine.state);
-#        else
+#            else
                 return hiprand_normal(&engine.state);
-#        endif
+#            endif
             }
         };
 
@@ -158,11 +160,11 @@ namespace alpaka::rand
             template<typename TEngine>
             __device__ auto operator()(TEngine& engine) -> double
             {
-#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#            ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                 return curand_normal_double(&engine.state);
-#        else
+#            else
                 return hiprand_normal_double(&engine.state);
-#        endif
+#            endif
             }
         };
 
@@ -175,11 +177,11 @@ namespace alpaka::rand
             __device__ auto operator()(TEngine& engine) -> float
             {
                 // (0.f, 1.0f]
-#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#            ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                 float const fUniformRand(curand_uniform(&engine.state));
-#        else
+#            else
                 float const fUniformRand(hiprand_uniform(&engine.state));
-#        endif
+#            endif
                 // NOTE: (1.0f - curand_uniform) does not work, because curand_uniform seems to return
                 // denormalized floats around 0.f. [0.f, 1.0f)
                 return fUniformRand * static_cast<float>(fUniformRand != 1.0f);
@@ -195,11 +197,11 @@ namespace alpaka::rand
             __device__ auto operator()(TEngine& engine) -> double
             {
                 // (0.f, 1.0f]
-#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#            ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                 double const fUniformRand(curand_uniform_double(&engine.state));
-#        else
+#            else
                 double const fUniformRand(hiprand_uniform_double(&engine.state));
-#        endif
+#            endif
                 // NOTE: (1.0f - curand_uniform_double) does not work, because curand_uniform_double seems to
                 // return denormalized floats around 0.f. [0.f, 1.0f)
                 return fUniformRand * static_cast<double>(fUniformRand != 1.0);
@@ -214,11 +216,11 @@ namespace alpaka::rand
             template<typename TEngine>
             __device__ auto operator()(TEngine& engine) -> unsigned int
             {
-#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#            ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
                 return curand(&engine.state);
-#        else
+#            else
                 return hiprand(&engine.state);
-#        endif
+#            endif
             }
         };
     } // namespace distribution::uniform_cuda_hip
@@ -275,7 +277,9 @@ namespace alpaka::rand
             }
         };
     } // namespace engine::trait
-#    endif
+#        endif
 } // namespace alpaka::rand
+
+#    endif
 
 #endif

--- a/include/alpaka/warp/WarpGenericSycl.hpp
+++ b/include/alpaka/warp/WarpGenericSycl.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/core/Assert.hpp"
 #include "alpaka/warp/Traits.hpp"
 
 #include <cstdint>


### PR DESCRIPTION
If `alpaka_DISABLE_VENDOR_RNG` is defined, alpaka will not include support for the vendor-specific random number generators (NVIDIA cuRAN, AMD hipRAND/rocRAND, Indel DPL).

Instead, all accelerators use the default configuration of the Philox RNG.