### PR TITLE
Mark variable as `[[maybe_unused]]`

### DIFF
--- a/include/alpaka/extent/Traits.hpp
+++ b/include/alpaka/extent/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Andrea Bocci, Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2023 Benjamin Worpitz, Andrea Bocci, Jan Stephan, Bernhard Manfred Gruber
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -76,11 +76,13 @@ ALPAKA_FN_HOST_ACC auto constexpr getExtentVecEnd(T const& object = {}) -> Vec<T
 {
     static_assert(TDim::value <= Dim<T>::value, "Cannot get more items than the extent holds");
 
-    auto const e = getExtents(object);
+    [[maybe_unused]] auto const e = getExtents(object);
     Vec<TDim, Idx<T>> v{};
     if constexpr(TDim::value > 0)
+    {
         for(unsigned i = 0; i < TDim::value; i++)
             v[i] = e[(Dim<T>::value - TDim::value) + i];
+    }
     return v;
 }
 


### PR DESCRIPTION
This PR fixes the following warning uncovered by #2107:

```
/home/runner/work/alpaka/alpaka/include/alpaka/extent/Traits.hpp:79:16: error: variable 'e' set but not used [-Werror=unused-but-set-variable]
   79 |     auto const e = getExtents(object);
      |                ^
```