### PR TITLE
Disable recursive macro expansion warning for icpx

### DIFF
--- a/test/common/devCompileOptions.cmake
+++ b/test/common/devCompileOptions.cmake
@@ -146,6 +146,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "Inte
     if(${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM")
         # fast math is turned on by default with ICPX, which breaks our unit tests
         list(APPEND alpaka_DEV_COMPILE_OPTIONS "-ffp-model=precise")
+
+        if (alpaka_ACC_SYCL_ENABLE)
+            # avoid: warning: disabled expansion of recursive macro
+            list(APPEND alpaka_DEV_COMPILE_OPTIONS "-Wno-disabled-macro-expansion")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
This silences warnings with icpx inside the `ALPAKA_CHECK` and `printf` macros.