### PR TITLE
Ensure CallbackThread/ThreadPool propagate exceptions

### DIFF
--- a/include/alpaka/core/ThreadPool.hpp
+++ b/include/alpaka/core/ThreadPool.hpp
@@ -53,7 +53,7 @@ namespace alpaka::core::detail
         //!             via move then move the lambda.
         //! \return     A future to the created task.
         template<typename TFnObj, typename... TArgs>
-        auto enqueueTask(TFnObj&& task, TArgs&&... args)
+        auto enqueueTask(TFnObj&& task, TArgs&&... args) -> std::future<void>
         {
             auto ptask = Task{[=, t = std::forward<TFnObj>(task)] { t(args...); }};
             auto future = ptask.get_future();

--- a/test/unit/core/src/CallbackThread.cpp
+++ b/test/unit/core/src/CallbackThread.cpp
@@ -1,0 +1,61 @@
+/* Copyright 2023 Bernhard Manfred Gruber
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/core/CallbackThread.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("callbackthread", "[core]")
+{
+    alpaka::core::CallbackThread cbt;
+
+    auto f1 = cbt.submit([] { throw std::runtime_error("42"); });
+    auto f2 = cbt.submit([] { throw 42; });
+    auto f3 = cbt.submit([] {});
+
+    CHECK_THROWS_AS(f1.get(), std::runtime_error);
+
+    try
+    {
+        f2.get();
+    }
+    catch(int i)
+    {
+        CHECK(i == 42);
+    }
+
+    CHECK_NOTHROW(f3.get());
+}
+
+TEST_CASE("callbackthread_copyable_task", "[core]")
+{
+    alpaka::core::CallbackThread cbt;
+
+    bool flag = false;
+    auto task = [&] { flag = true; };
+    cbt.submit(task).get(); // lvalue
+    CHECK(flag == true);
+
+    flag = false;
+    cbt.submit(std::move(task)).get(); // xvalue
+    CHECK(flag == true);
+
+    flag = false;
+    cbt.submit([&] { flag = true; }).get(); // prvalue
+    CHECK(flag == true);
+}
+
+TEST_CASE("callbackthread_non_copyable_task", "[core]")
+{
+    alpaka::core::CallbackThread cbt;
+
+    bool flag = false;
+    auto task = [&, dummy = std::unique_ptr<int>{nullptr}] { flag = true; };
+    cbt.submit(std::move(task)).get(); // xvalue
+    CHECK(flag == true);
+
+    flag = false;
+    cbt.submit([&] { flag = true; }).get(); // prvalue
+    CHECK(flag == true);
+}

--- a/test/unit/core/src/ThreadPool.cpp
+++ b/test/unit/core/src/ThreadPool.cpp
@@ -1,0 +1,29 @@
+/* Copyright 2023 Bernhard Manfred Gruber
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/core/ThreadPool.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("threadpool", "[core]")
+{
+    alpaka::core::detail::ThreadPool tp{2};
+
+    auto f1 = tp.enqueueTask([] { throw std::runtime_error("42"); });
+    auto f2 = tp.enqueueTask([] { throw 42; });
+    auto f3 = tp.enqueueTask([] {});
+
+    CHECK_THROWS_AS(f1.get(), std::runtime_error);
+
+    try
+    {
+        f2.get();
+    }
+    catch(int i)
+    {
+        CHECK(i == 42);
+    }
+
+    CHECK_NOTHROW(f3.get());
+}

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -47,6 +47,29 @@ TEMPLATE_LIST_TEST_CASE("queueCallbackIsWorking", "[queue]", TestQueues)
     CHECK(promise.get_future().get());
 }
 
+TEMPLATE_LIST_TEST_CASE("queueTaskValueCategories", "[queue]", TestQueues)
+{
+    using DevQueue = TestType;
+    using Fixture = alpaka::test::QueueTestFixture<DevQueue>;
+    Fixture f;
+
+    bool flag = false;
+    auto task = [&] { flag = true; };
+    alpaka::enqueue(f.m_queue, task); // lvalue
+    alpaka::wait(f.m_queue);
+    CHECK(flag == true);
+
+    flag = false;
+    alpaka::enqueue(f.m_queue, std::move(task)); // xvalue
+    alpaka::wait(f.m_queue);
+    CHECK(flag == true);
+
+    flag = false;
+    alpaka::enqueue(f.m_queue, [&] { flag = true; }); // prvalue
+    alpaka::wait(f.m_queue);
+    CHECK(flag == true);
+}
+
 TEMPLATE_LIST_TEST_CASE("queueWaitShouldWork", "[queue]", TestQueues)
 {
     using DevQueue = TestType;


### PR DESCRIPTION
As a side effect, this replaces the `std::packaged_task` inside `CallbackThread` by a custom virtualization mechanism, so exceptions are propagated.

Fixes: #1994