### PR TITLE
Add missing `ALPAKA_UNREACHABLE`

### DIFF
--- a/include/alpaka/core/CudaHipCommon.hpp
+++ b/include/alpaka/core/CudaHipCommon.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2023 Axel Hübl, Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci, Bernhard Manfred Gruber,
+                  Jan Stephan
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -134,6 +135,8 @@ namespace alpaka
                     return {value.w, value.z, value.y, value.x};
                 else
                     static_assert(sizeof(value) == 0, "Not implemented");
+
+                ALPAKA_UNREACHABLE({});
             }
         };
 


### PR DESCRIPTION
This PR fixes a warning I stumbled upon while working on #2135:

```
/builds/hzdr/crp/alpaka/include/alpaka/core/CudaHipCommon.hpp(137): warning #940-D: missing return statement at end of non-void function "alpaka::trait::GetExtents<TCudaHipBuiltin, std::enable_if_t<alpaka::detail::isCudaHipBuiltInType, void>>::operator() [with TCudaHipBuiltin=dim3]"
```