### PR TITLE
Remove unnecessary `-fintelfpga` flag

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -614,7 +614,6 @@ if(alpaka_ACC_SYCL_ENABLE)
 
         if(alpaka_SYCL_ONEAPI_FPGA)
             target_compile_definitions(alpaka INTERFACE "ALPAKA_SYCL_ONEAPI_FPGA")
-            alpaka_set_compiler_options(DEVICE target alpaka "-fintelfpga")
 
             if(alpaka_SYCL_ONEAPI_FPGA_MODE STREQUAL "emulation")
                 target_compile_definitions(alpaka INTERFACE "ALPAKA_FPGA_EMULATION")


### PR DESCRIPTION
I tested the `1.0.0-rc1` branch on Intel's DevCloud and noticed that `-fintelfpga` now conflicts with the `-fsycl-targets=spir64_fpga` flag. According to the [documentation](https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/2023-2/fintelfpga.html) those two are equivalent so I removed `-fintelfpga`. I couldn't do further tests because Intel's DevCloud doesn't provide an up-to-date installation of oneAPI (most recent version is 2023.0 - alpaka requires at least 2023.1).

This will also be cherry-picked into the `1.0.0-rc1` branch.