### PR TITLE
Turn off fast math for Catch2 build

### DIFF
--- a/test/common/devCompileOptions.cmake
+++ b/test/common/devCompileOptions.cmake
@@ -146,7 +146,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "Inte
 
     if(${CMAKE_CXX_COMPILER_ID} STREQUAL "IntelLLVM")
         # fast math is turned on by default with ICPX, which breaks our unit tests
-        list(APPEND alpaka_DEV_COMPILE_OPTIONS "-ffp-model=precise")
+        list(APPEND alpaka_DEV_COMPILE_OPTIONS "-fp-model=precise")
 
         if (alpaka_ACC_SYCL_ENABLE)
             # avoid: warning: disabled expansion of recursive macro

--- a/thirdParty/CMakeLists.txt
+++ b/thirdParty/CMakeLists.txt
@@ -26,6 +26,9 @@ if(BUILD_TESTING)
         # Remarks are not treated as warnings so we need to disable them manually. 
         add_compile_options($<$<AND:$<CONFIG:Debug>,$<CXX_COMPILER_ID:IntelLLVM>>:-Rno-debug-disables-optimization>)
 
+        # Turn off fast math to prevent warnings inside Catch2 (icpx defaults to -fp-model=fast)
+        add_compile_options($<$<CXX_COMPILER_ID:IntelLLVM>:-fp-model=precise>)
+        
         add_subdirectory(catch2)
 
         # hide Catch2 cmake variables by default in cmake gui


### PR DESCRIPTION
`icpx` defaults to `-fp-model=fast` which generates the following warning while building Catch2:

```
/home/stepha27/workspace/caravan/alpaka/thirdParty/catch2/src/catch2/catch_approx.cpp:55:82: warning: explicit comparison with infinity in fast floating point mode [-Wtautological-constant-compare]
            || marginComparison(m_value, other, m_epsilon * (m_scale + std::fabs(std::isinf(m_value)? 0 : m_value)));
                                                                                 ^~~~~~~~~~~~~~~~~~~
1 warning generated.
```

For alpaka we manually set this to `-fp-model=precise`. This PR does the same for the Catch2 build.