### PR TITLE
Fix slow getWarpSize problem

### DIFF
--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -75,6 +75,7 @@ namespace alpaka
         static constexpr DeviceAttr_t deviceAttributeMaxSharedMemoryPerBlock = ::cudaDevAttrMaxSharedMemoryPerBlock;
         static constexpr DeviceAttr_t deviceAttributeMaxThreadsPerBlock = ::cudaDevAttrMaxThreadsPerBlock;
         static constexpr DeviceAttr_t deviceAttributeMultiprocessorCount = ::cudaDevAttrMultiProcessorCount;
+        static constexpr DeviceAttr_t deviceAttributeWarpSize = ::cudaDevAttrWarpSize;
 
         static constexpr Limit_t limitPrintfFifoSize = ::cudaLimitPrintfFifoSize;
         static constexpr Limit_t limitMallocHeapSize = ::cudaLimitMallocHeapSize;

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -78,6 +78,7 @@ namespace alpaka
             = ::hipDeviceAttributeMaxSharedMemoryPerBlock;
         static constexpr DeviceAttr_t deviceAttributeMaxThreadsPerBlock = ::hipDeviceAttributeMaxThreadsPerBlock;
         static constexpr DeviceAttr_t deviceAttributeMultiprocessorCount = ::hipDeviceAttributeMultiprocessorCount;
+        static constexpr DeviceAttr_t deviceAttributeWarpSize = ::hipDeviceAttributeWarpSize;
 
 #    if HIP_VERSION >= 40'500'000
         static constexpr Limit_t limitPrintfFifoSize = ::hipLimitPrintfFifoSize;

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -175,10 +175,11 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getPreferredWarpSize(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                typename TApi::DeviceProp_t devProp;
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, dev.getNativeHandle()));
+                int warpSize = 0;
 
-                return static_cast<std::size_t>(devProp.warpSize);
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, dev.getNativeHandle()));
+                return static_cast<std::size_t>(warpSize);
             }
         };
 


### PR DESCRIPTION
 It was noticed that the use of the `alpaka::getWarpSizes(device)` function incurs a noticeable overhead. (The Issue #2192 )

**Solution:** 

- Cuda: The fastest option is returning 32, it is not changed. But specialisation is taken to the DevCudaRt.hpp file, which is much cleaner than using nested preprocessor statements. 

- Hip:  Rather than getting the whole device properties and selecting the attribute from that struct; getting directly the attribute seems a faster solution. `hipDeviceGetAttribute(&size, hipDeviceAttributeWarpSize, device)` (credits to @fwyzard )

**Notes:**
deviceAttributeWarpSize is added to ApiCudaRt.hpp but is not used.  
