### PR TITLE
[SYCL] remove dependencies from `memcpy`, `memset` and kernel launch

### DIFF
--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -70,7 +70,7 @@ namespace alpaka
                 for(auto& q_ptr : m_queues)
                 {
                     if(auto ptr = q_ptr.lock(); ptr != nullptr)
-                        ptr->register_dependency(event);
+                        ptr->getNativeHandle().ext_oneapi_submit_barrier({event});
                 }
             }
 

--- a/include/alpaka/event/EventGenericSycl.hpp
+++ b/include/alpaka/event/EventGenericSycl.hpp
@@ -87,7 +87,7 @@ namespace alpaka::trait
     {
         static auto enqueue(QueueGenericSyclNonBlocking<TDev>& queue, EventGenericSycl<TDev>& event)
         {
-            event.setEvent(queue.m_spQueueImpl->get_last_event());
+            event.setEvent(queue.getNativeHandle().ext_oneapi_submit_barrier());
         }
     };
 
@@ -97,7 +97,7 @@ namespace alpaka::trait
     {
         static auto enqueue(QueueGenericSyclBlocking<TDev>& queue, EventGenericSycl<TDev>& event)
         {
-            event.setEvent(queue.m_spQueueImpl->get_last_event());
+            event.setEvent(queue.getNativeHandle().ext_oneapi_submit_barrier());
         }
     };
 
@@ -120,7 +120,7 @@ namespace alpaka::trait
     {
         static auto waiterWaitFor(QueueGenericSyclNonBlocking<TDev>& queue, EventGenericSycl<TDev> const& event)
         {
-            queue.m_spQueueImpl->register_dependency(event.getNativeHandle());
+            queue.getNativeHandle().ext_oneapi_submit_barrier({event.getNativeHandle()});
         }
     };
 
@@ -130,7 +130,7 @@ namespace alpaka::trait
     {
         static auto waiterWaitFor(QueueGenericSyclBlocking<TDev>& queue, EventGenericSycl<TDev> const& event)
         {
-            queue.m_spQueueImpl->register_dependency(event.getNativeHandle());
+            queue.getNativeHandle().ext_oneapi_submit_barrier({event.getNativeHandle()});
         }
     };
 

--- a/include/alpaka/mem/buf/sycl/Copy.hpp
+++ b/include/alpaka/mem/buf/sycl/Copy.hpp
@@ -93,7 +93,7 @@ namespace alpaka::detail
 
         using TaskCopySyclBase<TDim, TViewDst, TViewSrc, TExtent>::TaskCopySyclBase;
 
-        auto operator()(sycl::queue& queue, std::vector<sycl::event> const& requirements) const -> sycl::event
+        auto operator()(sycl::queue& queue) const -> sycl::event
         {
             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
@@ -126,8 +126,7 @@ namespace alpaka::detail
                                 this->m_srcMemNative
                                 + (castVec<SrcSize>(idx) * srcPitchBytesWithoutOutmost)
                                       .foldrAll(std::plus<SrcSize>())),
-                            static_cast<std::size_t>(this->m_extentWidthBytes),
-                            requirements));
+                            static_cast<std::size_t>(this->m_extentWidthBytes)));
                     });
             }
 
@@ -144,7 +143,7 @@ namespace alpaka::detail
         using TaskCopySyclBase<DimInt<1u>, TViewDst, TViewSrc, TExtent>::TaskCopySyclBase;
         using Elem = alpaka::Elem<TViewSrc>;
 
-        auto operator()(sycl::queue& queue, std::vector<sycl::event> const& requirements) const -> sycl::event
+        auto operator()(sycl::queue& queue) const -> sycl::event
         {
             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
@@ -156,8 +155,7 @@ namespace alpaka::detail
                 return queue.memcpy(
                     reinterpret_cast<void*>(this->m_dstMemNative),
                     reinterpret_cast<void const*>(this->m_srcMemNative),
-                    sizeof(Elem) * static_cast<std::size_t>(this->m_extent.prod()),
-                    requirements);
+                    sizeof(Elem) * static_cast<std::size_t>(this->m_extent.prod()));
             }
             else
             {
@@ -187,9 +185,9 @@ namespace alpaka::detail
             ALPAKA_ASSERT(getExtentVec(viewSrc).prod() == 1u);
         }
 
-        auto operator()(sycl::queue& queue, std::vector<sycl::event> const& requirements) const -> sycl::event
+        auto operator()(sycl::queue& queue) const -> sycl::event
         {
-            return queue.memcpy(m_dstMemNative, m_srcMemNative, sizeof(Elem), requirements);
+            return queue.memcpy(m_dstMemNative, m_srcMemNative, sizeof(Elem));
         }
 
         void* m_dstMemNative;

--- a/include/alpaka/mem/buf/sycl/Set.hpp
+++ b/include/alpaka/mem/buf/sycl/Set.hpp
@@ -83,7 +83,7 @@ namespace alpaka
 
             using TaskSetSyclBase<TDim, TView, TExtent>::TaskSetSyclBase;
 
-            auto operator()(sycl::queue& queue, std::vector<sycl::event> const& requirements) const -> sycl::event
+            auto operator()(sycl::queue& queue) const -> sycl::event
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
@@ -112,8 +112,7 @@ namespace alpaka
                                     + (castVec<DstSize>(idx) * dstPitchBytesWithoutOutmost)
                                           .foldrAll(std::plus<DstSize>())),
                                 this->m_byte,
-                                static_cast<std::size_t>(this->m_extentWidthBytes),
-                                requirements));
+                                static_cast<std::size_t>(this->m_extentWidthBytes)));
                         });
                 }
 
@@ -128,7 +127,7 @@ namespace alpaka
         {
             using TaskSetSyclBase<DimInt<1u>, TView, TExtent>::TaskSetSyclBase;
 
-            auto operator()(sycl::queue& queue, std::vector<sycl::event> const& requirements) const -> sycl::event
+            auto operator()(sycl::queue& queue) const -> sycl::event
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
@@ -140,8 +139,7 @@ namespace alpaka
                     return queue.memset(
                         reinterpret_cast<void*>(this->m_dstMemNative),
                         this->m_byte,
-                        static_cast<std::size_t>(this->m_extentWidthBytes),
-                        requirements);
+                        static_cast<std::size_t>(this->m_extentWidthBytes));
                 }
                 else
                 {
@@ -178,14 +176,14 @@ namespace alpaka
             }
 #    endif
 
-            auto operator()(sycl::queue& queue, std::vector<sycl::event> const& requirements) const -> sycl::event
+            auto operator()(sycl::queue& queue) const -> sycl::event
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 printDebug();
 #    endif
-                return queue.memset(reinterpret_cast<void*>(m_dstMemNative), m_byte, sizeof(Elem), requirements);
+                return queue.memset(reinterpret_cast<void*>(m_dstMemNative), m_byte, sizeof(Elem));
             }
 
             std::uint8_t const m_byte;


### PR DESCRIPTION
The requirements / dependencies were needed for the buffers, so now can be removed.
SYCL `queue`s and `event`s are thread-safe, the mutex in `QueueGenericSyclBase.hpp` has been removed as well.
When there is an event to wait for, instead of registering it as a dependency, the method `ext_oneapi_submit_barrier(const std::vector<event> &)` is used.