### PR TITLE
Add verbose output to alpaka-ls

### DIFF
--- a/example/ls/src/ls.cpp
+++ b/example/ls/src/ls.cpp
@@ -5,21 +5,46 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include <string_view>
+
 struct PerAcc
 {
+    bool verbose;
+
     template<typename TAcc>
     void operator()() const
     {
         auto const platform = alpaka::Platform<TAcc>{};
         std::cout << alpaka::getAccName<TAcc>() << '\n';
         for(auto const& dev : alpaka::getDevs(platform))
+        {
             std::cout << '\t' << alpaka::getName(dev) << '\n';
+            if(verbose)
+            {
+                auto const props = alpaka::getAccDevProps<TAcc>(dev);
+                auto const globalMem = alpaka::getMemBytes(dev);
+
+                std::cout << "\t\tMultiProcessorCount  " << props.m_multiProcessorCount << '\n';
+                std::cout << "\t\tGlobalMemSizeBytes   " << globalMem << '\n';
+                std::cout << "\t\tSharedMemSizeBytes   " << props.m_sharedMemSizeBytes << '\n';
+
+                std::cout << "\t\tGridBlockExtentMax   " << props.m_gridBlockExtentMax << '\n';
+                std::cout << "\t\tBlockThreadExtentMax " << props.m_blockThreadExtentMax << '\n';
+                std::cout << "\t\tThreadElemExtentMax  " << props.m_threadElemExtentMax << '\n';
+
+                std::cout << "\t\tGridBlockCountMax    " << props.m_gridBlockCountMax << '\n';
+                std::cout << "\t\tBlockThreadCountMax  " << props.m_blockThreadCountMax << '\n';
+                std::cout << "\t\tThreadElemCountMax   " << props.m_threadElemCountMax << '\n';
+            }
+        }
     }
 };
 
-int main()
+int main(int argc, char const* argv[])
 {
+    auto const verbose = argc >= 2 && std::string_view{argv[1]} == "-v";
+
     using Idx = int;
     using Dim = alpaka::DimInt<1>;
-    alpaka::meta::forEachType<alpaka::test::EnabledAccs<Dim, Idx>>(PerAcc{});
+    alpaka::meta::forEachType<alpaka::test::EnabledAccs<Dim, Idx>>(PerAcc{verbose});
 }


### PR DESCRIPTION
I needed to get some numbers on the device I use for benchmarking, so here is a patch to add them to `alpaka-ls`.