### PR TITLE
Strip namespaces from mathTest

### DIFF
--- a/test/unit/math/src/Buffer.hpp
+++ b/test/unit/math/src/Buffer.hpp
@@ -10,101 +10,91 @@
 
 #include <ostream>
 
-namespace alpaka
+namespace mathtest
 {
-    namespace test
+    //! Provides alpaka-style buffer with arguments' data.
+    //! TData can be a plain value or a complex data-structure.
+    //! The operator() is overloaded and returns the value from the correct Buffer,
+    //! either from the host (index) or device buffer (index, acc).
+    //! Index out of range errors are not checked.
+    //! @brief Encapsulates buffer initialisation and communication with Device.
+    //! @tparam TAcc Used accelerator, not interchangeable
+    //! @tparam TData The Data-type, only restricted by the alpaka-interface.
+    //! @tparam Tcapacity The size of the buffer.
+    template<typename TAcc, typename TData, size_t Tcapacity>
+    struct Buffer
     {
-        namespace unit
+        using value_type = TData;
+        static constexpr size_t capacity = Tcapacity;
+        using Dim = typename alpaka::trait::DimType<TAcc>::type;
+        using Idx = typename alpaka::trait::IdxType<TAcc>::type;
+
+        // Defines using's for alpaka-buffer.
+        using DevHost = alpaka::DevCpu;
+        using PlatformHost = alpaka::Platform<DevHost>;
+        using BufHost = alpaka::Buf<DevHost, TData, Dim, Idx>;
+
+        using DevAcc = alpaka::Dev<TAcc>;
+        using PlatformAcc = alpaka::Platform<DevAcc>;
+        using BufAcc = alpaka::Buf<DevAcc, TData, Dim, Idx>;
+
+        PlatformHost platformHost;
+        DevHost devHost;
+
+        BufHost hostBuffer;
+        BufAcc devBuffer;
+        PlatformAcc platformAcc;
+
+        // Native pointer to access buffer.
+        TData* const pHostBuffer;
+        TData* const pDevBuffer;
+
+        // This constructor cant be used,
+        // because BufHost and BufAcc need to be initialised.
+        Buffer() = delete;
+
+        // Constructor needs to initialize all Buffer.
+        Buffer(DevAcc const& devAcc)
+            : devHost{alpaka::getDevByIdx(platformHost, 0)}
+            , hostBuffer{alpaka::allocMappedBufIfSupported<TData, Idx>(devHost, platformAcc, Tcapacity)}
+            , devBuffer{alpaka::allocBuf<TData, Idx>(devAcc, Tcapacity)}
+            , pHostBuffer{alpaka::getPtrNative(hostBuffer)}
+            , pDevBuffer{alpaka::getPtrNative(devBuffer)}
         {
-            namespace math
+        }
+
+        // Copy Host -> Acc.
+        template<typename Queue>
+        auto copyToDevice(Queue queue) -> void
+        {
+            alpaka::memcpy(queue, devBuffer, hostBuffer);
+        }
+
+        // Copy Acc -> Host.
+        template<typename Queue>
+        auto copyFromDevice(Queue queue) -> void
+        {
+            alpaka::memcpy(queue, hostBuffer, devBuffer);
+        }
+
+        ALPAKA_FN_ACC auto operator()(size_t idx, TAcc const& /* acc */) const -> TData&
+        {
+            return pDevBuffer[idx];
+        }
+
+        ALPAKA_FN_HOST auto operator()(size_t idx) const -> TData&
+        {
+            return pHostBuffer[idx];
+        }
+
+        ALPAKA_FN_HOST friend auto operator<<(std::ostream& os, Buffer const& buffer) -> std::ostream&
+        {
+            os << "capacity: " << capacity << "\n";
+            for(size_t i = 0; i < capacity; ++i)
             {
-                //! Provides alpaka-style buffer with arguments' data.
-                //! TData can be a plain value or a complex data-structure.
-                //! The operator() is overloaded and returns the value from the correct Buffer,
-                //! either from the host (index) or device buffer (index, acc).
-                //! Index out of range errors are not checked.
-                //! @brief Encapsulates buffer initialisation and communication with Device.
-                //! @tparam TAcc Used accelerator, not interchangeable
-                //! @tparam TData The Data-type, only restricted by the alpaka-interface.
-                //! @tparam Tcapacity The size of the buffer.
-                template<typename TAcc, typename TData, size_t Tcapacity>
-                struct Buffer
-                {
-                    using value_type = TData;
-                    static constexpr size_t capacity = Tcapacity;
-                    using Dim = typename alpaka::trait::DimType<TAcc>::type;
-                    using Idx = typename alpaka::trait::IdxType<TAcc>::type;
-
-                    // Defines using's for alpaka-buffer.
-                    using DevHost = alpaka::DevCpu;
-                    using PlatformHost = alpaka::Platform<DevHost>;
-                    using BufHost = alpaka::Buf<DevHost, TData, Dim, Idx>;
-
-                    using DevAcc = alpaka::Dev<TAcc>;
-                    using PlatformAcc = alpaka::Platform<DevAcc>;
-                    using BufAcc = alpaka::Buf<DevAcc, TData, Dim, Idx>;
-
-                    PlatformHost platformHost;
-                    DevHost devHost;
-
-                    BufHost hostBuffer;
-                    BufAcc devBuffer;
-                    PlatformAcc platformAcc;
-
-                    // Native pointer to access buffer.
-                    TData* const pHostBuffer;
-                    TData* const pDevBuffer;
-
-                    // This constructor cant be used,
-                    // because BufHost and BufAcc need to be initialised.
-                    Buffer() = delete;
-
-                    // Constructor needs to initialize all Buffer.
-                    Buffer(DevAcc const& devAcc)
-                        : devHost{alpaka::getDevByIdx(platformHost, 0)}
-                        , hostBuffer{alpaka::allocMappedBufIfSupported<TData, Idx>(devHost, platformAcc, Tcapacity)}
-                        , devBuffer{alpaka::allocBuf<TData, Idx>(devAcc, Tcapacity)}
-                        , pHostBuffer{alpaka::getPtrNative(hostBuffer)}
-                        , pDevBuffer{alpaka::getPtrNative(devBuffer)}
-                    {
-                    }
-
-                    // Copy Host -> Acc.
-                    template<typename Queue>
-                    auto copyToDevice(Queue queue) -> void
-                    {
-                        alpaka::memcpy(queue, devBuffer, hostBuffer);
-                    }
-
-                    // Copy Acc -> Host.
-                    template<typename Queue>
-                    auto copyFromDevice(Queue queue) -> void
-                    {
-                        alpaka::memcpy(queue, hostBuffer, devBuffer);
-                    }
-
-                    ALPAKA_FN_ACC auto operator()(size_t idx, TAcc const& /* acc */) const -> TData&
-                    {
-                        return pDevBuffer[idx];
-                    }
-
-                    ALPAKA_FN_HOST auto operator()(size_t idx) const -> TData&
-                    {
-                        return pHostBuffer[idx];
-                    }
-
-                    ALPAKA_FN_HOST friend auto operator<<(std::ostream& os, Buffer const& buffer) -> std::ostream&
-                    {
-                        os << "capacity: " << capacity << "\n";
-                        for(size_t i = 0; i < capacity; ++i)
-                        {
-                            os << i << ": " << buffer.pHostBuffer[i] << "\n";
-                        }
-                        return os;
-                    }
-                };
-
-            } // namespace math
-        } // namespace unit
-    } // namespace test
-} // namespace alpaka
+                os << i << ": " << buffer.pHostBuffer[i] << "\n";
+            }
+            return os;
+        }
+    };
+} // namespace mathtest

--- a/test/unit/math/src/DataGen.hpp
+++ b/test/unit/math/src/DataGen.hpp
@@ -11,203 +11,191 @@
 #include <limits>
 #include <random>
 
