### PR TITLE
fix CUDA/HIP device wait for event

### DIFF
--- a/include/alpaka/dev/common/QueueRegistry.hpp
+++ b/include/alpaka/dev/common/QueueRegistry.hpp
@@ -13,7 +13,9 @@
 
 namespace alpaka::detail
 {
-    //! The CPU device implementation.
+    //! The CPU/GPU device queue registry implementation.
+    //!
+    //! @tparam TQueue queue implementation
     template<typename TQueue>
     struct QueueRegistry
     {

--- a/include/alpaka/event/EventUniformCudaHipRt.hpp
+++ b/include/alpaka/event/EventUniformCudaHipRt.hpp
@@ -227,7 +227,14 @@ namespace alpaka
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::streamWaitEvent(nullptr, event.getNativeHandle(), 0));
+                // Get all the queues on the device at the time of invocation.
+                // All queues added afterwards are ignored.
+                auto vQueues = dev.getAllQueues();
+                for(auto&& spQueue : vQueues)
+                {
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        TApi::streamWaitEvent(spQueue->getNativeHandle(), event.getNativeHandle(), 0));
+                }
             }
         };
         //! The CUDA/HIP RT event native handle trait specialization.

--- a/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda_hip/QueueUniformCudaHipRt.hpp
@@ -9,11 +9,11 @@
 #include "alpaka/core/Concepts.hpp"
 #include "alpaka/core/Cuda.hpp"
 #include "alpaka/core/Hip.hpp"
-#include "alpaka/dev/DevUniformCudaHipRt.hpp"
 #include "alpaka/dev/Traits.hpp"
 #include "alpaka/event/Traits.hpp"
 #include "alpaka/meta/DependentFalseType.hpp"
 #include "alpaka/queue/Traits.hpp"
+#include "alpaka/traits/Traits.hpp"
 #include "alpaka/wait/Traits.hpp"
 
 #include <condition_variable>
@@ -29,6 +29,9 @@ namespace alpaka
 {
     template<typename TApi>
     class EventUniformCudaHipRt;
+
+    template<typename TApi>
+    class DevUniformCudaHipRt;
 
     namespace uniform_cuda_hip::detail
     {
@@ -94,6 +97,7 @@ namespace alpaka
             ALPAKA_FN_HOST QueueUniformCudaHipRt(DevUniformCudaHipRt<TApi> const& dev)
                 : m_spQueueImpl(std::make_shared<QueueUniformCudaHipRtImpl<TApi>>(dev))
             {
+                dev.registerQueue(m_spQueueImpl);
             }
             ALPAKA_FN_HOST auto operator==(QueueUniformCudaHipRt const& rhs) const -> bool
             {


### PR DESCRIPTION
fix #2060

The implementationto let a device wait for an event was wrongly implemented.

**new implementation**

Collect all queues of an device within the device itself, equal to the CPU device implementation, and let each stream wait for the event.