### PR TITLE
[SYCL] Adopt the experimental free function extension

### DIFF
--- a/include/alpaka/acc/AccGenericSycl.hpp
+++ b/include/alpaka/acc/AccGenericSycl.hpp
@@ -75,25 +75,11 @@ namespace alpaka
 
         AccGenericSycl(
             Vec<TDim, TIdx> const& threadElemExtent,
-            sycl::nd_item<TDim::value> work_item,
             sycl::local_accessor<std::byte> dyn_shared_acc,
             sycl::local_accessor<std::byte> st_shared_acc)
-            : WorkDivGenericSycl<TDim, TIdx>{threadElemExtent, work_item}
-            , gb::IdxGbGenericSycl<TDim, TIdx>{work_item}
-            , bt::IdxBtGenericSycl<TDim, TIdx>{work_item}
-            , AtomicHierarchy<AtomicGenericSycl, AtomicGenericSycl, AtomicGenericSycl>{}
-            , math::MathGenericSycl{}
+            : WorkDivGenericSycl<TDim, TIdx>{threadElemExtent}
             , BlockSharedMemDynGenericSycl{dyn_shared_acc}
             , BlockSharedMemStGenericSycl{st_shared_acc}
-            , BlockSyncGenericSycl<TDim>{work_item}
-            , IntrinsicGenericSycl{}
-            , MemFenceGenericSycl{}
-#    ifdef ALPAKA_DISABLE_VENDOR_RNG
-            , rand::RandDefault{}
-#    else
-            , rand::RandGenericSycl<TDim>{work_item}
-#    endif
-            , warp::WarpGenericSycl<TDim>{work_item}
         {
         }
     };

--- a/include/alpaka/idx/bt/IdxBtGenericSycl.hpp
+++ b/include/alpaka/idx/bt/IdxBtGenericSycl.hpp
@@ -23,11 +23,7 @@ namespace alpaka::bt
     public:
         using IdxBtBase = IdxBtGenericSycl;
 
-        explicit IdxBtGenericSycl(sycl::nd_item<TDim::value> work_item) : m_item_bt{work_item}
-        {
-        }
-
-        sycl::nd_item<TDim::value> m_item_bt;
+        IdxBtGenericSycl() = default;
     };
 } // namespace alpaka::bt
 
@@ -46,22 +42,24 @@ namespace alpaka::trait
     {
         //! \return The index of the current thread in the block.
         template<typename TWorkDiv>
-        static auto getIdx(bt::IdxBtGenericSycl<TDim, TIdx> const& idx, TWorkDiv const&) -> Vec<TDim, TIdx>
+        static auto getIdx(bt::IdxBtGenericSycl<TDim, TIdx> const&, TWorkDiv const&) -> Vec<TDim, TIdx>
         {
+            auto const item = sycl::ext::oneapi::experimental::this_nd_item<TDim::value>();
+
             if constexpr(TDim::value == 1)
-                return Vec<TDim, TIdx>{static_cast<TIdx>(idx.m_item_bt.get_local_id(0))};
+                return Vec<TDim, TIdx>{static_cast<TIdx>(item.get_local_id(0))};
             else if constexpr(TDim::value == 2)
             {
                 return Vec<TDim, TIdx>{
-                    static_cast<TIdx>(idx.m_item_bt.get_local_id(1)),
-                    static_cast<TIdx>(idx.m_item_bt.get_local_id(0))};
+                    static_cast<TIdx>(item.get_local_id(1)),
+                    static_cast<TIdx>(item.get_local_id(0))};
             }
             else
             {
                 return Vec<TDim, TIdx>{
-                    static_cast<TIdx>(idx.m_item_bt.get_local_id(2)),
-                    static_cast<TIdx>(idx.m_item_bt.get_local_id(1)),
-                    static_cast<TIdx>(idx.m_item_bt.get_local_id(0))};
+                    static_cast<TIdx>(item.get_local_id(2)),
+                    static_cast<TIdx>(item.get_local_id(1)),
+                    static_cast<TIdx>(item.get_local_id(0))};
             }
         }
     };

--- a/include/alpaka/idx/gb/IdxGbGenericSycl.hpp
+++ b/include/alpaka/idx/gb/IdxGbGenericSycl.hpp
@@ -23,11 +23,7 @@ namespace alpaka::gb
     public:
         using IdxGbBase = IdxGbGenericSycl;
 
-        explicit IdxGbGenericSycl(sycl::nd_item<TDim::value> work_item) : m_item_gb{work_item}
-        {
-        }
-
-        sycl::nd_item<TDim::value> m_item_gb;
+        IdxGbGenericSycl() = default;
     };
 } // namespace alpaka::gb
 
