### PR TITLE
Remove Obsolete #ifdefs from the examples

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -66,10 +66,6 @@ struct FillBufferKernel
 
 auto main() -> int
 {
-// Fallback for the CI with disabled sequential backend
-#if defined(ALPAKA_CI) && !defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
-    return EXIT_SUCCESS;
-#else
     // Define the index domain
     using Dim = alpaka::DimInt<3u>;
     using Idx = std::size_t;
@@ -260,5 +256,4 @@ auto main() -> int
     std::cout << std::endl;
 
     return EXIT_SUCCESS;
-#endif
 }

--- a/example/complex/src/complex.cpp
+++ b/example/complex/src/complex.cpp
@@ -30,10 +30,6 @@ struct ComplexKernel
 
 auto main() -> int
 {
-// Fallback for the CI with disabled sequential backend
-#if defined(ALPAKA_CI) && !defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
-    return EXIT_SUCCESS;
-#else
     using Idx = std::size_t;
 
     // Define the accelerator
@@ -91,5 +87,4 @@ auto main() -> int
     alpaka::Complex<float> z = x + y;
 
     return EXIT_SUCCESS;
-#endif
 }

--- a/example/counterBasedRng/src/counterBasedRng.cpp
+++ b/example/counterBasedRng/src/counterBasedRng.cpp
@@ -97,11 +97,6 @@ public:
 
 auto main() -> int
 {
-// Fallback for the CI with disabled sequential backend
-#if defined(ALPAKA_CI) && !defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
-    return EXIT_SUCCESS;
-#else
-
     // Define the index domain
     using Dim = alpaka::DimInt<3u>;
     using Idx = std::size_t;
@@ -233,5 +228,4 @@ auto main() -> int
                   << "Execution results incorrect!" << std::endl;
         return EXIT_FAILURE;
     }
-#endif
 }

--- a/example/heatEquation/src/heatEquation.cpp
+++ b/example/heatEquation/src/heatEquation.cpp
@@ -64,9 +64,6 @@ auto exactSolution(double const x, double const t) -> double
 //! from the next-buffer.
 auto main() -> int
 {
-#if defined(ALPAKA_CI) && !defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
-    return EXIT_SUCCESS;
-#else
     // Parameters (a user is supposed to change numNodesX, numTimeSteps)
     uint32_t const numNodesX = 1000;
     uint32_t const numTimeSteps = 10000;
@@ -181,5 +178,4 @@ auto main() -> int
                   << std::endl;
         return EXIT_FAILURE;
     }
-#endif
 }

--- a/example/helloWorld/src/helloWorld.cpp
+++ b/example/helloWorld/src/helloWorld.cpp
@@ -49,10 +49,6 @@ struct HelloWorldKernel
 
 auto main() -> int
 {
-// Fallback for the CI with disabled sequential backend
-#if defined(ALPAKA_CI) && !defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
-    return EXIT_SUCCESS;
-#else
     // Define the index domain
     //
     // Depending on your type of problem, you have to define
@@ -176,5 +172,4 @@ auto main() -> int
     alpaka::wait(queue);
 
     return EXIT_SUCCESS;
-#endif
 }

--- a/example/kernelSpecialization/src/kernelSpecialization.cpp
+++ b/example/kernelSpecialization/src/kernelSpecialization.cpp
@@ -55,11 +55,6 @@ struct Kernel
 
 auto main() -> int
 {
-// Fallback for the CI with disabled sequential backend
-#if defined(ALPAKA_CI) && !defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
-    return EXIT_SUCCESS;
-#else
-
     // Define the accelerator
     //
     // It is possible to choose from a set of accelerators:
@@ -101,5 +96,4 @@ auto main() -> int
     alpaka::wait(queue);
 
     return EXIT_SUCCESS;
-#endif
 }

--- a/example/parallelLoopPatterns/src/parallelLoopPatterns.cpp
+++ b/example/parallelLoopPatterns/src/parallelLoopPatterns.cpp
@@ -403,11 +403,6 @@ void openMPSimdStyle(TDev& dev, TQueue& queue, TBufAcc& bufAcc)
 
 auto main() -> int
 {
-// Fallback for the CI with disabled sequential backend
-#if defined(ALPAKA_CI) && !defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
-    return EXIT_SUCCESS;
-#else
-
     // Define the index domain, this example is only for 1d
     using Dim = alpaka::DimInt<1u>;
 
@@ -441,6 +436,4 @@ auto main() -> int
     chunkedGridStridedLoop<Acc>(devAcc, queue, bufAcc);
     naiveOpenMPStyle<Acc>(devAcc, queue, bufAcc);
     openMPSimdStyle<Acc>(devAcc, queue, bufAcc);
-
-#endif
 }

--- a/example/tagSpecialization/src/tagSpecialization.cpp
+++ b/example/tagSpecialization/src/tagSpecialization.cpp
@@ -78,11 +78,6 @@ struct WrapperKernel
 
 auto main() -> int
 {
-// Fallback for the CI with disabled sequential backend
-#if defined(ALPAKA_CI) && !defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
-    return EXIT_SUCCESS;
-#else
-
     // Define the accelerator
     //
     // It is possible to choose from a set of accelerators:
@@ -126,5 +121,4 @@ auto main() -> int
     alpaka::exec<Acc>(queue, workDiv, WrapperKernel{});
     alpaka::wait(queue);
     return EXIT_SUCCESS;
-#endif
 }

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -56,11 +56,6 @@ public:
 
 auto main() -> int
 {
-// Fallback for the CI with disabled sequential backend
-#if defined(ALPAKA_CI) && !defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
-    return EXIT_SUCCESS;
-#else
-
     // Define the index domain
     using Dim = alpaka::DimInt<1u>;
     using Idx = std::size_t;
@@ -206,5 +201,4 @@ auto main() -> int
                   << "Execution results incorrect!" << std::endl;
         return EXIT_FAILURE;
     }
-#endif
 }


### PR DESCRIPTION
There were obsolete `if defined ` clauses at the beginning of main() functions of 9 examples, they are removed by this MR. It is never triggered because ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED always on at CI.

```
-// Fallback for the CI with disabled sequential backend
-#if defined(ALPAKA_CI) && !defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
-    return EXIT_SUCCESS;
-#else
...
...
#endif
```
