### PR TITLE
Redefine pitches

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -215,10 +215,10 @@ auto main() -> int
     // padding between rows/planes of multidimensional memory allocations.
     // Therefore the pitch (distance between consecutive rows/planes) may be
     // greater than the space required for the data.
-    Idx const deviceBuffer1Pitch(alpaka::getPitchesInBytes(deviceBuffer1)[2] / sizeof(Data));
-    Idx const deviceBuffer2Pitch(alpaka::getPitchesInBytes(deviceBuffer2)[2] / sizeof(Data));
-    Idx const hostBuffer1Pitch(alpaka::getPitchesInBytes(hostBuffer)[2] / sizeof(Data));
-    Idx const hostViewPlainPtrPitch(alpaka::getPitchesInBytes(hostViewPlainPtr)[2] / sizeof(Data));
+    Idx const deviceBuffer1Pitch(alpaka::getPitchesInBytes(deviceBuffer1)[1] / sizeof(Data));
+    Idx const deviceBuffer2Pitch(alpaka::getPitchesInBytes(deviceBuffer2)[1] / sizeof(Data));
+    Idx const hostBuffer1Pitch(alpaka::getPitchesInBytes(hostBuffer)[1] / sizeof(Data));
+    Idx const hostViewPlainPtrPitch(alpaka::getPitchesInBytes(hostViewPlainPtr)[1] / sizeof(Data));
 
     // Test device Buffer
     //

--- a/example/randomCells2D/src/randomCells2D.cpp
+++ b/example/randomCells2D/src/randomCells2D.cpp
@@ -201,16 +201,16 @@ auto main() -> int
     RandomEngineVector<Acc>* const ptrBufAccRandV{alpaka::getPtrNative(bufAccRandV)};
 
     InitRandomKernel initRandomKernel;
-    auto pitchBufAccRandS = alpaka::getPitchesInBytes(bufAccRandS)[1];
+    auto pitchBufAccRandS = alpaka::getPitchesInBytes(bufAccRandS)[0];
     alpaka::exec<Acc>(queue, workdiv, initRandomKernel, extent, ptrBufAccRandS, pitchBufAccRandS);
     alpaka::wait(queue);
 
-    auto pitchBufAccRandV = alpaka::getPitchesInBytes(bufAccRandV)[1];
+    auto pitchBufAccRandV = alpaka::getPitchesInBytes(bufAccRandV)[0];
     alpaka::exec<Acc>(queue, workdiv, initRandomKernel, extent, ptrBufAccRandV, pitchBufAccRandV);
     alpaka::wait(queue);
 
-    auto pitchHostS = alpaka::getPitchesInBytes(bufHostS)[1];
-    auto pitchHostV = alpaka::getPitchesInBytes(bufHostV)[1];
+    auto pitchHostS = alpaka::getPitchesInBytes(bufHostS)[0];
+    auto pitchHostV = alpaka::getPitchesInBytes(bufHostV)[0];
 
     for(Idx y = 0; y < numY; ++y)
     {
@@ -221,7 +221,7 @@ auto main() -> int
         }
     }
 
-    auto pitchBufAccS = alpaka::getPitchesInBytes(bufAccS)[1];
+    auto pitchBufAccS = alpaka::getPitchesInBytes(bufAccS)[0];
     alpaka::memcpy(queue, bufAccS, bufHostS);
     RunTimestepKernelSingle runTimestepKernelSingle;
     alpaka::exec<Acc>(
@@ -235,7 +235,7 @@ auto main() -> int
         pitchBufAccS);
     alpaka::memcpy(queue, bufHostS, bufAccS);
 
