### PR TITLE
Address `nvcc` + `clang++` issues

### DIFF
--- a/include/alpaka/extent/Traits.hpp
+++ b/include/alpaka/extent/Traits.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/core/Common.hpp"
+#include "alpaka/core/Unreachable.hpp"
 #include "alpaka/dim/DimIntegralConst.hpp"
 #include "alpaka/idx/Traits.hpp"
 #include "alpaka/meta/Fold.hpp"
@@ -97,6 +98,8 @@ namespace alpaka
             return getExtents(extent)[Dim<TExtent>::value - 1u];
         else
             return 1;
+
+        ALPAKA_UNREACHABLE({});
     }
 
     //! \return The height.
@@ -108,6 +111,8 @@ namespace alpaka
             return getExtents(extent)[Dim<TExtent>::value - 2u];
         else
             return 1;
+
+        ALPAKA_UNREACHABLE({});
     }
 
     //! \return The depth.
@@ -119,6 +124,8 @@ namespace alpaka
             return getExtents(extent)[Dim<TExtent>::value - 3u];
         else
             return 1;
+
+        ALPAKA_UNREACHABLE({});
     }
 
     //! \return The product of the extents of the given object.

--- a/test/common/devCompileOptions.cmake
+++ b/test/common/devCompileOptions.cmake
@@ -145,6 +145,11 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "Inte
     # Triggers for all instances of alpaka_DEBUG_MINIMAL_LOG_SCOPE and similar macros followed by semicolon
     list(APPEND alpaka_DEV_COMPILE_OPTIONS "-Wno-extra-semi-stmt")
 
+    # Silence warnings caused by nvcc-generated code and -Weverything
+    list(APPEND alpaka_DEV_COMPILE_OPTIONS "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:SHELL:-Xcompiler -Wno-reserved-id-macro>")
+    list(APPEND alpaka_DEV_COMPILE_OPTIONS "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:SHELL:-Xcompiler -Wno-missing-variable-declarations>")
+    list(APPEND alpaka_DEV_COMPILE_OPTIONS "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:SHELL:-Xcompiler -Wno-old-style-cast>")
+
     if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)
         list(APPEND alpaka_DEV_COMPILE_OPTIONS "-Wno-poison-system-directories")
     endif()


### PR DESCRIPTION
This PR fixes another set of warnings / errors uncovered by #2107:

* Silences warnings caused by nvcc-generated code which `clang++ -Weverything` doesn't like.
* Adds `ALPAKA_UNREACHABLE` to `extents/Traits.hpp`.