### PR TITLE
Refactor Vec

### DIFF
--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -383,17 +383,15 @@ namespace alpaka
     template<typename TView>
     auto getPitchBytesVec(TView const& view = TView()) -> Vec<Dim<TView>, Idx<TView>>
     {
-        return createVecFromIndexedFn<Dim<TView>, detail::CreatePitchBytes>(view);
+        return Vec<Dim<TView>, Idx<TView>>([&](auto ic) { return getPitchBytes<decltype(ic)::value>(view); });
     }
 
     //! \return The pitch but only the last N elements.
     template<typename TDim, typename TView>
     ALPAKA_FN_HOST auto getPitchBytesVecEnd(TView const& view = TView()) -> Vec<TDim, Idx<TView>>
     {
-        using IdxOffset = std::integral_constant<
-            std::intmax_t,
-            static_cast<std::intmax_t>(Dim<TView>::value) - static_cast<std::intmax_t>(TDim::value)>;
-        return createVecFromIndexedFnOffset<TDim, detail::CreatePitchBytes, IdxOffset>(view);
+        return Vec<TDim, Idx<TView>>(
+            [&](auto ic) { return getPitchBytes<decltype(ic)::value + Dim<TView>::value - TDim::value>(view); });
     }
 
     //! \return A view to static device memory.

--- a/include/alpaka/test/Extent.hpp
+++ b/include/alpaka/test/Extent.hpp
@@ -10,46 +10,30 @@
 
 namespace alpaka::test
 {
-    template<typename TIdx>
-    struct CreateVecWithIdx
+    template<typename TDim, typename TVal>
+    inline constexpr auto extentBuf = []
     {
-        //! 1D: (11)
-        //! 2D: (11, 10)
-        //! 3D: (11, 10, 9)
-        //! 4D: (11, 10, 9, 8)
-        template<std::size_t Tidx>
-        struct ForExtentBuf
-        {
-            ALPAKA_FN_HOST_ACC static auto create()
-            {
-                return static_cast<TIdx>(11u - Tidx);
-            }
-        };
+        Vec<TDim, TVal> v;
+        for(TVal i = 0; i < TVal{TDim::value}; i++)
+            v[i] = 11 - i;
+        return v;
+    }();
 
-        //! 1D: (8)
-        //! 2D: (8, 6)
-        //! 3D: (8, 6, 4)
-        //! 4D: (8, 6, 4, 2)
-        template<std::size_t Tidx>
-        struct ForExtentSubView
-        {
-            ALPAKA_FN_HOST_ACC static auto create()
-            {
-                return static_cast<TIdx>(8u - (Tidx * 2u));
-            }
-        };
+    template<typename TDim, typename TVal>
+    inline constexpr auto extentSubView = []
+    {
+        Vec<TDim, TVal> v;
+        for(TVal i = 0; i < TVal{TDim::value}; i++)
+            v[i] = 8 - i * 2;
+        return v;
+    }();
 
-        //! 1D: (2)
-        //! 2D: (2, 3)
-        //! 3D: (2, 3, 4)
-        //! 4D: (2, 3, 4, 5)
-        template<std::size_t Tidx>
-        struct ForOffset
-        {
-            ALPAKA_FN_HOST_ACC static auto create()
-            {
-                return static_cast<TIdx>(2u + Tidx);
-            }
-        };
-    };
+    template<typename TDim, typename TVal>
+    inline constexpr auto offset = []
+    {
+        Vec<TDim, TVal> v;
+        for(TVal i = 0; i < TVal{TDim::value}; i++)
+            v[i] = 2 + i;
+        return v;
+    }();
 } // namespace alpaka::test

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -150,6 +150,26 @@ namespace alpaka
             return m_data + TDim::value;
         }
 
