### PR TITLE
Workaround gcc warning on uninitialized PlatformCpu

### DIFF
--- a/include/alpaka/platform/PlatformCpu.hpp
+++ b/include/alpaka/platform/PlatformCpu.hpp
@@ -16,6 +16,12 @@ namespace alpaka
     //! The CPU device platform.
     struct PlatformCpu : concepts::Implements<ConceptPlatform, PlatformCpu>
     {
+#if defined(BOOST_COMP_GNUC) && BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(11, 0, 0)                                     \
+    && BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(12, 0, 0)
+        // This is a workaround for g++-11 bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96295
+        // g++-11 complains in *all* places where a PlatformCpu is used, that it "may be used uninitialized"
+        char c = {};
+#endif
     };
 
     namespace trait

--- a/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/include/alpaka/test/KernelExecutionFixture.hpp
@@ -25,13 +25,6 @@ namespace alpaka::test
     template<typename TAcc>
     class KernelExecutionFixture
     {
-#if defined(BOOST_COMP_GNUC) && BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(11, 0, 0)                                     \
-    && BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(12, 0, 0)
-// g++-11 (wrongly) believes that m_platformHost is used in an uninitialized state.
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-
     public:
         using Acc = TAcc;
         using Dim = alpaka::Dim<Acc>;
@@ -82,9 +75,5 @@ namespace alpaka::test
         Device m_device{getDevByIdx(m_platform, 0)};
         Queue m_queue{m_device};
         WorkDiv m_workDiv;
-#if defined(BOOST_COMP_GNUC) && BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(11, 0, 0)                                     \
-    && BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(12, 0, 0)
-#    pragma GCC diagnostic pop
-#endif
     };
 } // namespace alpaka::test

--- a/include/alpaka/test/queue/QueueTestFixture.hpp
+++ b/include/alpaka/test/queue/QueueTestFixture.hpp
@@ -12,12 +12,6 @@ namespace alpaka::test
     template<typename TDevQueue>
     struct QueueTestFixture
     {
-#if defined(BOOST_COMP_GNUC) && BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(11, 0, 0)                                     \
-    && BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(12, 0, 0)
-// g++-11 (wrongly) believes that m_platform is used in an uninitialized state.
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
         using Dev = std::tuple_element_t<0, TDevQueue>;
         using Queue = std::tuple_element_t<1, TDevQueue>;
         using Platform = alpaka::Platform<Dev>;
@@ -25,9 +19,5 @@ namespace alpaka::test
         Platform m_platform{};
         Dev m_dev{getDevByIdx(m_platform, 0)};
         Queue m_queue{m_dev};
-#if defined(BOOST_COMP_GNUC) && BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(11, 0, 0)                                     \
-    && BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(12, 0, 0)
-#    pragma GCC diagnostic pop
-#endif
     };
 } // namespace alpaka::test

--- a/test/unit/mem/copy/src/BufSlicing.cpp
+++ b/test/unit/mem/copy/src/BufSlicing.cpp
@@ -20,12 +20,6 @@
 template<typename TDim, typename TIdx, typename TAcc, typename TData, typename Vec = alpaka::Vec<TDim, TIdx>>
 struct TestContainer
 {
-#if defined(BOOST_COMP_GNUC) && BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(11, 0, 0)                                     \
-    && BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(12, 0, 0)
-// g++-11 (wrongly) believes that platformHost is used in an uninitialized state.
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
     using AccQueueProperty = alpaka::Blocking;
     using DevQueue = alpaka::Queue<TAcc, AccQueueProperty>;
     using DevAcc = alpaka::Dev<TAcc>;
@@ -106,10 +100,6 @@ struct TestContainer
             REQUIRE(ptrA[i] == Catch::Approx(ptrB[i]));
         }
     }
-#if defined(BOOST_COMP_GNUC) && BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(11, 0, 0)                                     \
-    && BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(12, 0, 0)
-#    pragma GCC diagnostic pop
-#endif
 };
 
 using DataTypes = std::tuple<int, float, double>;


### PR DESCRIPTION
This is a workaround for g++-11 bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96295
g++-11 complains in *all* places where a PlatformCpu is used, that it "may be used uninitialized"