### PR TITLE
GitLab CI: job generator checks if container images exists

### DIFF
--- a/docs/source/dev/ci.rst
+++ b/docs/source/dev/ci.rst
@@ -132,6 +132,10 @@ One of them or none is also possible.
 
   You can test your regex offline before creating and pushing a commit. The ``job_generator.py`` provides the ``--filter`` and ``--reorder`` flags that do the same thing as the lines starting with ``CI_FILTER`` and ``CI_REORDER`` in the commit message.
 
+.. hint::
+
+  Each time the job generator runs it checks whether the container images exist. This is done by a request to the container registry which takes a lot of time. Therefore you can skip the check with the ``--no-image-check`` argument to speed up checking filters and reordering regex strings.
+
 Develop new Feature for the alpaka-job-coverage Library
 *******************************************************
 

--- a/script/job_generator/job_generator.py
+++ b/script/job_generator/job_generator.py
@@ -32,6 +32,7 @@ from generate_job_yaml import (
 )
 from job_modifier import add_job_parameters
 from verify import verify
+from util import print_warn
 
 
 def get_args() -> argparse.Namespace:
@@ -94,6 +95,12 @@ def get_args() -> argparse.Namespace:
         "--runtime-only", action="store_true", help="Generate only runtime jobs."
     )
 
+    parser.add_argument(
+        "--no-image-check",
+        action="store_false",
+        help="Disable registry check for existing Docker image.",
+    )
+
     return parser.parse_args()
 
 
@@ -147,7 +154,9 @@ if __name__ == "__main__":
             sys.exit(1)
 
     job_matrix_yaml = generate_job_yaml_list(
-        job_matrix=job_matrix, container_version=args.version
+        job_matrix=job_matrix,
+        container_version=args.version,
+        online_check=args.no_image_check,
     )
 
     add_custom_jobs(job_matrix_yaml, args.version)
@@ -183,7 +192,7 @@ if __name__ == "__main__":
     wave_job_matrix = distribute_to_waves(job_matrix_yaml, {JOB_COMPILE_ONLY: 20})
 
     if wave_job_matrix[JOB_UNKNOWN]:
-        print('\033[33mWARNING: Generator distribute jobs of type "JOB_UNKNOWN"\033[m')
+        print_warn('Generator distributed jobs of type "JOB_UNKNOWN"')
         for wave in wave_job_matrix[JOB_UNKNOWN]:
             for job in wave:
                 print(job)

--- a/script/job_generator/requirements.txt
+++ b/script/job_generator/requirements.txt
@@ -3,3 +3,4 @@ allpairspy == 2.5.0
 typeguard < 3.0.0
 pyaml
 types-PyYAML
+python-gitlab

--- a/script/job_generator/util.py
+++ b/script/job_generator/util.py
@@ -1,0 +1,32 @@
+from typeguard import typechecked
+
+
+@typechecked
+def print_info(text: str):
+    """Prints info message.
+
+    Args:
+        text (str): Info message.
+    """
+    print(f"\033[0;32m[INFO]: {text}\033[0m")
+
+
+@typechecked
+def print_warn(text: str):
+    """Prints warning message.
+
+    Args:
+        text (str): Warning message.
+    """
+    print(f"\033[0;33m[WARN]: {text}\033[0m")
+
+
+@typechecked
+def exit_error(text: str):
+    """Prints error message and exits application with error code 1.
+
+    Args:
+        text (str): Error message.
+    """
+    print(f"\033[0;31m[ERROR]: {text}\033[0m")
+    exit(1)


### PR DESCRIPTION
- Fetch all images from the container registry when the jobs are generated.
- If an image does not exist use the best working alternative.
- The check can be disabled because it takes a lot of time and is annoying if you want to test a regex to filter jobs.