### PR TITLE
fix warning maxing struct/class definition

### DIFF
--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -45,7 +45,7 @@ namespace alpaka
     struct PlatformUniformCudaHipRt;
 
     template<typename TApi, typename TElem, typename TDim, typename TIdx>
-    class BufUniformCudaHipRt;
+    struct BufUniformCudaHipRt;
 
     //! The CUDA/HIP RT device handle.
     template<typename TApi>


### PR DESCRIPTION
fix the following warning:

```
alpaka/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp:54:5: warning: 'BufUniformCudaHipRt' defined as a struct template here but previously declared as a class template; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags]
    struct BufUniformCudaHipRt
    ^
/home/runner/work/alpaka/alpaka/include/alpaka/dev/DevUniformCudaHipRt.hpp:50:5: note: did you mean struct here?
    class BufUniformCudaHipRt;
    ^~~~~
    struct
```