-    auto pitchBufAccV = alpaka::getPitchesInBytes(bufAccV)[1];
+    auto pitchBufAccV = alpaka::getPitchesInBytes(bufAccV)[0];
     alpaka::memcpy(queue, bufAccV, bufHostV);
     RunTimestepKernelVector runTimestepKernelVector;
     alpaka::exec<Acc>(

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -45,7 +45,7 @@ namespace alpaka
     struct PlatformUniformCudaHipRt;
 
     template<typename TApi, typename TElem, typename TDim, typename TIdx>
-    class BufUniformCudaHipRt;
+    struct BufUniformCudaHipRt;
 
     //! The CUDA/HIP RT device handle.
     template<typename TApi>

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -182,16 +182,18 @@ namespace alpaka
         struct GetPitchesInBytes<BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>>
         {
             ALPAKA_FN_HOST auto operator()(BufUniformCudaHipRt<TApi, TElem, TDim, TIdx> const& buf) const
+                -> Vec<TDim, TIdx>
             {
                 Vec<TDim, TIdx> v{};
                 if constexpr(TDim::value > 0)
                 {
+                    v.back() = sizeof(TElem);
                     if constexpr(TDim::value > 1)
-                        v.back() = buf.m_rowPitchInBytes;
-                    else
-                        v.back() = buf.m_extentElements.back() * sizeof(TElem);
-                    for(int i = static_cast<int>(TDim::value) - 2; i >= 0; i--)
-                        v[i] = buf.m_extentElements[i] * v[i + 1];
+                    {
+                        v[TDim::value - 2] = static_cast<TIdx>(buf.m_rowPitchInBytes);
+                        for(TIdx i = TDim::value - 2; i > 0; i--)
+                            v[i - 1] = buf.m_extentElements[i] * v[i];
+                    }
                 }
                 return v;
             }

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -23,6 +23,8 @@ namespace alpaka
         template<typename TDim, typename TView, typename TExtent>
         struct TaskSetCpuBase
         {
+            static_assert(TDim::value > 0);
+
             using ExtentSize = Idx<TExtent>;
             using DstSize = Idx<TView>;
             using Elem = alpaka::Elem<TView>;
@@ -31,15 +33,16 @@ namespace alpaka
             TaskSetCpuBase(TViewFwd&& view, std::uint8_t const& byte, TExtent const& extent)
                 : m_byte(byte)
                 , m_extent(getExtents(extent))
-                , m_extentWidthBytes(m_extent[TDim::value - 1u] * static_cast<ExtentSize>(sizeof(Elem)))
+                , m_extentWidthBytes(m_extent.back() * static_cast<ExtentSize>(sizeof(Elem)))
 #if(!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
                 , m_dstExtent(getExtents(view))
 #endif
                 , m_dstPitchBytes(getPitchesInBytes(view))
                 , m_dstMemNative(reinterpret_cast<std::uint8_t*>(getPtrNative(view)))
             {
-                ALPAKA_ASSERT((castVec<DstSize>(m_extent) <= m_dstExtent).foldrAll(std::logical_or<bool>()));
-                ALPAKA_ASSERT(m_extentWidthBytes <= m_dstPitchBytes[TDim::value - 1u]);
+                ALPAKA_ASSERT((castVec<DstSize>(m_extent) <= m_dstExtent).all());
+                if constexpr(TDim::value > 1)
+                    ALPAKA_ASSERT(m_extentWidthBytes <= m_dstPitchBytes[TDim::value - 2]);
             }
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
@@ -80,9 +83,8 @@ namespace alpaka
 #endif
                 // [z, y, x] -> [z, y] because all elements with the innermost x dimension are handled within one
                 // iteration.
-                Vec<DimMin1, ExtentSize> const extentWithoutInnermost(subVecBegin<DimMin1>(this->m_extent));
-                // [z, y, x] -> [y, x] because the z pitch (the full idx of the buffer) is not required.
-                Vec<DimMin1, DstSize> const dstPitchBytesWithoutOutmost(subVecEnd<DimMin1>(this->m_dstPitchBytes));
+                Vec<DimMin1, ExtentSize> const extentWithoutInnermost = subVecBegin<DimMin1>(this->m_extent);
+                Vec<DimMin1, DstSize> const dstPitchBytesWithoutOutmost = subVecBegin<DimMin1>(this->m_dstPitchBytes);
 
                 if(static_cast<std::size_t>(this->m_extent.prod()) != 0u)
                 {
@@ -91,10 +93,7 @@ namespace alpaka
                         [&](Vec<DimMin1, ExtentSize> const& idx)
                         {
                             std::memset(
-                                reinterpret_cast<void*>(
-                                    this->m_dstMemNative
-                                    + (castVec<DstSize>(idx) * dstPitchBytesWithoutOutmost)
-                                          .foldrAll(std::plus<DstSize>())),
+                                this->m_dstMemNative + (castVec<DstSize>(idx) * dstPitchBytesWithoutOutmost).sum(),
                                 this->m_byte,
                                 static_cast<std::size_t>(this->m_extentWidthBytes));
                         });

--- a/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Set.hpp
@@ -149,7 +149,7 @@ namespace alpaka
                 auto const dstWidth = getWidth(view);
                 auto const dstHeight = getHeight(view);
 #    endif
-                auto const dstPitchBytes = static_cast<std::size_t>(getPitchesInBytes(view)[Dim<TView>::value - 1u]);
+                auto const dstRowPitchBytes = static_cast<std::size_t>(getPitchesInBytes(view)[0]);
                 auto const dstNativePtr = reinterpret_cast<void*>(getPtrNative(view));
                 ALPAKA_ASSERT(extentWidth <= dstWidth);
                 ALPAKA_ASSERT(extentHeight <= dstHeight);
@@ -157,7 +157,7 @@ namespace alpaka
                 // Initiate the memory set.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memset2DAsync(
                     dstNativePtr,
-                    dstPitchBytes,
+                    dstRowPitchBytes,
                     static_cast<int>(this->m_byte),
                     extentWidthBytes,
                     static_cast<std::size_t>(extentHeight),
@@ -202,9 +202,7 @@ namespace alpaka
                 auto const dstHeight = getHeight(view);
                 auto const dstDepth = getDepth(view);
 #    endif
-                auto const dstPitchBytesX = static_cast<std::size_t>(getPitchesInBytes(view)[Dim<TView>::value - 1u]);
-                auto const dstPitchBytesY
-                    = static_cast<std::size_t>(getPitchesInBytes(view)[Dim<TView>::value - (2u % Dim<TView>::value)]);
+                auto const [dstSlicePitchBytes, dstRowPitchBytes, _] = getPitchesInBytes(view);
                 auto const dstNativePtr = reinterpret_cast<void*>(getPtrNative(view));
                 ALPAKA_ASSERT(extentWidth <= dstWidth);
                 ALPAKA_ASSERT(extentHeight <= dstHeight);
@@ -213,9 +211,9 @@ namespace alpaka
                 // Fill CUDA parameter structures.
                 typename TApi::PitchedPtr_t const pitchedPtrVal = TApi::makePitchedPtr(
                     dstNativePtr,
-                    dstPitchBytesX,
+                    static_cast<std::size_t>(dstRowPitchBytes),
                     static_cast<std::size_t>(dstWidth) * sizeof(Elem),
-                    dstPitchBytesY / dstPitchBytesX);
+                    static_cast<std::size_t>(dstSlicePitchBytes / dstRowPitchBytes));
 
                 typename TApi::Extent_t const extentVal = TApi::makeExtent(
                     static_cast<std::size_t>(extentWidth) * sizeof(Elem),

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -98,15 +98,7 @@ namespace alpaka::internal
 
             auto ptr = reinterpret_cast<uintptr_t>(data());
             if constexpr(Dim::value > 0)
-            {
-                auto const pitchesInBytes = getPitchesInBytes(*static_cast<TView const*>(this));
-                for(std::size_t i = 0u; i < Dim::value; i++)
-                {
-                    Idx const pitch
-                        = i + 1 < Dim::value ? pitchesInBytes[i + 1] : static_cast<Idx>(sizeof(value_type));
-                    ptr += static_cast<uintptr_t>(index[i] * pitch);
-                }
-            }
+                ptr += (getPitchesInBytes(*static_cast<TView const*>(this)) * castVec<Idx>(index)).sum();
             return reinterpret_cast<const_pointer>(ptr);
         }
 

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -34,23 +34,26 @@ namespace alpaka
         //! \param view The view this view is a sub-view of.
         //! \param extentElements The extent in elements.
         //! \param relativeOffsetsElements The offsets in elements.
-        template<typename TView, typename TOffsets, typename TExtent>
+        template<typename TQualifiedView, typename TOffsets, typename TExtent>
         ViewSubView(
-            TView const& view,
+            TQualifiedView& view,
             TExtent const& extentElements,
             TOffsets const& relativeOffsetsElements = TOffsets())
             : m_viewParentView(getPtrNative(view), getDev(view), getExtents(view), getPitchesInBytes(view))
             , m_extentElements(getExtents(extentElements))
-            , m_offsetsElements(getOffsetVec(relativeOffsetsElements))
+            , m_offsetsElements(getOffsets(relativeOffsetsElements))
+            , m_nativePtr(computeNativePtr())
         {
             ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
+            using View = std::remove_cv_t<TQualifiedView>;
+
             static_assert(
-                std::is_same_v<Dev, alpaka::Dev<TView>>,
+                std::is_same_v<Dev, alpaka::Dev<View>>,
                 "The dev type of TView and the Dev template parameter have to be identical!");
 
             static_assert(
-                std::is_same_v<TIdx, Idx<TView>>,
+                std::is_same_v<TIdx, Idx<View>>,
                 "The idx type of TView and the TIdx template parameter have to be identical!");
             static_assert(
                 std::is_same_v<TIdx, Idx<TExtent>>,
@@ -60,7 +63,7 @@ namespace alpaka
                 "The idx type of TOffsets and the TIdx template parameter have to be identical!");
 
             static_assert(
-                std::is_same_v<TDim, Dim<TView>>,
+                std::is_same_v<TDim, Dim<View>>,
                 "The dim type of TView and the TDim template parameter have to be identical!");
             static_assert(
                 std::is_same_v<TDim, Dim<TExtent>>,
@@ -69,67 +72,43 @@ namespace alpaka
                 std::is_same_v<TDim, Dim<TOffsets>>,
                 "The dim type of TOffsets and the TDim template parameter have to be identical!");
 
-            ALPAKA_ASSERT(
-                ((m_offsetsElements + m_extentElements) <= getExtents(view)).foldrAll(std::logical_and<bool>(), true));
-        }
-        //! Constructor.
-        //! \param view The view this view is a sub-view of.
-        //! \param extentElements The extent in elements.
-        //! \param relativeOffsetsElements The offsets in elements.
-        template<typename TView, typename TOffsets, typename TExtent>
-        ViewSubView(TView& view, TExtent const& extentElements, TOffsets const& relativeOffsetsElements = TOffsets())
-            : m_viewParentView(getPtrNative(view), getDev(view), getExtents(view), getPitchesInBytes(view))
-            , m_extentElements(getExtents(extentElements))
-            , m_offsetsElements(getOffsetVec(relativeOffsetsElements))
-        {
-            ALPAKA_DEBUG_FULL_LOG_SCOPE;
-
-            static_assert(
-                std::is_same_v<Dev, alpaka::Dev<TView>>,
-                "The dev type of TView and the Dev template parameter have to be identical!");
-
-            static_assert(
-                std::is_same_v<TIdx, Idx<TView>>,
-                "The idx type of TView and the TIdx template parameter have to be identical!");
-            static_assert(
-                std::is_same_v<TIdx, Idx<TExtent>>,
-                "The idx type of TExtent and the TIdx template parameter have to be identical!");
-            static_assert(
-                std::is_same_v<TIdx, Idx<TOffsets>>,
-                "The idx type of TOffsets and the TIdx template parameter have to be identical!");
-
-            static_assert(
-                std::is_same_v<TDim, Dim<TView>>,
-                "The dim type of TView and the TDim template parameter have to be identical!");
-            static_assert(
-                std::is_same_v<TDim, Dim<TExtent>>,
-                "The dim type of TExtent and the TDim template parameter have to be identical!");
-            static_assert(
-                std::is_same_v<TDim, Dim<TOffsets>>,
-                "The dim type of TOffsets and the TDim template parameter have to be identical!");
-
-            ALPAKA_ASSERT(
-                ((m_offsetsElements + m_extentElements) <= getExtents(view)).foldrAll(std::logical_and<bool>(), true));
+            ALPAKA_ASSERT(((m_offsetsElements + m_extentElements) <= getExtents(view)).all());
         }
 
         //! \param view The view this view is a sub-view of.
         template<typename TView>
-        explicit ViewSubView(TView const& view) : ViewSubView(view, view, Vec<TDim, TIdx>::all(0))
+        explicit ViewSubView(TView const& view) : ViewSubView(view, getExtents(view), Vec<TDim, TIdx>::zeros())
         {
             ALPAKA_DEBUG_FULL_LOG_SCOPE;
         }
 
         //! \param view The view this view is a sub-view of.
         template<typename TView>
-        explicit ViewSubView(TView& view) : ViewSubView(view, view, Vec<TDim, TIdx>::all(0))
+        explicit ViewSubView(TView& view) : ViewSubView(view, getExtents(view), Vec<TDim, TIdx>::zeros())
         {
             ALPAKA_DEBUG_FULL_LOG_SCOPE;
         }
 
     public:
+        ALPAKA_FN_HOST auto computeNativePtr()
+        {
+#if BOOST_COMP_GNUC
+#    pragma GCC diagnostic push
+            // "cast from 'std::uint8_t*' to 'TElem*' increases required alignment of target type"
+#    pragma GCC diagnostic ignored "-Wcast-align"
+#endif
+            return reinterpret_cast<TElem*>(
+                reinterpret_cast<std::uint8_t*>(alpaka::getPtrNative(m_viewParentView))
+                + (m_offsetsElements * getPitchesInBytes(m_viewParentView)).sum());
+#if BOOST_COMP_GNUC
+#    pragma GCC diagnostic pop
+#endif
+        }
+
         ViewPlainPtr<Dev, TElem, TDim, TIdx> m_viewParentView; // This wraps the parent view.
         Vec<TDim, TIdx> m_extentElements; // The extent of this view.
         Vec<TDim, TIdx> m_offsetsElements; // The offset relative to the parent view.
+        TElem* m_nativePtr;
     };
 
     // Trait specializations for ViewSubView.
@@ -176,57 +155,19 @@ namespace alpaka
             }
         };
 
