### PR TITLE
Simplify pitch API

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -215,10 +215,10 @@ auto main() -> int
     // padding between rows/planes of multidimensional memory allocations.
     // Therefore the pitch (distance between consecutive rows/planes) may be
     // greater than the space required for the data.
-    Idx const deviceBuffer1Pitch(alpaka::getPitchBytes<2u>(deviceBuffer1) / sizeof(Data));
-    Idx const deviceBuffer2Pitch(alpaka::getPitchBytes<2u>(deviceBuffer2) / sizeof(Data));
-    Idx const hostBuffer1Pitch(alpaka::getPitchBytes<2u>(hostBuffer) / sizeof(Data));
-    Idx const hostViewPlainPtrPitch(alpaka::getPitchBytes<2u>(hostViewPlainPtr) / sizeof(Data));
+    Idx const deviceBuffer1Pitch(alpaka::getPitchesInBytes(deviceBuffer1)[2] / sizeof(Data));
+    Idx const deviceBuffer2Pitch(alpaka::getPitchesInBytes(deviceBuffer2)[2] / sizeof(Data));
+    Idx const hostBuffer1Pitch(alpaka::getPitchesInBytes(hostBuffer)[2] / sizeof(Data));
+    Idx const hostViewPlainPtrPitch(alpaka::getPitchesInBytes(hostViewPlainPtr)[2] / sizeof(Data));
 
     // Test device Buffer
     //

--- a/example/randomCells2D/src/randomCells2D.cpp
+++ b/example/randomCells2D/src/randomCells2D.cpp
@@ -201,16 +201,16 @@ auto main() -> int
     RandomEngineVector<Acc>* const ptrBufAccRandV{alpaka::getPtrNative(bufAccRandV)};
 
     InitRandomKernel initRandomKernel;
-    auto pitchBufAccRandS = alpaka::getPitchBytes<1u>(bufAccRandS);
+    auto pitchBufAccRandS = alpaka::getPitchesInBytes(bufAccRandS)[1];
     alpaka::exec<Acc>(queue, workdiv, initRandomKernel, extent, ptrBufAccRandS, pitchBufAccRandS);
     alpaka::wait(queue);
 
-    auto pitchBufAccRandV = alpaka::getPitchBytes<1u>(bufAccRandV);
+    auto pitchBufAccRandV = alpaka::getPitchesInBytes(bufAccRandV)[1];
     alpaka::exec<Acc>(queue, workdiv, initRandomKernel, extent, ptrBufAccRandV, pitchBufAccRandV);
     alpaka::wait(queue);
 
-    auto pitchHostS = alpaka::getPitchBytes<1u>(bufHostS);
-    auto pitchHostV = alpaka::getPitchBytes<1u>(bufHostV);
+    auto pitchHostS = alpaka::getPitchesInBytes(bufHostS)[1];
+    auto pitchHostV = alpaka::getPitchesInBytes(bufHostV)[1];
 
     for(Idx y = 0; y < numY; ++y)
     {
@@ -221,7 +221,7 @@ auto main() -> int
         }
     }
 
-    auto pitchBufAccS = alpaka::getPitchBytes<1u>(bufAccS);
+    auto pitchBufAccS = alpaka::getPitchesInBytes(bufAccS)[1];
     alpaka::memcpy(queue, bufAccS, bufHostS);
     RunTimestepKernelSingle runTimestepKernelSingle;
     alpaka::exec<Acc>(
@@ -235,7 +235,7 @@ auto main() -> int
         pitchBufAccS);
     alpaka::memcpy(queue, bufHostS, bufAccS);
 
