### PR TITLE
Check for HIP versions in min/max range

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -503,11 +503,7 @@ if(alpaka_ACC_GPU_HIP_ENABLE)
     # supported HIP version range
     set(_alpaka_HIP_MIN_VER 5.0)
     set(_alpaka_HIP_MAX_VER 5.5)
-    find_package(hip "${_alpaka_HIP_MAX_VER}")
-    if(NOT TARGET hip)
-        message(STATUS "Could not find HIP v${_alpaka_HIP_MAX_VER}. Now searching for HIP v${_alpaka_HIP_MIN_VER}")
-        find_package(hip "${_alpaka_HIP_MIN_VER}")
-    endif()
+    find_package(hip "${_alpaka_HIP_MIN_VER}...<${_alpaka_HIP_MAX_VER}")
 
     if(NOT TARGET hip)
         message(FATAL_ERROR "Optional alpaka dependency HIP could not be found!")

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -506,7 +506,7 @@ if(alpaka_ACC_GPU_HIP_ENABLE)
     find_package(hip "${_alpaka_HIP_MIN_VER}...${_alpaka_HIP_MAX_VER}")
 
     if(NOT TARGET hip)
-        message(STATUS "Could not find HIP <=v${_alpaka_HIP_MAX_VER}. Now searching for unsupported HIP >v${_alpaka_HIP_MAX_VER}")
+        message(WARNING "Could not find HIP <=v${_alpaka_HIP_MAX_VER}. Now searching for unsupported HIP >v${_alpaka_HIP_MAX_VER}")
         find_package(hip "${_alpaka_HIP_MAX_VER}")
     endif()
 

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -503,7 +503,12 @@ if(alpaka_ACC_GPU_HIP_ENABLE)
     # supported HIP version range
     set(_alpaka_HIP_MIN_VER 5.0)
     set(_alpaka_HIP_MAX_VER 5.5)
-    find_package(hip "${_alpaka_HIP_MIN_VER}...<${_alpaka_HIP_MAX_VER}")
+    find_package(hip "${_alpaka_HIP_MIN_VER}...${_alpaka_HIP_MAX_VER}")
+
+    if(NOT TARGET hip)
+        message(STATUS "Could not find HIP <=v${_alpaka_HIP_MAX_VER}. Now searching for unsupported HIP >v${_alpaka_HIP_MAX_VER}")
+        find_package(hip "${_alpaka_HIP_MAX_VER}")
+    endif()
 
     if(NOT TARGET hip)
         message(FATAL_ERROR "Optional alpaka dependency HIP could not be found!")


### PR DESCRIPTION
With the current logic, cmake checks first for HIP 5.5, then for 5.0:
```
CMake Warning at cmake/alpakaCommon.cmake:506 (find_package):
  By not providing "Findhip.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "hip", but
  CMake did not find one.

  Could not find a package configuration file provided by "hip" (requested
  version 5.5) with any of the following names:

    hipConfig.cmake
    hip-config.cmake

  Add the installation prefix of "hip" to CMAKE_PREFIX_PATH or set "hip_DIR"
  to a directory containing one of the above files.  If "hip" provides a
  separate development package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:94 (include)


-- Could not find HIP v5.5. Now searching for HIP v5.0
CMake Warning at cmake/alpakaCommon.cmake:509 (find_package):
  By not providing "Findhip.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "hip", but
  CMake did not find one.

  Could not find a package configuration file provided by "hip" (requested
  version 5.0) with any of the following names:

    hipConfig.cmake
    hip-config.cmake

  Add the installation prefix of "hip" to CMAKE_PREFIX_PATH or set "hip_DIR"
  to a directory containing one of the above files.  If "hip" provides a
  separate development package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:94 (include)


CMake Error at cmake/alpakaCommon.cmake:514 (message):
  Optional alpaka dependency HIP could not be found!
Call Stack (most recent call first):
  CMakeLists.txt:94 (include)
```

I think the behaviour should give an inclusive range but I don't immediately have a way to test this (only having a somewhat broken HIP 5.1 installation).