-namespace alpaka
+namespace mathtest
 {
-    namespace test
+    //! Helper to generate random numbers of the given type for testing
+    //!
+    //! The general implementation supports float and double types
+    //!
+    //! @tparam TData generated type
+    template<typename TData>
+    struct RngWrapper
     {
-        namespace unit
+        auto getMax()
         {
-            namespace math
+            return std::numeric_limits<TData>::max();
+        }
+
+        auto getLowest()
+        {
+            return std::numeric_limits<TData>::lowest();
+        }
+
+        auto getDistribution()
+        {
+            return std::uniform_real_distribution<TData>{0, 1000};
+        }
+
+        template<typename TDistribution, typename TEngine>
+        auto getNumber(TDistribution& distribution, TEngine& engine)
+        {
+            return distribution(engine);
+        }
+    };
+
+    //! Specialization for generating alpaka::Complex<TData>
+    //!
+    //! It has a much reduced range of numbers.
+    //! The reason is, the results of operations much easier go to infinity area.
+    //! Also, alpaka may emulate complex number math via calling other functions.
+    //! As a result, it may produce some infinities and NaNs when the std:: implementation would not.
+    //! So this range at least makes sure the "simple" cases work and therefore the implementation is
+    //! logically correct.
+    template<typename TData>
+    struct RngWrapper<alpaka::Complex<TData>>
+    {
+        auto getMax()
+        {
+            return alpaka::Complex<TData>{TData{10}, TData{10}};
+        }
+
+        auto getLowest()
+        {
+            return -getMax();
+        }
+
+        auto getDistribution()
+        {
+            return std::uniform_real_distribution<TData>{0, 5};
+        }
+
+        template<typename TDistribution, typename TEngine>
+        auto getNumber(TDistribution& distribution, TEngine& engine)
+        {
+            return alpaka::Complex<TData>{distribution(engine), distribution(engine)};
+        }
+    };
+
+    /**
+     * Fills buffer with random numbers (host-only).
+     *
+     * @tparam TData The used data-type (float, double, Complex<float> or Complex<double>).
+     * @tparam TArgs The args-buffer to be filled.
+     * @tparam TFunctor The used Functor-type.
+     * @param args The buffer that should be filled.
+     * @param functor The Functor, needed for ranges.
+     * @param seed The used seed.
+     */
+    template<typename TData, typename TArgs, typename TFunctor>
+    auto fillWithRndArgs(TArgs& args, TFunctor functor, unsigned int const& seed) -> void
+    {
+        /*
+         * Each "sub-buffer" is filled with zero and/or max and/or lowest,
+         * depending on the specified range (at [0] - [2]).
+         *
+         * Every switch case needs to return!
+         * If no switch case was matched an assert(false) will be triggered.
+         *
+         * This function is easily extendable. It is only necessary to add extra
+         * definitions in the switch case, for more Range-types.
+         */
+        static_assert(TArgs::value_type::arity == TFunctor::arity, "Buffer properties must match TFunctor::arity");
+        static_assert(TArgs::capacity > 6, "Set of args must provide > 6 entries.");
+        auto rngWrapper = RngWrapper<TData>{};
+        auto const max = rngWrapper.getMax();
+        auto const low = rngWrapper.getLowest();
+        std::default_random_engine eng{static_cast<std::default_random_engine::result_type>(seed)};
+
+        // These pseudo-random numbers are implementation/platform specific!
+        auto dist = rngWrapper.getDistribution();
+        decltype(dist) distOne(-1, 1);
+        for(size_t k = 0; k < TFunctor::arity_nr; ++k)
+        {
+            [[maybe_unused]] bool matchedSwitch = false;
+            switch(functor.ranges[k])
             {
-                //! Helper to generate random numbers of the given type for testing
-                //!
-                //! The general implementation supports float and double types
-                //!
-                //! @tparam TData generated type
-                template<typename TData>
-                struct RngWrapper
+            case Range::OneNeighbourhood:
+                matchedSwitch = true;
+                for(size_t i = 0; i < TArgs::capacity; ++i)
                 {
-                    auto getMax()
-                    {
-                        return std::numeric_limits<TData>::max();
-                    }
-
-                    auto getLowest()
-                    {
-                        return std::numeric_limits<TData>::lowest();
-                    }
-
-                    auto getDistribution()
-                    {
-                        return std::uniform_real_distribution<TData>{0, 1000};
-                    }
-
-                    template<typename TDistribution, typename TEngine>
-                    auto getNumber(TDistribution& distribution, TEngine& engine)
-                    {
-                        return distribution(engine);
-                    }
-                };
-
-                //! Specialization for generating alpaka::Complex<TData>
-                //!
-                //! It has a much reduced range of numbers.
-                //! The reason is, the results of operations much easier go to infinity area.
-                //! Also, alpaka may emulate complex number math via calling other functions.
-                //! As a result, it may produce some infinities and NaNs when the std:: implementation would not.
-                //! So this range at least makes sure the "simple" cases work and therefore the implementation is
-                //! logically correct.
-                template<typename TData>
-                struct RngWrapper<Complex<TData>>
-                {
-                    auto getMax()
-                    {
-                        return Complex<TData>{TData{10}, TData{10}};
-                    }
-
-                    auto getLowest()
-                    {
-                        return -getMax();
-                    }
-
-                    auto getDistribution()
-                    {
-                        return std::uniform_real_distribution<TData>{0, 5};
-                    }
-
-                    template<typename TDistribution, typename TEngine>
-                    auto getNumber(TDistribution& distribution, TEngine& engine)
-                    {
-                        return Complex<TData>{distribution(engine), distribution(engine)};
-                    }
-                };
-
-                /**
-                 * Fills buffer with random numbers (host-only).
-                 *
-                 * @tparam TData The used data-type (float, double, Complex<float> or Complex<double>).
-                 * @tparam TArgs The args-buffer to be filled.
-                 * @tparam TFunctor The used Functor-type.
-                 * @param args The buffer that should be filled.
-                 * @param functor The Functor, needed for ranges.
-                 * @param seed The used seed.
-                 */
-                template<typename TData, typename TArgs, typename TFunctor>
-                auto fillWithRndArgs(TArgs& args, TFunctor functor, unsigned int const& seed) -> void
-                {
-                    /*
-                     * Each "sub-buffer" is filled with zero and/or max and/or lowest,
-                     * depending on the specified range (at [0] - [2]).
-                     *
-                     * Every switch case needs to return!
-                     * If no switch case was matched an assert(false) will be triggered.
-                     *
-                     * This function is easily extendable. It is only necessary to add extra
-                     * definitions in the switch case, for more Range-types.
-                     */
-                    static_assert(
-                        TArgs::value_type::arity == TFunctor::arity,
-                        "Buffer properties must match TFunctor::arity");
-                    static_assert(TArgs::capacity > 6, "Set of args must provide > 6 entries.");
-                    auto rngWrapper = RngWrapper<TData>{};
-                    auto const max = rngWrapper.getMax();
-                    auto const low = rngWrapper.getLowest();
-                    std::default_random_engine eng{static_cast<std::default_random_engine::result_type>(seed)};
-
-                    // These pseudo-random numbers are implementation/platform specific!
-                    auto dist = rngWrapper.getDistribution();
-                    decltype(dist) distOne(-1, 1);
-                    for(size_t k = 0; k < TFunctor::arity_nr; ++k)
-                    {
-                        [[maybe_unused]] bool matchedSwitch = false;
-                        switch(functor.ranges[k])
-                        {
-                        case Range::OneNeighbourhood:
-                            matchedSwitch = true;
-                            for(size_t i = 0; i < TArgs::capacity; ++i)
-                            {
-                                args(i).arg[k] = rngWrapper.getNumber(distOne, eng);
-                            }
-                            break;
-
-                        case Range::PositiveOnly:
-                            matchedSwitch = true;
-                            args(0).arg[k] = max;
-                            for(size_t i = 1; i < TArgs::capacity; ++i)
-                            {
-                                args(i).arg[k] = rngWrapper.getNumber(dist, eng) + TData{1};
-                            }
-                            break;
-
-                        case Range::PositiveAndZero:
-                            matchedSwitch = true;
-                            args(0).arg[k] = TData{0};
-                            args(1).arg[k] = max;
-                            for(size_t i = 2; i < TArgs::capacity; ++i)
-                            {
-                                args(i).arg[k] = rngWrapper.getNumber(dist, eng);
-                            }
-                            break;
-
-                        case Range::NotZero:
-                            matchedSwitch = true;
-                            args(0).arg[k] = max;
-                            args(1).arg[k] = low;
-                            for(size_t i = 2; i < TArgs::capacity; ++i)
-                            {
-                                TData arg;
-                                do
-                                {
-                                    arg = rngWrapper.getNumber(dist, eng);
-                                } while(std::equal_to<TData>()(arg, 1));
-                                if(i % 2 == 0)
-                                    args(i).arg[k] = arg;
-                                else
-                                    args(i).arg[k] = -arg;
-                            }
-                            break;
-
-                        case Range::Unrestricted:
-                            matchedSwitch = true;
-                            args(0).arg[k] = TData{0};
-                            args(1).arg[k] = max;
-                            args(2).arg[k] = low;
-                            for(size_t i = 3; i < TArgs::capacity; ++i)
-                            {
-                                if(i % 2 == 0)
-                                    args(i).arg[k] = rngWrapper.getNumber(dist, eng);
-                                else
-                                    args(i).arg[k] = -rngWrapper.getNumber(dist, eng);
-                            }
-                            break;
-
-                        case Range::Anything:
-                            matchedSwitch = true;
-                            args(0).arg[k] = TData{0};
-                            args(1).arg[k] = std::numeric_limits<TData>::quiet_NaN();
-                            args(2).arg[k] = std::numeric_limits<TData>::signaling_NaN();
-                            args(3).arg[k] = std::numeric_limits<TData>::infinity();
-                            args(4).arg[k] = -std::numeric_limits<TData>::infinity();
-                            constexpr size_t nFixed = 5;
-                            size_t i = nFixed;
-                            // no need to test for denormal for now: not supported by CUDA
-                            // for(; i < nFixed + (TArgs::capacity - nFixed) / 2; ++i)
-                            // {
-                            //     const TData v = rngWrapper.getNumber(dist, eng) *
-                            //     std::numeric_limits<TData>::denorm_min(); args(i).arg[k] = (i % 2 == 0) ? v : -v;
-                            // }
-                            for(; i < TArgs::capacity; ++i)
-                            {
-                                const TData v = rngWrapper.getNumber(dist, eng);
-                                args(i).arg[k] = (i % 2 == 0) ? v : -v;
-                            }
-                            break;
-                        }
-                        assert(matchedSwitch);
-                    }
+                    args(i).arg[k] = rngWrapper.getNumber(distOne, eng);
                 }
+                break;
 
-            } // namespace math
-        } // namespace unit
-    } // namespace test
-} // namespace alpaka
+            case Range::PositiveOnly:
+                matchedSwitch = true;
+                args(0).arg[k] = max;
+                for(size_t i = 1; i < TArgs::capacity; ++i)
+                {
+                    args(i).arg[k] = rngWrapper.getNumber(dist, eng) + TData{1};
+                }
+                break;
+
+            case Range::PositiveAndZero:
+                matchedSwitch = true;
+                args(0).arg[k] = TData{0};
+                args(1).arg[k] = max;
+                for(size_t i = 2; i < TArgs::capacity; ++i)
+                {
+                    args(i).arg[k] = rngWrapper.getNumber(dist, eng);
+                }
+                break;
+
+            case Range::NotZero:
+                matchedSwitch = true;
+                args(0).arg[k] = max;
+                args(1).arg[k] = low;
+                for(size_t i = 2; i < TArgs::capacity; ++i)
+                {
+                    TData arg;
+                    do
+                    {
+                        arg = rngWrapper.getNumber(dist, eng);
+                    } while(std::equal_to<TData>()(arg, 1));
+                    if(i % 2 == 0)
+                        args(i).arg[k] = arg;
+                    else
+                        args(i).arg[k] = -arg;
+                }
+                break;
+
+            case Range::Unrestricted:
+                matchedSwitch = true;
+                args(0).arg[k] = TData{0};
+                args(1).arg[k] = max;
+                args(2).arg[k] = low;
+                for(size_t i = 3; i < TArgs::capacity; ++i)
+                {
+                    if(i % 2 == 0)
+                        args(i).arg[k] = rngWrapper.getNumber(dist, eng);
+                    else
+                        args(i).arg[k] = -rngWrapper.getNumber(dist, eng);
+                }
+                break;
+
+            case Range::Anything:
+                matchedSwitch = true;
+                args(0).arg[k] = TData{0};
+                args(1).arg[k] = std::numeric_limits<TData>::quiet_NaN();
+                args(2).arg[k] = std::numeric_limits<TData>::signaling_NaN();
+                args(3).arg[k] = std::numeric_limits<TData>::infinity();
+                args(4).arg[k] = -std::numeric_limits<TData>::infinity();
+                constexpr size_t nFixed = 5;
+                size_t i = nFixed;
+                // no need to test for denormal for now: not supported by CUDA
+                // for(; i < nFixed + (TArgs::capacity - nFixed) / 2; ++i)
+                // {
+                //     const TData v = rngWrapper.getNumber(dist, eng) *
+                //     std::numeric_limits<TData>::denorm_min(); args(i).arg[k] = (i % 2 == 0) ? v : -v;
+                // }
+                for(; i < TArgs::capacity; ++i)
+                {
+                    TData const v = rngWrapper.getNumber(dist, eng);
+                    args(i).arg[k] = (i % 2 == 0) ? v : -v;
+                }
+                break;
+            }
+            assert(matchedSwitch);
+        }
+    }
+} // namespace mathtest