-#if BOOST_COMP_GNUC
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored                                                                                    \
-        "-Wcast-align" // "cast from 'std::uint8_t*' to 'TElem*' increases required alignment of target type"
-#endif
         //! The ViewSubView native pointer get trait specialization.
         template<typename TElem, typename TDim, typename TDev, typename TIdx>
         struct GetPtrNative<ViewSubView<TDev, TElem, TDim, TIdx>>
         {
-        private:
-            using IdxSequence = std::make_index_sequence<TDim::value>;
-
-        public:
             ALPAKA_FN_HOST static auto getPtrNative(ViewSubView<TDev, TElem, TDim, TIdx> const& view) -> TElem const*
             {
-                // \TODO: pre-calculate this pointer for faster execution.
-                return reinterpret_cast<TElem const*>(
-                    reinterpret_cast<std::uint8_t const*>(alpaka::getPtrNative(view.m_viewParentView))
-                    + pitchedOffsetBytes(view, IdxSequence()));
+                return view.m_nativePtr;
             }
             ALPAKA_FN_HOST static auto getPtrNative(ViewSubView<TDev, TElem, TDim, TIdx>& view) -> TElem*
             {
-                // \TODO: pre-calculate this pointer for faster execution.
-                return reinterpret_cast<TElem*>(
-                    reinterpret_cast<std::uint8_t*>(alpaka::getPtrNative(view.m_viewParentView))
-                    + pitchedOffsetBytes(view, IdxSequence()));
-            }
-
-        private:
-            //! For a 3D vector this calculates:
-            //!
-            //! getOffsets(view)[0] * getPitchBytes<1u>(view)
-            //! + getOffsets(view)[1] * getPitchBytes<2u>(view)
-            //! + getOffsets(view)[2] * getPitchBytes<3u>(view)
-            //! while getPitchBytes<3u>(view) is equivalent to sizeof(TElem)
-            template<typename TView, std::size_t... TIndices>
-            ALPAKA_FN_HOST static auto pitchedOffsetBytes(TView const& view, std::index_sequence<TIndices...> const&)
-                -> TIdx
-            {
-                auto const offsets = getOffsets(view);
-                auto const pitches = getPitchesInBytes(view);
-                return (
-                    (offsets[TIndices]
-                     * (TIndices + 1 < Dim<TView>::value ? pitches[TIndices + 1]
-                                                         : static_cast<TIdx>(sizeof(Elem<TView>))))
-                    + ... + TIdx{0}); // FIXME: see comment above
+                return view.m_nativePtr;
             }
         };
