### PR TITLE
fix macOS CI error at brew link step: "Target already exists"

### DIFF
--- a/script/install_omp.sh
+++ b/script/install_omp.sh
@@ -16,5 +16,17 @@ then
     rm '/usr/local/bin/pydoc3.12'
     rm '/usr/local/bin/python3.12'
     rm '/usr/local/bin/python3.12-config'
+    rm '/usr/local/bin/2to3' || true
+    rm '/usr/local/bin/idle3' || true
+    rm '/usr/local/bin/pydoc3' || true
+    rm '/usr/local/bin/python3' || true
+    rm '/usr/local/bin/python3-config' || true
+    rm '/usr/local/share/man/man1/python3.1' || true
+    rm '/usr/local/lib/pkgconfig/python3-embed.pc' || true
+    rm '/usr/local/lib/pkgconfig/python3.pc' || true
+    rm '/usr/local/Frameworks/Python.framework/Headers' || true
+    rm '/usr/local/Frameworks/Python.framework/Python' || true
+    rm '/usr/local/Frameworks/Python.framework/Resources' || true
+    rm '/usr/local/Frameworks/Python.framework/Versions/Current'  || true
     brew reinstall --build-from-source --formula ./script/homebrew/${ALPAKA_CI_XCODE_VER}/libomp.rb
 fi


### PR DESCRIPTION
CI error at compilation 14.3.1. CI needs to run script for libomp. The script _alpaka/script/homebrew/14.3.1/libomp.rb_ tries to install python again and a "target already exists" error is created. As a solution before calling the script the links are removed; to solve the issue.

**- ERROR at [CI of macos_xcode 14.3.1](https://github.com/alpaka-group/alpaka/actions/runs/8042544801/job/21963360599#step:5:742)**

> ==> Installing libomp dependency: python@3.12
> ==> Downloading https://ghcr.io/v2/homebrew/core/python/3.12/manifests/3.12.2_1
> Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/db6a7027cff95a641d6d0c07e00f7b8fa26b0733b6d215c3752b745a381ebcb8--python@3.12-3.12.2_1.bottle_manifest.json
> ==> Pouring python@3.12--3.12.2_1.ventura.bottle.tar.gz
> Error: The `brew link` step did not complete successfully
> The formula built, but is not symlinked into /usr/local
> Could not symlink bin/2to3
> Target /usr/local/bin/2to3
> already exists. 

A quick-fix is provided since the issue is blocking. The fix is similar to [a previous fix](https://github.com/alpaka-group/alpaka/commit/cf105b78eb48e0c1b3ca7324ada3d72a39834c63). In fact, changing /libomp.rb could be a proper fix.