### PR TITLE
Simplify oneTBB installation

### DIFF
--- a/script/install_oneapi.sh
+++ b/script/install_oneapi.sh
@@ -17,7 +17,7 @@ then
     # intel-basekit intel-hpckit are too large in size
 
     travis_retry sudo apt-get -qqq update
-    travis_retry sudo apt-get install -y wget build-essential pkg-config cmake ca-certificates gnupg
+    travis_retry sudo apt-get install -y wget ca-certificates gnupg
     travis_retry sudo wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
 
     sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB

--- a/script/install_tbb.sh
+++ b/script/install_tbb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber, Simeon Ehrig
+# Copyright 2023 Benjamin Worpitz, Bernhard Manfred Gruber, Simeon Ehrig, Jan Stephan
 # SPDX-License-Identifier: MPL-2.0
 #
 
@@ -17,7 +17,7 @@ then
     if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
     then
         travis_retry sudo apt-get -qqq update
-        travis_retry sudo apt-get install -y wget build-essential pkg-config cmake ca-certificates gnupg
+        travis_retry sudo apt-get install -y wget ca-certificates gnupg
 
         travis_retry sudo wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB


### PR DESCRIPTION
While working on #2107 I noticed that the install scripts for oneAPI and oneTBB pull in some unnecessary packages: `build-essential`, `cmake`, and `pkg-config`. The first one is a bug since this causes a reset of the `CXX` variable. The gcc-13 job for example will actually use gcc-11 instead. `cmake` is unnecessary because we install it manually anyway. And since we are using an `apt` repository the package manager should figure out all other dependencies - there is no need to install these basic tools along oneTBB.