### PR TITLE
fix CI bug for omp installation

### DIFF
--- a/script/install_omp.sh
+++ b/script/install_omp.sh
@@ -11,6 +11,11 @@ source ./script/set.sh
 if [ "$ALPAKA_CI_OS_NAME" = "macOS" ]
 then
     # workaround to avoid link issues from python 2 to 3 during libomp dependency installation
+    rm '/usr/local/bin/2to3-3.11' || true
+    rm '/usr/local/bin/idle3.11' || true
+    rm '/usr/local/bin/pydoc3.11' || true
+    rm '/usr/local/bin/python3.11' || true
+    rm '/usr/local/bin/python3.11-config' || true
     rm '/usr/local/bin/2to3-3.12'
     rm '/usr/local/bin/idle3.12'
     rm '/usr/local/bin/pydoc3.12'


### PR DESCRIPTION
- The CI error: `Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3-3.11
Target /usr/local/bin/2to3-3.11
already exists.`

- The link for the failing CI: https://github.com/alpaka-group/alpaka/actions/runs/8160092065/job/22305929356
- Solution: The already existing links related to 3.11 are removed before running the installation script.
