### PR TITLE
Remove setExtent and setOffset APIs

### DIFF
--- a/include/alpaka/core/CudaHipCommon.hpp
+++ b/include/alpaka/core/CudaHipCommon.hpp
@@ -137,62 +137,6 @@ namespace alpaka
             }
         };
 
-        //! The CUDA/HIP vectors extent set trait specialization.
-        template<typename TExtent, typename TExtentVal>
-        struct SetExtent<
-            DimInt<Dim<TExtent>::value - 1u>,
-            TExtent,
-            TExtentVal,
-            std::enable_if_t<alpaka::detail::isCudaHipBuiltInType<TExtent> && (Dim<TExtent>::value >= 1)>>
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto setExtent(TExtent const& extent, TExtentVal const& extentVal) -> void
-            {
-                extent.x = extentVal;
-            }
-        };
-        //! The CUDA/HIP vectors extent set trait specialization.
-        template<typename TExtent, typename TExtentVal>
-        struct SetExtent<
-            DimInt<Dim<TExtent>::value - 2u>,
-            TExtent,
-            TExtentVal,
-            std::enable_if_t<alpaka::detail::isCudaHipBuiltInType<TExtent> && (Dim<TExtent>::value >= 2)>>
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto setExtent(TExtent const& extent, TExtentVal const& extentVal) -> void
-            {
-                extent.y = extentVal;
-            }
-        };
-        //! The CUDA/HIP vectors extent set trait specialization.
-        template<typename TExtent, typename TExtentVal>
-        struct SetExtent<
-            DimInt<Dim<TExtent>::value - 3u>,
-            TExtent,
-            TExtentVal,
-            std::enable_if_t<alpaka::detail::isCudaHipBuiltInType<TExtent> && (Dim<TExtent>::value >= 3)>>
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto setExtent(TExtent const& extent, TExtentVal const& extentVal) -> void
-            {
-                extent.z = extentVal;
-            }
-        };
-        //! The CUDA/HIP vectors extent set trait specialization.
-        template<typename TExtent, typename TExtentVal>
-        struct SetExtent<
-            DimInt<Dim<TExtent>::value - 4u>,
-            TExtent,
-            TExtentVal,
-            std::enable_if_t<alpaka::detail::isCudaHipBuiltInType<TExtent> && (Dim<TExtent>::value >= 4)>>
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto setExtent(TExtent const& extent, TExtentVal const& extentVal) -> void
-            {
-                extent.w = extentVal;
-            }
-        };
 
         template<typename TCudaHipBuiltin>
         struct GetOffsets<TCudaHipBuiltin, std::enable_if_t<alpaka::detail::isCudaHipBuiltInType<TCudaHipBuiltin>>>

--- a/include/alpaka/core/CudaHipCommon.hpp
+++ b/include/alpaka/core/CudaHipCommon.hpp
@@ -144,62 +144,6 @@ namespace alpaka
         {
         };
 
-        //! The CUDA/HIP vectors offset set trait specialization.
-        template<typename TOffsets, typename TOffset>
-        struct SetOffset<
-            DimInt<Dim<TOffsets>::value - 1u>,
-            TOffsets,
-            TOffset,
-            std::enable_if_t<alpaka::detail::isCudaHipBuiltInType<TOffsets> && (Dim<TOffsets>::value >= 1)>>
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto setOffset(TOffsets const& offsets, TOffset const& offset) -> void
-            {
-                offsets.x = offset;
-            }
-        };
-        //! The CUDA/HIP vectors offset set trait specialization.
-        template<typename TOffsets, typename TOffset>
-        struct SetOffset<
-            DimInt<Dim<TOffsets>::value - 2u>,
-            TOffsets,
-            TOffset,
-            std::enable_if_t<alpaka::detail::isCudaHipBuiltInType<TOffsets> && (Dim<TOffsets>::value >= 2)>>
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto setOffset(TOffsets const& offsets, TOffset const& offset) -> void
-            {
-                offsets.y = offset;
-            }
-        };
-        //! The CUDA/HIP vectors offset set trait specialization.
-        template<typename TOffsets, typename TOffset>
-        struct SetOffset<
-            DimInt<Dim<TOffsets>::value - 3u>,
-            TOffsets,
-            TOffset,
-            std::enable_if_t<alpaka::detail::isCudaHipBuiltInType<TOffsets> && (Dim<TOffsets>::value >= 3)>>
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto setOffset(TOffsets const& offsets, TOffset const& offset) -> void
-            {
-                offsets.z = offset;
-            }
-        };
-        //! The CUDA/HIP vectors offset set trait specialization.
-        template<typename TOffsets, typename TOffset>
-        struct SetOffset<
-            DimInt<Dim<TOffsets>::value - 4u>,
-            TOffsets,
-            TOffset,
-            std::enable_if_t<alpaka::detail::isCudaHipBuiltInType<TOffsets> && (Dim<TOffsets>::value >= 4)>>
-        {
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto setOffset(TOffsets const& offsets, TOffset const& offset) -> void
-            {
-                offsets.w = offset;
-            }
-        };
 
         //! The CUDA/HIP vectors idx type trait specialization.
         template<typename TIdx>

