### PR TITLE
fix events and the tests

### DIFF
--- a/include/alpaka/event/EventGenericThreads.hpp
+++ b/include/alpaka/event/EventGenericThreads.hpp
@@ -297,15 +297,8 @@ namespace alpaka
                 {
                     auto oldFuture = spEventImpl->m_future;
 
-                    // Enqueue a task that waits for the given event.
-                    queueImpl.m_workerThread.submit(
-                        [spEventImpl, oldFuture]() mutable
-                        {
-                            std::unique_lock<std::mutex> lk2(spEventImpl->m_mutex);
-                            lk2.unlock();
-                            oldFuture.get();
-                            lk2.lock();
-                        });
+                    // Enqueue a task that waits for the given future of the event.
+                    queueImpl.m_workerThread.submit([oldFuture]() { oldFuture.get(); });
                 }
             }
         };

--- a/include/alpaka/queue/Traits.hpp
+++ b/include/alpaka/queue/Traits.hpp
@@ -41,6 +41,8 @@ namespace alpaka
     //!   If the event has previously been queued, then this call will overwrite any existing state of the event.
     //!   Any subsequent calls which examine the status of event will only examine the completion of this most recent
     //!   call to enqueue.
+    //!   If a queue is waiting for an event the event state of the recently captured state at the time of the API call
+    //!   to wait() will be used to release the queue.
     template<typename TQueue, typename TTask>
     ALPAKA_FN_HOST auto enqueue(TQueue& queue, TTask&& task) -> void
     {

--- a/include/alpaka/queue/Traits.hpp
+++ b/include/alpaka/queue/Traits.hpp
@@ -41,8 +41,8 @@ namespace alpaka
     //!   If the event has previously been queued, then this call will overwrite any existing state of the event.
     //!   Any subsequent calls which examine the status of event will only examine the completion of this most recent
     //!   call to enqueue.
-    //!   If a queue is waiting for an event the event state of the recently captured state at the time of the API call
-    //!   to wait() will be used to release the queue.
+    //!   If a queue is waiting for an event the latter's event state at the time of the API call to wait() will be
+    //!   used to release the queue.
     template<typename TQueue, typename TTask>
     ALPAKA_FN_HOST auto enqueue(TQueue& queue, TTask&& task) -> void
     {

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -57,6 +57,8 @@ namespace alpaka::test
                     m_bIsReady = true;
                 }
                 m_conditionVariable.notify_one();
+                // Give alpaka time to update into the new state, process all events and tasks.
+                std::this_thread::sleep_for(std::chrono::milliseconds(200u));
             }
 
         public:
@@ -96,6 +98,8 @@ namespace alpaka::test
         void trigger()
         {
             m_spEventImpl->trigger();
+            // Give alpaka time to update into the new state, process all events and tasks.
+            std::this_thread::sleep_for(std::chrono::milliseconds(200u));
         }
 
     public:
@@ -282,6 +286,8 @@ namespace alpaka::test
                 // Initiate the memory set.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     cudaMemset(m_devMem, static_cast<int>(1u), static_cast<size_t>(sizeof(int32_t))));
+                // Give alpaka time to update into the new state, process all events and tasks.
+                std::this_thread::sleep_for(std::chrono::milliseconds(200u));
             }
 
         public:
@@ -315,6 +321,8 @@ namespace alpaka::test
         void trigger()
         {
             m_spEventImpl->trigger();
+            // Give alpaka time to update into the new state, process all events and tasks.
+            std::this_thread::sleep_for(std::chrono::milliseconds(200u));
         }
 
     public:
@@ -509,6 +517,8 @@ namespace alpaka::test
                 // Initiate the memory set.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     hipMemset(m_devMem, static_cast<int>(1u), static_cast<size_t>(sizeof(int32_t))));
+                // Give alpaka time to update into the new state, process all events and tasks.
+                std::this_thread::sleep_for(std::chrono::milliseconds(200u));
             }
 
         public:
@@ -542,6 +552,8 @@ namespace alpaka::test
         void trigger()
         {
             m_spEventImpl->trigger();
+            // Give alpaka time to update into the new state, process all events and tasks.
+            std::this_thread::sleep_for(std::chrono::milliseconds(200u));
         }
 
     public:

--- a/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
+++ b/include/alpaka/test/queue/QueueCpuOmp2Collective.hpp
@@ -229,8 +229,8 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto enqueue(QueueCpuOmp2Collective&, test::EventHostManualTriggerCpu<>&) -> void
             {
-                // EventHostManualTriggerCpu are not supported for together with the queue QueueCpuOmp2Collective
-                // but a specialization is needed to path the EventTests
+                // EventHostManualTriggerCpu are not supported for together with the queue
+                // QueueCpuOmp2Collective but a specialization is needed to path the EventTests
             }
         };
 

