### PR TITLE
Always use `std::size_t` for CUDA pitch calculations

### DIFF
--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Andrea Bocci, Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2023 Axel Hübl, Benjamin Worpitz, Matthias Werner, Andrea Bocci, Jan Stephan, Bernhard Manfred Gruber
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -17,6 +17,7 @@
 #include "alpaka/vec/Vec.hpp"
 
 #include <array>
+#include <cstddef>
 #include <iosfwd>
 #include <type_traits>
 #include <vector>
@@ -352,13 +353,13 @@ namespace alpaka
     namespace detail
     {
         //! A class with a create method that returns the pitch for each index.
-        template<std::size_t Tidx>
+        template<std::size_t TIdx>
         struct CreatePitchBytes
         {
             template<typename TView>
             ALPAKA_FN_HOST static auto create(TView const& view) -> Idx<TView>
             {
-                return getPitchBytes<Tidx>(view);
+                return getPitchBytes<TIdx>(view);
             }
         };
 
@@ -370,7 +371,7 @@ namespace alpaka
             if constexpr(TDim::value > 0)
             {
                 pitchBytes[TDim::value - 1u] = extent[TDim::value - 1u] * static_cast<TIdx>(sizeof(TElem));
-                for(TIdx i = TDim::value - 1u; i > static_cast<TIdx>(0u); --i)
+                for(auto i = TDim::value - 1u; i > TIdx{0}; --i)
                 {
                     pitchBytes[i - 1] = extent[i - 1] * pitchBytes[i];
                 }
@@ -433,7 +434,7 @@ namespace alpaka
     //! \param pitch Pitch in bytes for each dimension. Dimensionality must be equal to extent.
     //! \return A view to device memory.
     template<typename TDev, typename TElem, typename TExtent, typename TPitch>
-    auto createView(TDev const& dev, TElem* pMem, TExtent const& extent, TPitch const& pitch)
+    auto createView(TDev const& dev, TElem* pMem, TExtent const& extent, TPitch pitch)
     {
         return trait::CreateViewPlainPtr<TDev>::createViewPlainPtr(dev, pMem, extent, pitch);
     }

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -37,7 +37,7 @@ namespace alpaka
         }
 
         template<typename TExtent, typename TPitch>
-        ALPAKA_FN_HOST ViewPlainPtr(TElem* pMem, Dev const dev, TExtent const& extent, TPitch const& pitchBytes)
+        ALPAKA_FN_HOST ViewPlainPtr(TElem* pMem, Dev const dev, TExtent const& extent, TPitch pitchBytes)
             : m_pMem(pMem)
             , m_dev(dev)
             , m_extentElements(getExtentVecEnd<TDim>(extent))
@@ -197,7 +197,7 @@ namespace alpaka
         struct CreateViewPlainPtr<DevCpu>
         {
             template<typename TElem, typename TExtent, typename TPitch>
-            static auto createViewPlainPtr(DevCpu const& dev, TElem* pMem, TExtent const& extent, TPitch const& pitch)
+            static auto createViewPlainPtr(DevCpu const& dev, TElem* pMem, TExtent const& extent, TPitch pitch)
             {
                 return alpaka::ViewPlainPtr<DevCpu, TElem, alpaka::Dim<TExtent>, alpaka::Idx<TExtent>>(
                     pMem,
@@ -217,7 +217,7 @@ namespace alpaka
                 DevUniformCudaHipRt<TApi> const& dev,
                 TElem* pMem,
                 TExtent const& extent,
-                TPitch const& pitch)
+                TPitch pitch)
             {
                 return alpaka::
                     ViewPlainPtr<DevUniformCudaHipRt<TApi>, TElem, alpaka::Dim<TExtent>, alpaka::Idx<TExtent>>(
@@ -239,7 +239,7 @@ namespace alpaka
                 DevGenericSycl<TPlatform> const& dev,
                 TElem* pMem,
                 TExtent const& extent,
-                TPitch const& pitch)
+                TPitch pitch)
             {
                 return alpaka::
                     ViewPlainPtr<DevGenericSycl<TPlatform>, TElem, alpaka::Dim<TExtent>, alpaka::Idx<TExtent>>(


### PR DESCRIPTION
This PR hard-codes buffer and pitch sizes to `std::size_t` as there is no real reason for having other types here. It is also an attempt to fix #1933.