-#if BOOST_COMP_GNUC
-#    pragma GCC diagnostic pop
-#endif
 
         //! The ViewSubView pitch get trait specialization.
         template<typename TDev, typename TElem, typename TDim, typename TIdx>
@@ -234,7 +175,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST auto operator()(ViewSubView<TDev, TElem, TDim, TIdx> const& view) const
             {
-                return alpaka::getPitchesInBytes(view.m_viewParentView);
+                return getPitchesInBytes(view.m_viewParentView);
             }
         };
 

--- a/include/alpaka/test/mem/view/Iterator.hpp
+++ b/include/alpaka/test/mem/view/Iterator.hpp
@@ -17,11 +17,6 @@ namespace alpaka::test
         template<typename T, typename TSource>
         using MimicConst = std::conditional_t<std::is_const_v<TSource>, std::add_const_t<T>, std::remove_const_t<T>>;
 
-#if BOOST_COMP_GNUC
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored                                                                                    \
-        "-Wcast-align" // "cast from 'Byte*' to 'Elem*' increases required alignment of target type"
-#endif
         template<typename TView, typename TSfinae = void>
         class IteratorView
         {
@@ -39,7 +34,7 @@ namespace alpaka::test
             {
             }
 
-            ALPAKA_FN_HOST IteratorView(TView& view) : IteratorView(view, 0)
+            ALPAKA_FN_HOST explicit IteratorView(TView& view) : IteratorView(view, 0)
             {
             }
 
@@ -87,37 +82,19 @@ namespace alpaka::test
                     return *m_nativePtr;
                 else
                 {
-                    using Dim1 = DimInt<1>;
-                    using DimMin1 = DimInt<Dim::value - 1u>;
-
-                    Vec<Dim1, Idx> const currentIdxDim1{m_currentIdx};
-                    Vec<Dim, Idx> const currentIdxDimx(mapIdx<Dim::value>(currentIdxDim1, m_extents));
-
-                    // [pz, py, px] -> [py, px]
-                    auto const pitchWithoutOutermost = subVecEnd<DimMin1>(m_pitchBytes);
-                    // [ElemSize]
-                    Vec<Dim1, Idx> const elementSizeVec = static_cast<Idx>(sizeof(Elem));
-                    // [py, px] ++ [ElemSize] -> [py, px, ElemSize]
-                    Vec<Dim, Idx> const dstPitchBytes = concatVec(pitchWithoutOutermost, elementSizeVec);
-                    // [py, px, ElemSize] [z, y, x] -> [py*z, px*y, ElemSize*x]
-                    auto const dimensionalOffsetsInByte = currentIdxDimx * dstPitchBytes;
-                    // sum{[py*z, px*y, ElemSize*x]} -> offset in byte
-                    auto const offsetInByte = dimensionalOffsetsInByte.foldrAll(std::plus<Idx>());
-
-                    using Byte = MimicConst<std::uint8_t, Elem>;
-                    Byte* ptr(reinterpret_cast<Byte*>(m_nativePtr) + offsetInByte);
-
-#if 0
-                    std::cout
-                        << " i1: " << currentIdxDim1
-                        << " in: " << currentIdxDimx
-                        << " dpb: " << dstPitchBytes
-                        << " offb: " << offsetInByte
-                        << " ptr: " << reinterpret_cast<void const *>(ptr)
-                        << " v: " << *reinterpret_cast<Elem *>(ptr)
-                        << std::endl;
+                    Vec<Dim, Idx> const currentIdxDimx
+                        = mapIdx<Dim::value>(Vec<DimInt<1>, Idx>{m_currentIdx}, m_extents);
+                    auto const offsetInBytes = (currentIdxDimx * m_pitchBytes).sum();
+                    using QualifiedByte = MimicConst<std::byte, Elem>;
+#if BOOST_COMP_GNUC
+#    pragma GCC diagnostic push
+                    // "cast from 'Byte*' to 'Elem*' increases required alignment of target type"
+#    pragma GCC diagnostic ignored "-Wcast-align"
 #endif
-                    return *reinterpret_cast<Elem*>(ptr);
+                    return *reinterpret_cast<Elem*>(reinterpret_cast<QualifiedByte*>(m_nativePtr) + offsetInBytes);
+#if BOOST_COMP_GNUC
+#    pragma GCC diagnostic pop
+#endif
                 }
                 ALPAKA_UNREACHABLE(*m_nativePtr);
             }
