### PR TITLE
Reduce console output

### DIFF
--- a/example/helloWorld/src/helloWorld.cpp
+++ b/example/helloWorld/src/helloWorld.cpp
@@ -142,8 +142,8 @@ auto main() -> int
     // Thus, a thread can process data element size wise with its
     // vector processing unit.
     using Vec = alpaka::Vec<Dim, Idx>;
-    Vec const elementsPerThread(Vec::all(static_cast<Idx>(1)));
-    Vec const threadsPerGrid(Vec::all(static_cast<Idx>(8)));
+    auto const elementsPerThread = Vec::all(static_cast<Idx>(1));
+    auto const threadsPerGrid = Vec{4, 2, 4};
     using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
     WorkDiv const workDiv = alpaka::getValidWorkDiv<Acc>(
         devAcc,

--- a/example/helloWorldLambda/src/helloWorldLambda.cpp
+++ b/example/helloWorldLambda/src/helloWorldLambda.cpp
@@ -79,8 +79,8 @@ auto main() -> int
 
     // Define the work division
     using Vec = alpaka::Vec<Dim, Idx>;
-    Vec const elementsPerThread(Vec::all(static_cast<Idx>(1)));
-    Vec const threadsPerGrid(Vec::all(static_cast<Idx>(8)));
+    auto const elementsPerThread = Vec::all(static_cast<Idx>(1));
+    auto const threadsPerGrid = Vec{4, 2, 4};
     using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
     WorkDiv const workDiv = alpaka::getValidWorkDiv<Acc>(
         devAcc,

--- a/test/unit/math/src/TestTemplate.hpp
+++ b/test/unit/math/src/TestTemplate.hpp
@@ -63,10 +63,11 @@ struct TestTemplate
     {
         std::random_device rd{};
         auto const seed = rd();
-        std::cout << "testing"
-                  << " acc:" << alpaka::core::demangled<TAcc> << " data type:"
-                  << alpaka::core::demangled<TData> << " functor:"
-                  << alpaka::core::demangled<TWrappedFunctor> << " seed:" << seed << std::endl;
+        INFO(
+            "testing"
+            << " acc:" << alpaka::core::demangled<TAcc> << " data type:"
+            << alpaka::core::demangled<TData> << " functor:" << alpaka::core::demangled<TWrappedFunctor> << " seed:"
+            << seed);
 
         // SETUP (defines and initialising)
         // DevAcc is defined in Buffer.hpp too.


### PR DESCRIPTION
A few tests and examples are a bit noisy when inspecting the CI logs, so here is a small reduction of their output.