--- a/test/unit/math/src/Defines.hpp
+++ b/test/unit/math/src/Defines.hpp
@@ -11,110 +11,100 @@
 #include <iostream>
 #include <limits>
 
-namespace alpaka
+namespace mathtest
 {
-    namespace test
+    // New types need to be added to the switch-case in DataGen.hpp
+    enum class Range
     {
-        namespace unit
+        OneNeighbourhood,
+        PositiveOnly,
+        PositiveAndZero,
+        NotZero,
+        Unrestricted,
+        Anything
+    };
+
+    // New types need to be added to the operator() function in Functor.hpp
+    enum class Arity
+    {
+        Unary = 1,
+        Binary = 2,
+        Ternary = 3
+    };
+
+    template<typename T, Arity Tarity>
+    struct ArgsItem
+    {
+        static constexpr Arity arity = Tarity;
+        static constexpr size_t arity_nr = static_cast<size_t>(Tarity);
+
+        T arg[arity_nr]; // represents arg0, arg1, ...
+
+        friend auto operator<<(std::ostream& os, ArgsItem const& argsItem) -> std::ostream&
         {
-            namespace math
-            {
-                // New types need to be added to the switch-case in DataGen.hpp
-                enum class Range
-                {
-                    OneNeighbourhood,
-                    PositiveOnly,
-                    PositiveAndZero,
-                    NotZero,
-                    Unrestricted,
-                    Anything
-                };
+            os.precision(17);
+            for(size_t i = 0; i < argsItem.arity_nr; ++i)
+                os << (i == 0 ? "[ " : ", ") << std::setprecision(std::numeric_limits<T>::digits10 + 1)
+                   << argsItem.arg[i];
+            os << " ]";
+            return os;
+        }
+    };
 
-                // New types need to be added to the operator() function in Functor.hpp
-                enum class Arity
-                {
-                    Unary = 1,
-                    Binary = 2,
-                    Ternary = 3
-                };
+    //! Reference implementation of rsqrt, since there is no std::rsqrt
+    template<typename T>
+    auto rsqrt(T const& arg)
+    {
+        // Need ADL for complex numbers
+        using std::sqrt;
+        return static_cast<T>(1) / sqrt(arg);
+    }
 
-                template<typename T, Arity Tarity>
-                struct ArgsItem
-                {
-                    static constexpr Arity arity = Tarity;
-                    static constexpr size_t arity_nr = static_cast<size_t>(Tarity);
+    //! Stub for division expressed same way as alpaka math traits
+    template<typename TAcc, typename T>
+    ALPAKA_FN_HOST_ACC auto divides(TAcc&, T const& arg1, T const& arg2)
+    {
+        return arg1 / arg2;
+    }
 
-                    T arg[arity_nr]; // represents arg0, arg1, ...
+    //! Stub for subtraction expressed same way as alpaka math traits
+    template<typename TAcc, typename T>
+    ALPAKA_FN_HOST_ACC auto minus(TAcc&, T const& arg1, T const& arg2)
+    {
+        return arg1 - arg2;
+    }
 
-                    friend auto operator<<(std::ostream& os, ArgsItem const& argsItem) -> std::ostream&
-                    {
-                        os.precision(17);
-                        for(size_t i = 0; i < argsItem.arity_nr; ++i)
-                            os << (i == 0 ? "[ " : ", ") << std::setprecision(std::numeric_limits<T>::digits10 + 1)
-                               << argsItem.arg[i];
-                        os << " ]";
-                        return os;
-                    }
-                };
+    //! Stub for multiplication expressed same way as alpaka math traits
+    template<typename TAcc, typename T>
+    ALPAKA_FN_HOST_ACC auto multiplies(TAcc&, T const& arg1, T const& arg2)
+    {
+        return arg1 * arg2;
+    }
 
-                //! Reference implementation of rsqrt, since there is no std::rsqrt
-                template<typename T>
-                auto rsqrt(T const& arg)
-                {
-                    // Need ADL for complex numbers
-                    using std::sqrt;
-                    return static_cast<T>(1) / sqrt(arg);
-                }
+    //! Stub for addition expressed same way as alpaka math traits
+    template<typename TAcc, typename T>
+    ALPAKA_FN_HOST_ACC auto plus(TAcc&, T const& arg1, T const& arg2)
+    {
+        return arg1 + arg2;
+    }
 
-                //! Stub for division expressed same way as alpaka math traits
-                template<typename TAcc, typename T>
-                ALPAKA_FN_HOST_ACC auto divides(TAcc&, T const& arg1, T const& arg2)
-                {
-                    return arg1 / arg2;
-                }
+    // https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
+    template<typename TAcc, typename FP>
+    ALPAKA_FN_ACC auto almost_equal(TAcc const& acc, FP x, FP y, int ulp)
+        -> std::enable_if_t<!std::numeric_limits<FP>::is_integer, bool>
+    {
+        // the machine epsilon has to be scaled to the magnitude of the values used
+        // and multiplied by the desired precision in ULPs (units in the last place)
+        return alpaka::math::abs(acc, x - y)
+                   <= std::numeric_limits<FP>::epsilon() * alpaka::math::abs(acc, x + y) * static_cast<FP>(ulp)
+               // unless the result is subnormal
+               || alpaka::math::abs(acc, x - y) < std::numeric_limits<FP>::min();
+    }
 
-                //! Stub for subtraction expressed same way as alpaka math traits
-                template<typename TAcc, typename T>
-                ALPAKA_FN_HOST_ACC auto minus(TAcc&, T const& arg1, T const& arg2)
-                {
-                    return arg1 - arg2;
-                }
-
-                //! Stub for multiplication expressed same way as alpaka math traits
-                template<typename TAcc, typename T>
-                ALPAKA_FN_HOST_ACC auto multiplies(TAcc&, T const& arg1, T const& arg2)
-                {
-                    return arg1 * arg2;
-                }
-
-                //! Stub for addition expressed same way as alpaka math traits
-                template<typename TAcc, typename T>
-                ALPAKA_FN_HOST_ACC auto plus(TAcc&, T const& arg1, T const& arg2)
-                {
-                    return arg1 + arg2;
-                }
-
-                // https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
-                template<typename TAcc, typename FP>
-                ALPAKA_FN_ACC auto almost_equal(TAcc const& acc, FP x, FP y, int ulp)
-                    -> std::enable_if_t<!std::numeric_limits<FP>::is_integer, bool>
-                {
-                    // the machine epsilon has to be scaled to the magnitude of the values used
-                    // and multiplied by the desired precision in ULPs (units in the last place)
-                    return alpaka::math::abs(acc, x - y) <= std::numeric_limits<FP>::epsilon()
-                                                                * alpaka::math::abs(acc, x + y) * static_cast<FP>(ulp)
-                           // unless the result is subnormal
-                           || alpaka::math::abs(acc, x - y) < std::numeric_limits<FP>::min();
-                }
-
-                //! Version for alpaka::Complex
-                template<typename TAcc, typename FP>
-                ALPAKA_FN_ACC bool almost_equal(TAcc const& acc, alpaka::Complex<FP> x, alpaka::Complex<FP> y, int ulp)
-                {
-                    return almost_equal(acc, x.real(), y.real(), ulp) && almost_equal(acc, x.imag(), y.imag(), ulp);
-                }
-
-            } // namespace math
-        } // namespace unit
-    } // namespace test
-} // namespace alpaka
+    //! Version for alpaka::Complex
+    template<typename TAcc, typename FP>
+    ALPAKA_FN_ACC bool almost_equal(TAcc const& acc, alpaka::Complex<FP> x, alpaka::Complex<FP> y, int ulp)
+    {
+        return almost_equal(acc, x.real(), y.real(), ulp) && almost_equal(acc, x.imag(), y.imag(), ulp);
+    }
+} // namespace mathtest