--- a/include/alpaka/wait/Traits.hpp
+++ b/include/alpaka/wait/Traits.hpp
@@ -28,8 +28,8 @@ namespace alpaka
     //! Waits the thread for the completion of the given awaited action to complete.
     //!
     //! Special Handling for events:
-    //!   If the event is re-enqueued wait will terminate when the re-enqueued event will be ready and previous enqueue
-    //!   sates of the event will be ignored.
+    //!   If the event is re-enqueued wait() will terminate when the re-enqueued event will be ready and previously
+    //!   enqueued states of the event will be ignored.
     template<typename TAwaited>
     ALPAKA_FN_HOST auto wait(TAwaited const& awaited) -> void
     {
@@ -39,9 +39,9 @@ namespace alpaka
 
     //! The waiter waits for the given awaited action to complete.
     //!
-    //! Special Handling if waiter is a queue and awaited an event:
-    //!   The waiter waits for the event state becoming ready based on the recently captured event state at the time of
-    //!   the API call even if the event is being re-enqueued later.
+    //! Special Handling if \p waiter is a queue and \p awaited an event:
+    //!   The \p waiter waits for the event state to become ready based on the recently captured event state at the
+    //!   time of the API call even if the event is being re-enqueued later.
     template<typename TWaiter, typename TAwaited>
     ALPAKA_FN_HOST auto wait(TWaiter& waiter, TAwaited const& awaited) -> void
     {

--- a/include/alpaka/wait/Traits.hpp
+++ b/include/alpaka/wait/Traits.hpp
@@ -26,6 +26,10 @@ namespace alpaka
     } // namespace trait
 
     //! Waits the thread for the completion of the given awaited action to complete.
+    //!
+    //! Special Handling for events:
+    //!   If the event is re-enqueued wait will terminate when the re-enqueued event will be ready and previous enqueue
+    //!   sates of the event will be ignored.
     template<typename TAwaited>
     ALPAKA_FN_HOST auto wait(TAwaited const& awaited) -> void
     {
@@ -34,6 +38,10 @@ namespace alpaka
     }
 
     //! The waiter waits for the given awaited action to complete.
+    //!
+    //! Special Handling if waiter is a queue and awaited an event:
+    //!   The waiter waits for the event state becoming ready based on the recently captured event state at the time of
+    //!   the API call even if the event is being re-enqueued later.
     template<typename TWaiter, typename TAwaited>
     ALPAKA_FN_HOST auto wait(TWaiter& waiter, TAwaited const& awaited) -> void
     {

--- a/test/unit/event/src/EventTest.cpp
+++ b/test/unit/event/src/EventTest.cpp
@@ -186,7 +186,7 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfSomeoneWaitsFor", "[eve
             REQUIRE(alpaka::isComplete(k1));
             REQUIRE(!alpaka::isComplete(k2));
             REQUIRE(!alpaka::isComplete(e1));
-            REQUIRE(!alpaka::isComplete(e2));
+            REQUIRE(alpaka::isComplete(e2));
 
             // q1 = [e1]
             k2.trigger();
@@ -203,7 +203,6 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfSomeoneWaitsFor", "[eve
         }
     }
 }
-
 
 // github issue #388
 TEMPLATE_LIST_TEST_CASE("waitForEventThatAlreadyFinishedShouldBeSkipped", "[event]", TestQueues)

--- a/test/unit/event/src/EventTest.cpp
+++ b/test/unit/event/src/EventTest.cpp
@@ -65,7 +65,7 @@ TEMPLATE_LIST_TEST_CASE("eventTestShouldBeFalseWhileInQueueAndTrueAfterBeingProc
     }
     else
     {
-        std::cerr << "Can not execute test because CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS is not supported!"
+        std::cerr << "Cannot execute test because CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS is not supported!"
                   << std::endl;
     }
 }
@@ -123,7 +123,8 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfNobodyWaitsFor", "[even
         }
         else
         {
-            std::cerr << "Can not execute test because CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS is not supported!"
+            std::cerr << "Cannot execute test because CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS is not supported by "
+                         "the device!"
                       << std::endl;
         }
     }
