### PR TITLE
refactor template order `allocMappedBufIfSupported`

### DIFF
--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -164,14 +164,14 @@ namespace alpaka
     //! this function is provided for convenience in the cases where the difference is not relevant,
     //! and the pinned/mapped memory is only used as a performance optimisation.
     //!
-    //! \tparam TPlatform The platform from which the buffer is accessible.
     //! \tparam TElem The element type of the returned buffer.
     //! \tparam TIdx The linear index type of the buffer.
     //! \tparam TExtent The extent type of the buffer.
+    //! \tparam TPlatform The platform from which the buffer is accessible.
     //! \param host The host device to allocate the buffer on.
     //! \param extent The extent of the buffer.
     //! \return The newly allocated buffer.
-    template<typename TPlatform, typename TElem, typename TIdx, typename TExtent>
+    template<typename TElem, typename TIdx, typename TExtent, typename TPlatform>
     ALPAKA_FN_HOST auto allocMappedBufIfSupported(
         DevCpu const& host,
         TPlatform const& platform,

--- a/test/integ/axpy/src/axpy.cpp
+++ b/test/integ/axpy/src/axpy.cpp
@@ -109,9 +109,9 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
               << std::endl;
 
     // Allocate host memory buffers in pinned memory.
-    auto memBufHostX = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extent);
-    auto memBufHostOrigY = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extent);
-    auto memBufHostY = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extent);
+    auto memBufHostX = alpaka::allocMappedBufIfSupported<Val, Idx>(devHost, platformAcc, extent);
+    auto memBufHostOrigY = alpaka::allocMappedBufIfSupported<Val, Idx>(devHost, platformAcc, extent);
+    auto memBufHostY = alpaka::allocMappedBufIfSupported<Val, Idx>(devHost, platformAcc, extent);
     Val* const pBufHostX = alpaka::getPtrNative(memBufHostX);
     Val* const pBufHostOrigY = alpaka::getPtrNative(memBufHostOrigY);
     Val* const pBufHostY = alpaka::getPtrNative(memBufHostY);

--- a/test/integ/hostOnlyAPI/src/hostOnlyAPI.cpp
+++ b/test/integ/hostOnlyAPI/src/hostOnlyAPI.cpp
@@ -47,8 +47,7 @@ TEMPLATE_LIST_TEST_CASE("hostOnlyAPI", "[hostOnlyAPI]", TestAccs)
     HostQueue hostQueue(host);
 
     // host buffer
-    auto h_buffer1
-        = alpaka::allocMappedBufIfSupported<alpaka::Platform<Device>, int, Idx>(host, platformAcc, Vec1D{Idx{42}});
+    auto h_buffer1 = alpaka::allocMappedBufIfSupported<int, Idx>(host, platformAcc, Vec1D{Idx{42}});
     INFO(
         "host buffer allocated at " << alpaka::getPtrNative(h_buffer1) << " with "
                                     << alpaka::getExtentProduct(h_buffer1) << " element(s)");

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -309,7 +309,7 @@ TEMPLATE_LIST_TEST_CASE("mandelbrot", "[mandelbrot]", TestAccs)
               << std::endl;
 
     // allocate host memory, potentially pinned for faster copy to/from the accelerator.
-    auto bufColorHost = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extent);
+    auto bufColorHost = alpaka::allocMappedBufIfSupported<Val, Idx>(devHost, platformAcc, extent);
 
     // Allocate the buffer on the accelerator.
     auto bufColorAcc = alpaka::allocBuf<Val, Idx>(devAcc, extent);

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -217,7 +217,7 @@ TEMPLATE_LIST_TEST_CASE("matMul", "[matMul]", TestAccs)
     auto bufBHost = alpaka::createView(devHost, bufBHost1d.data(), extentB);
 
     // Allocate C and set it to zero.
-    auto bufCHost = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extentC);
+    auto bufCHost = alpaka::allocMappedBufIfSupported<Val, Idx>(devHost, platformAcc, extentC);
     alpaka::memset(queueHost, bufCHost, 0u);
 
     // Allocate the buffers on the accelerator.

--- a/test/integ/separableCompilation/src/main.cpp
+++ b/test/integ/separableCompilation/src/main.cpp
@@ -103,9 +103,9 @@ TEMPLATE_LIST_TEST_CASE("separableCompilation", "[separableCompilation]", TestAc
               << ", numElements:" << numElements << ")" << std::endl;
 
     // Allocate host memory buffers, potentially pinned for faster copy to/from the accelerator.
-    auto memBufHostA = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extent);
-    auto memBufHostB = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extent);
-    auto memBufHostC = alpaka::allocMappedBufIfSupported<PlatformAcc, Val, Idx>(devHost, platformAcc, extent);
+    auto memBufHostA = alpaka::allocMappedBufIfSupported<Val, Idx>(devHost, platformAcc, extent);
+    auto memBufHostB = alpaka::allocMappedBufIfSupported<Val, Idx>(devHost, platformAcc, extent);
+    auto memBufHostC = alpaka::allocMappedBufIfSupported<Val, Idx>(devHost, platformAcc, extent);
 
     // Initialize the host input vectors
     for(Idx i = 0; i < numElements; ++i)

--- a/test/unit/math/src/Buffer.hpp
+++ b/test/unit/math/src/Buffer.hpp
@@ -62,10 +62,7 @@ namespace alpaka
                     // Constructor needs to initialize all Buffer.
                     Buffer(DevAcc const& devAcc)
                         : devHost{alpaka::getDevByIdx(platformHost, 0)}
-                        , hostBuffer{alpaka::allocMappedBufIfSupported<PlatformAcc, TData, Idx>(
-                              devHost,
-                              platformAcc,
-                              Tcapacity)}
+                        , hostBuffer{alpaka::allocMappedBufIfSupported<TData, Idx>(devHost, platformAcc, Tcapacity)}
                         , devBuffer{alpaka::allocBuf<TData, Idx>(devAcc, Tcapacity)}
                         , pHostBuffer{alpaka::getPtrNative(hostBuffer)}
                         , pDevBuffer{alpaka::getPtrNative(devBuffer)}

--- a/test/unit/mem/fence/src/FenceTest.cpp
+++ b/test/unit/mem/fence/src/FenceTest.cpp
@@ -188,7 +188,7 @@ TEMPLATE_LIST_TEST_CASE("FenceTest", "[fence]", TestAccs)
 
     auto const numElements = Idx{2ul};
     auto const extent = alpaka::Vec<Dim, Idx>{numElements};
-    auto vars_host = alpaka::allocMappedBufIfSupported<Platform, int, Idx>(host, platformAcc, extent);
+    auto vars_host = alpaka::allocMappedBufIfSupported<int, Idx>(host, platformAcc, extent);
     auto vars_dev = alpaka::allocBuf<int, Idx>(dev, extent);
     vars_host[0] = 1;
     vars_host[1] = 2;


### PR DESCRIPTION
Move template `TPlatform` as the last template. There is no need to provide the platform template signature if we pass the platform as an instance.


@j-stephan This PR should be cherry-picked into the current open-release branch!