-    auto pitchBufAccV = alpaka::getPitchBytes<1u>(bufAccV);
+    auto pitchBufAccV = alpaka::getPitchesInBytes(bufAccV)[1];
     alpaka::memcpy(queue, bufAccV, bufHostV);
     RunTimestepKernelVector runTimestepKernelVector;
     alpaka::exec<Acc>(

--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -42,8 +42,8 @@ namespace alpaka
                 , m_dstExtent(getExtents(viewDst))
                 , m_srcExtent(getExtents(viewSrc))
 #endif
-                , m_dstPitchBytes(getPitchBytesVec(viewDst))
-                , m_srcPitchBytes(getPitchBytesVec(viewSrc))
+                , m_dstPitchBytes(getPitchesInBytes(viewDst))
+                , m_srcPitchBytes(getPitchesInBytes(viewSrc))
                 , m_dstMemNative(reinterpret_cast<std::uint8_t*>(getPtrNative(viewDst)))
                 , m_srcMemNative(reinterpret_cast<std::uint8_t const*>(getPtrNative(viewSrc)))
             {

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -35,7 +35,7 @@ namespace alpaka
 #if(!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
                 , m_dstExtent(getExtents(view))
 #endif
-                , m_dstPitchBytes(getPitchBytesVec(view))
+                , m_dstPitchBytes(getPitchesInBytes(view))
                 , m_dstMemNative(reinterpret_cast<std::uint8_t*>(getPtrNative(view)))
             {
                 ALPAKA_ASSERT((castVec<DstSize>(m_extent) <= m_dstExtent).foldrAll(std::logical_or<bool>()));

--- a/include/alpaka/mem/buf/sycl/Copy.hpp
+++ b/include/alpaka/mem/buf/sycl/Copy.hpp
@@ -46,8 +46,8 @@ namespace alpaka::detail
             , m_dstExtent(getExtents(viewDst))
             , m_srcExtent(getExtents(viewSrc))
 #    endif
-            , m_dstPitchBytes(getPitchBytesVec(viewDst))
-            , m_srcPitchBytes(getPitchBytesVec(viewSrc))
+            , m_dstPitchBytes(getPitchesInBytes(viewDst))
+            , m_srcPitchBytes(getPitchesInBytes(viewSrc))
             , m_dstMemNative(reinterpret_cast<std::uint8_t*>(getPtrNative(viewDst)))
             , m_srcMemNative(reinterpret_cast<std::uint8_t const*>(getPtrNative(viewSrc)))
         {

--- a/include/alpaka/mem/buf/sycl/Set.hpp
+++ b/include/alpaka/mem/buf/sycl/Set.hpp
@@ -45,7 +45,7 @@ namespace alpaka
                 , m_dstExtent(getExtents(view))
 #    endif
 
-                , m_dstPitchBytes(getPitchBytesVec(view))
+                , m_dstPitchBytes(getPitchesInBytes(view))
                 , m_dstMemNative(reinterpret_cast<std::uint8_t*>(getPtrNative(view)))
 
             {

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -202,8 +202,8 @@ namespace alpaka
                 , m_dstHeight(static_cast<Idx>(getHeight(viewDst)))
                 , m_srcHeight(static_cast<Idx>(getHeight(viewSrc)))
 #    endif
-                , m_dstPitchBytes(static_cast<std::size_t>(getPitchBytes<Dim<TViewDst>::value - 1u>(viewDst)))
-                , m_srcPitchBytes(static_cast<std::size_t>(getPitchBytes<Dim<TViewSrc>::value - 1u>(viewSrc)))
+                , m_dstPitchBytes(static_cast<std::size_t>(getPitchesInBytes(viewDst)[Dim<TViewDst>::value - 1u]))
+                , m_srcPitchBytes(static_cast<std::size_t>(getPitchesInBytes(viewSrc)[Dim<TViewSrc>::value - 1u]))
                 , m_dstMemNative(reinterpret_cast<void*>(getPtrNative(viewDst)))
                 , m_srcMemNative(reinterpret_cast<void const*>(getPtrNative(viewSrc)))
             {
@@ -308,12 +308,12 @@ namespace alpaka
                 , m_dstDepth(static_cast<Idx>(getDepth(viewDst)))
                 , m_srcDepth(static_cast<Idx>(getDepth(viewSrc)))
 #    endif
-                , m_dstPitchBytesX(static_cast<std::size_t>(getPitchBytes<Dim<TViewDst>::value - 1u>(viewDst)))
-                , m_srcPitchBytesX(static_cast<std::size_t>(getPitchBytes<Dim<TViewSrc>::value - 1u>(viewSrc)))
+                , m_dstPitchBytesX(static_cast<std::size_t>(getPitchesInBytes(viewDst)[Dim<TViewDst>::value - 1u]))
+                , m_srcPitchBytesX(static_cast<std::size_t>(getPitchesInBytes(viewSrc)[Dim<TViewSrc>::value - 1u]))
                 , m_dstPitchBytesY(static_cast<std::size_t>(
-                      getPitchBytes<Dim<TViewDst>::value - (2u % Dim<TViewDst>::value)>(viewDst)))
+                      getPitchesInBytes(viewDst)[Dim<TViewDst>::value - (2u % Dim<TViewDst>::value)]))
                 , m_srcPitchBytesY(static_cast<std::size_t>(
-                      getPitchBytes<Dim<TViewSrc>::value - (2u % Dim<TViewSrc>::value)>(viewSrc)))
+                      getPitchesInBytes(viewSrc)[Dim<TViewSrc>::value - (2u % Dim<TViewDst>::value)]))
                 , m_dstMemNative(reinterpret_cast<void*>(getPtrNative(viewDst)))
                 , m_srcMemNative(reinterpret_cast<void const*>(getPtrNative(viewSrc)))
             {

--- a/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Copy.hpp
@@ -366,14 +366,14 @@ namespace alpaka
                     const_cast<void*>(m_srcMemNative),
                     m_srcPitchBytesX,
                     static_cast<std::size_t>(m_srcWidth),
-                    static_cast<std::size_t>(m_srcPitchBytesY / m_srcPitchBytesX));
+                    m_srcPitchBytesY / m_srcPitchBytesX);
                 memCpy3DParms.dstArray = nullptr; // Either dstArray or dstPtr.
                 memCpy3DParms.dstPos = TApi::makePos(0, 0, 0); // Optional. Offset in bytes.
                 memCpy3DParms.dstPtr = TApi::makePitchedPtr(
                     m_dstMemNative,
                     m_dstPitchBytesX,
                     static_cast<std::size_t>(m_dstWidth),
-                    static_cast<std::size_t>(m_dstPitchBytesY / m_dstPitchBytesX));
+                    m_dstPitchBytesY / m_dstPitchBytesX);
                 memCpy3DParms.extent = TApi::makeExtent(
                     m_extentWidthBytes,
                     static_cast<std::size_t>(m_extentHeight),

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -149,7 +149,7 @@ namespace alpaka
                 auto const dstWidth = getWidth(view);
                 auto const dstHeight = getHeight(view);
 #    endif
-                auto const dstPitchBytes = static_cast<std::size_t>(getPitchBytes<Dim<TView>::value - 1u>(view));
+                auto const dstPitchBytes = static_cast<std::size_t>(getPitchesInBytes(view)[Dim<TView>::value - 1u]);
                 auto const dstNativePtr = reinterpret_cast<void*>(getPtrNative(view));
                 ALPAKA_ASSERT(extentWidth <= dstWidth);
                 ALPAKA_ASSERT(extentHeight <= dstHeight);
@@ -202,9 +202,9 @@ namespace alpaka
                 auto const dstHeight = getHeight(view);
                 auto const dstDepth = getDepth(view);
 #    endif
-                auto const dstPitchBytesX = static_cast<std::size_t>(getPitchBytes<Dim<TView>::value - 1u>(view));
+                auto const dstPitchBytesX = static_cast<std::size_t>(getPitchesInBytes(view)[Dim<TView>::value - 1u]);
                 auto const dstPitchBytesY
-                    = static_cast<std::size_t>(getPitchBytes<Dim<TView>::value - (2u % Dim<TView>::value)>(view));
+                    = static_cast<std::size_t>(getPitchesInBytes(view)[Dim<TView>::value - (2u % Dim<TView>::value)]);
                 auto const dstNativePtr = reinterpret_cast<void*>(getPtrNative(view));
                 ALPAKA_ASSERT(extentWidth <= dstWidth);
                 ALPAKA_ASSERT(extentHeight <= dstHeight);

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -24,7 +24,7 @@ namespace alpaka::internal
             Idx<TView>,
             Dim<TView>,
             decltype(getPtrNative(std::declval<TView>())),
-            decltype(getPitchBytes<0>(std::declval<TView>())),
+            decltype(getPitchesInBytes(std::declval<TView>())),
             decltype(getExtents(std::declval<TView>()))>> = true;
 
     template<typename TView>
@@ -99,7 +99,7 @@ namespace alpaka::internal
             auto ptr = reinterpret_cast<uintptr_t>(data());
             if constexpr(Dim::value > 0)
             {
-                auto const pitchesInBytes = getPitchBytesVec(*static_cast<TView const*>(this));
+                auto const pitchesInBytes = getPitchesInBytes(*static_cast<TView const*>(this));
                 for(std::size_t i = 0u; i < Dim::value; i++)
                 {
                     Idx const pitch

--- a/include/alpaka/mem/view/ViewConst.hpp
+++ b/include/alpaka/mem/view/ViewConst.hpp
@@ -89,12 +89,12 @@ namespace alpaka
             }
         };
 
-        template<typename I, typename TView>
-        struct GetPitchBytes<I, ViewConst<TView>>
+        template<typename TView>
+        struct GetPitchesInBytes<ViewConst<TView>>
         {
-            ALPAKA_FN_HOST static auto getPitchBytes(ViewConst<TView> const& view)
+            ALPAKA_FN_HOST auto operator()(ViewConst<TView> const& view) const
             {
-                return alpaka::getPitchBytes<I::value>(view.m_view);
+                return alpaka::getPitchesInBytes(view.m_view);
             }
         };
 

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -127,14 +127,12 @@ namespace alpaka
             }
         };
 
