### PR TITLE
Replace deprecated function call

### DIFF
--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Axel Huebl, Benjamin Worpitz, Erik Zenker, Bernhard Manfred Gruber, Jan Stephan
+/* Copyright 2023 Axel Hübl, Benjamin Worpitz, Erik Zenker, Bernhard Manfred Gruber, Jan Stephan
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -79,7 +79,7 @@ namespace alpaka::test
 
         auto buf2 = alpaka::allocBuf<TElem, Idx>(dev, alpaka::test::extentBuf<Dim, Idx>);
         auto nativePtr2 = alpaka::getPtrNative(buf);
-        View view2(nativePtr2, alpaka::getDev(buf2), alpaka::getExtents(buf2), alpaka::getPitchBytesVec(buf2));
+        View view2(nativePtr2, alpaka::getDev(buf2), alpaka::getExtents(buf2), alpaka::getPitchesInBytes(buf2));
 
         // copy-assign
         viewCopy = view2;


### PR DESCRIPTION
One of the test cases still uses a deprecated function call. I replace it with its current analogue. This makes the following `g++-13` warning disappear: `-Wdeprecated-declarations`.
