### PR TITLE
Remove extra semicolon

### DIFF
--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -61,7 +61,9 @@ namespace alpaka
         using IDeviceQueue = uniform_cuda_hip::detail::QueueUniformCudaHipRtImpl<TApi>;
 
     protected:
-        DevUniformCudaHipRt() : m_QueueRegistry(std::make_shared<alpaka::detail::QueueRegistry<IDeviceQueue>>()){};
+        DevUniformCudaHipRt() : m_QueueRegistry{std::make_shared<alpaka::detail::QueueRegistry<IDeviceQueue>>()}
+        {
+        }
 
     public:
         ALPAKA_FN_HOST auto operator==(DevUniformCudaHipRt const& rhs) const -> bool


### PR DESCRIPTION
This PR fixes a warning uncovered by #2107:

```
 In file included from /home/runner/work/alpaka/alpaka/include/alpaka/rand/RandUniformCudaHipRand.hpp:11:
/home/runner/work/alpaka/alpaka/include/alpaka/dev/DevUniformCudaHipRt.hpp:64:115: error: extra ';' after member function definition [-Werror,-Wextra-semi]
        DevUniformCudaHipRt() : m_QueueRegistry(std::make_shared<alpaka::detail::QueueRegistry<IDeviceQueue>>()){};
                                                                                                                  ^
1 error generated when compiling for sm_52.
```