### PR TITLE
fix icpx atomic OpenMP methods

### DIFF
--- a/include/alpaka/atomic/AtomicOmpBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicOmpBuiltIn.hpp
@@ -179,7 +179,7 @@ namespace alpaka
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicMin, AtomicOmpBuiltIn, T, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T value) -> T
             {
                 T old;
                 auto& ref(*addr);
@@ -187,8 +187,12 @@ namespace alpaka
 #        pragma omp atomic capture compare
                 {
                     old = ref;
+                    // Do not remove the curly brackets of the if body else
+                    // icpx 2024.0 is not able to compile the atomics.
                     if(value < ref)
+                    {
                         ref = value;
+                    }
                 }
                 return old;
             }
@@ -198,7 +202,7 @@ namespace alpaka
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicMax, AtomicOmpBuiltIn, T, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T value) -> T
             {
                 T old;
                 auto& ref(*addr);
@@ -206,8 +210,12 @@ namespace alpaka
 #        pragma omp atomic capture compare
                 {
                     old = ref;
+                    // Do not remove the curly brackets of the if body else
+                    // icpx 2024.0 is not able to compile the atomics.
                     if(value > ref)
+                    {
                         ref = value;
+                    }
                 }
                 return old;
             }
@@ -249,11 +257,7 @@ namespace alpaka
         template<typename T, typename THierarchy>
         struct AtomicOp<AtomicCas, AtomicOmpBuiltIn, T, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(
-                AtomicOmpBuiltIn const&,
-                T* const addr,
-                T const& compare,
-                T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T compare, T value) -> T
             {
                 T old;
                 auto& ref(*addr);
@@ -261,7 +265,12 @@ namespace alpaka
 #        pragma omp atomic capture compare
                 {
                     old = ref;
-                    ref = (ref == compare ? value : ref);
+                    // Do not remove the curly brackets of the if body else
+                    // icpx 2024.0 is not able to compile the atomics.
+                    if(ref == compare)
+                    {
+                        ref = value;
+                    }
                 }
                 return old;
             }


### PR DESCRIPTION
fix #2205

The compiler requires that the atomics are written in a very specific syntax else the code is not compiling.

This PR is replacing #2209. We do not check icpx 2024.0 in the CI because we can not use the TBB and OpenMP backend simultaneously.