### PR TITLE
Fix compilation of bufferCopy example

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -109,8 +109,10 @@ auto main() -> int
     using HostQueue = alpaka::Queue<Host, HostQueueProperty>;
 
     // Select devices
-    auto const devAcc = alpaka::getDevByIdx<Acc>(0u);
-    auto const devHost = alpaka::getDevByIdx<Host>(0u);
+    auto const platformHost = alpaka::PlatformCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
+    auto const platformAcc = alpaka::Platform<Acc>{};
+    auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
 
     // Create queues
     DevQueue devQueue(devAcc);


### PR DESCRIPTION
The creation of a platform object was missing.