### PR TITLE
[WIP] Use  executionTask+enqueue instead of exec in examples

### DIFF
--- a/example/babelstream/src/AlpakaStream.cpp
+++ b/example/babelstream/src/AlpakaStream.cpp
@@ -51,8 +51,7 @@ void AlpakaStream<T>::init_arrays(T initA, T initB, T initC)
 {
     auto const workdiv = WorkDiv{arraySize / blockSize, blockSize, 1};
     // auto const workdiv = alpaka::getValidWorkDiv(devAcc, arraySize);
-    alpaka::exec<Acc>(
-        queue,
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(
         workdiv,
         InitKernel{},
         alpaka::getPtrNative(d_a),
@@ -61,7 +60,7 @@ void AlpakaStream<T>::init_arrays(T initA, T initB, T initC)
         initA,
         initB,
         initC);
-    alpaka::wait(queue);
+    alpaka::enqueue(queue, taskKernel);
 }
 
 template<typename T>
@@ -87,8 +86,10 @@ void AlpakaStream<T>::copy()
 {
     auto const workdiv = WorkDiv{arraySize / blockSize, blockSize, 1};
     // auto const workdiv = alpaka::getValidWorkDiv(devAcc, arraySize);
-    alpaka::exec<Acc>(queue, workdiv, CopyKernel{}, alpaka::getPtrNative(d_a), alpaka::getPtrNative(d_c));
-    alpaka::wait(queue);
+    auto const taskKernel
+        = alpaka::createTaskKernel<Acc>(workdiv, CopyKernel{}, alpaka::getPtrNative(d_a), alpaka::getPtrNative(d_c));
+    // Enqueue the kernel
+    alpaka::enqueue(queue, taskKernel);
 }
 
 struct MulKernel
@@ -107,8 +108,10 @@ void AlpakaStream<T>::mul()
 {
     auto const workdiv = WorkDiv{arraySize / blockSize, blockSize, 1};
     // auto const workdiv = alpaka::getValidWorkDiv(devAcc, arraySize);
-    alpaka::exec<Acc>(queue, workdiv, MulKernel{}, alpaka::getPtrNative(d_b), alpaka::getPtrNative(d_c));
-    alpaka::wait(queue);
+    auto const taskKernel
+        = alpaka::createTaskKernel<Acc>(workdiv, MulKernel{}, alpaka::getPtrNative(d_b), alpaka::getPtrNative(d_c));
+    // Enqueue the kernel
+    alpaka::enqueue(queue, taskKernel);
 }
 
 struct AddKernel
@@ -126,14 +129,14 @@ void AlpakaStream<T>::add()
 {
     auto const workdiv = WorkDiv{arraySize / blockSize, blockSize, 1};
     // auto const workdiv = alpaka::getValidWorkDiv(devAcc, arraySize);
-    alpaka::exec<Acc>(
-        queue,
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(
         workdiv,
         AddKernel{},
         alpaka::getPtrNative(d_a),
         alpaka::getPtrNative(d_b),
         alpaka::getPtrNative(d_c));
-    alpaka::wait(queue);
+    // Enqueue the kernel
+    alpaka::enqueue(queue, taskKernel);
 }
 
 struct TriadKernel
@@ -152,14 +155,14 @@ void AlpakaStream<T>::triad()
 {
     auto const workdiv = WorkDiv{arraySize / blockSize, blockSize, 1};
     // auto const workdiv = alpaka::getValidWorkDiv(devAcc, arraySize);
-    alpaka::exec<Acc>(
-        queue,
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(
         workdiv,
         TriadKernel{},
         alpaka::getPtrNative(d_a),
         alpaka::getPtrNative(d_b),
         alpaka::getPtrNative(d_c));
-    alpaka::wait(queue);
+    // Enqueue the kernel
+    alpaka::enqueue(queue, taskKernel);
 }
 
 struct NstreamKernel
@@ -178,14 +181,14 @@ void AlpakaStream<T>::nstream()
 {
     auto const workdiv = WorkDiv{arraySize / blockSize, blockSize, 1};
     // auto const workdiv = alpaka::getValidWorkDiv(devAcc, arraySize);
-    alpaka::exec<Acc>(
-        queue,
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(
         workdiv,
         NstreamKernel{},
         alpaka::getPtrNative(d_a),
         alpaka::getPtrNative(d_b),
         alpaka::getPtrNative(d_c));
-    alpaka::wait(queue);
+    // Enqueue the kernel
+    alpaka::enqueue(queue, taskKernel);
 }
 
 struct DotKernel
@@ -224,15 +227,15 @@ auto AlpakaStream<T>::dot() -> T
 {
     auto const workdiv = WorkDiv{dotBlockSize, blockSize, 1};
     // auto const workdiv = alpaka::getValidWorkDiv(devAcc, dotBlockSize * blockSize);
-    alpaka::exec<Acc>(
-        queue,
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(
         workdiv,
         DotKernel{},
         alpaka::getPtrNative(d_a),
         alpaka::getPtrNative(d_b),
         alpaka::getPtrNative(d_sum),
         arraySize);
-    alpaka::wait(queue);
+    // Enqueue the kernel
+    alpaka::enqueue(queue, taskKernel);
 
     alpaka::memcpy(queue, sums, d_sum);
     T const* sumPtr = alpaka::getPtrNative(sums);

--- a/example/complex/src/complex.cpp
+++ b/example/complex/src/complex.cpp
@@ -79,8 +79,9 @@ auto main() -> int
         alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
 
     // Run the kernel
-    alpaka::exec<Acc>(queue, workDiv, ComplexKernel{});
-    alpaka::wait(queue);
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(workDiv, ComplexKernel{});
+    // Enqueue the kernel
+    alpaka::enqueue(queue, taskKernel);
 
     // Usage of alpaka::Complex<T> on the host side is the same as inside kernels, except math functions are not
     // supported
@@ -89,7 +90,7 @@ auto main() -> int
     auto y = alpaka::Complex<float>(0.3f, 0.4f);
     x *= 2.0f;
     alpaka::Complex<float> z = x + y;
-
+    std::cout << "z: " << z.real() << " " << std::showpos << z.imag() << "i" << std::endl;
     return EXIT_SUCCESS;
 #endif
 }

--- a/example/heatEquation/src/heatEquation.cpp
+++ b/example/heatEquation/src/heatEquation.cpp
@@ -148,7 +148,9 @@ auto main() -> int
     for(uint32_t step = 0; step < numTimeSteps; step++)
     {
         // Compute next values
-        alpaka::exec<Acc>(queue, workdiv, kernel, pCurrAcc, pNextAcc, numNodesX, dx, dt);
+        auto const taskKernel = alpaka::createTaskKernel<Acc>(workdiv, kernel, pCurrAcc, pNextAcc, numNodesX, dx, dt);
+        // Enqueue the kernel
+        alpaka::enqueue(queue, taskKernel);
 
         // We assume the boundary conditions are constant and so these values
         // do not need to be updated.

--- a/example/helloWorld/src/helloWorld.cpp
+++ b/example/helloWorld/src/helloWorld.cpp
@@ -159,21 +159,24 @@ auto main() -> int
     // argument. So a kernel can be a class or struct, a lambda, etc.
     HelloWorldKernel helloWorldKernel;
 
-    // Run the kernel
-    //
-    // To execute the kernel, you have to provide the
+    // Create the kernel execution task
+    // To create the kernel eecuion task, you have to provide the
     // work division as well as the additional kernel function
     // parameters.
+    auto const taskKernelHelloWorld = alpaka::createTaskKernel<Acc>(
+        workDiv,
+        helloWorldKernel
+        /* put kernel arguments here */);
+
+    // Run the kernel
+    //
     // The kernel execution task is enqueued into an accelerator queue.
     // The queue can be blocking or non-blocking
     // depending on the chosen queue type (see type definitions above).
     // Here it is synchronous which means that the kernel is directly executed.
-    alpaka::exec<Acc>(
-        queue,
-        workDiv,
-        helloWorldKernel
-        /* put kernel arguments here */);
-    alpaka::wait(queue);
+
+    // enqueue the kernel execution task
+    alpaka::enqueue(queue, taskKernelHelloWorld);
 
     return EXIT_SUCCESS;
 #endif

--- a/example/helloWorldLambda/src/helloWorldLambda.cpp
+++ b/example/helloWorldLambda/src/helloWorldLambda.cpp
@@ -106,8 +106,9 @@ auto main() -> int
     // To define a fully generic kernel lambda, the type of acc must be
     // auto. The Nvidia nvcc does not support generic lambdas, so the
     // type is set to Acc.
-    alpaka::exec<Acc>(
-        queue,
+
+    // create the kernel execution task
+    auto const taskKernelHelloWorldLambda = alpaka::createTaskKernel<Acc>(
         workDiv,
         [] ALPAKA_FN_ACC(Acc const& acc, size_t const nExclamationMarksAsArg) -> void
         {
@@ -130,7 +131,9 @@ auto main() -> int
             printf("\n");
         },
         nExclamationMarks);
-    alpaka::wait(queue);
+
+    // enqueue the kernel execution task.
+    alpaka::enqueue(queue, taskKernelHelloWorldLambda);
 
     return EXIT_SUCCESS;
 

--- a/example/kernelSpecialization/src/kernelSpecialization.cpp
+++ b/example/kernelSpecialization/src/kernelSpecialization.cpp
@@ -96,9 +96,10 @@ auto main() -> int
         false,
         alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
 
-    // Run the kernel
-    alpaka::exec<Acc>(queue, workDiv, Kernel{});
-    alpaka::wait(queue);
+
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(workDiv, Kernel{});
+    // Enqueue the kernel
+    alpaka::enqueue(queue, taskKernel);
 
     return EXIT_SUCCESS;
 #endif

--- a/example/monteCarloIntegration/src/monteCarloIntegration.cpp
+++ b/example/monteCarloIntegration/src/monteCarloIntegration.cpp
@@ -114,9 +114,10 @@ auto main() -> int
     alpaka::memcpy(queue, bufAcc, bufHost);
 
     Kernel kernel;
-    alpaka::exec<Acc>(queue, workdiv, kernel, numPoints, ptrBufAcc, Function{});
+    auto const taskKernelMonteCarlo = alpaka::createTaskKernel<Acc>(workdiv, kernel, numPoints, ptrBufAcc, Function{});
+
+    alpaka::enqueue(queue, taskKernelMonteCarlo);
     alpaka::memcpy(queue, bufHost, bufAcc);
-    alpaka::wait(queue);
 
     // Check the result.
     uint32_t globalCount = *ptrBufHost;

--- a/example/parallelLoopPatterns/src/parallelLoopPatterns.cpp
+++ b/example/parallelLoopPatterns/src/parallelLoopPatterns.cpp
@@ -115,7 +115,10 @@ void naiveCudaStyle(TDev& dev, TQueue& queue, TBufAcc& bufAcc)
     std::cout << "\nNaive CUDA style processing - each thread processes one data point:\n";
     std::cout << "   " << blocksPerGrid << " blocks, " << threadsPerBlock << " threads per block, "
               << "alpaka element layer not used\n";
-    alpaka::exec<TAcc>(queue, workDiv, NaiveCudaStyleKernel{}, alpaka::getPtrNative(bufAcc), n);
+    auto const taskKernel
+        = alpaka::createTaskKernel<TAcc>(workDiv, NaiveCudaStyleKernel{}, alpaka::getPtrNative(bufAcc), n);
+    // Enqueue the kernel
+    alpaka::enqueue(queue, taskKernel);
     testResult(queue, bufAcc);
 }
 
@@ -178,7 +181,10 @@ void gridStridedLoop(TDev& dev, TQueue& queue, TBufAcc& bufAcc)
     std::cout << "\nGrid strided loop processing - fixed number of threads and blocks:\n";
     std::cout << "   " << blocksPerGrid << " blocks, " << threadsPerBlock << " threads per block, "
               << "alpaka element layer not used\n";
-    alpaka::exec<TAcc>(queue, workDiv, GridStridedLoopKernel{}, alpaka::getPtrNative(bufAcc), n);
+    auto const taskKernel
+        = alpaka::createTaskKernel<TAcc>(workDiv, GridStridedLoopKernel{}, alpaka::getPtrNative(bufAcc), n);
+    // Enqueue the kernel
+    alpaka::enqueue(queue, taskKernel);
     testResult(queue, bufAcc);
 }
 
@@ -253,7 +259,10 @@ void chunkedGridStridedLoop(TDev& dev, TQueue& queue, TBufAcc& bufAcc)
     std::cout << "\nChunked grid strided loop processing - fixed number of threads and blocks:\n";
     std::cout << "   " << blocksPerGrid << " blocks, " << threadsPerBlock << " threads per block, "
               << elementsPerThread << " alpaka elements per thread\n";
-    alpaka::exec<TAcc>(queue, workDiv, ChunkedGridStridedLoopKernel{}, alpaka::getPtrNative(bufAcc), n);
+    auto const taskKernel
+        = alpaka::createTaskKernel<TAcc>(workDiv, ChunkedGridStridedLoopKernel{}, alpaka::getPtrNative(bufAcc), n);
+    // Enqueue the kernel
+    alpaka::enqueue(queue, taskKernel);
     testResult(queue, bufAcc);
 }
 
@@ -319,7 +328,10 @@ void naiveOpenMPStyle(TDev& dev, TQueue& queue, TBufAcc& bufAcc)
     std::cout << "\nNaive OpenMP style processing - each thread processes a single consecutive range of elements:\n";
     std::cout << "   " << blocksPerGrid << " blocks, " << threadsPerBlock << " threads per block, "
               << "alpaka element layer not used\n";
-    alpaka::exec<TAcc>(queue, workDiv, NaiveOpenMPStyleKernel{}, alpaka::getPtrNative(bufAcc), n);
+    auto const taskKernel
+        = alpaka::createTaskKernel<TAcc>(workDiv, NaiveOpenMPStyleKernel{}, alpaka::getPtrNative(bufAcc), n);
+    // Enqueue the kernel
+    alpaka::enqueue(queue, taskKernel);
     testResult(queue, bufAcc);
 }
 
@@ -397,7 +409,10 @@ void openMPSimdStyle(TDev& dev, TQueue& queue, TBufAcc& bufAcc)
     std::cout << "\nOpenMP SIMD style processing - each thread processes a single consecutive range of elements:\n";
     std::cout << "   " << blocksPerGrid << " blocks, " << threadsPerBlock << " threads per block, "
               << elementsPerThread << " alpaka elements per thread\n";
-    alpaka::exec<TAcc>(queue, workDiv, OpenMPSimdStyleKernel{}, alpaka::getPtrNative(bufAcc), n);
+    auto const taskKernel
+        = alpaka::createTaskKernel<TAcc>(workDiv, OpenMPSimdStyleKernel{}, alpaka::getPtrNative(bufAcc), n);
+    // Enqueue the kernel
+    alpaka::enqueue(queue, taskKernel);
     testResult(queue, bufAcc);
 }
 

--- a/example/tagSpecialization/src/tagSpecialization.cpp
+++ b/example/tagSpecialization/src/tagSpecialization.cpp
@@ -123,8 +123,9 @@ auto main() -> int
     // Run the wrapper kernel, which calls the actual specialized
     // Specializing the entry kernel with tags is not possible. Therefore pre processor guards are required, see
     // kernelSpecialization example.
-    alpaka::exec<Acc>(queue, workDiv, WrapperKernel{});
-    alpaka::wait(queue);
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(workDiv, WrapperKernel{});
+    // Enqueue the kernel
+    alpaka::enqueue(queue, taskKernel);
     return EXIT_SUCCESS;
 #endif
 }


### PR DESCRIPTION
There are 2 ways of running a kernel. Some of the examples use `alpaka::exec<Acc>(queue, workdiv...) + wait(queue)` some others use `createTaskKernel<Acc> and enqueue` functions. 

All of the exec and wait function call pairs converted to `createTaskKernel + enqueue` calls.

**Tests**
All example results are the same as before these changes.

**Clarification Needed:** 

-  If there is a function call between `exec` call and `wait` call, how the change above could be done?  See the change in **MonteCarlo** example.

- **Note from @psychocoderHPC :**
_I checked the code. And enqueue requires that we bind together already the kernel with the work division. 
Where exec allows to pass the work division and kernel separate more similar to how CUDA works.
I like the exec way more because very often the kernel will be started with different work division size. IN that case the user must always call_  

```
alpaka::createTaskKernel<Acc>(
        workDiv2,
        kernel2, ...
)
``` 
 _for any new block and grid configuration. So the user code becomes longer.
IMO we should provide additionally an enqueue which has the same signature as exec has and provide two interfaces of enqueue. Let us have a short discussion in the next developer meeting._