@@ -46,22 +42,22 @@ namespace alpaka::trait
     {
         //! \return The index of the current block in the grid.
         template<typename TWorkDiv>
-        static auto getIdx(gb::IdxGbGenericSycl<TDim, TIdx> const& idx, TWorkDiv const&)
+        static auto getIdx(gb::IdxGbGenericSycl<TDim, TIdx> const&, TWorkDiv const&)
         {
+            auto const item = sycl::ext::oneapi::experimental::this_nd_item<TDim::value>();
+
             if constexpr(TDim::value == 1)
-                return Vec<TDim, TIdx>(static_cast<TIdx>(idx.m_item_gb.get_group(0)));
+                return Vec<TDim, TIdx>(static_cast<TIdx>(item.get_group(0)));
             else if constexpr(TDim::value == 2)
             {
-                return Vec<TDim, TIdx>(
-                    static_cast<TIdx>(idx.m_item_gb.get_group(1)),
-                    static_cast<TIdx>(idx.m_item_gb.get_group(0)));
+                return Vec<TDim, TIdx>(static_cast<TIdx>(item.get_group(1)), static_cast<TIdx>(item.get_group(0)));
             }
             else
             {
                 return Vec<TDim, TIdx>(
-                    static_cast<TIdx>(idx.m_item_gb.get_group(2)),
-                    static_cast<TIdx>(idx.m_item_gb.get_group(1)),
-                    static_cast<TIdx>(idx.m_item_gb.get_group(0)));
+                    static_cast<TIdx>(item.get_group(2)),
+                    static_cast<TIdx>(item.get_group(1)),
+                    static_cast<TIdx>(item.get_group(0)));
             }
         }
     };

--- a/include/alpaka/kernel/TaskKernelGenericSycl.hpp
+++ b/include/alpaka/kernel/TaskKernelGenericSycl.hpp
@@ -40,10 +40,10 @@
 #    define LAUNCH_SYCL_KERNEL_IF_SUBGROUP_SIZE_IS(sub_group_size)                                                    \
         cgh.parallel_for(                                                                                             \
             sycl::nd_range<TDim::value>{global_size, local_size},                                                     \
-            [item_elements, dyn_shared_accessor, st_shared_accessor, k_func, k_args](                                 \
-                sycl::nd_item<TDim::value> work_item) [[intel::reqd_sub_group_size(sub_group_size)]]                  \
+            [item_elements, dyn_shared_accessor, st_shared_accessor, k_func, k_args](sycl::nd_item<TDim::value>)      \
+                [[intel::reqd_sub_group_size(sub_group_size)]]                                                        \
             {                                                                                                         \
-                auto acc = TAcc{item_elements, work_item, dyn_shared_accessor, st_shared_accessor};                   \
+                auto acc = TAcc{item_elements, dyn_shared_accessor, st_shared_accessor};                              \
                 core::apply(                                                                                          \
                     [k_func, &acc](typename std::decay_t<TArgs> const&... args) { k_func(acc, args...); },            \
                     k_args);                                                                                          \
@@ -52,10 +52,9 @@
 #    define LAUNCH_SYCL_KERNEL_WITH_DEFAULT_SUBGROUP_SIZE                                                             \
         cgh.parallel_for(                                                                                             \
             sycl::nd_range<TDim::value>{global_size, local_size},                                                     \
-            [item_elements, dyn_shared_accessor, st_shared_accessor, k_func, k_args](                                 \
-                sycl::nd_item<TDim::value> work_item)                                                                 \
+            [item_elements, dyn_shared_accessor, st_shared_accessor, k_func, k_args](sycl::nd_item<TDim::value>)      \
             {                                                                                                         \
-                auto acc = TAcc{item_elements, work_item, dyn_shared_accessor, st_shared_accessor};                   \
+                auto acc = TAcc{item_elements, dyn_shared_accessor, st_shared_accessor};                              \
                 core::apply(                                                                                          \
                     [k_func, &acc](typename std::decay_t<TArgs> const&... args) { k_func(acc, args...); },            \
                     k_args);                                                                                          \
@@ -65,8 +64,7 @@
         throw sycl::exception(sycl::make_error_code(sycl::errc::kernel_not_supported));                               \
         cgh.parallel_for(                                                                                             \
             sycl::nd_range<TDim::value>{global_size, local_size},                                                     \
-            [item_elements, dyn_shared_accessor, st_shared_accessor, k_func, k_args](                                 \
-                sycl::nd_item<TDim::value> work_item) {});
+            [item_elements, dyn_shared_accessor, st_shared_accessor, k_func, k_args](sycl::nd_item<TDim::value>) {});
 
 namespace alpaka
 {

--- a/include/alpaka/rand/RandGenericSycl.hpp
+++ b/include/alpaka/rand/RandGenericSycl.hpp
@@ -40,11 +40,7 @@ namespace alpaka::rand
     template<typename TDim>
     struct RandGenericSycl : concepts::Implements<ConceptRand, RandGenericSycl<TDim>>
     {
-        explicit RandGenericSycl(sycl::nd_item<TDim::value> my_item) : m_item_rand{my_item}
-        {
-        }
-
-        sycl::nd_item<TDim::value> m_item_rand;
+        RandGenericSycl() = default;
     };
 
 #        if !defined(ALPAKA_HOST_ONLY)
@@ -72,7 +68,8 @@ namespace alpaka::rand
 
             Minstd(RandGenericSycl<TDim> rand, std::uint32_t const& seed)
             {
-                oneapi::dpl::minstd_rand engine(seed, rand.m_item_rand.get_global_linear_id());
+                auto const item = sycl::ext::oneapi::experimental::this_nd_item<TDim::value>();
+                oneapi::dpl::minstd_rand engine(seed, item.get_global_linear_id());
                 rng_engine = engine;
             }
 

--- a/include/alpaka/workdiv/WorkDivGenericSycl.hpp
+++ b/include/alpaka/workdiv/WorkDivGenericSycl.hpp
@@ -23,14 +23,11 @@ namespace alpaka
     public:
         using WorkDivBase = WorkDivGenericSycl;
 
-        WorkDivGenericSycl(Vec<TDim, TIdx> const& threadElemExtent, sycl::nd_item<TDim::value> work_item)
-            : m_threadElemExtent{threadElemExtent}
-            , m_item_workdiv{work_item}
+        WorkDivGenericSycl(Vec<TDim, TIdx> const& threadElemExtent) : m_threadElemExtent{threadElemExtent}
         {
         }
 
         Vec<TDim, TIdx> const& m_threadElemExtent;
-        sycl::nd_item<TDim::value> m_item_workdiv;
     };
 } // namespace alpaka
 
@@ -55,24 +52,26 @@ namespace alpaka::trait
     struct GetWorkDiv<WorkDivGenericSycl<TDim, TIdx>, origin::Grid, unit::Blocks>
     {
         //! \return The number of blocks in each dimension of the grid.
-        static auto getWorkDiv(WorkDivGenericSycl<TDim, TIdx> const& workDiv) -> Vec<TDim, TIdx>
+        static auto getWorkDiv(WorkDivGenericSycl<TDim, TIdx> const&) -> Vec<TDim, TIdx>
         {
+            auto const item = sycl::ext::oneapi::experimental::this_nd_item<TDim::value>();
+
             if constexpr(TDim::value == 0)
                 return Vec<TDim, TIdx>{};
             else if constexpr(TDim::value == 1)
-                return Vec<TDim, TIdx>{static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(0))};
+                return Vec<TDim, TIdx>{static_cast<TIdx>(item.get_group_range(0))};
             else if constexpr(TDim::value == 2)
             {
                 return Vec<TDim, TIdx>{
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(1)),
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(0))};
+                    static_cast<TIdx>(item.get_group_range(1)),
+                    static_cast<TIdx>(item.get_group_range(0))};
             }
             else
             {
                 return Vec<TDim, TIdx>{
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(2)),
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(1)),
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(0))};
+                    static_cast<TIdx>(item.get_group_range(2)),
+                    static_cast<TIdx>(item.get_group_range(1)),
+                    static_cast<TIdx>(item.get_group_range(0))};
             }
         }
     };