--- a/include/alpaka/core/Sycl.hpp
+++ b/include/alpaka/core/Sycl.hpp
@@ -188,27 +188,6 @@ namespace alpaka::trait
     {
     };
 
-    //! The SYCL vectors' offset set trait specialization.
-    template<typename TOffsets, typename TOffset>
-    struct SetOffset<
-        DimInt<Dim<TOffsets>::value>,
-        TOffsets,
-        TOffset,
-        std::enable_if_t<IsSyclBuiltInType<TOffsets>::value>>
-    {
-        static auto setOffset(TOffsets const& offsets, TOffset const& offset)
-        {
-            if constexpr(std::is_scalar_v<TOffsets>)
-                offsets = offset;
-            else
-            {
-                // Creates a SYCL vector with one element from a multidimensional vector. The element is a reference
-                // to the requested dimension's vector element. Then set the element's value.
-                offsets.template swizzle<DimInt<Dim<TOffsets>::value>::value>() = offset;
-            }
-        }
-    };
-
     //! The SYCL vectors' idx type trait specialization.
     template<typename TIdx>
     struct IdxType<TIdx, std::enable_if_t<IsSyclBuiltInType<TIdx>::value>>

--- a/include/alpaka/core/Sycl.hpp
+++ b/include/alpaka/core/Sycl.hpp
@@ -182,27 +182,6 @@ namespace alpaka::trait
         }
     };
 
-    //! The SYCL vectors' extent set trait specialization.
-    template<typename TExtent, typename TExtentVal>
-    struct SetExtent<
-        DimInt<Dim<TExtent>::value>,
-        TExtent,
-        TExtentVal,
-        std::enable_if_t<IsSyclBuiltInType<TExtent>::value>>
-    {
-        static auto setExtent(TExtent const& extent, TExtentVal const& extentVal)
-        {
-            if constexpr(std::is_scalar_v<TExtent>)
-                extent = extentVal;
-            else
-            {
-                // Creates a SYCL vector with one element from a multidimensional vector. The element is a reference
-                // to the requested dimension's vector element. Then set the element's value.
-                extent.template swizzle<DimInt<Dim<TExtent>::value>::value>() = extentVal;
-            }
-        }
-    };
-
     //! The SYCL vectors' offset get trait specialization.
     template<typename T>
     struct GetOffsets<T, std::enable_if_t<IsSyclBuiltInType<T>::value>> : GetExtents<T>

--- a/include/alpaka/extent/Traits.hpp
+++ b/include/alpaka/extent/Traits.hpp
@@ -32,10 +32,6 @@ namespace alpaka
 //! The GetExtents trait for getting the extents of an object as an alpaka::Vec.
 template<typename TExtent, typename TSfinae = void>
 struct GetExtents;
-
-//! The extent set trait.
-template<typename TIdxIntegralConst, typename TExtent, typename TExtentVal, typename TSfinae = void>
-struct SetExtent;
 } // namespace trait
 
 //! \return The extent in the given dimension.
@@ -133,55 +129,7 @@ namespace trait
             return extent;
         }
     };
-    //! The Vec extent set trait specialization.
-    template<typename TIdxIntegralConst, typename TDim, typename TVal, typename TExtentVal>
-    struct SetExtent<
-        TIdxIntegralConst,
-        Vec<TDim, TVal>,
-        TExtentVal,
-        std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
-    {
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC static constexpr auto setExtent(Vec<TDim, TVal>& extent, TExtentVal const& extentVal)
-            -> void
-        {
-            extent[TIdxIntegralConst::value] = extentVal;
-        }
-    };
-} // namespace trait
 
-//! Sets the extent in the given dimension.
-ALPAKA_NO_HOST_ACC_WARNING
-template<std::size_t Tidx, typename TExtent, typename TExtentVal>
-ALPAKA_FN_HOST_ACC auto setExtent(TExtent& extent, TExtentVal const& extentVal) -> void
-{
-    trait::SetExtent<DimInt<Tidx>, TExtent, TExtentVal>::setExtent(extent, extentVal);
-}
-//! Sets the width.
-ALPAKA_NO_HOST_ACC_WARNING
-template<typename TExtent, typename TWidth>
-ALPAKA_FN_HOST_ACC auto setWidth(TExtent& extent, TWidth const& width) -> void
-{
-    setExtent<Dim<TExtent>::value - 1u>(extent, width);
-}
-//! Sets the height.
-ALPAKA_NO_HOST_ACC_WARNING
-template<typename TExtent, typename THeight>
-ALPAKA_FN_HOST_ACC auto setHeight(TExtent& extent, THeight const& height) -> void
-{
-    setExtent<Dim<TExtent>::value - 2u>(extent, height);
-}
-//! Sets the depth.
-ALPAKA_NO_HOST_ACC_WARNING
-template<typename TExtent, typename TDepth>
-ALPAKA_FN_HOST_ACC auto setDepth(TExtent& extent, TDepth const& depth) -> void
-{
-    setExtent<Dim<TExtent>::value - 3u>(extent, depth);
-}
-
-// Trait specializations for integral types.
-namespace trait
-{
     template<typename Integral>
     struct GetExtents<Integral, std::enable_if_t<std::is_integral_v<Integral>>>
     {
@@ -189,16 +137,6 @@ namespace trait
         ALPAKA_FN_HOST_ACC auto operator()(Integral i) const
         {
             return Vec{i};
-        }
-    };
-    //! The unsigned integral width set trait specialization.
-    template<typename TExtent, typename TExtentVal>
-    struct SetExtent<DimInt<0u>, TExtent, TExtentVal, std::enable_if_t<std::is_integral_v<TExtent>>>
-    {
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC static auto setExtent(TExtent const& extent, TExtentVal const& extentVal) -> void
-        {
-            extent = extentVal;
         }
     };
 } // namespace trait