--- a/test/unit/math/src/FloatEqualExactTest.cpp
+++ b/test/unit/math/src/FloatEqualExactTest.cpp
@@ -9,9 +9,8 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-class FloatEqualExactTestKernel
+struct FloatEqualExactTestKernel
 {
-public:
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& /* acc */, bool* success) const -> void

--- a/test/unit/math/src/Functor.hpp
+++ b/test/unit/math/src/Functor.hpp
@@ -11,31 +11,25 @@
 #include <complex>
 #include <type_traits>
 
-namespace alpaka
+namespace mathtest
 {
-    namespace test
+    //! Helper trait to define a type conversion before passing T to a std:: math function
+    //!
+    //! The default implementation does no conversion
+    //!
+    //! @tparam T input type
+    template<typename T>
+    struct StdLibType
     {
-        namespace unit
-        {
-            namespace math
-            {
-                //! Helper trait to define a type conversion before passing T to a std:: math function
-                //!
-                //! The default implementation does no conversion
-                //!
-                //! @tparam T input type
-                template<typename T>
-                struct StdLibType
-                {
-                    using type = T;
-                };
+        using type = T;
+    };
 
-                //! Specialization converting alpaka::Complex<T> to std::complex<T>
-                template<typename T>
-                struct StdLibType<alpaka::Complex<T>>
-                {
-                    using type = std::complex<T>;
-                };
+    //! Specialization converting alpaka::Complex<T> to std::complex<T>
+    template<typename T>
+    struct StdLibType<alpaka::Complex<T>>
+    {
+        using type = std::complex<T>;
+    };
 
 // Can be used with operator() that will use either the std. function or the
 // equivalent alpaka function (if an accelerator is passed additionally).
@@ -131,303 +125,233 @@ namespace alpaka
     };
 
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpAbs, Arity::Unary, std::abs, alpaka::math::abs, Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpAbs, Arity::Unary, std::abs, alpaka::math::abs, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpAcos,
-                    Arity::Unary,
-                    std::acos,
-                    alpaka::math::acos,
-                    Range::OneNeighbourhood)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpAcos, Arity::Unary, std::acos, alpaka::math::acos, Range::OneNeighbourhood)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpAcosh,
-                    Arity::Unary,
-                    std::acosh,
-                    alpaka::math::acosh,
-                    Range::PositiveOnly)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpAcosh, Arity::Unary, std::acosh, alpaka::math::acosh, Range::PositiveOnly)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpArg, Arity::Unary, std::arg, alpaka::math::arg, Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpArg, Arity::Unary, std::arg, alpaka::math::arg, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpAsin,
-                    Arity::Unary,
-                    std::asin,
-                    alpaka::math::asin,
-                    Range::OneNeighbourhood)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpAsin, Arity::Unary, std::asin, alpaka::math::asin, Range::OneNeighbourhood)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpAsinh,
-                    Arity::Unary,
-                    std::asinh,
-                    alpaka::math::asinh,
-                    Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpAsinh, Arity::Unary, std::asinh, alpaka::math::asinh, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpAtan, Arity::Unary, std::atan, alpaka::math::atan, Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpAtan, Arity::Unary, std::atan, alpaka::math::atan, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpAtanh,
-                    Arity::Unary,
-                    std::atanh,
-                    alpaka::math::atanh,
-                    Range::OneNeighbourhood)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpAtanh, Arity::Unary, std::atanh, alpaka::math::atanh, Range::OneNeighbourhood)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpCbrt, Arity::Unary, std::cbrt, alpaka::math::cbrt, Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpCbrt, Arity::Unary, std::cbrt, alpaka::math::cbrt, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpCeil, Arity::Unary, std::ceil, alpaka::math::ceil, Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpCeil, Arity::Unary, std::ceil, alpaka::math::ceil, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpCos, Arity::Unary, std::cos, alpaka::math::cos, Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpCos, Arity::Unary, std::cos, alpaka::math::cos, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpCosh, Arity::Unary, std::cosh, alpaka::math::cosh, Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpCosh, Arity::Unary, std::cosh, alpaka::math::cosh, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpErf, Arity::Unary, std::erf, alpaka::math::erf, Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpErf, Arity::Unary, std::erf, alpaka::math::erf, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpExp, Arity::Unary, std::exp, alpaka::math::exp, Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpExp, Arity::Unary, std::exp, alpaka::math::exp, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpFloor,
-                    Arity::Unary,
-                    std::floor,
-                    alpaka::math::floor,
-                    Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpFloor, Arity::Unary, std::floor, alpaka::math::floor, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpLog, Arity::Unary, std::log, alpaka::math::log, Range::PositiveOnly)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpLog, Arity::Unary, std::log, alpaka::math::log, Range::PositiveOnly)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpLog2, Arity::Unary, std::log2, alpaka::math::log2, Range::PositiveOnly)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpLog2, Arity::Unary, std::log2, alpaka::math::log2, Range::PositiveOnly)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpLog10,
-                    Arity::Unary,
-                    std::log10,
-                    alpaka::math::log10,
-                    Range::PositiveOnly)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpLog10, Arity::Unary, std::log10, alpaka::math::log10, Range::PositiveOnly)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpRound,
-                    Arity::Unary,
-                    std::round,
-                    alpaka::math::round,
-                    Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpRound, Arity::Unary, std::round, alpaka::math::round, Range::Unrestricted)
 
-                // There is no std implementation, look in Defines.hpp.
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpRsqrt,
-                    Arity::Unary,
-                    alpaka::test::unit::math::rsqrt,
-                    alpaka::math::rsqrt,
-                    Range::PositiveOnly)
+    // There is no std implementation, look in Defines.hpp.
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpRsqrt, Arity::Unary, rsqrt, alpaka::math::rsqrt, Range::PositiveOnly)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpSin, Arity::Unary, std::sin, alpaka::math::sin, Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpSin, Arity::Unary, std::sin, alpaka::math::sin, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpSinh, Arity::Unary, std::sinh, alpaka::math::sinh, Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpSinh, Arity::Unary, std::sinh, alpaka::math::sinh, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpSqrt,
-                    Arity::Unary,
-                    std::sqrt,
-                    alpaka::math::sqrt,
-                    Range::PositiveAndZero)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpSqrt, Arity::Unary, std::sqrt, alpaka::math::sqrt, Range::PositiveAndZero)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpTan, Arity::Unary, std::tan, alpaka::math::tan, Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpTan, Arity::Unary, std::tan, alpaka::math::tan, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpTanh, Arity::Unary, std::tanh, alpaka::math::tanh, Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpTanh, Arity::Unary, std::tanh, alpaka::math::tanh, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpTrunc,
-                    Arity::Unary,
-                    std::trunc,
-                    alpaka::math::trunc,
-                    Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpTrunc, Arity::Unary, std::trunc, alpaka::math::trunc, Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpIsnan, Arity::Unary, std::isnan, alpaka::math::isnan, Range::Anything)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpIsnan, Arity::Unary, std::isnan, alpaka::math::isnan, Range::Anything)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpIsinf, Arity::Unary, std::isinf, alpaka::math::isinf, Range::Anything)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpIsinf, Arity::Unary, std::isinf, alpaka::math::isinf, Range::Anything)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpIsfinite,
-                    Arity::Unary,
-                    std::isfinite,
-                    alpaka::math::isfinite,
-                    Range::Anything)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpIsfinite, Arity::Unary, std::isfinite, alpaka::math::isfinite, Range::Anything)
 
