### PR TITLE
Fix a dangling pointer in the SYCL memory buffer deleter

### DIFF
--- a/include/alpaka/mem/buf/BufGenericSycl.hpp
+++ b/include/alpaka/mem/buf/BufGenericSycl.hpp
@@ -196,9 +196,7 @@ namespace alpaka::trait
                 static_cast<std::size_t>(getExtentProduct(extent)),
                 nativeDev,
                 nativeContext);
-            // captured structured bindings are a C++20 extension
-            // auto deleter = [nativeContext](TElem* ptr) { sycl::free(ptr, nativeContext); };
-            auto deleter = [&dev](TElem* ptr) { sycl::free(ptr, dev.getNativeHandle().second); };
+            auto deleter = [ctx = nativeContext](TElem* ptr) { sycl::free(ptr, ctx); };
 
             return BufGenericSycl<TElem, TDim, TIdx, TPlatform>(dev, memPtr, std::move(deleter), extent);
         }


### PR DESCRIPTION
In
```c++
template<typename TExtent>
static auto allocBuf(DevGenericSycl<TPlatform> const& dev, TExtent const& extent)
  -> BufGenericSycl<TElem, TDim, TIdx, TPlatform>
  {
    //...
    auto deleter = [&dev](TElem* ptr) { sycl::free(ptr, dev.getNativeHandle().second); };
    return BufGenericSycl<TElem, TDim, TIdx, TPlatform>(dev, memPtr, std::move(deleter), extent);
  }
```
the lambda captured `dev1 by reference.

`dev` is a `const&` to the device object used in the call to `allocBuf(dev, extent)`.

If that object is itself a temporary, the reference to `dev` captured by the lambda may be dangling by the time `deleter` is called.

This change solves the problem by capturing directly the SYCL context by value.