--- a/include/alpaka/offset/Traits.hpp
+++ b/include/alpaka/offset/Traits.hpp
@@ -29,10 +29,6 @@ namespace alpaka
 //! The GetOffsets trait for getting the offsets of an object as an alpaka::Vec.
 template<typename TExtent, typename TSfinae = void>
 struct GetOffsets;
-
-//! The x offset set trait.
-template<typename TIdx, typename TOffsets, typename TOffset, typename TSfinae = void>
-struct SetOffset;
 } // namespace trait
 
 //! \return The offset in the given dimension.
@@ -105,35 +101,6 @@ ALPAKA_FN_HOST_ACC auto getOffsetZ(TOffsets const& offsets = TOffsets()) -> Idx<
     return getOffsets(offsets)[Dim<TOffsets>::value - 3u];
 }
 
-//! Sets the offset in the given dimension.
-ALPAKA_NO_HOST_ACC_WARNING
-template<std::size_t Tidx, typename TOffsets, typename TOffset>
-ALPAKA_FN_HOST_ACC auto setOffset(TOffsets const& offsets, TOffset const& offset) -> void
-{
-    trait::SetOffset<DimInt<Tidx>, TOffsets, TOffset>::setOffset(offsets, offset);
-}
-//! Sets the offset in x dimension.
-ALPAKA_NO_HOST_ACC_WARNING
-template<typename TOffsets, typename TOffset>
-ALPAKA_FN_HOST_ACC auto setOffsetX(TOffsets const& offsets, TOffset const& offset) -> void
-{
-    setOffset<Dim<TOffsets>::value - 1u>(offsets, offset);
-}
-//! Sets the offset in y dimension.
-ALPAKA_NO_HOST_ACC_WARNING
-template<typename TOffsets, typename TOffset>
-ALPAKA_FN_HOST_ACC auto setOffsetY(TOffsets const& offsets, TOffset const& offset) -> void
-{
-    setOffset<Dim<TOffsets>::value - 2u>(offsets, offset);
-}
-//! Sets the offset in z dimension.
-ALPAKA_NO_HOST_ACC_WARNING
-template<typename TOffsets, typename TOffset>
-ALPAKA_FN_HOST_ACC auto setOffsetZ(TOffsets const& offsets, TOffset const& offset) -> void
-{
-    setOffset<Dim<TOffsets>::value - 3u>(offsets, offset);
-}
-
 namespace trait
 {
     //! The Vec offset get trait specialization.
@@ -147,21 +114,6 @@ namespace trait
         }
     };
 
-    //! The Vec offset set trait specialization.
-    template<typename TIdxIntegralConst, typename TDim, typename TVal, typename TOffset>
-    struct SetOffset<
-        TIdxIntegralConst,
-        Vec<TDim, TVal>,
-        TOffset,
-        std::enable_if_t<(TDim::value > TIdxIntegralConst::value)>>
-    {
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC static constexpr auto setOffset(Vec<TDim, TVal>& offsets, TOffset const& offset) -> void
-        {
-            offsets[TIdxIntegralConst::value] = offset;
-        }
-    };
-
     //! The unsigned integral x offset get trait specialization.
     template<typename TIntegral>
     struct GetOffsets<TIntegral, std::enable_if_t<std::is_integral_v<TIntegral>>>
@@ -170,17 +122,6 @@ namespace trait
         ALPAKA_FN_HOST_ACC constexpr auto operator()(TIntegral const& i) const
         {
             return Vec{i};
-        }
-    };
-
-    //! The unsigned integral x offset set trait specialization.
-    template<typename TIntegral, typename TOtherIntegral>
-    struct SetOffset<DimInt<0u>, TIntegral, TOtherIntegral, std::enable_if_t<std::is_integral_v<TOtherIntegral>>>
-    {
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC static auto setOffset(TIntegral const& offsets, TOtherIntegral const& offset) -> void
-        {
-            offsets = offset;
         }
     };
 } // namespace trait


### PR DESCRIPTION
These APIs are not used anywhere within our repository and are also only specialized for CUDA any SYCL built-in types, as well as `Vec`.

If any user uses those APIs, it's a breaking change for them.

Relates to #2079.