@@ -82,24 +81,26 @@ namespace alpaka::trait
     struct GetWorkDiv<WorkDivGenericSycl<TDim, TIdx>, origin::Block, unit::Threads>
     {
         //! \return The number of threads in each dimension of a block.
-        static auto getWorkDiv(WorkDivGenericSycl<TDim, TIdx> const& workDiv) -> Vec<TDim, TIdx>
+        static auto getWorkDiv(WorkDivGenericSycl<TDim, TIdx> const&) -> Vec<TDim, TIdx>
         {
+            auto const item = sycl::ext::oneapi::experimental::this_nd_item<TDim::value>();
+
             if constexpr(TDim::value == 0)
                 return Vec<TDim, TIdx>{};
             else if constexpr(TDim::value == 1)
-                return Vec<TDim, TIdx>{static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(0))};
+                return Vec<TDim, TIdx>{static_cast<TIdx>(item.get_local_range(0))};
             else if constexpr(TDim::value == 2)
             {
                 return Vec<TDim, TIdx>{
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(1)),
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(0))};
+                    static_cast<TIdx>(item.get_local_range(1)),
+                    static_cast<TIdx>(item.get_local_range(0))};
             }
             else
             {
                 return Vec<TDim, TIdx>{
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(2)),
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(1)),
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(0))};
+                    static_cast<TIdx>(item.get_local_range(2)),
+                    static_cast<TIdx>(item.get_local_range(1)),
+                    static_cast<TIdx>(item.get_local_range(0))};
             }
         }
     };


### PR DESCRIPTION
Access the current nd_item via a free function instead of storing it as a data member of the various SYCL accelerator base classes.