### PR TITLE
Refactor test classes

### DIFF
--- a/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/include/alpaka/test/KernelExecutionFixture.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2023 Benjamin Worpitz, Andrea Bocci, Bernhard Manfred Gruber, Jan Stephan
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -25,6 +25,13 @@ namespace alpaka::test
     template<typename TAcc>
     class KernelExecutionFixture
     {
+#if defined(BOOST_COMP_GNUC) && BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(11, 0, 0)                                     \
+    && BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(12, 0, 0)
+// g++-11 (wrongly) believes that m_platformHost is used in an uninitialized state.
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
     public:
         using Acc = TAcc;
         using Dim = alpaka::Dim<Acc>;
@@ -34,25 +41,18 @@ namespace alpaka::test
         using Queue = test::DefaultQueue<Device>;
         using WorkDiv = WorkDivMembers<Dim, Idx>;
 
-        KernelExecutionFixture(WorkDiv workDiv)
-            : m_devHost{getDevByIdx(m_platformHost, 0)}
-            , m_device{getDevByIdx(m_platform, 0)}
-            , m_queue{m_device}
-            , m_workDiv{std::move(workDiv)}
+        KernelExecutionFixture(WorkDiv workDiv) : m_workDiv{std::move(workDiv)}
         {
         }
 
         template<typename TExtent>
         KernelExecutionFixture(TExtent const& extent)
-            : m_devHost{getDevByIdx(m_platformHost, 0)}
-            , m_device{getDevByIdx(m_platform, 0)}
-            , m_queue{m_device}
-            , m_workDiv{getValidWorkDiv<Acc>(
-                  m_device,
-                  extent,
-                  Vec<Dim, Idx>::ones(),
-                  false,
-                  GridBlockExtentSubDivRestrictions::Unrestricted)}
+            : m_workDiv{getValidWorkDiv<Acc>(
+                m_device,
+                extent,
+                Vec<Dim, Idx>::ones(),
+                false,
+                GridBlockExtentSubDivRestrictions::Unrestricted)}
         {
         }
 
@@ -76,11 +76,15 @@ namespace alpaka::test
         }
 
     private:
-        PlatformCpu m_platformHost;
-        DevCpu m_devHost;
-        Platform m_platform;
-        Device m_device;
-        Queue m_queue;
+        PlatformCpu m_platformHost{};
+        DevCpu m_devHost{getDevByIdx(m_platformHost, 0)};
+        Platform m_platform{};
+        Device m_device{getDevByIdx(m_platform, 0)};
+        Queue m_queue{m_device};
         WorkDiv m_workDiv;
+#if defined(BOOST_COMP_GNUC) && BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(11, 0, 0)                                     \
+    && BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(12, 0, 0)
+#    pragma GCC diagnostic pop
+#endif
     };
 } // namespace alpaka::test

--- a/include/alpaka/test/queue/QueueTestFixture.hpp
+++ b/include/alpaka/test/queue/QueueTestFixture.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Benjamin Worpitz
+/* Copyright 2023 Benjamin Worpitz, Jan Stephan
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -12,16 +12,24 @@ namespace alpaka::test
     template<typename TDevQueue>
     struct QueueTestFixture
     {
+#if defined(BOOST_COMP_GNUC) && BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(11, 0, 0)                                     \
+    && BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(12, 0, 0)
+// g++-11 (wrongly) believes that m_platform is used in an uninitialized state.
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
         using Dev = std::tuple_element_t<0, TDevQueue>;
         using Queue = std::tuple_element_t<1, TDevQueue>;
         using Platform = alpaka::Platform<Dev>;
 
-        QueueTestFixture() : m_dev(getDevByIdx(m_platform, 0)), m_queue(m_dev)
-        {
-        }
+        QueueTestFixture() = default;
 
-        Platform m_platform;
-        Dev m_dev;
-        Queue m_queue;
+        Platform m_platform{};
+        Dev m_dev{getDevByIdx(m_platform, 0)};
+        Queue m_queue{m_dev};
+#if defined(BOOST_COMP_GNUC) && BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(11, 0, 0)                                     \
+    && BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(12, 0, 0)
+#    pragma GCC diagnostic pop
+#endif
     };
 } // namespace alpaka::test


### PR DESCRIPTION
This PR refactors some of our test classes. It also silences the following wrong `g++-11` warning uncovered by #2107:

```
/builds/hzdr/crp/alpaka/include/alpaka/test/KernelExecutionFixture.hpp:47:15: error: 'fixture' may be used uninitialized [-Werror=maybe-uninitialized]
   47 |             : m_devHost{getDevByIdx(m_platformHost, 0)}
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /builds/hzdr/crp/alpaka/include/alpaka/acc/Traits.hpp:15,
                 from /builds/hzdr/crp/alpaka/include/alpaka/acc/AccCpuOmp2Blocks.hpp:27,
                 from /builds/hzdr/crp/alpaka/include/alpaka/alpaka.hpp:13,
                 from /builds/hzdr/crp/alpaka/include/alpaka/test/KernelExecutionFixture.hpp:7,
                 from /builds/hzdr/crp/alpaka/test/unit/intrinsic/src/Popcount.cpp:6:
/builds/hzdr/crp/alpaka/include/alpaka/platform/Traits.hpp: In function 'void CATCH2_INTERNAL_TEMPLATE_TEST_0() [with TestType = alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 1>, long unsigned int>]':
/builds/hzdr/crp/alpaka/include/alpaka/platform/Traits.hpp:62:25: note: by argument 1 of type 'const alpaka::PlatformCpu&' to 'alpaka::Dev<TPlatform> alpaka::getDevByIdx(const TPlatform&, const size_t&) [with TPlatform = alpaka::PlatformCpu]' declared here
   62 |     ALPAKA_FN_HOST auto getDevByIdx(TPlatform const& platform, std::size_t const& devIdx) -> Dev<TPlatform>
      |                         ^~~~~~~~~~~
/builds/hzdr/crp/alpaka/test/unit/intrinsic/src/Popcount.cpp:60:47: note: 'fixture' declared here
   60 |     alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::ones());
      |                                               ^~~~~~~
```