+        ALPAKA_FN_HOST_ACC constexpr auto front() -> TVal&
+        {
+            return m_data[0];
+        }
+
+        ALPAKA_FN_HOST_ACC constexpr auto front() const -> TVal const&
+        {
+            return m_data[0];
+        }
+
+        ALPAKA_FN_HOST_ACC constexpr auto back() -> TVal&
+        {
+            return m_data[Dim::value - 1];
+        }
+
+        ALPAKA_FN_HOST_ACC constexpr auto back() const -> TVal const&
+        {
+            return m_data[Dim::value - 1];
+        }
+
         //! Value reference accessor at the given non-unsigned integer index.
         //! \return A reference to the value at the given index.
         ALPAKA_NO_HOST_ACC_WARNING

--- a/test/unit/idx/src/MapIdx.cpp
+++ b/test/unit/idx/src/MapIdx.cpp
@@ -17,8 +17,7 @@ TEMPLATE_LIST_TEST_CASE("mapIdx", "[idx]", alpaka::test::TestDims)
     using Idx = std::size_t;
     using Vec = alpaka::Vec<Dim, Idx>;
 
-    auto const extentNd
-        = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+    auto const extentNd = alpaka::test::extentBuf<Dim, Idx>;
     auto const idxNd = extentNd - Vec::all(4u);
 
     auto const idx1d = alpaka::mapIdx<1u>(idxNd, extentNd);

--- a/test/unit/idx/src/MapIdxPitchBytes.cpp
+++ b/test/unit/idx/src/MapIdxPitchBytes.cpp
@@ -20,8 +20,7 @@ TEMPLATE_LIST_TEST_CASE("mapIdxPitchBytes", "[idx]", alpaka::test::NonZeroTestDi
     using Idx = std::size_t;
     using Vec = alpaka::Vec<Dim, Idx>;
 
-    auto const extentNd
-        = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+    auto const extentNd = alpaka::test::extentBuf<Dim, Idx>;
 
     using Acc = alpaka::ExampleDefaultAcc<Dim, Idx>;
     using Elem = std::uint8_t;

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -72,11 +72,7 @@ TEMPLATE_LIST_TEST_CASE("memBufBasicTest", "[memBuf]", alpaka::test::TestAccs)
     using Acc = TestType;
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
-
-    auto const extent
-        = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-
-    testBufferMutable<Acc>(extent);
+    testBufferMutable<Acc>(alpaka::test::extentBuf<Dim, Idx>);
 }
 
 TEMPLATE_LIST_TEST_CASE("memBufZeroSizeTest", "[memBuf]", alpaka::test::TestAccs)
