### PR TITLE
Rewrite counterBasedRng example using mdspan

### DIFF
--- a/example/counterBasedRng/CMakeLists.txt
+++ b/example/counterBasedRng/CMakeLists.txt
@@ -33,6 +33,11 @@ if(NOT TARGET alpaka::alpaka)
     endif()
 endif()
 
+if (alpaka_USE_MDSPAN STREQUAL "OFF")
+    message(STATUS "The counterBasedRng example requires mdspan. Please set alpaka_USE_MDSPAN accordingly. Example disabled.")
+    return()
+endif ()
+
 #-------------------------------------------------------------------------------
 # Add executable.
 

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -594,6 +594,13 @@ namespace alpaka
         {
             return traits::GetMdSpan<TView>::getMdSpanTransposed(view);
         }
+
+        template<typename TElem, typename TIdx, typename TDim>
+        using MdSpan = alpaka::experimental::mdspan<
+            TElem,
+            alpaka::experimental::dextents<TIdx, TDim::value>,
+            alpaka::experimental::layout_stride,
+            alpaka::experimental::traits::detail::ByteIndexedAccessor<TElem>>;
     } // namespace experimental
 #endif
 } // namespace alpaka


### PR DESCRIPTION
In order to remove the experimental accessors, we first need to rewrite the `counterBasedRng` example to use something else, e.g. `std::mdspan`.