-        //! The ViewPlainPtr memory pitch get trait specialization.
-        template<typename TIdxIntegralConst, typename TDev, typename TElem, typename TDim, typename TIdx>
-            struct GetPitchBytes < TIdxIntegralConst,
-            ViewPlainPtr<TDev, TElem, TDim, TIdx>, std::enable_if_t<TIdxIntegralConst::value<TDim::value>>
+        template<typename TDev, typename TElem, typename TDim, typename TIdx>
+        struct GetPitchesInBytes<ViewPlainPtr<TDev, TElem, TDim, TIdx>>
         {
-            ALPAKA_FN_HOST static auto getPitchBytes(ViewPlainPtr<TDev, TElem, TDim, TIdx> const& view) -> TIdx
+            ALPAKA_FN_HOST auto operator()(ViewPlainPtr<TDev, TElem, TDim, TIdx> const& view) const
             {
-                return view.m_pitchBytes[TIdxIntegralConst::value];
+                return view.m_pitchBytes;
             }
         };
 

--- a/include/alpaka/test/mem/view/Iterator.hpp
+++ b/include/alpaka/test/mem/view/Iterator.hpp
@@ -35,7 +35,7 @@ namespace alpaka::test
                 : m_nativePtr(getPtrNative(view))
                 , m_currentIdx(idx)
                 , m_extents(getExtents(view))