@@ -208,7 +209,8 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueShouldBePossibleIfSomeoneWaitsFor", "[eve
         }
         else
         {
-            std::cerr << "Can not execute test because CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS is not supported!"
+            std::cerr << "Cannot execute test because CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS is not supported by "
+                         "the device!"
                       << std::endl;
         }
     }
@@ -284,7 +286,8 @@ TEMPLATE_LIST_TEST_CASE("waitForEventThatAlreadyFinishedShouldBeSkipped", "[even
         }
         else
         {
-            std::cerr << "Can not execute test because CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS is not supported!"
+            std::cerr << "Cannot execute test because CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS is not supported by "
+                         "the device!"
                       << std::endl;
         }
     }
@@ -329,7 +332,7 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueWithSomeoneWaitsForEventInOrderLifetimeRe
 
             alpaka::wait(q2, e1);
             alpaka::enqueue(q2, e2);
-            // q2 = [->e1,e2]
+            // q2 = [k2,->e1,e2]
             alpaka::enqueue(q1, k1_1);
             alpaka::enqueue(q1, e1);
             // q1 = [k1_0,e1,k1_1,e1_new]
@@ -374,7 +377,7 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueWithSomeoneWaitsForEventInOrderLifetimeRe
             REQUIRE(!alpaka::isComplete(e2));
             REQUIRE(!alpaka::isComplete(e3));
 
-            // After the kernel k1_0 is released e3 is not allowed to be ready because q3 depends on the oldest e1
+            // After the kernel k1_0 is released e3 is not allowed to be ready because q3 depends on the oldest e1_new
             // state.
             k1_0.trigger();
             // q1 = [k1_1,e1_new]
@@ -392,6 +395,7 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueWithSomeoneWaitsForEventInOrderLifetimeRe
             k1_1.trigger();
             // q1 = []
             // q2 = []
+            // q3 = []
             REQUIRE(alpaka::isComplete(k1_0));
             REQUIRE(alpaka::isComplete(k1_1));
             REQUIRE(alpaka::isComplete(k2));
@@ -402,7 +406,8 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueWithSomeoneWaitsForEventInOrderLifetimeRe
         }
         else
         {
-            std::cerr << "Can not execute test because CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS is not supported!"
+            std::cerr << "Cannot execute test because CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS is not supported by "
+                         "the device!"
                       << std::endl;
         }
     }
@@ -441,16 +446,16 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueWithSomeoneWaitsForEventOutOfOrderLifetim
             // q2 = [k2]
             REQUIRE(!alpaka::isComplete(k1_0));
 
-            alpaka::wait(q3, e1); // let wait
+            alpaka::wait(q3, e1);
             alpaka::enqueue(q3, e3);
             // q3 = [->e1,e3]
 
             alpaka::enqueue(q2, e1);
-            // q2 = [k2,e1(1)]
+            // q2 = [k2,e1_new]
 
             alpaka::enqueue(q2, e2);
             // q1 = [k1_0,e1]
-            // q2 = [k2,e1_new,e3]
+            // q2 = [k2,e1_new,e2]
             // q3 = [->e1,e3]
 
             REQUIRE(!alpaka::isComplete(k1_0));
@@ -459,8 +464,8 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueWithSomeoneWaitsForEventOutOfOrderLifetim
             REQUIRE(!alpaka::isComplete(e2));
             REQUIRE(!alpaka::isComplete(e3));
 
-            // We release first the kernel which is blocking the most resent enqueue of event e1.
-            // Queue q3 is not allowed to be freed because these queue depends on the oldest enqueue of e1.
+            // We release first the kernel which is blocking the most recent enqueue of event e1.
+            // q3 is not allowed to be freed because this queue depends on the oldest enqueue of e1.
             k2.trigger();
 
             // q1 = [k1_0,e1]
@@ -493,7 +498,8 @@ TEMPLATE_LIST_TEST_CASE("eventReEnqueueWithSomeoneWaitsForEventOutOfOrderLifetim
         }
         else
         {
-            std::cerr << "Can not execute test because CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS is not supported!"
+            std::cerr << "Cannot execute test because CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS is not supported by "
+                         "the device!"
                       << std::endl;
         }
     }


### PR DESCRIPTION
- fix event tests
- add a sleep to the test EventHostManualTrigger to be able to use  `alpaka::isComplete()` without taking false negatives into account.
- fix EventGenericThreads implementation
  - The behavior for a re-enqueued event was not following the CUDA  the behavior we assume in alpaka
- extend the documenation for `alpaka::wait()` and `alpaka::enqueue()`
- add tests to check the correct behavior for `alpaka::wait(queue, event)`.