### PR TITLE
extend inline macro documentation

### DIFF
--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -14,10 +14,13 @@
 
 //! All functions that can be used on an accelerator have to be attributed with ALPAKA_FN_ACC or ALPAKA_FN_HOST_ACC.
 //!
+//! \code{.cpp}
 //! Usage:
 //! ALPAKA_FN_ACC
 //! auto add(std::int32_t a, std::int32_t b)
 //! -> std::int32_t;
+//! \endcode
+//! @{
 #if BOOST_LANG_CUDA || BOOST_LANG_HIP
 #    if defined(ALPAKA_ACC_GPU_CUDA_ONLY_MODE) || defined(ALPAKA_ACC_GPU_HIP_ONLY_MODE)
 #        define ALPAKA_FN_ACC __device__
@@ -31,6 +34,7 @@
 #    define ALPAKA_FN_HOST_ACC
 #    define ALPAKA_FN_HOST
 #endif
+//! @}
 
 //! All functions marked with ALPAKA_FN_ACC or ALPAKA_FN_HOST_ACC that are exported to / imported from different
 //! translation units have to be attributed with ALPAKA_FN_EXTERN. Note that this needs to be applied to both the
@@ -74,6 +78,8 @@
 #endif
 
 //! Macro defining the inline function attribute.
+//!
+//! The macro should stay on the left hand side of keywords, e.g. 'static', 'constexpr', 'explicit' or the return type.
 #if BOOST_LANG_CUDA || BOOST_LANG_HIP
 #    define ALPAKA_FN_INLINE __forceinline__
 #elif BOOST_COMP_MSVC || defined(BOOST_COMP_MSVC_EMULATED)


### PR DESCRIPTION
The inline macro should be left of any keyword because depending of the alpaka backend std attribute specifiers will be used.