-                // All binary operators.
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpAtan2,
-                    Arity::Binary,
-                    std::atan2,
-                    alpaka::math::atan2,
-                    Range::NotZero,
-                    Range::NotZero)
+    // All binary operators.
+    ALPAKA_TEST_MATH_OP_FUNCTOR(
+        OpAtan2,
+        Arity::Binary,
+        std::atan2,
+        alpaka::math::atan2,
+        Range::NotZero,
+        Range::NotZero)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpCopysign,
-                    Arity::Binary,
-                    std::copysign,
-                    alpaka::math::copysign,
-                    Range::Unrestricted,
-                    Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(
+        OpCopysign,
+        Arity::Binary,
+        std::copysign,
+        alpaka::math::copysign,
+        Range::Unrestricted,
+        Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpFmod,
-                    Arity::Binary,
-                    std::fmod,
-                    alpaka::math::fmod,
-                    Range::Unrestricted,
-                    Range::NotZero)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(
+        OpFmod,
+        Arity::Binary,
+        std::fmod,
+        alpaka::math::fmod,
+        Range::Unrestricted,
+        Range::NotZero)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpMax,
-                    Arity::Binary,
-                    std::max,
-                    alpaka::math::max,
-                    Range::Unrestricted,
-                    Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(
+        OpMax,
+        Arity::Binary,
+        std::max,
+        alpaka::math::max,
+        Range::Unrestricted,
+        Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpMin,
-                    Arity::Binary,
-                    std::min,
-                    alpaka::math::min,
-                    Range::Unrestricted,
-                    Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(
+        OpMin,
+        Arity::Binary,
+        std::min,
+        alpaka::math::min,
+        Range::Unrestricted,
+        Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpPow,
-                    Arity::Binary,
-                    std::pow,
-                    alpaka::math::pow,
-                    Range::PositiveAndZero,
-                    Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(
+        OpPow,
+        Arity::Binary,
+        std::pow,
+        alpaka::math::pow,
+        Range::PositiveAndZero,
+        Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpRemainder,
-                    Arity::Binary,
-                    std::remainder,
-                    alpaka::math::remainder,
-                    Range::Unrestricted,
-                    Range::NotZero)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(
+        OpRemainder,
+        Arity::Binary,
+        std::remainder,
+        alpaka::math::remainder,
+        Range::Unrestricted,
+        Range::NotZero)
 
-                // All ternary operators.
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpFma,
-                    Arity::Ternary,
-                    std::fma,
-                    alpaka::math::fma,
-                    Range::Unrestricted,
-                    Range::Unrestricted,
-                    Range::Unrestricted)
+    // All ternary operators.
+    ALPAKA_TEST_MATH_OP_FUNCTOR(
+        OpFma,
+        Arity::Ternary,
+        std::fma,
+        alpaka::math::fma,
+        Range::Unrestricted,
+        Range::Unrestricted,
+        Range::Unrestricted)
 
-                // Unary functors to be used only for real types
-                using UnaryFunctorsReal = std::tuple<
-                    OpAbs,
-                    OpAcos,
-                    OpAcosh,
-                    OpArg,
-                    OpAsin,
-                    OpAsinh,
-                    OpAtan,
-                    OpAtanh,
-                    OpCbrt,
-                    OpCeil,
-                    OpCos,
-                    OpCosh,
-                    OpErf,
-                    OpExp,
-                    OpFloor,
-                    OpLog,
-                    OpLog2,
-                    OpLog10,
-                    OpRound,
-                    OpRsqrt,
-                    OpSin,
-                    OpSinh,
-                    OpSqrt,
-                    OpTan,
-                    OpTanh,
-                    OpTrunc,
-                    OpIsnan,
-                    OpIsinf,
-                    OpIsfinite>;
+    // Unary functors to be used only for real types
+    using UnaryFunctorsReal = std::tuple<
+        OpAbs,
+        OpAcos,
+        OpAcosh,
+        OpArg,
+        OpAsin,
+        OpAsinh,
+        OpAtan,
+        OpAtanh,
+        OpCbrt,
+        OpCeil,
+        OpCos,
+        OpCosh,
+        OpErf,
+        OpExp,
+        OpFloor,
+        OpLog,
+        OpLog2,
+        OpLog10,
+        OpRound,
+        OpRsqrt,
+        OpSin,
+        OpSinh,
+        OpSqrt,
+        OpTan,
+        OpTanh,
+        OpTrunc,
+        OpIsnan,
+        OpIsinf,
+        OpIsfinite>;
 
-                // Binary functors to be used only for real types
-                using BinaryFunctorsReal = std::tuple<OpAtan2, OpCopysign, OpFmod, OpMax, OpMin, OpPow, OpRemainder>;
+    // Binary functors to be used only for real types
+    using BinaryFunctorsReal = std::tuple<OpAtan2, OpCopysign, OpFmod, OpMax, OpMin, OpPow, OpRemainder>;
 
-                // Ternary functors to be used only for real types
-                using TernaryFunctorsReal = std::tuple<OpFma>;
+    // Ternary functors to be used only for real types
+    using TernaryFunctorsReal = std::tuple<OpFma>;
 
-                // For complex numbers also test arithmetic operations
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpDivides,
-                    Arity::Binary,
-                    std::divides<>{},
-                    alpaka::test::unit::math::divides,
-                    Range::Unrestricted,
-                    Range::NotZero)
+    // For complex numbers also test arithmetic operations
+    ALPAKA_TEST_MATH_OP_FUNCTOR(
+        OpDivides,
+        Arity::Binary,
+        std::divides<>{},
+        divides,
+        Range::Unrestricted,
+        Range::NotZero)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpMinus,
-                    Arity::Binary,
-                    std::minus<>{},
-                    alpaka::test::unit::math::minus,
-                    Range::Unrestricted,
-                    Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(
+        OpMinus,
+        Arity::Binary,
+        std::minus<>{},
+        minus,
+        Range::Unrestricted,
+        Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpMultiplies,
-                    Arity::Binary,
-                    std::multiplies<>{},
-                    alpaka::test::unit::math::multiplies,
-                    Range::Unrestricted,
-                    Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(
+        OpMultiplies,
+        Arity::Binary,
+        std::multiplies<>{},
+        multiplies,
+        Range::Unrestricted,
+        Range::Unrestricted)
 
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpPlus,
-                    Arity::Binary,
-                    std::plus<>{},
-                    alpaka::test::unit::math::plus,
-                    Range::Unrestricted,
-                    Range::Unrestricted)
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpPlus, Arity::Binary, std::plus<>{}, plus, Range::Unrestricted, Range::Unrestricted)
 
-                // conj() is only tested for complex as it returns a complex type for real arguments
-                // and it doesn't fit the existing tests' infrastructure
-                ALPAKA_TEST_MATH_OP_FUNCTOR(OpConj, Arity::Unary, std::conj, alpaka::math::conj, Range::Unrestricted)
+    // conj() is only tested for complex as it returns a complex type for real arguments
+    // and it doesn't fit the existing tests' infrastructure
+    ALPAKA_TEST_MATH_OP_FUNCTOR(OpConj, Arity::Unary, std::conj, alpaka::math::conj, Range::Unrestricted)
 
-                // As a workaround for complex 0^0 unit tests issues, test complex pow for positive range only
-                ALPAKA_TEST_MATH_OP_FUNCTOR(
-                    OpPowComplex,
-                    Arity::Binary,
-                    std::pow,
-                    alpaka::math::pow,
-                    Range::PositiveOnly,
-                    Range::Unrestricted)
+    // As a workaround for complex 0^0 unit tests issues, test complex pow for positive range only
+    ALPAKA_TEST_MATH_OP_FUNCTOR(
+        OpPowComplex,
+        Arity::Binary,
+        std::pow,
+        alpaka::math::pow,
+        Range::PositiveOnly,
+        Range::Unrestricted)
 
-                // Unary functors to be used for both real and complex types
-                using UnaryFunctorsComplex = std::tuple<
-                    OpAbs,
-                    OpAcos,
-                    OpAcosh,
-                    OpArg,
-                    OpAsin,
-                    OpAsinh,
-                    OpAtan,
-                    OpAtanh,
-                    OpConj,
-                    OpCos,
-                    OpCosh,
-                    OpExp,
-                    OpLog,
-                    OpLog10,
-                    OpRsqrt,
-                    OpSin,
-                    OpSinh,
-                    OpSqrt,
-                    OpTan,
-                    OpTanh>;
+    // Unary functors to be used for both real and complex types
+    using UnaryFunctorsComplex = std::tuple<
+        OpAbs,
+        OpAcos,
+        OpAcosh,
+        OpArg,
+        OpAsin,
+        OpAsinh,
+        OpAtan,
+        OpAtanh,
+        OpConj,
+        OpCos,
+        OpCosh,
+        OpExp,
+        OpLog,
+        OpLog10,
+        OpRsqrt,
+        OpSin,
+        OpSinh,
+        OpSqrt,
+        OpTan,
+        OpTanh>;
 
