### PR TITLE
fix CUDA CMake support

### DIFF
--- a/cmake/addExecutable.cmake
+++ b/cmake/addExecutable.cmake
@@ -18,6 +18,7 @@ macro(alpaka_add_executable In_Name)
     add_executable(${In_Name} ${ARGN})
 
     if(alpaka_ACC_GPU_CUDA_ENABLE)
+       enable_language(CUDA)
        foreach(_file ${ARGN})
             if((${_file} MATCHES "\\.cpp$") OR 
                (${_file} MATCHES "\\.cxx$") OR 

--- a/cmake/addLibrary.cmake
+++ b/cmake/addLibrary.cmake
@@ -19,6 +19,7 @@ macro(alpaka_add_library libraryName)
     add_library(${libraryName} ${ARGN})
 
     if(alpaka_ACC_GPU_CUDA_ENABLE)
+        enable_language(CUDA)
         foreach(_file ${ARGN})
             if((${_file} MATCHES "\\.cpp$") OR
                (${_file} MATCHES "\\.cxx$") OR


### PR DESCRIPTION
fix bug introduced with https://github.com/alpaka-group/alpaka/pull/2072

The following CMake error is shown if alpaka is used as a subtree. The project is not a CUDA project therefore the language support must be enabled.

```
CMake Error in CMakeLists.txt:
  No known features for CUDA compiler

  ""

  version .
```