@@ -128,9 +105,6 @@ namespace alpaka::test
             Vec<Dim, Idx> m_extents;
             Vec<Dim, Idx> m_pitchBytes;
         };
-#if BOOST_COMP_GNUC
-#    pragma GCC diagnostic pop
-#endif
 
         template<typename TView, typename TSfinae = void>
         struct Begin

--- a/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/include/alpaka/test/mem/view/ViewTest.hpp
@@ -57,16 +57,7 @@ namespace alpaka::test
 
         // trait::GetPitchBytes
         {
-            // The pitches have to be at least as large as the values we calculate here.
-            auto pitchMinimum = Vec<DimInt<TDim::value + 1u>, TIdx>::ones();
-            // Initialize the pitch between two elements of the X dimension ...
-            pitchMinimum[TDim::value] = sizeof(TElem);
-            // ... and fill all the other dimensions.
-            for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)
-            {
-                pitchMinimum[i - 1] = extent[i - 1] * pitchMinimum[i];
-            }
-
+            auto const pitchMinimum = alpaka::detail::calculatePitchesFromExtents<TElem>(extent);
             auto const pitchView = getPitchesInBytes(view);
 
             for(TIdx i = TDim::value; i > static_cast<TIdx>(0u); --i)

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -240,8 +240,6 @@ TEMPLATE_LIST_TEST_CASE("matMul", "[matMul]", TestAccs)
               << alpaka::test::integ::measureRunTimeMs([&] { alpaka::memcpy(queueAcc, bufCAcc, bufCHost); }) << " ms"
               << std::endl;
 
-    alpaka::memcpy(queueAcc, bufCAcc, bufCHost);
-
     auto const pitchA = alpaka::getPitchesInBytes(bufAAcc)[1];
     auto const pitchB = alpaka::getPitchesInBytes(bufBAcc)[1];
     auto const pitchC = alpaka::getPitchesInBytes(bufCAcc)[1];


### PR DESCRIPTION
This PR shifts the values returned from getPitchesInBytes to be consistent with std::mdspan (except in bytes).

Example: the pitch vector for the extent {42, 10, 2} changes:

Before: {4, 3360, 80, 8}
After: {80, 8, 4}

The new meaning is that the pitch value is the number of bytes to jump from one element to the next in the given dimension.

Fixes: #2083

~~Waiting on #2092 to be merged before rebase.~~

This is a **silent breaking change**. However, to a function that was only introduced a few days ago with #2092.