### PR TITLE
Replace ALPAKA_DECAY_T by std::decay_t

### DIFF
--- a/include/alpaka/atomic/AtomicUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicUniformCudaHipBuiltIn.hpp
@@ -76,7 +76,7 @@ namespace alpaka
                     T const& value) -> T
                 {
                     auto* const addressAsIntegralType = reinterpretAddress(addr);
-                    using EmulatedType = ALPAKA_DECAY_T(decltype(*addressAsIntegralType));
+                    using EmulatedType = std::decay_t<decltype(*addressAsIntegralType)>;
 
                     // Emulating atomics with atomicCAS is mentioned in the programming guide too.
                     // http://docs.nvidia.com/cuda/cuda-c-programming-guide/#atomic-functions
@@ -117,7 +117,7 @@ namespace alpaka
                     T const& value) -> T
                 {
                     auto* const addressAsIntegralType = reinterpretAddress(addr);
-                    using EmulatedType = ALPAKA_DECAY_T(decltype(*addressAsIntegralType));
+                    using EmulatedType = std::decay_t<decltype(*addressAsIntegralType)>;
                     EmulatedType reinterpretedCompare = reinterpretValue(compare);
                     EmulatedType reinterpretedValue = reinterpretValue(value);
 

--- a/include/alpaka/core/Decay.hpp
+++ b/include/alpaka/core/Decay.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Sergei Bastrakov, Jan Stephan
+/* Copyright 2023 Sergei Bastrakov, Jan Stephan, Bernhard Manfred Gruber
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -8,26 +8,9 @@
 
 #include <type_traits>
 
-//! Wrapper around std::decay_t for parameter pack expansion expressions
-//
-// Works around PGI compiler internal error when used in empty template pack
-// extension as discussed in #995. It seems not possible to make a workaround
-// with pure C++ tools, like an alias template, so macro it is. Note that
-// there is no known issue outside of empty parameter pack expansions,
-// so the normal std::decay_t can and should be used there.
-//
-// The choice of macro over writing typename std::decay<Type>::type explicitly
-// in parameter pack expansion expressions is to avoid warnings from diagnostic
-// tools, and also for brevity.
-#if BOOST_COMP_PGI
-#    define ALPAKA_DECAY_T(Type) typename std::decay<Type>::type
-#else
-#    define ALPAKA_DECAY_T(Type) std::decay_t<Type>
-#endif
-
 namespace alpaka
 {
     //! Provides a decaying wrapper around std::is_same. Example: is_decayed_v<volatile float, float> returns true.
     template<typename T, typename U>
-    inline constexpr auto is_decayed_v = std::is_same_v<ALPAKA_DECAY_T(T), ALPAKA_DECAY_T(U)>;
+    inline constexpr auto is_decayed_v = std::is_same_v<std::decay_t<T>, std::decay_t<U>>;
 } // namespace alpaka

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -807,7 +807,7 @@ namespace alpaka
 
             // Get the size of the block shared dynamic memory.
             auto const blockSharedMemDynSizeBytes = std::apply(
-                [&](ALPAKA_DECAY_T(TArgs) const&... args)
+                [&](std::decay_t<TArgs> const&... args)
                 {
                     return getBlockSharedMemDynSizeBytes<AccCpuOmp2Blocks<TDim, TIdx>>(
                         m_kernelFnObj,
@@ -831,7 +831,7 @@ namespace alpaka
 
             // Get the OpenMP schedule information for the given kernel and parameter types
             auto const schedule = std::apply(
-                [&](ALPAKA_DECAY_T(TArgs) const&... args) {
+                [&](std::decay_t<TArgs> const&... args) {
                     return getOmpSchedule<AccCpuOmp2Blocks<TDim, TIdx>>(
                         m_kernelFnObj,
                         blockThreadExtent,

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -64,7 +64,7 @@ namespace alpaka
 
             // Get the size of the block shared dynamic memory.
             auto const blockSharedMemDynSizeBytes = std::apply(
-                [&](ALPAKA_DECAY_T(TArgs) const&... args)
+                [&](std::decay_t<TArgs> const&... args)
                 {
                     return getBlockSharedMemDynSizeBytes<AccCpuOmp2Threads<TDim, TIdx>>(
                         m_kernelFnObj,

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -58,7 +58,7 @@ namespace alpaka
 
             // Get the size of the block shared dynamic memory.
             auto const blockSharedMemDynSizeBytes = std::apply(
-                [&](ALPAKA_DECAY_T(TArgs) const&... args)
+                [&](std::decay_t<TArgs> const&... args)
                 {
                     return getBlockSharedMemDynSizeBytes<AccCpuSerial<TDim, TIdx>>(
                         m_kernelFnObj,

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -63,7 +63,7 @@ namespace alpaka
 
             // Get the size of the block shared dynamic memory.
             auto const blockSharedMemDynSizeBytes = std::apply(
-                [&](ALPAKA_DECAY_T(TArgs) const&... args)
+                [&](std::decay_t<TArgs> const&... args)
                 {
                     return getBlockSharedMemDynSizeBytes<AccCpuTbbBlocks<TDim, TIdx>>(
                         m_kernelFnObj,

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -219,7 +219,7 @@ namespace alpaka
 
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes = std::apply(
-                    [&](remove_restrict_t<ALPAKA_DECAY_T(TArgs)> const&... args) {
+                    [&](remove_restrict_t<std::decay_t<TArgs>> const&... args) {
                         return getBlockSharedMemDynSizeBytes<TAcc>(
                             task.m_kernelFnObj,
                             blockThreadExtent,
@@ -257,7 +257,7 @@ namespace alpaka
                 // (MSVC). If not given by value, the kernel launch code does not copy the value but the pointer to the
                 // value location.
                 std::apply(
-                    [&](remove_restrict_t<ALPAKA_DECAY_T(TArgs)> const&... args)
+                    [&](remove_restrict_t<std::decay_t<TArgs>> const&... args)
                     {
                         kernelName<<<
                             gridDim,
@@ -327,7 +327,7 @@ namespace alpaka
 
                 // Get the size of the block shared dynamic memory.
                 auto const blockSharedMemDynSizeBytes = std::apply(
-                    [&](remove_restrict_t<ALPAKA_DECAY_T(TArgs)> const&... args) {
+                    [&](remove_restrict_t<std::decay_t<TArgs>> const&... args) {
                         return getBlockSharedMemDynSizeBytes<TAcc>(
                             task.m_kernelFnObj,
                             blockThreadExtent,
@@ -361,7 +361,7 @@ namespace alpaka
 
                 // Enqueue the kernel execution.
                 std::apply(
-                    [&](remove_restrict_t<ALPAKA_DECAY_T(TArgs)> const&... args)
+                    [&](remove_restrict_t<std::decay_t<TArgs>> const&... args)
                     {
                         kernelName<<<
                             gridDim,


### PR DESCRIPTION
This feature was introduced as a workaround to a bug in the Intel classic compiler (see #995). Alpaka no longer supports that compiler, so the workaround is no longer necessary.