### PR TITLE
Fix debug info for SYCL zero-dim buffer alloc

### DIFF
--- a/include/alpaka/mem/buf/BufGenericSycl.hpp
+++ b/include/alpaka/mem/buf/BufGenericSycl.hpp
@@ -160,7 +160,9 @@ namespace alpaka::trait
             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-            if constexpr(TDim::value == 0 || TDim::value == 1)
+            if constexpr(TDim::value == 0)
+                std::cout << __func__ << " ewb: " << sizeof(TElem) << '\n';
+            else if constexpr(TDim::value == 1)
             {
                 auto const width = getWidth(extent);
 

--- a/include/alpaka/mem/buf/sycl/Common.hpp
+++ b/include/alpaka/mem/buf/sycl/Common.hpp
@@ -21,14 +21,18 @@ namespace alpaka::detail
     {
         constexpr auto dim = Dim<TExtent>::value;
 
-        auto const width = getWidth(ext) * multiplier;
-
-        if constexpr(dim == 1)
-            return sycl::range<1>{width};
-        else if constexpr(dim == 2)
-            return sycl::range<2>{width, getHeight(ext)};
+        if constexpr(dim == 0)
+            return sycl::range<1>{multiplier};
         else
-            return sycl::range<3>{width, getHeight(ext), getDepth(ext)};
+        {
+            auto const width = getWidth(ext) * multiplier;
+            if constexpr(dim == 1)
+                return sycl::range<1>{width};
+            else if constexpr(dim == 2)
+                return sycl::range<2>{width, getHeight(ext)};
+            else
+                return sycl::range<3>{width, getHeight(ext), getDepth(ext)};
+        }
     }
 
     template<typename TView>
@@ -36,12 +40,17 @@ namespace alpaka::detail
     {
         constexpr auto dim = Dim<TView>::value;
 
-        if constexpr(dim == 1)
-            return sycl::id<1>{getOffsetX(view)};
-        else if constexpr(dim == 2)
-            return sycl::id<2>{getOffsetX(view), getOffsetY(view)};
+        if constexpr(dim == 0)
+            return sycl::range<1>{1};
         else
-            return sycl::id<3>{getOffsetX(view), getOffsetY(view), getOffsetZ(view)};
+        {
+            if constexpr(dim == 1)
+                return sycl::id<1>{getOffsetX(view)};
+            else if constexpr(dim == 2)
+                return sycl::id<2>{getOffsetX(view), getOffsetY(view)};
+            else
+                return sycl::id<3>{getOffsetX(view), getOffsetY(view), getOffsetZ(view)};
+        }
     }
 } // namespace alpaka::detail
 


### PR DESCRIPTION
This fixes a compilation error with the SYCL backend in debug mode.

I also made `make_sycl_range` and `make_sycl_offset` support zero-dimensional extents, but this may be unrelated to the issue at hand.

Fixes: #2124