@@ -98,9 +94,7 @@ TEMPLATE_LIST_TEST_CASE("memBufAsyncBasicTest", "[memBuf]", alpaka::test::TestAc
 
     if constexpr(alpaka::hasAsyncBufSupport<alpaka::Dev<Acc>, Dim>)
     {
-        auto const extent
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-        testAsyncBufferMutable<Acc>(extent);
+        testAsyncBufferMutable<Acc>(alpaka::test::extentBuf<Dim, Idx>);
     }
     else
     {
@@ -147,11 +141,7 @@ TEMPLATE_LIST_TEST_CASE("memBufConstTest", "[memBuf]", alpaka::test::TestAccs)
     using Acc = TestType;
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
-
-    auto const extent
-        = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-
-    testBufferImmutable<Acc>(extent);
+    testBufferImmutable<Acc>(alpaka::test::extentBuf<Dim, Idx>);
 }
 
 template<typename TAcc>
@@ -199,9 +189,7 @@ TEMPLATE_LIST_TEST_CASE("memBufAsyncConstTest", "[memBuf]", alpaka::test::TestAc
 
     if constexpr(alpaka::hasAsyncBufSupport<alpaka::Dev<Acc>, Dim>)
     {
-        auto const extent
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-        testAsyncBufferImmutable<Acc>(extent);
+        testAsyncBufferImmutable<Acc>(alpaka::test::extentBuf<Dim, Idx>);
     }
     else
     {
@@ -264,11 +252,7 @@ TEMPLATE_LIST_TEST_CASE("memBufAccessorAdaptorTest", "[memBuf]", alpaka::test::T
     using Acc = TestType;
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
-
-    auto extent = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-    auto index = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>();
-
-    testBufferAccessorAdaptor<Acc>(extent, index);
+    testBufferAccessorAdaptor<Acc>(alpaka::test::extentBuf<Dim, Idx>, alpaka::test::offset<Dim, Idx>);
 }
 
 TEMPLATE_LIST_TEST_CASE("memBufMove", "[memBuf]", alpaka::test::TestAccs)

--- a/test/unit/mem/copy/src/BufSlicing.cpp
+++ b/test/unit/mem/copy/src/BufSlicing.cpp
@@ -126,12 +126,9 @@ TEMPLATE_LIST_TEST_CASE("memBufSlicingMemcpyTest", "[memBuf]", TestAccWithDataTy
     {
         TestContainer<Dim, Idx, Acc, Data> slicingTest;
 
-        auto const extents
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-        auto const extentsSubView
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentSubView>();
-        auto const offsets
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>();
+        auto const extents = alpaka::test::extentBuf<Dim, Idx>;
+        auto const extentsSubView = alpaka::test::extentSubView<Dim, Idx>;
+        auto const offsets = alpaka::test::offset<Dim, Idx>;
 
         // This is the initial buffer.
         auto const indexedBuffer = slicingTest.createHostBuffer(extents, true);
@@ -182,12 +179,9 @@ TEMPLATE_LIST_TEST_CASE("memBufSlicingMemsetTest", "[memBuf]", TestAccWithDataTy
     {
         TestContainer<Dim, Idx, Acc, Data> slicingTest;
 
-        auto const extents
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-        auto const extentsSubView
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentSubView>();
-        auto const offsets
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>();
+        auto const extents = alpaka::test::extentBuf<Dim, Idx>;
+        auto const extentsSubView = alpaka::test::extentSubView<Dim, Idx>;
+        auto const offsets = alpaka::test::offset<Dim, Idx>;
 
         // This is the initial buffer.
         auto const indexedBuffer = slicingTest.createHostBuffer(extents, true);

--- a/test/unit/mem/p2p/src/P2P.cpp
+++ b/test/unit/mem/p2p/src/P2P.cpp
@@ -57,9 +57,5 @@ TEMPLATE_LIST_TEST_CASE("memP2PTest", "[memP2P]", alpaka::test::TestAccs)
     using Acc = TestType;
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
-
-    auto const extent
-        = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-
-    testP2P<Acc>(extent);
+    testP2P<Acc>(alpaka::test::extentBuf<Dim, Idx>);
 }

--- a/test/unit/mem/view/src/MdSpan.cpp
+++ b/test/unit/mem/view/src/MdSpan.cpp
@@ -46,8 +46,7 @@ TEMPLATE_LIST_TEST_CASE("mdSpan", "[memView]", alpaka::test::TestAccs)
     auto const dev = alpaka::getDevByIdx(platform, 0);
     auto queue = alpaka::Queue<Dev, alpaka::Blocking>(dev);
 
-    auto const extent
-        = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+    auto const extent = alpaka::test::extentBuf<Dim, Idx>;
     auto buf = alpaka::allocBuf<TElem, Idx>(dev, extent);
     alpaka::test::iotaFillView(queue, buf);
 

--- a/test/unit/mem/view/src/ViewConst.cpp
+++ b/test/unit/mem/view/src/ViewConst.cpp
@@ -68,8 +68,7 @@ TEMPLATE_LIST_TEST_CASE("viewConstTest", "[memView]", alpaka::test::TestAccs)
     auto const platformAcc = alpaka::Platform<Acc>{};
     auto const dev = alpaka::getDevByIdx(platformAcc, 0);
 
-    auto const extents
-        = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+    auto const extents = alpaka::test::extentBuf<Dim, Idx>;
     auto buf = alpaka::allocBuf<Elem, Idx>(dev, extents);
     auto queue = alpaka::test::DefaultQueue<Dev>{dev};
     alpaka::test::iotaFillView(queue, buf);

--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -58,8 +58,7 @@ namespace alpaka::test
         auto const platform = alpaka::Platform<TAcc>{};
         auto const dev = alpaka::getDevByIdx(platform, 0);
 
-        auto const extentBuf
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+        auto const extentBuf = alpaka::test::extentBuf<Dim, Idx>;
         auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
 
         auto const extentView = extentBuf;
@@ -84,8 +83,7 @@ namespace alpaka::test
         auto const platform = alpaka::Platform<TAcc>{};
         auto const dev = alpaka::getDevByIdx(platform, 0);
 
-        auto const extentBuf
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+        auto const extentBuf = alpaka::test::extentBuf<Dim, Idx>;
         auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
 
         auto const extentView = extentBuf;
@@ -110,9 +108,7 @@ namespace alpaka::test
         auto const platform = alpaka::Platform<TAcc>{};
         auto const dev = alpaka::getDevByIdx(platform, 0);
 
-        auto const extentBuf
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
-        auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
+        auto buf = alpaka::allocBuf<TElem, Idx>(dev, alpaka::test::extentBuf<Dim, Idx>);
 
         View view(
             alpaka::getPtrNative(buf),

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -89,12 +89,11 @@ namespace alpaka::test
         auto const platform = alpaka::Platform<TAcc>{};
         auto const dev = alpaka::getDevByIdx(platform, 0);
 
-        auto const extentBuf
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+        auto const extentBuf = alpaka::test::extentBuf<Dim, Idx>;
         auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
 
         auto const extentView = extentBuf;
-        auto const offsetView = alpaka::Vec<Dim, Idx>::all(static_cast<Idx>(0));
+        auto const offsetView = alpaka::Vec<Dim, Idx>::zeros();
         View view(buf);
 
         alpaka::test::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
@@ -111,14 +110,11 @@ namespace alpaka::test
         auto const platform = alpaka::Platform<TAcc>{};
         auto const dev = alpaka::getDevByIdx(platform, 0);
 
-        auto const extentBuf
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+        auto const extentBuf = alpaka::test::extentBuf<Dim, Idx>;
         auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
 
-        auto const extentView
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentSubView>();
-        auto const offsetView
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>();
+        auto const extentView = alpaka::test::extentSubView<Dim, Idx>;
+        auto const offsetView = alpaka::test::offset<Dim, Idx>;
         View view(buf, extentView, offsetView);
 
         alpaka::test::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
@@ -135,14 +131,11 @@ namespace alpaka::test
         auto const platform = alpaka::Platform<TAcc>{};
         auto const dev = alpaka::getDevByIdx(platform, 0);
 
-        auto const extentBuf
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentBuf>();
+        auto const extentBuf = alpaka::test::extentBuf<Dim, Idx>;
         auto buf = alpaka::allocBuf<TElem, Idx>(dev, extentBuf);
 
-        auto const extentView
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForExtentSubView>();
-        auto const offsetView
-            = alpaka::createVecFromIndexedFn<Dim, alpaka::test::CreateVecWithIdx<Idx>::template ForOffset>();
+        auto const extentView = alpaka::test::extentSubView<Dim, Idx>;
+        auto const offsetView = alpaka::test::offset<Dim, Idx>;
         View const view(buf, extentView, offsetView);
 
         alpaka::test::testViewSubViewImmutable<TAcc>(view, buf, dev, extentView, offsetView);

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -304,6 +304,12 @@ TEST_CASE("basicVecTraits", "[vec]")
                     sum += e; // read
                 return sum == Dim::value;
             }());
+
+        // front/back
+        STATIC_REQUIRE(vec3.front() == 47); // const overload
+        STATIC_REQUIRE(vec3.back() == 3); // const overload
+        STATIC_REQUIRE(Vec{1, 2, 3}.front() == 1); // non-const overload
+        STATIC_REQUIRE(Vec{1, 2, 3}.back() == 3); // non-const overload
     }
 }
 


### PR DESCRIPTION
This PR adds `front()` and `back()` to `Vec` and replaces `createVecFromIndexedFn` by a generator constructor (cf. [`std::simd`'s generator ctor](https://en.cppreference.com/w/cpp/experimental/simd/simd/simd)). The latter is a breaking change.

The unit tests are refactored to use globally defined extents instead of generator functions.