### PR TITLE
Remove FP contraction for math test

### DIFF
--- a/test/unit/math/CMakeLists.txt
+++ b/test/unit/math/CMakeLists.txt
@@ -23,12 +23,6 @@ target_include_directories(
 target_link_libraries(
     ${_TARGET_NAME}
     PRIVATE common)
-target_compile_options(
-    ${_TARGET_NAME}
-    PRIVATE
-    # ffp-contract: https://llvm.org/docs/CompileCudaWithLLVM.html#flags-that-control-numerical-code
-    "$<$<COMPILE_LANG_AND_ID:CUDA,AppleClang,Clang,IntelLLVM>:SHELL:-ffp-contract=off>"
-    )
 
 set_target_properties(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 target_compile_definitions(${_TARGET_NAME} PRIVATE "-DTEST_UNIT_MATH")


### PR DESCRIPTION
This PR removes the flag `-ffp-contract=off` from the math tests for certain compilers. It's not needed anymore (although I made no attempt to find out why).