### PR TITLE
Allow non-integral types in Vec generator constructor

### DIFF
--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -87,18 +87,22 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC constexpr explicit Vec(
             F&& generator,
             std::void_t<decltype(generator(std::integral_constant<std::size_t, 0>{}))>* ignore = nullptr)
+            : Vec(std::forward<F>(generator), std::make_index_sequence<TDim::value>{})
+        {
+            static_cast<void>(ignore);
+        }
 #else
         template<typename F, std::enable_if_t<std::is_invocable_v<F, std::integral_constant<std::size_t, 0>>, int> = 0>
         ALPAKA_FN_HOST_ACC constexpr explicit Vec(F&& generator)
-#endif
-            : Vec(std::forward<F>(generator), std::make_integer_sequence<TVal, TDim::value>{})
+            : Vec(std::forward<F>(generator), std::make_index_sequence<TDim::value>{})
         {
         }
+#endif
 
     private:
-        template<typename F, TVal... Is>
-        ALPAKA_FN_HOST_ACC constexpr explicit Vec(F&& generator, std::integer_sequence<TVal, Is...>)
-            : m_data{generator(std::integral_constant<TVal, Is>{})...}
+        template<typename F, std::size_t... Is>
+        ALPAKA_FN_HOST_ACC constexpr explicit Vec(F&& generator, std::index_sequence<Is...>)
+            : m_data{generator(std::integral_constant<std::size_t, Is>{})...}
         {
         }
 

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -468,3 +468,27 @@ TEST_CASE("accessByNameConstexpr", "[vec]")
     STATIC_REQUIRE(v4.z() == 3);
     STATIC_REQUIRE(v4.w() == 4);
 }
+
+TEMPLATE_TEST_CASE("Vec generator constructor", "[vec]", std::size_t, int, unsigned, float, double)
+{
+    // Define a generator function
+    auto generator = [](auto index) { return static_cast<TestType>(index.value + 1); };
+
+    // Create a Vec object using the generator function
+    alpaka::Vec<alpaka::DimInt<5>, TestType> vec(generator);
+
+    // Check that the values in the Vec object are as expected
+    for(std::size_t i = 0; i < 5; ++i)
+    {
+        // Floating point types require a precision check instead of an exact == match
+        if constexpr(std::is_floating_point<TestType>::value)
+        {
+            auto const precision = std::numeric_limits<TestType>::epsilon() * 5; // Arbitrary precision requirement
+            CHECK(std::abs(vec[i] - static_cast<TestType>(i + 1)) < precision);
+        }
+        else
+        {
+            CHECK(vec[i] == static_cast<TestType>(i + 1));
+        }
+    }
+}


### PR DESCRIPTION
The `explicit Vec(F&& generator, std::integer_sequence<TVal, Is...>)` accepted a parameter pack of `TVal` which is defined to be the inner vector value and can possible be non-integral, which makes it invalid in pre-C++20 codebases. We've restricted the parameter to an integral type, thus disallowing this construction method for non-integral inner types.