-                , m_pitchBytes(getPitchBytesVec(view))
+                , m_pitchBytes(getPitchesInBytes(view))
             {
             }
 

--- a/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/include/alpaka/test/mem/view/ViewTest.hpp
@@ -129,11 +129,20 @@ namespace alpaka::test
                 auto const pBytes = reinterpret_cast<std::uint8_t const*>(&elem);
                 for(std::size_t i = 0u; i < elemSizeInByte; ++i)
                 {
-                    ALPAKA_CHECK(*success, pBytes[i] == byte);
+                    if(pBytes[i] != byte)
+                    {
+                        printf(
+                            "Byte at offset %lu is different: %u != %u\n",
+                            static_cast<long unsigned>(i),
+                            static_cast<unsigned>(pBytes[i]),
+                            static_cast<unsigned>(byte));
+                        *success = false;
+                    }
                 }
             }
         }
     };
+
     template<typename TAcc, typename TView>
     ALPAKA_FN_HOST auto verifyBytesSet(TView const& view, std::uint8_t const& byte) -> void
     {

--- a/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/include/alpaka/test/mem/view/ViewTest.hpp
@@ -67,7 +67,7 @@ namespace alpaka::test
                 pitchMinimum[i - 1] = extent[i - 1] * pitchMinimum[i];
             }
 