-                // Binary functors to be used for complex types
-                using BinaryFunctorsComplex = std::tuple<OpDivides, OpMinus, OpMultiplies, OpPlus, OpPowComplex>;
-
-            } // namespace math
-        } // namespace unit
-    } // namespace test
-} // namespace alpaka
+    // Binary functors to be used for complex types
+    using BinaryFunctorsComplex = std::tuple<OpDivides, OpMinus, OpMultiplies, OpPlus, OpPowComplex>;
+} // namespace mathtest

--- a/test/unit/math/src/TestTemplate.hpp
+++ b/test/unit/math/src/TestTemplate.hpp
@@ -18,163 +18,166 @@
 
 #include <cmath>
 
-template<std::size_t TCapacity>
-struct TestKernel
+namespace mathtest
 {
+    template<std::size_t TCapacity>
+    struct TestKernel
+    {
+        //! @tparam TAcc Accelerator.
+        //! @tparam TFunctor Functor defined in Functor.hpp.
+        //! @param acc Accelerator given from alpaka.
+        //! @param functor Accessible with operator().
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<typename TAcc, typename TResults, typename TFunctor, typename TArgs>
+        ALPAKA_FN_ACC auto operator()(TAcc const& acc, TResults* results, TFunctor const& functor, TArgs const* args)
+            const noexcept -> void
+        {
+            for(size_t i = 0; i < TCapacity; ++i)
+            {
+                results[i] = functor(args[i], acc);
+            }
+        }
+    };
+
+    //! Helper trait to determine underlying type of real and complex numbers
+    template<typename T>
+    struct UnderlyingType
+    {
+        using type = T;
+    };
+
+    //! Specialization for complex
+    template<typename T>
+    struct UnderlyingType<alpaka::Complex<T>>
+    {
+        using type = T;
+    };
+
+    //! Base test template for math unit tests
     //! @tparam TAcc Accelerator.
     //! @tparam TFunctor Functor defined in Functor.hpp.
-    //! @param acc Accelerator given from alpaka.
-    //! @param functor Accessible with operator().
-    ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TAcc, typename TResults, typename TFunctor, typename TArgs>
-    ALPAKA_FN_ACC auto operator()(TAcc const& acc, TResults* results, TFunctor const& functor, TArgs const* args)
-        const noexcept -> void
+    template<typename TAcc, typename TFunctor>
+    struct TestTemplate
     {
-        for(size_t i = 0; i < TCapacity; ++i)
+        //! wrappedFunctor is either a TFunctor{} or TFunctor{} wrapped into a host-device lambda
+        template<typename TData, typename TWrappedFunctor = TFunctor>
+        auto operator()(TWrappedFunctor const& wrappedFunctor = TWrappedFunctor{}) -> void
         {
-            results[i] = functor(args[i], acc);
-        }
-    }
-};
+            std::random_device rd{};
+            auto const seed = rd();
+            INFO(
+                "testing"
+                << " acc:" << alpaka::core::demangled<TAcc> << " data type:" << alpaka::core::demangled<TData>
+                << " functor:" << alpaka::core::demangled<TWrappedFunctor> << " seed:" << seed);
 
-//! Helper trait to determine underlying type of real and complex numbers
-template<typename T>
-struct UnderlyingType
-{
-    using type = T;
-};
+            // SETUP (defines and initialising)
+            // DevAcc is defined in Buffer.hpp too.
+            using DevAcc = alpaka::Dev<TAcc>;
 
-//! Specialization for complex
-template<typename T>
-struct UnderlyingType<alpaka::Complex<T>>
-{
-    using type = T;
-};
+            using Dim = alpaka::DimInt<1u>;
+            using Idx = std::size_t;
+            using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
+            using QueueAcc = alpaka::test::DefaultQueue<DevAcc>;
+            using TArgsItem = ArgsItem<TData, TFunctor::arity>;
 
