### PR TITLE
Update special CUDA jobs

### DIFF
--- a/script/gitlabci/job_cuda.yml
+++ b/script/gitlabci/job_cuda.yml
@@ -1,27 +1,27 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # nvcc + g++
-linux_nvcc-11.0_gcc-9_debug_separable_compilation_compile_only:
+linux_nvcc12.0_gcc12_debug_separable_compilation_compile_only:
   extends: .base_cuda_gcc_compile_only
   image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu20.04-cuda110-gcc:3.1
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
-    ALPAKA_CI_CUDA_VERSION: "11.0"
-    ALPAKA_CI_GCC_VER: 9
+    ALPAKA_CI_CUDA_VERSION: "12.0"
+    ALPAKA_CI_GCC_VER: 12
     CMAKE_BUILD_TYPE: Debug
-    ALPAKA_BOOST_VERSION: 1.74.0
-    ALPAKA_CI_CMAKE_VER: 3.22.6
+    ALPAKA_BOOST_VERSION: 1.81.0
+    ALPAKA_CI_CMAKE_VER: 3.26.5
     CUDA_SEPARABLE_COMPILATION: "ON"
 
-linux_nvcc-11.0_gcc-9_release_extended_lambda_off_compile_only:
+linux_nvcc12.0_gcc12_release_extended_lambda_off_compile_only:
   extends: .base_cuda_gcc_compile_only
   image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu20.04-cuda110-gcc:3.1
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
-    ALPAKA_CI_CUDA_VERSION: "11.0"
-    ALPAKA_CI_GCC_VER: 9
+    ALPAKA_CI_CUDA_VERSION: "12.0"
+    ALPAKA_CI_GCC_VER: 12
     CMAKE_BUILD_TYPE: Release
-    ALPAKA_BOOST_VERSION: 1.75.0
-    ALPAKA_CI_CMAKE_VER: 3.23.5
+    ALPAKA_BOOST_VERSION: 1.82.0
+    ALPAKA_CI_CMAKE_VER: 3.27.1
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
     alpaka_CUDA_EXPT_EXTENDED_LAMBDA: "OFF"


### PR DESCRIPTION
This PR is another prerequisite for #1977. It updates the special CUDA jobs to CUDA 12.0 to circumvent some CUDA bugs in the present older versions. The special jobs also now follow the naming scheme of the generated jobs.