### PR TITLE
Add `alpaka::getPreferredWarpSize(dev)`

### DIFF
--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -1,5 +1,5 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Jan Stephan, Bernhard Manfred Gruber,
- * Antonio Di Pilato
+/* Copyright 2024 Axel Huebl, Benjamin Worpitz, Matthias Werner, Jan Stephan, Bernhard Manfred Gruber,
+ *                Antonio Di Pilato, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -132,6 +132,16 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getWarpSizes(DevCpu const& /* dev */) -> std::vector<std::size_t>
             {
                 return {1u};
+            }
+        };
+
+        //! The CPU device preferred warp size get trait specialization.
+        template<>
+        struct GetPreferredWarpSize<DevCpu>
+        {
+            ALPAKA_FN_HOST static constexpr auto getPreferredWarpSize(DevCpu const& /* dev */) -> std::size_t
+            {
+                return 1u;
             }
         };
 

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Jan Stephan, Antonio Di Pilato, Luca Ferragina, Aurora Perego
+/* Copyright 2024 Jan Stephan, Antonio Di Pilato, Luca Ferragina, Aurora Perego, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -181,7 +182,19 @@ namespace alpaka::trait
             auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
             if(find64 != warp_sizes.end())
                 warp_sizes.erase(find64);
+            // Sort the warp sizes in decreasing order
+            std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
             return warp_sizes;
+        }
+    };
+
+    //! The SYCL device preferred warp size get trait specialization.
+    template<typename TPlatform>
+    struct GetPreferredWarpSize<DevGenericSycl<TPlatform>>
+    {
+        static auto getPreferredWarpSize(DevGenericSycl<TPlatform> const& dev) -> std::size_t
+        {
+            return GetWarpSizes<DevGenericSycl<TPlatform>>::getWarpSizes(dev).front();
         }
     };
 

--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber, Jan Stephan
+/* Copyright 2024 Benjamin Worpitz, Bernhard Manfred Gruber, Jan Stephan, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -41,6 +41,10 @@ namespace alpaka
         //! The device warp size get trait.
         template<typename T, typename TSfinae = void>
         struct GetWarpSizes;
+
+        //! The device preferred warp size get trait.
+        template<typename T, typename TSfinae = void>
+        struct GetPreferredWarpSize;
 
         //! The device reset trait.
         template<typename T, typename TSfinae = void>
@@ -107,6 +111,13 @@ namespace alpaka
     ALPAKA_FN_HOST auto getWarpSizes(TDev const& dev) -> std::vector<std::size_t>
     {
         return trait::GetWarpSizes<TDev>::getWarpSizes(dev);
+    }
+
+    //! \return The preferred warp size on the device in number of threads.
+    template<typename TDev>
+    ALPAKA_FN_HOST constexpr auto getPreferredWarpSize(TDev const& dev) -> std::size_t
+    {
+        return trait::GetPreferredWarpSize<TDev>::getPreferredWarpSize(dev);
     }
 
     //! Resets the device.

--- a/test/unit/dev/src/DevWarpSizeTest.cpp
+++ b/test/unit/dev/src/DevWarpSizeTest.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan
+/* Copyright 2024 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -20,4 +20,12 @@ TEMPLATE_LIST_TEST_CASE("getWarpSizes", "[dev]", alpaka::test::TestAccs)
         std::cbegin(warpExtents),
         std::cend(warpExtents),
         [](std::size_t warpExtent) { return warpExtent > 0; }));
+}
+
+TEMPLATE_LIST_TEST_CASE("getPreferredWarpSize", "[dev]", alpaka::test::TestAccs)
+{
+    auto const platform = alpaka::Platform<TestType>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
+    auto const preferredWarpSize = alpaka::getPreferredWarpSize(dev);
+    REQUIRE(preferredWarpSize > 0);
 }


### PR DESCRIPTION
`alpaka::getPreferredWarpSize(dev)` returns one of the possible warp sizes supported by the device.

On devices that support a single work size (cpu, CUDA gpu, ROCm gpu), `getPreferredWarpSize(dev)` avoids the overhead of wrapping that value in an `std::vector`.

On devices that support multiple warp sizes, the value returned by `getPreferredWarpSize(dev)` is unspecified. Currently it returns the largest supported value -- but this could change in a future version of alpaka.

Add a test for `alpaka::getPreferredWarpSize(dev)`.