### PR TITLE
Check for C++20 features

### DIFF
--- a/include/alpaka/intrinsic/IntrinsicCpu.hpp
+++ b/include/alpaka/intrinsic/IntrinsicCpu.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Sergei Bastrakov, Bernhard Manfred Gruber
+/* Copyright 2023 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -10,7 +10,10 @@
 
 #include <bitset>
 #include <climits>
-#if __has_include(<bit>)
+#if __has_include(<version>) // Not part of the C++17 standard but all major standard libraries include this
+#    include <version>
+#endif
+#ifdef __cpp_lib_bitops
 #    include <bit>
 #endif
 

--- a/include/alpaka/math/Traits.hpp
+++ b/include/alpaka/math/Traits.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2023 Benjamin Worpitz, Matthias Werner, Jan Stephan, Bernhard Manfred Gruber, Sergei Bastrakov,
- * Andrea Bocci
+ *                Andrea Bocci, René Widera
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -10,7 +10,10 @@
 
 #include <cmath>
 #include <complex>
-#if __has_include(<numbers>)
+#if __has_include(<version>) // Not part of the C++17 standard but all major standard libraries include this
+#    include <version>
+#endif
+#ifdef __cpp_lib_math_constants
 #    include <numbers>
 #endif
 


### PR DESCRIPTION
In some places we include C++20 headers if available. On MSVC these headers are available even for C++ versions before C++20 but they will issue the following warning:

```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.36.32532\include\bit(12): warning STL4038: The contents of <bit> are available only with C++20 or later. [D:\a\alpaka\alpaka\build\test\unit\workDiv\workDivTest.vcxproj]
```

This PR ensures that the headers are definitely only included when the C++20 standard is active.

Uncovered by #2107.