### PR TITLE
Mark lambda as `noexcept`

### DIFF
--- a/include/alpaka/core/ThreadPool.hpp
+++ b/include/alpaka/core/ThreadPool.hpp
@@ -55,7 +55,7 @@ namespace alpaka::core::detail
         template<typename TFnObj, typename... TArgs>
         auto enqueueTask(TFnObj&& task, TArgs&&... args) -> std::future<void>
         {
-            auto ptask = Task{[=, t = std::forward<TFnObj>(task)] { t(args...); }};
+            auto ptask = Task{[=, t = std::forward<TFnObj>(task)]() noexcept(noexcept(task(args...))) { t(args...); }};
             auto future = ptask.get_future();
             {
                 std::lock_guard<std::mutex> lock{m_mutex};

--- a/test/unit/core/src/ThreadPool.cpp
+++ b/test/unit/core/src/ThreadPool.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Bernhard Manfred Gruber
+/* Copyright 2023 Bernhard Manfred Gruber, Jan Stephan
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -18,7 +18,7 @@ TEST_CASE("threadpool", "[core]")
 
     auto f1 = tp.enqueueTask([] { throw std::runtime_error("42"); });
     auto f2 = tp.enqueueTask([] { throw 42; });
-    auto f3 = tp.enqueueTask([] {});
+    auto f3 = tp.enqueueTask([]() noexcept {});
 
     CHECK_THROWS_AS(f1.get(), std::runtime_error);
 


### PR DESCRIPTION
This PR fixes the following warning obtained by compiling with `g++-13` and `-Werror`:

```
/usr/include/c++/13.2.1/type_traits:3024:14: error: noexcept-expression evaluates to 'false' because of a call to 'alpaka::core::detail::ThreadPool::enqueueTask<CATCH2_INTERNAL_TEST_0()::<lambda()> >(CATCH2_INTERNAL_TEST_0()::<lambda()>&&)::<lambda()>' [-Werror=noexcept]
 3024 |       return noexcept(std::declval<_Fn>()(std::declval<_Args>()...));
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/stepha27/workspace/caravan/alpaka/include/alpaka/core/ThreadPool.hpp:59:31: note: but 'alpaka::core::detail::ThreadPool::enqueueTask<CATCH2_INTERNAL_TEST_0()::<lambda()> >(CATCH2_INTERNAL_TEST_0()::<lambda()>&&)::<lambda()>' does not throw; perhaps it should be declared 'noexcept'
   59 |             auto ptask = Task{[=, t = std::forward<TFnObj>(task)]() { t(args...); }};
      |                               ^
```

Related to #2107.