### PR TITLE
Let CMake print TSan warning

### DIFF
--- a/test/unit/core/CMakeLists.txt
+++ b/test/unit/core/CMakeLists.txt
@@ -1,11 +1,16 @@
-#
-# Copyright 2018-2020 Benjamin Worpitz, Axel Huebl, Jan Stephan
+# Copyright 2023 Benjamin Worpitz, Jan Stephan, Antonio Di Pilato
 # SPDX-License-Identifier: MPL-2.0
 #
 
 set(_TARGET_NAME "coreTest")
 
 append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
+
+# TODO(bgruber): Revisit this in the future on a new CI image. This problem does not happen locally.
+if(CMAKE_CXX_FLAGS MATCHES ".*-fsanitize=thread.*")
+    message(WARNING "Part of the threadpool test fails the TSan CI and is therefore disabled. See also: https://github.com/alpaka-group/alpaka/issues/2101")
+    set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/src/ThreadPool.cpp" PROPERTIES COMPILE_DEFINITIONS "ALPAKA_USES_TSAN")
+endif()
 
 alpaka_add_executable(
     ${_TARGET_NAME}

--- a/test/unit/core/src/ThreadPool.cpp
+++ b/test/unit/core/src/ThreadPool.cpp
@@ -6,12 +6,6 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#if defined(__has_feature)
-#    if __has_feature(thread_sanitizer)
-#        define TSAN
-#    endif
-#endif
-
 TEST_CASE("threadpool", "[core]")
 {
     alpaka::core::detail::ThreadPool tp{2};
@@ -22,10 +16,7 @@ TEST_CASE("threadpool", "[core]")
 
     CHECK_THROWS_AS(f1.get(), std::runtime_error);
 
-#ifdef TSAN
-#    warning "Part of the threadpool test fails the TSAN CI and is therefore disabled."
-    // TODO(bgruber): Revisit this in the future on a new CI image. This problem does not happen locally.
-#else
+#ifndef ALPAKA_USES_TSAN
     try
     {
         f2.get();

--- a/test/unit/mem/fence/CMakeLists.txt
+++ b/test/unit/mem/fence/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 if (CMAKE_CXX_FLAGS MATCHES ".*-fsanitize=thread.*")
-    message(WARNING "TSAN does not support memory fences yet. The fenceTest has been disabled. See also: https://github.com/google/sanitizers/issues/1352")
+    message(WARNING "TSan does not support memory fences yet. The fenceTest has been disabled. See also: https://github.com/google/sanitizers/issues/1352")
     return()
 endif()
 


### PR DESCRIPTION
#2107 uncovered the following warning:

```
/home/runner/work/alpaka/alpaka/test/unit/core/src/ThreadPool.cpp:26:6: error: #warning is a C++2b extension [-Werror,-Wpedantic]
#    warning "Part of the threadpool test fails the TSAN CI and is therefore disabled."
     ^
/home/runner/work/alpaka/alpaka/test/unit/core/src/ThreadPool.cpp:26:6: error: "Part of the threadpool test fails the TSAN CI and is therefore disabled." [-Werror,-W#warnings]
2 errors generated.
```

This PR moves the corresponding warning into CMake, thus disabling the warning from the C++ compiler.