-//! Base test template for math unit tests
-//! @tparam TAcc Accelerator.
-//! @tparam TFunctor Functor defined in Functor.hpp.
-template<typename TAcc, typename TFunctor>
-struct TestTemplate
-{
-    //! wrappedFunctor is either a TFunctor{} or TFunctor{} wrapped into a host-device lambda
-    template<typename TData, typename TWrappedFunctor = TFunctor>
-    auto operator()(TWrappedFunctor const& wrappedFunctor = TWrappedFunctor{}) -> void
-    {
-        std::random_device rd{};
-        auto const seed = rd();
-        INFO(
-            "testing"
-            << " acc:" << alpaka::core::demangled<TAcc> << " data type:" << alpaka::core::demangled<TData>
-            << " functor:" << alpaka::core::demangled<TWrappedFunctor> << " seed:" << seed);
+            static constexpr auto capacity = 1000;
 
-        // SETUP (defines and initialising)
-        // DevAcc is defined in Buffer.hpp too.
-        using DevAcc = alpaka::Dev<TAcc>;
+            using Args = Buffer<TAcc, TArgsItem, capacity>;
+            using Results = Buffer<TAcc, TData, capacity>;
 
-        using Dim = alpaka::DimInt<1u>;
-        using Idx = std::size_t;
-        using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
-        using QueueAcc = alpaka::test::DefaultQueue<DevAcc>;
-        using TArgsItem = alpaka::test::unit::math::ArgsItem<TData, TFunctor::arity>;
+            // Every functor is executed individual on one kernel.
+            static constexpr size_t elementsPerThread = 1u;
+            static constexpr size_t sizeExtent = 1u;
 
-        static constexpr auto capacity = 1000;
+            auto const platformAcc = alpaka::Platform<TAcc>{};
+            auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
+            auto const platformHost = alpaka::PlatformCpu{};
+            auto const devHost = alpaka::getDevByIdx(platformHost, 0);
 
-        using Args = alpaka::test::unit::math::Buffer<TAcc, TArgsItem, capacity>;
-        using Results = alpaka::test::unit::math::Buffer<TAcc, TData, capacity>;
+            QueueAcc queue{devAcc};
 
-        // Every functor is executed individual on one kernel.
-        static constexpr size_t elementsPerThread = 1u;
-        static constexpr size_t sizeExtent = 1u;
+            TestKernel<capacity> kernel;
+            TFunctor functor;
+            Args args{devAcc};
+            Results results{devAcc};
 
-        auto const platformAcc = alpaka::Platform<TAcc>{};
-        auto const devAcc = alpaka::getDevByIdx(platformAcc, 0);
-        auto const platformHost = alpaka::PlatformCpu{};
-        auto const devHost = alpaka::getDevByIdx(platformHost, 0);
+            WorkDiv const workDiv = alpaka::getValidWorkDiv<TAcc>(
+                devAcc,
+                sizeExtent,
+                elementsPerThread,
+                false,
+                alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
+            // SETUP COMPLETED.
 
-        QueueAcc queue{devAcc};
+            // Fill the buffer with random test-numbers.
+            fillWithRndArgs<TData>(args, functor, seed);
+            using Underlying = typename UnderlyingType<TData>::type;
+            for(size_t i = 0; i < Results::capacity; ++i)
+                results(i) = static_cast<Underlying>(std::nan(""));
 
-        TestKernel<capacity> kernel;
-        TFunctor functor;
-        Args args{devAcc};
-        Results results{devAcc};
+            // Copy both buffer to the device
+            args.copyToDevice(queue);
+            results.copyToDevice(queue);
 
-        WorkDiv const workDiv = alpaka::getValidWorkDiv<TAcc>(
-            devAcc,
-            sizeExtent,
-            elementsPerThread,
-            false,
-            alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
-        // SETUP COMPLETED.
+            // Enqueue the kernel execution task.
+            auto const taskKernel
+                = alpaka::createTaskKernel<TAcc>(workDiv, kernel, results.pDevBuffer, wrappedFunctor, args.pDevBuffer);
+            alpaka::enqueue(queue, taskKernel);
 
-        // Fill the buffer with random test-numbers.
-        alpaka::test::unit::math::fillWithRndArgs<TData>(args, functor, seed);
-        using Underlying = typename UnderlyingType<TData>::type;
-        for(size_t i = 0; i < Results::capacity; ++i)
-            results(i) = static_cast<Underlying>(std::nan(""));
+            // Copy back the results (encapsulated in the buffer class).
+            results.copyFromDevice(queue);
+            alpaka::wait(queue);
+            std::cout.precision(std::numeric_limits<Underlying>::digits10 + 1);
 
-        // Copy both buffer to the device
-        args.copyToDevice(queue);
-        results.copyToDevice(queue);
-
-        // Enqueue the kernel execution task.
-        auto const taskKernel
-            = alpaka::createTaskKernel<TAcc>(workDiv, kernel, results.pDevBuffer, wrappedFunctor, args.pDevBuffer);
-        alpaka::enqueue(queue, taskKernel);
-
-        // Copy back the results (encapsulated in the buffer class).
-        results.copyFromDevice(queue);
-        alpaka::wait(queue);
-        std::cout.precision(std::numeric_limits<Underlying>::digits10 + 1);
-
-        INFO("Operator: " << functor);
-        INFO("Type: " << alpaka::core::demangled<TData>); // Compiler specific.
+            INFO("Operator: " << functor);
+            INFO("Type: " << alpaka::core::demangled<TData>); // Compiler specific.
 #if ALPAKA_DEBUG_FULL
-        INFO(
-            "The args buffer: \n"
-            << std::setprecision(std::numeric_limits<Underlying>::digits10 + 1) << args << "\n");
+            INFO(
+                "The args buffer: \n"
+                << std::setprecision(std::numeric_limits<Underlying>::digits10 + 1) << args << "\n");
 #endif
-        for(size_t i = 0; i < Args::capacity; ++i)
-        {
-            TData std_result = functor(args(i));
-            INFO("Idx i: " << i << " computed : " << results(i) << " vs expected: " << std_result);
-            REQUIRE(isApproxEqual(results(i), std_result));
+            for(size_t i = 0; i < Args::capacity; ++i)
+            {
+                TData std_result = functor(args(i));
+                INFO("Idx i: " << i << " computed : " << results(i) << " vs expected: " << std_result);
+                REQUIRE(isApproxEqual(results(i), std_result));
+            }
         }
-    }
 
-    //! Approximate comparison of real numbers
-    template<typename T>
-    static bool isApproxEqual(T const& a, T const& b)
-    {
-        return a == Catch::Approx(b).margin(std::numeric_limits<T>::epsilon());
-    }
+        //! Approximate comparison of real numbers
+        template<typename T>
+        static bool isApproxEqual(T const& a, T const& b)
+        {
+            return a == Catch::Approx(b).margin(std::numeric_limits<T>::epsilon());
+        }
 
-    //! Is complex number considered finite for math testing.
-    //! Complex numbers with absolute value close to max() of underlying type are considered infinite.
-    //! The reason is, CUDA/HIP implementation cannot guarantee correct treatment of such values due to implementing
-    //! some math functions via calls to others. For extreme values of arguments, it could cause intermediate results
-    //! to become infinite or NaN. So in this function we consider all large enough values to be effectively infinite
-    //! and equivalent to one another. Thus, the tests do not concern accuracy for extreme values. However, they still
-    //! check the implementation for "reasonable" values.
-    template<typename T>
-    static bool isFinite(alpaka::Complex<T> const& z)
-    {
-        auto const absValue = abs(z);
-        auto const maxAbs = static_cast<T>(0.1) * std::numeric_limits<T>::max();
-        return std::isfinite(absValue) && (absValue < maxAbs);
-    }
+        //! Is complex number considered finite for math testing.
+        //! Complex numbers with absolute value close to max() of underlying type are considered infinite.
+        //! The reason is, CUDA/HIP implementation cannot guarantee correct treatment of such values due to
+        //! implementing some math functions via calls to others. For extreme values of arguments, it could cause
+        //! intermediate results to become infinite or NaN. So in this function we consider all large enough values to
+        //! be effectively infinite and equivalent to one another. Thus, the tests do not concern accuracy for extreme
+        //! values. However, they still check the implementation for "reasonable" values.
+        template<typename T>
+        static bool isFinite(alpaka::Complex<T> const& z)
+        {
+            auto const absValue = abs(z);
+            auto const maxAbs = static_cast<T>(0.1) * std::numeric_limits<T>::max();
+            return std::isfinite(absValue) && (absValue < maxAbs);
+        }
 
-    //! Approximate comparison of complex numbers
-    template<typename T>
-    static bool isApproxEqual(alpaka::Complex<T> const& a, alpaka::Complex<T> const& b)
-    {
-        // Consider all infinite values equal, @see comment at isFinite()
-        if(!isFinite(a) && !isFinite(b))
-            return true;
-        // For the same reason use relative difference comparison with a large margin
-        auto const scalingFactor = static_cast<T>(std::is_same_v<T, float> ? 1.1e4 : 1.1e6);
-        auto const marginValue = scalingFactor * std::numeric_limits<T>::epsilon();
-        return (a.real() == Catch::Approx(b.real()).margin(marginValue).epsilon(marginValue))
-               && (a.imag() == Catch::Approx(b.imag()).margin(marginValue).epsilon(marginValue));
-    }
-};
+        //! Approximate comparison of complex numbers
+        template<typename T>
+        static bool isApproxEqual(alpaka::Complex<T> const& a, alpaka::Complex<T> const& b)
+        {
+            // Consider all infinite values equal, @see comment at isFinite()
+            if(!isFinite(a) && !isFinite(b))
+                return true;
+            // For the same reason use relative difference comparison with a large margin
+            auto const scalingFactor = static_cast<T>(std::is_same_v<T, float> ? 1.1e4 : 1.1e6);
+            auto const marginValue = scalingFactor * std::numeric_limits<T>::epsilon();
+            return (a.real() == Catch::Approx(b.real()).margin(marginValue).epsilon(marginValue))
+                   && (a.imag() == Catch::Approx(b.imag()).margin(marginValue).epsilon(marginValue));
+        }
+    };
+} // namespace mathtest

--- a/test/unit/math/src/mathComplexDouble.cpp
+++ b/test/unit/math/src/mathComplexDouble.cpp
@@ -20,8 +20,7 @@ using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, std::size_t>;
 
 // This file only has unit tests for complex numbers in order to split the tests between object files and save compiler
 // memory. For the same reason single- and double-precision are done separately and not wrapped into a common template.
-using FunctorsComplex = alpaka::meta::
-    Concatenate<alpaka::test::unit::math::UnaryFunctorsComplex, alpaka::test::unit::math::BinaryFunctorsComplex>;
+using FunctorsComplex = alpaka::meta::Concatenate<mathtest::UnaryFunctorsComplex, mathtest::BinaryFunctorsComplex>;
 using TestAccFunctorTuplesComplex = alpaka::meta::CartesianProduct<std::tuple, TestAccs, FunctorsComplex>;
 
 TEMPLATE_LIST_TEST_CASE("mathOpsComplexDouble", "[math] [operator]", TestAccFunctorTuplesComplex)
@@ -29,7 +28,7 @@ TEMPLATE_LIST_TEST_CASE("mathOpsComplexDouble", "[math] [operator]", TestAccFunc
     // Same as "mathOpsFloat" template test, but for complex double. See detailed explanation there.
     using Acc = std::tuple_element_t<0u, TestType>;
     using Functor = std::tuple_element_t<1u, TestType>;
-    auto testTemplate = TestTemplate<Acc, Functor>{};
+    auto testTemplate = mathtest::TestTemplate<Acc, Functor>{};
     testTemplate.template operator()<alpaka::Complex<double>>();
 }
 

--- a/test/unit/math/src/mathComplexFloat.cpp
+++ b/test/unit/math/src/mathComplexFloat.cpp
@@ -20,8 +20,7 @@ using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, std::size_t>;
 
 // This file only has unit tests for complex numbers in order to split the tests between object files and save compiler
 // memory. For the same reason single- and double-precision are done separately and not wrapped into a common template.
-using FunctorsComplex = alpaka::meta::
-    Concatenate<alpaka::test::unit::math::UnaryFunctorsComplex, alpaka::test::unit::math::BinaryFunctorsComplex>;
+using FunctorsComplex = alpaka::meta::Concatenate<mathtest::UnaryFunctorsComplex, mathtest::BinaryFunctorsComplex>;
 using TestAccFunctorTuplesComplex = alpaka::meta::CartesianProduct<std::tuple, TestAccs, FunctorsComplex>;
 
 TEMPLATE_LIST_TEST_CASE("mathOpsComplexFloat", "[math] [operator]", TestAccFunctorTuplesComplex)
@@ -29,7 +28,7 @@ TEMPLATE_LIST_TEST_CASE("mathOpsComplexFloat", "[math] [operator]", TestAccFunct
     // Same as "mathOpsFloat" template test, but for complex float. See detailed explanation there.
     using Acc = std::tuple_element_t<0u, TestType>;
     using Functor = std::tuple_element_t<1u, TestType>;
-    auto testTemplate = TestTemplate<Acc, Functor>{};
+    auto testTemplate = mathtest::TestTemplate<Acc, Functor>{};
     testTemplate.template operator()<alpaka::Complex<float>>();
 }
 

--- a/test/unit/math/src/mathDouble.cpp
+++ b/test/unit/math/src/mathDouble.cpp
@@ -15,10 +15,8 @@
 using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, std::size_t>;
 
 // This file only has unit tests for real numbers in order to split the tests between object files
