### PR TITLE
CI: Fix amalgamation

### DIFF
--- a/script/create-single-header.sh
+++ b/script/create-single-header.sh
@@ -4,6 +4,6 @@ workingcopy_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/nul
 dst=${1:-$workingcopy_dir/single-header/include/alpaka/alpaka.hpp}
 tmp_dir=$(mktemp -d)
 git clone https://github.com/shrpnsld/amalgamate.git --depth 1 $tmp_dir/clone
-$tmp_dir/clone/amalgamate -o $tmp_dir -H -v -a -n 'alpaka' -I $workingcopy_dir/include -- $workingcopy_dir/include/alpaka/alpaka.hpp
+$tmp_dir/clone/amalgamate -o $tmp_dir -v -a -n 'alpaka' -I $workingcopy_dir/include -- $workingcopy_dir/include/alpaka/alpaka.hpp
 mv $tmp_dir/alpaka-amalgamated/alpaka.hpp $dst
 rm -rf $tmp_dir


### PR DESCRIPTION
Since commit https://github.com/shrpnsld/amalgamate/commit/2f360f58f78a6fe4482480fd7ec5db997c66a257, `amalgamate` removed the `-H` option, and now the default behavior is to generate a single header. This PR fixes #2191.