### PR TITLE
Fix clang-format version in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,19 +2,19 @@
 
 ## Formatting
 
-Please format your code before before opening pull requests using clang-format 14 and the .clang-format file placed in the repository root.
+Please format your code before before opening pull requests using clang-format 16 and the .clang-format file placed in the repository root.
 
 ### Visual Studio and CLion
 Suport for clang-format is built-in since Visual Studio 2017 15.7 and CLion 2019.1.
 The .clang-format file in the repository will be automatically detected and formatting is done as you type, or triggered when pressing the format hotkey.
 
 ### Bash
-First install clang-format-14. Instructions therefore can be found on the web.
+First install clang-format-16. Instructions therefore can be found on the web.
 To format your changes since branching off develop, you can run this command in bash:
 ```
-git clang-format-14 develop
+git clang-format-16 develop
 ```
 To format all code in your working copy, you can run this command in bash:
 ```
-find -iname '*.cpp' -o -iname '*.hpp' | xargs clang-format-14 -i
+find -iname '*.cpp' -o -iname '*.hpp' | xargs clang-format-16 -i
 ```

--- a/docs/source/dev/style.rst
+++ b/docs/source/dev/style.rst
@@ -14,13 +14,13 @@ whitespace and braces automatically. Usage:
 
 .. code-block:: bash
 
-  clang-format-14 -i <sourcefile>
+  clang-format-16 -i <sourcefile>
 
 * If you want to format the entire code base execute the following command from alpaka's top-level directory:
 
 .. code-block:: bash
 
-  find example include test -name '*.hpp' -o -name '*.cpp' | xargs clang-format-14 -i
+  find example include test -name '*.hpp' -o -name '*.cpp' | xargs clang-format-16 -i
 
 Windows users should use `Visual Studio's native clang-format integration
 <https://devblogs.microsoft.com/cppblog/clangformat-support-in-visual-studio-2017-15-7-preview-1/>`.


### PR DESCRIPTION
The documentation on the clang-format version we use is outdated in a few places. This PR fixes this.