-            auto const pitchView = getPitchBytesVec(view);
+            auto const pitchView = getPitchesInBytes(view);
 
             for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
             {

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -668,10 +668,7 @@ namespace alpaka
                 ALPAKA_UNREACHABLE({});
             }
         };
-    } // namespace trait
 
-    namespace trait
-    {
         //! ReverseVec specialization for Vec.
         template<typename TDim, typename TVal>
         struct ReverseVec<Vec<TDim, TVal>>

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -203,7 +203,7 @@ auto writeTgaColorImage(std::string const& fileName, TBuf const& bufRgba) -> voi
     ALPAKA_ASSERT(bufWidthColors >= 1);
     auto const bufHeightColors = alpaka::getHeight(bufRgba);
     ALPAKA_ASSERT(bufHeightColors >= 1);
-    auto const bufPitchBytes = alpaka::getPitchBytes<alpaka::Dim<TBuf>::value - 1u>(bufRgba);
+    auto const bufPitchBytes = alpaka::getPitchesInBytes(bufRgba)[alpaka::Dim<TBuf>::value - 1u];
     ALPAKA_ASSERT(bufPitchBytes >= bufWidthBytes);
 
     std::ofstream ofs(fileName, std::ofstream::out | std::ofstream::binary);
@@ -321,7 +321,7 @@ TEMPLATE_LIST_TEST_CASE("mandelbrot", "[mandelbrot]", TestAccs)
         alpaka::getPtrNative(bufColorAcc),
         numRows,
         numCols,
-        alpaka::getPitchBytes<1u>(bufColorAcc),
+        alpaka::getPitchesInBytes(bufColorAcc)[1],
         fMinR,
         fMaxR,
         fMinI,

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -242,9 +242,9 @@ TEMPLATE_LIST_TEST_CASE("matMul", "[matMul]", TestAccs)
 
     alpaka::memcpy(queueAcc, bufCAcc, bufCHost);
 
-    auto const pitchA = alpaka::getPitchBytes<1u>(bufAAcc);
-    auto const pitchB = alpaka::getPitchBytes<1u>(bufBAcc);
-    auto const pitchC = alpaka::getPitchBytes<1u>(bufCAcc);
+    auto const pitchA = alpaka::getPitchesInBytes(bufAAcc)[1];
+    auto const pitchB = alpaka::getPitchesInBytes(bufBAcc)[1];
+    auto const pitchC = alpaka::getPitchesInBytes(bufCAcc)[1];
 
     // Assumptions we make
     REQUIRE(pitchA % sizeof(Val) == 0);

--- a/test/unit/idx/src/MapIdxPitchBytes.cpp
+++ b/test/unit/idx/src/MapIdxPitchBytes.cpp
@@ -32,7 +32,7 @@ TEMPLATE_LIST_TEST_CASE("mapIdxPitchBytes", "[idx]", alpaka::test::NonZeroTestDi
     auto const extent = Vec::all(4u);
     auto const idxNd = Vec::all(2u);
     auto view = alpaka::createSubView(parentView, extent, offset);
-    auto pitch = alpaka::getPitchBytesVec(view);
+    auto pitch = alpaka::getPitchesInBytes(view);
 
     auto const idx1d = alpaka::mapIdxPitchBytes<1u>(idxNd, pitch);
     auto const idx1dDelta = alpaka::mapIdx<1u>(idxNd + offset, extentNd) - alpaka::mapIdx<1u>(offset, extentNd);

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -216,7 +216,7 @@ static auto testBufferAccessorAdaptor(
     auto buf = alpaka::allocBuf<Elem, Idx>(dev, extent);
 
     // check that the array subscript operator access the correct element
-    auto const& pitch = alpaka::getPitchBytesVec(buf);
+    auto const& pitch = alpaka::getPitchesInBytes(buf);
     INFO("buffer extent: " << extent << " elements");
     INFO("buffer pitch: " << pitch << " bytes");
     CHECK((index < extent).foldrAll(std::logical_and<bool>(), true));

--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -67,7 +67,7 @@ namespace alpaka::test
             alpaka::getPtrNative(buf),
             alpaka::getDev(buf),
             alpaka::getExtents(buf),
-            alpaka::getPitchBytesVec(buf));
+            alpaka::getPitchesInBytes(buf));
 
         alpaka::test::testViewPlainPtrMutable<TAcc>(view, dev, extentView, offsetView);
     }