-using FunctorsReal = alpaka::meta::Concatenate<
-    alpaka::test::unit::math::UnaryFunctorsReal,
-    alpaka::test::unit::math::BinaryFunctorsReal,
-    alpaka::test::unit::math::TernaryFunctorsReal>;
+using FunctorsReal = alpaka::meta::
+    Concatenate<mathtest::UnaryFunctorsReal, mathtest::BinaryFunctorsReal, mathtest::TernaryFunctorsReal>;
 using TestAccFunctorTuplesReal = alpaka::meta::CartesianProduct<std::tuple, TestAccs, FunctorsReal>;
 
 TEMPLATE_LIST_TEST_CASE("mathOpsDouble", "[math] [operator]", TestAccFunctorTuplesReal)
@@ -26,6 +24,6 @@ TEMPLATE_LIST_TEST_CASE("mathOpsDouble", "[math] [operator]", TestAccFunctorTupl
     // Same as "mathOpsFloat" template test, but for double. See detailed explanation there.
     using Acc = std::tuple_element_t<0u, TestType>;
     using Functor = std::tuple_element_t<1u, TestType>;
-    auto testTemplate = TestTemplate<Acc, Functor>{};
+    auto testTemplate = mathtest::TestTemplate<Acc, Functor>{};
     testTemplate.template operator()<double>();
 }

--- a/test/unit/math/src/mathFloat.cpp
+++ b/test/unit/math/src/mathFloat.cpp
@@ -15,10 +15,8 @@
 using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, std::size_t>;
 
 // This file only has unit tests for real numbers in order to split the tests between object files
-using FunctorsReal = alpaka::meta::Concatenate<
-    alpaka::test::unit::math::UnaryFunctorsReal,
-    alpaka::test::unit::math::BinaryFunctorsReal,
-    alpaka::test::unit::math::TernaryFunctorsReal>;
+using FunctorsReal = alpaka::meta::
+    Concatenate<mathtest::UnaryFunctorsReal, mathtest::BinaryFunctorsReal, mathtest::TernaryFunctorsReal>;
 using TestAccFunctorTuplesReal = alpaka::meta::CartesianProduct<std::tuple, TestAccs, FunctorsReal>;
 
 TEMPLATE_LIST_TEST_CASE("mathOpsFloat", "[math] [operator]", TestAccFunctorTuplesReal)
@@ -72,6 +70,6 @@ TEMPLATE_LIST_TEST_CASE("mathOpsFloat", "[math] [operator]", TestAccFunctorTuple
 
     using Acc = std::tuple_element_t<0u, TestType>;
     using Functor = std::tuple_element_t<1u, TestType>;
-    auto testTemplate = TestTemplate<Acc, Functor>{};
+    auto testTemplate = mathtest::TestTemplate<Acc, Functor>{};
     testTemplate.template operator()<float>();
 }

--- a/test/unit/math/src/mathLambda.cpp
+++ b/test/unit/math/src/mathLambda.cpp
@@ -24,13 +24,6 @@
 
 using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, std::size_t>;
 
-// This file only has unit tests for real numbers in order to split the tests between object files
-using UnaryFunctorsReal = alpaka::test::unit::math::UnaryFunctorsReal;
-using BinaryFunctorsReal = alpaka::test::unit::math::BinaryFunctorsReal;
-using TernaryFunctorsReal = alpaka::test::unit::math::TernaryFunctorsReal;
-using UnaryFunctorsComplex = alpaka::test::unit::math::UnaryFunctorsComplex;
-using BinaryFunctorsComplex = alpaka::test::unit::math::BinaryFunctorsComplex;
-
 //! Caller of test template with additional lambda wrapping the functor
 //! @tparam TAcc Accelerator.
 //! @tparam TData Input data type..
@@ -47,10 +40,10 @@ struct LambdaMathTestTemplate
         // To avoid always using the first functor from the list, calculate index based on input data type sizes.
         constexpr uint32_t index = (sizeof(TAcc) + sizeof(TData) + sizeof(TFunctors)) % std::tuple_size_v<TFunctors>;
         using Functor = std::tuple_element_t<index, TFunctors>;
-        using ArgsItem = alpaka::test::unit::math::ArgsItem<TData, Functor::arity>;
+        using ArgsItem = mathtest::ArgsItem<TData, Functor::arity>;
         auto wrappedFunctor
             = [] ALPAKA_FN_HOST_ACC(ArgsItem const& arguments, TAcc const& acc) { return Functor{}(arguments, acc); };
-        auto testTemplate = TestTemplate<TAcc, Functor>{};
+        auto testTemplate = mathtest::TestTemplate<TAcc, Functor>{};
         testTemplate.template operator()<TData>(wrappedFunctor);
     }
 };
@@ -59,33 +52,33 @@ TEMPLATE_LIST_TEST_CASE("mathOpsLambdaFloat", "[math] [operator]", TestAccs)
 {
     using Acc = TestType;
     auto testTemplate = LambdaMathTestTemplate<Acc, float>{};
-    testTemplate.template operator()<UnaryFunctorsReal>();
-    testTemplate.template operator()<BinaryFunctorsReal>();
-    testTemplate.template operator()<TernaryFunctorsReal>();
+    testTemplate.template operator()<mathtest::UnaryFunctorsReal>();
+    testTemplate.template operator()<mathtest::BinaryFunctorsReal>();
+    testTemplate.template operator()<mathtest::TernaryFunctorsReal>();
 }
 
 TEMPLATE_LIST_TEST_CASE("mathOpsLambdaDouble", "[math] [operator]", TestAccs)
 {
     using Acc = TestType;
     auto testTemplate = LambdaMathTestTemplate<Acc, double>{};
-    testTemplate.template operator()<UnaryFunctorsReal>();
-    testTemplate.template operator()<BinaryFunctorsReal>();
-    testTemplate.template operator()<TernaryFunctorsReal>();
+    testTemplate.template operator()<mathtest::UnaryFunctorsReal>();
+    testTemplate.template operator()<mathtest::BinaryFunctorsReal>();
+    testTemplate.template operator()<mathtest::TernaryFunctorsReal>();
 }
 
 TEMPLATE_LIST_TEST_CASE("mathOpsLambdaComplexFloat", "[math] [operator]", TestAccs)
 {
     using Acc = TestType;
     auto testTemplate = LambdaMathTestTemplate<Acc, alpaka::Complex<float>>{};
-    testTemplate.template operator()<UnaryFunctorsComplex>();
-    testTemplate.template operator()<BinaryFunctorsComplex>();
+    testTemplate.template operator()<mathtest::UnaryFunctorsComplex>();
+    testTemplate.template operator()<mathtest::BinaryFunctorsComplex>();
 }
 
 TEMPLATE_LIST_TEST_CASE("mathOpsLambdaComplexDouble", "[math] [operator]", TestAccs)
 {
     using Acc = TestType;
     auto testTemplate = LambdaMathTestTemplate<Acc, alpaka::Complex<double>>{};
-    testTemplate.template operator()<UnaryFunctorsComplex>();
-    testTemplate.template operator()<BinaryFunctorsComplex>();
+    testTemplate.template operator()<mathtest::UnaryFunctorsComplex>();
+    testTemplate.template operator()<mathtest::BinaryFunctorsComplex>();
 }
 #endif

--- a/test/unit/math/src/powMixedTypes.cpp
+++ b/test/unit/math/src/powMixedTypes.cpp
@@ -49,17 +49,15 @@ struct Convert<TInput, alpaka::Complex<TOutputValueType>, std::enable_if_t<std::
 };
 
 template<typename TExpected>
-class PowMixedTypesTestKernel
+struct PowMixedTypesTestKernel
 {
-public:
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc, typename TArg1, typename TArg2>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, TArg1 const arg1, TArg2 const arg2) const -> void
     {
         auto expected = alpaka::math::pow(acc, Convert<TArg1, TExpected>{}(arg1), Convert<TArg2, TExpected>{}(arg2));
         auto actual = alpaka::math::pow(acc, arg1, arg2);
-        using alpaka::test::unit::math::almost_equal;
-        ALPAKA_CHECK(*success, almost_equal(acc, expected, actual, 1));
+        ALPAKA_CHECK(*success, mathtest::almost_equal(acc, expected, actual, 1));
     }
 };
 

--- a/test/unit/math/src/sincos.cpp
+++ b/test/unit/math/src/sincos.cpp
@@ -15,9 +15,8 @@
 
 #include <type_traits>
 
-class SinCosTestKernel
+struct SinCosTestKernel
 {
-public:
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc, typename FP>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, FP const arg) const -> void
@@ -29,10 +28,10 @@ public:
         auto result_sin = FP{0};
         auto result_cos = FP{0};
         alpaka::math::sincos(acc, arg, result_sin, result_cos);
-        using alpaka::test::unit::math::almost_equal;
         ALPAKA_CHECK(
             *success,
-            almost_equal(acc, result_sin, check_sin, 1) && almost_equal(acc, result_cos, check_cos, 1));
+            mathtest::almost_equal(acc, result_sin, check_sin, 1)
+                && mathtest::almost_equal(acc, result_cos, check_cos, 1));
     }
 };
 


### PR DESCRIPTION
Just ran into the deeply nested namespaces inside the `mathTest` and decided to remove them to save indentation.