### PR TITLE
Change cheatsheet to clarify some alpaka structures

### DIFF
--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -115,9 +115,10 @@ Create a CPU device for memory allocation on the host side
 
 Allocate a buffer in host memory
   .. code-block:: c++
-
-     Vec<Dim, Idx> extent = value;
-     using BufHost = Buf<DevHost, DataType, Dim, Idx>;
+     // Use alpaka vector as a static array for the extents
+     alpaka::Vec<Dim, Idx> extent = value;
+     // Allocate memory for the alpaka buffer, which is a dynamic array
+     using BufHost = alpaka::Buf<DevHost, DataType, Dim, Idx>;
      BufHost bufHost = allocBuf<DataType, Idx>(devHost, extent);
 
 (Optional, affects CPU – GPU memory copies) Prepare it for asynchronous memory copies
@@ -129,7 +130,8 @@ Create a view to host memory represented by a pointer
   .. code-block:: c++
 
      using Dim = alpaka::DimInt<1u>;
-     Vec<Dim, Idx> extent = size;
+     // Create an alpaka vector which is a static array
+     alpaka::Vec<Dim, Idx> extent = size;
      DataType* ptr = ...;
      auto hostView = createView(devHost, ptr, extent);
 
@@ -231,7 +233,7 @@ Access multi-dimensional indices and extents of blocks, threads, and elements
      // Origin: Grid, Block, Thread
      // Unit: Blocks, Threads, Elems
 
-Access components of and destructuremulti-dimensional indices and extents
+Access components of and destructure multi-dimensional indices and extents
   .. code-block:: c++
 
      auto idxX = idx[0];

--- a/docs/source/basic/library.rst
+++ b/docs/source/basic/library.rst
@@ -211,7 +211,8 @@ Memory Management
 
 The memory allocation function of the *alpaka* library (``alpaka::allocBuf<TElem>(device, extents)``) is uniform for all devices, even for the host device.
 It does not return raw pointers but reference counted memory buffer objects that remove the necessity for manual freeing and the possibility of memory leaks.
-Additionally the memory buffer objects know their extents, their pitches as well as the device they reside on.
+Additionally, the memory buffer objects know their extents, their pitches as well as the device they reside on.
+Due to padding, the allocated number of bytes may be more than the required storage; the pitch value gives the correct stride for each dimension for row-major access.
 This allows buffers that possibly reside on different devices with different pitches to be copied only by providing the buffer objects as well as the extents of the region to copy (``alpaka::memcpy(bufDevA, bufDevB, copyExtents``).
 
 Kernel Execution


### PR DESCRIPTION
Some simple clarifications for the novice alpaka user are added to the cheatsheet and library file. Alpaka vector is a static array, Buffer is a dynamic array. Pitch is the allocated memory with padding (till the alignment point) and extent is actually dimensions.