@@ -92,7 +92,7 @@ namespace alpaka::test
             alpaka::getPtrNative(buf),
             alpaka::getDev(buf),
             alpaka::getExtents(buf),
-            alpaka::getPitchBytesVec(buf));
+            alpaka::getPitchesInBytes(buf));
 
         alpaka::test::testViewPlainPtrImmutable<TAcc>(view, dev, extentView, offsetView);
     }
@@ -114,7 +114,7 @@ namespace alpaka::test
             alpaka::getPtrNative(buf),
             alpaka::getDev(buf),
             alpaka::getExtents(buf),
-            alpaka::getPitchBytesVec(buf));
+            alpaka::getPitchesInBytes(buf));
 
         // copy-constructor
         View viewCopy(view);

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -33,11 +33,11 @@ namespace alpaka::test
     {
         alpaka::test::testViewImmutable<TElem>(view, dev, extentView, offsetView);
 
-        // alpaka::trait::GetPitchBytes
+        // alpaka::trait::GetPitchesInBytes
         // The pitch of the view has to be identical to the pitch of the underlying buffer in all dimensions.
         {
-            auto const pitchBuf = alpaka::getPitchBytesVec(buf);
-            auto const pitchView = alpaka::getPitchBytesVec(view);
+            auto const pitchBuf = alpaka::getPitchesInBytes(buf);
+            auto const pitchView = alpaka::getPitchesInBytes(view);
 
             for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
             {
@@ -51,7 +51,7 @@ namespace alpaka::test
             auto viewPtrNative = reinterpret_cast<std::uint8_t*>(alpaka::getPtrNative(buf));
             if constexpr(TDim::value > 0)
             {
-                auto const pitchBuf = alpaka::getPitchBytesVec(buf);
+                auto const pitchBuf = alpaka::getPitchesInBytes(buf);
                 for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
                 {
                     auto const pitch


### PR DESCRIPTION
* Add getPitchesInBytes and GetPitchesInBytes returning extents as alpaka::Vec.
* Deprecate getPitchBytes, GetPitchBytes and getPitchBytesVec.
* Includes 2 unrelated refactorings and an improvement to the reporting if the bytes of a view were correctly set.

Fixes: #2079
