### PR TITLE
Fix getValidWorkDiv for CUDA and ROCm [I] #2222

### DIFF
--- a/include/alpaka/acc/AccGenericSycl.hpp
+++ b/include/alpaka/acc/AccGenericSycl.hpp
@@ -119,7 +119,6 @@ namespace alpaka::trait
     };
 
     //! The SYCL accelerator device properties get trait specialization.
-
     template<template<typename, typename> typename TAcc, typename TDim, typename TIdx>
     struct GetAccDevProps<
         TAcc<TDim, TIdx>,

--- a/include/alpaka/acc/AccGenericSycl.hpp
+++ b/include/alpaka/acc/AccGenericSycl.hpp
@@ -119,11 +119,14 @@ namespace alpaka::trait
     };
 
     //! The SYCL accelerator device properties get trait specialization.
+    ALPAKA_NO_HOST_ACC_WARNING
+
     template<template<typename, typename> typename TAcc, typename TDim, typename TIdx>
     struct GetAccDevProps<
         TAcc<TDim, TIdx>,
         std::enable_if_t<std::is_base_of_v<AccGenericSycl<TDim, TIdx>, TAcc<TDim, TIdx>>>>
     {
+        ALPAKA_NO_HOST_ACC_WARNING
         static auto getAccDevProps(typename DevType<TAcc<TDim, TIdx>>::type const& dev) -> AccDevProps<TDim, TIdx>
         {
             auto const device = dev.getNativeHandle().first;

--- a/include/alpaka/acc/AccGenericSycl.hpp
+++ b/include/alpaka/acc/AccGenericSycl.hpp
@@ -119,14 +119,12 @@ namespace alpaka::trait
     };
 
     //! The SYCL accelerator device properties get trait specialization.
-    ALPAKA_NO_HOST_ACC_WARNING
 
     template<template<typename, typename> typename TAcc, typename TDim, typename TIdx>
     struct GetAccDevProps<
         TAcc<TDim, TIdx>,
         std::enable_if_t<std::is_base_of_v<AccGenericSycl<TDim, TIdx>, TAcc<TDim, TIdx>>>>
     {
-        ALPAKA_NO_HOST_ACC_WARNING
         static auto getAccDevProps(typename DevType<TAcc<TDim, TIdx>>::type const& dev) -> AccDevProps<TDim, TIdx>
         {
             auto const device = dev.getNativeHandle().first;

--- a/include/alpaka/kernel/KernelBundle.hpp
+++ b/include/alpaka/kernel/KernelBundle.hpp
@@ -1,0 +1,65 @@
+/* Copyright 2022 Benjamin Worpitz, Bert Wesarg, René Widera, Sergei Bastrakov, Bernhard Manfred Gruber, Mehmet
+ * Yusufoglu SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <alpaka/core/RemoveRestrict.hpp>
+
+#include <tuple>
+#include <type_traits>
+
+namespace alpaka
+{
+    //! \brief The class used to bind kernel function object and arguments together. Once an instance of this class is
+    //! created, arguments are not needed to be separately given to functions who need kernel function and arguments.
+    //! \tparam TKernelFn The kernel function object type.
+    //! \tparam TArgs Kernel function object invocation argument types as a parameter pack.
+    template<typename TKernelFn, typename... TArgs>
+    class KernelBundle
+    {
+    public:
+#if BOOST_COMP_CLANG
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdocumentation" // clang does not support the syntax for variadic template
+                                                       // arguments "args,...". Ignore the error.
+#endif
+        //! \param kernelFn The kernel function-object
+        //! \param args,... The kernel invocation arguments.
+#if BOOST_COMP_CLANG
+#    pragma clang diagnostic pop
+#endif
+        KernelBundle(TKernelFn const& kernelFn, TArgs&&... args)
+            : m_kernelFn(kernelFn)
+            , m_args(std::forward<TArgs>(args)...)
+        {
+        }
+
+        //! The function object type
+        using KernelFn = TKernelFn;
+        //! Tuple type to encapsulate kernel function argument types and argument values
+        using ArgTuple = std::tuple<remove_restrict_t<std::decay_t<TArgs>>...>;
+
+        KernelFn m_kernelFn;
+        ArgTuple m_args;
+    };
+
+    //! \brief User defined deduction guide with trailing return type. For CTAD during the construction.
+    //! \tparam TKernelFn The kernel function object type.
+    //! \tparam TArgs Kernel function object argument types as a parameter pack.
+    //! \param kernelFn The kernel object
+#if BOOST_COMP_CLANG
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdocumentation" // clang does not support the syntax for variadic template
+                                                       // arguments "args,...". Ignore the error.
+#endif
+    //! \param args,... The kernel invocation arguments.
+#if BOOST_COMP_CLANG
+#    pragma clang diagnostic pop
+#endif
+    //! \return Kernel function bundle. An instance of KernelBundle which consists the kernel function object and its
+    //! arguments.
+    template<typename TKernelFn, typename... TArgs>
+    KernelBundle(TKernelFn const& kernelFn, TArgs&&... args) -> KernelBundle<TKernelFn, TArgs...>;
+
+} // namespace alpaka

--- a/include/alpaka/kernel/KernelFunctionAttributes.hpp
+++ b/include/alpaka/kernel/KernelFunctionAttributes.hpp
@@ -1,0 +1,25 @@
+/* Copyright 2022 René Widera, Mehmet Yusufoglu
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+
+namespace alpaka
+{
+    //! Kernel function attributes struct. Attributes are filled by calling the API of the accelerator using the kernel
+    //! function as an argument. In case of a CPU backend, maxThreadsPerBlock is set to 1 and other values remain zero
+    //! since there are no correponding API functions to get the values.
+    struct KernelFunctionAttributes
+    {
+        std::size_t constSizeBytes{0};
+        std::size_t localSizeBytes{0};
+        std::size_t sharedSizeBytes{0};
+        int maxDynamicSharedSizeBytes{0};
+        int numRegs{0};
+        // This field is ptx or isa version if the backend is GPU
+        int asmVersion{0};
+        int maxThreadsPerBlock{0};
+    };
+} // namespace alpaka

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -17,6 +17,8 @@
 #include "alpaka/core/OmpSchedule.hpp"
 #include "alpaka/dev/DevCpu.hpp"
 #include "alpaka/idx/MapIdx.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
+#include "alpaka/kernel/KernelFunctionAttributes.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/workdiv/WorkDivMembers.hpp"
 
@@ -946,6 +948,30 @@ namespace alpaka
         {
             using type = TIdx;
         };
+
+        //! \brief Specialisation of the class template FunctionAttributes
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TKernelFn Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
+        template<typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
+        struct FunctionAttributes<AccCpuOmp2Blocks<TDim, TIdx>, KernelBundle<TKernelFn, TArgs...>>
+        {
+            //! \param kernelBundle Kernel bundeled with it's arguments. The function attributes of this kernel will be
+            //! determined. Max threads per block is one of the attributes.
+            //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
+            //! fields. For CPU, the field of max threads allowed by kernel function for the block is 1.
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_HOST_ACC static auto getFunctionAttributes(
+                [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
+                -> alpaka::KernelFunctionAttributes
+            {
+                alpaka::KernelFunctionAttributes kernelFunctionAttributes;
+                kernelFunctionAttributes.maxThreadsPerBlock = 1u;
+                return kernelFunctionAttributes;
+            }
+        };
+
     } // namespace trait
 } // namespace alpaka
 

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -975,6 +975,8 @@ namespace alpaka
                 // properties function.
                 auto const& props = alpaka::getAccDevProps<AccCpuOmp2Blocks<TDim, TIdx>>(dev);
                 kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
+                kernelFunctionAttributes.maxDynamicSharedSizeBytes
+                    = static_cast<int>(alpaka::BlockSharedDynMemberAllocKiB * 1024);
                 return kernelFunctionAttributes;
             }
         };

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -951,27 +951,29 @@ namespace alpaka
         };
 
         //! \brief Specialisation of the class template FunctionAttributes
+        //! \tparam TDev The device type.
         //! \tparam TDim The dimensionality of the accelerator device properties.
         //! \tparam TIdx The idx type of the accelerator device properties.
         //! \tparam TKernelFn Kernel function object type.
         //! \tparam TArgs Kernel function object argument types as a parameter pack.
-        template<typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
-        struct FunctionAttributes<AccCpuOmp2Blocks<TDim, TIdx>, KernelBundle<TKernelFn, TArgs...>>
+        template<typename TDev, typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
+        struct FunctionAttributes<AccCpuOmp2Blocks<TDim, TIdx>, TDev, KernelBundle<TKernelFn, TArgs...>>
         {
+            //! \param dev The device instance
             //! \param kernelBundle Kernel bundeled with it's arguments. The function attributes of this kernel will be
             //! determined. Max threads per block is one of the attributes.
             //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
             //! fields. For CPU, the field of max threads allowed by kernel function for the block is 1.
             ALPAKA_FN_HOST static auto getFunctionAttributes(
+                TDev const& dev,
                 [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
                 -> alpaka::KernelFunctionAttributes
             {
                 alpaka::KernelFunctionAttributes kernelFunctionAttributes;
-                using Acc = AccCpuOmp2Blocks<TDim, TIdx>;
-                auto const platformAcc = alpaka::Platform<Acc>{};
-                auto const dev = alpaka::getDevByIdx(platformAcc, 0);
-                // set function properties to device properties
-                auto const& props = alpaka::getAccDevProps<Acc>(dev);
+
+                // set function properties for maxThreadsPerBlock to device properties, since API doesn't have function
+                // properties function.
+                auto const& props = alpaka::getAccDevProps<AccCpuOmp2Blocks<TDim, TIdx>>(dev);
                 kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
                 return kernelFunctionAttributes;
             }

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -15,6 +15,8 @@
 #include "alpaka/acc/AccCpuOmp2Threads.hpp"
 #include "alpaka/core/Decay.hpp"
 #include "alpaka/dev/DevCpu.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
+#include "alpaka/kernel/KernelFunctionAttributes.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/meta/NdLoop.hpp"
 #include "alpaka/workdiv/WorkDivMembers.hpp"
@@ -192,6 +194,30 @@ namespace alpaka
         {
             using type = TIdx;
         };
+
+        //! \brief Specialisation of the class template FunctionAttributes
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TKernelFn Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
+        template<typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
+        struct FunctionAttributes<AccCpuOmp2Threads<TDim, TIdx>, KernelBundle<TKernelFn, TArgs...>>
+        {
+            //! \param kernelBundle Kernel bundeled with it's arguments. The function attributes of this kernel will be
+            //! determined. Max threads per block is one of the attributes.
+            //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
+            //! fields. For CPU, the field of max threads allowed by the given kernel function for the block is 1.
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_HOST_ACC static auto getFunctionAttributes(
+                [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
+                -> alpaka::KernelFunctionAttributes
+            {
+                alpaka::KernelFunctionAttributes kernelFunctionAttributes;
+                kernelFunctionAttributes.maxThreadsPerBlock = 1u;
+                return kernelFunctionAttributes;
+            }
+        };
+
     } // namespace trait
 } // namespace alpaka
 

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -221,6 +221,8 @@ namespace alpaka
                 // properties function.
                 auto const& props = alpaka::getAccDevProps<AccCpuOmp2Threads<TDim, TIdx>>(dev);
                 kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
+                kernelFunctionAttributes.maxDynamicSharedSizeBytes
+                    = static_cast<int>(alpaka::BlockSharedDynMemberAllocKiB * 1024);
                 return kernelFunctionAttributes;
             }
         };

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -19,6 +19,7 @@
 #include "alpaka/kernel/KernelFunctionAttributes.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/meta/NdLoop.hpp"
+#include "alpaka/platform/PlatformCpu.hpp"
 #include "alpaka/workdiv/WorkDivMembers.hpp"
 
 #include <functional>
@@ -208,12 +209,17 @@ namespace alpaka
             //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
             //! fields. For CPU, the field of max threads allowed by the given kernel function for the block is 1.
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto getFunctionAttributes(
+            ALPAKA_FN_HOST static auto getFunctionAttributes(
                 [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
                 -> alpaka::KernelFunctionAttributes
             {
                 alpaka::KernelFunctionAttributes kernelFunctionAttributes;
-                kernelFunctionAttributes.maxThreadsPerBlock = 1u;
+                using Acc = AccCpuOmp2Threads<TDim, TIdx>;
+                auto const platformAcc = alpaka::Platform<Acc>{};
+                auto const dev = alpaka::getDevByIdx(platformAcc, 0);
+                // set function properties to device properties
+                auto const& props = alpaka::getAccDevProps<Acc>(dev);
+                kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
                 return kernelFunctionAttributes;
             }
         };

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -197,28 +197,29 @@ namespace alpaka
         };
 
         //! \brief Specialisation of the class template FunctionAttributes
+        //! \tparam TDev The device type.
         //! \tparam TDim The dimensionality of the accelerator device properties.
         //! \tparam TIdx The idx type of the accelerator device properties.
         //! \tparam TKernelFn Kernel function object type.
         //! \tparam TArgs Kernel function object argument types as a parameter pack.
-        template<typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
-        struct FunctionAttributes<AccCpuOmp2Threads<TDim, TIdx>, KernelBundle<TKernelFn, TArgs...>>
+        template<typename TDev, typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
+        struct FunctionAttributes<AccCpuOmp2Threads<TDim, TIdx>, TDev, KernelBundle<TKernelFn, TArgs...>>
         {
+            //! \param dev The device instance
             //! \param kernelBundle Kernel bundeled with it's arguments. The function attributes of this kernel will be
             //! determined. Max threads per block is one of the attributes.
             //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
-            //! fields. For CPU, the field of max threads allowed by the given kernel function for the block is 1.
-            ALPAKA_NO_HOST_ACC_WARNING
+            //! fields. For CPU, the field of max threads allowed by kernel function for the block is 1.
             ALPAKA_FN_HOST static auto getFunctionAttributes(
+                TDev const& dev,
                 [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
                 -> alpaka::KernelFunctionAttributes
             {
                 alpaka::KernelFunctionAttributes kernelFunctionAttributes;
-                using Acc = AccCpuOmp2Threads<TDim, TIdx>;
-                auto const platformAcc = alpaka::Platform<Acc>{};
-                auto const dev = alpaka::getDevByIdx(platformAcc, 0);
-                // set function properties to device properties
-                auto const& props = alpaka::getAccDevProps<Acc>(dev);
+
+                // set function properties for maxThreadsPerBlock to device properties, since API doesn't have function
+                // properties function.
+                auto const& props = alpaka::getAccDevProps<AccCpuOmp2Threads<TDim, TIdx>>(dev);
                 kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
                 return kernelFunctionAttributes;
             }

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -15,6 +15,8 @@
 #include "alpaka/acc/AccCpuSerial.hpp"
 #include "alpaka/core/Decay.hpp"
 #include "alpaka/dev/DevCpu.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
+#include "alpaka/kernel/KernelFunctionAttributes.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/meta/NdLoop.hpp"
 #include "alpaka/workdiv/WorkDivMembers.hpp"
@@ -136,6 +138,29 @@ namespace alpaka
         struct IdxType<TaskKernelCpuSerial<TDim, TIdx, TKernelFnObj, TArgs...>>
         {
             using type = TIdx;
+        };
+
+        //! \brief Specialisation of the class template FunctionAttributes
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TKernelFn Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
+        template<typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
+        struct FunctionAttributes<AccCpuSerial<TDim, TIdx>, KernelBundle<TKernelFn, TArgs...>>
+        {
+            //! \param kernelBundle Kernel bundeled with it's arguments. The function attributes of this kernel will be
+            //! determined. Max threads per block is one of the attributes.
+            //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
+            //! fields. For CPU, the field of max threads allowed by kernel function for the block is 1.
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_HOST_ACC static auto getFunctionAttributes(
+                [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
+                -> alpaka::KernelFunctionAttributes
+            {
+                alpaka::KernelFunctionAttributes kernelFunctionAttributes;
+                kernelFunctionAttributes.maxThreadsPerBlock = 1u;
+                return kernelFunctionAttributes;
+            }
         };
     } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -19,6 +19,7 @@
 #include "alpaka/kernel/KernelFunctionAttributes.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/meta/NdLoop.hpp"
+#include "alpaka/platform/PlatformCpu.hpp"
 #include "alpaka/workdiv/WorkDivMembers.hpp"
 
 #include <functional>
@@ -153,12 +154,17 @@ namespace alpaka
             //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
             //! fields. For CPU, the field of max threads allowed by kernel function for the block is 1.
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto getFunctionAttributes(
+            ALPAKA_FN_HOST static auto getFunctionAttributes(
                 [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
                 -> alpaka::KernelFunctionAttributes
             {
                 alpaka::KernelFunctionAttributes kernelFunctionAttributes;
-                kernelFunctionAttributes.maxThreadsPerBlock = 1u;
+                using Acc = AccCpuSerial<TDim, TIdx>;
+                auto const platformAcc = alpaka::Platform<Acc>{};
+                auto const dev = alpaka::getDevByIdx(platformAcc, 0);
+                // set function properties to device properties
+                auto const& props = alpaka::getAccDevProps<Acc>(dev);
+                kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
                 return kernelFunctionAttributes;
             }
         };

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -142,28 +142,29 @@ namespace alpaka
         };
 
         //! \brief Specialisation of the class template FunctionAttributes
+        //! \tparam TDev The device type.
         //! \tparam TDim The dimensionality of the accelerator device properties.
         //! \tparam TIdx The idx type of the accelerator device properties.
         //! \tparam TKernelFn Kernel function object type.
         //! \tparam TArgs Kernel function object argument types as a parameter pack.
-        template<typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
-        struct FunctionAttributes<AccCpuSerial<TDim, TIdx>, KernelBundle<TKernelFn, TArgs...>>
+        template<typename TDev, typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
+        struct FunctionAttributes<AccCpuSerial<TDim, TIdx>, TDev, KernelBundle<TKernelFn, TArgs...>>
         {
+            //! \param dev The device instance
             //! \param kernelBundle Kernel bundeled with it's arguments. The function attributes of this kernel will be
             //! determined. Max threads per block is one of the attributes.
             //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
             //! fields. For CPU, the field of max threads allowed by kernel function for the block is 1.
-            ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST static auto getFunctionAttributes(
+                TDev const& dev,
                 [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
                 -> alpaka::KernelFunctionAttributes
             {
                 alpaka::KernelFunctionAttributes kernelFunctionAttributes;
-                using Acc = AccCpuSerial<TDim, TIdx>;
-                auto const platformAcc = alpaka::Platform<Acc>{};
-                auto const dev = alpaka::getDevByIdx(platformAcc, 0);
-                // set function properties to device properties
-                auto const& props = alpaka::getAccDevProps<Acc>(dev);
+
+                // set function properties for maxThreadsPerBlock to device properties, since API doesn't have function
+                // properties function.
+                auto const& props = alpaka::getAccDevProps<AccCpuSerial<TDim, TIdx>>(dev);
                 kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
                 return kernelFunctionAttributes;
             }

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -166,6 +166,8 @@ namespace alpaka
                 // properties function.
                 auto const& props = alpaka::getAccDevProps<AccCpuSerial<TDim, TIdx>>(dev);
                 kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
+                kernelFunctionAttributes.maxDynamicSharedSizeBytes
+                    = static_cast<int>(alpaka::BlockSharedDynMemberAllocKiB * 1024);
                 return kernelFunctionAttributes;
             }
         };

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -16,6 +16,8 @@
 #include "alpaka/core/Decay.hpp"
 #include "alpaka/dev/DevCpu.hpp"
 #include "alpaka/idx/MapIdx.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
+#include "alpaka/kernel/KernelFunctionAttributes.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/meta/NdLoop.hpp"
 #include "alpaka/workdiv/WorkDivMembers.hpp"
@@ -148,6 +150,29 @@ namespace alpaka
         struct IdxType<TaskKernelCpuTbbBlocks<TDim, TIdx, TKernelFnObj, TArgs...>>
         {
             using type = TIdx;
+        };
+
+        //! \brief Specialisation of the class template FunctionAttributes
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TKernelFn Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
+        template<typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
+        struct FunctionAttributes<AccCpuTbbBlocks<TDim, TIdx>, KernelBundle<TKernelFn, TArgs...>>
+        {
+            //! \param kernelBundle Kernel bundeled with it's arguments. The function attributes of this kernel will be
+            //! determined. Max threads per block is one of the attributes.
+            //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
+            //! fields. For CPU, the field of max threads allowed by kernel function for the block is 1.
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_HOST_ACC static auto getFunctionAttributes(
+                [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
+                -> alpaka::KernelFunctionAttributes
+            {
+                alpaka::KernelFunctionAttributes kernelFunctionAttributes;
+                kernelFunctionAttributes.maxThreadsPerBlock = 1u;
+                return kernelFunctionAttributes;
+            }
         };
     } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -154,28 +154,29 @@ namespace alpaka
         };
 
         //! \brief Specialisation of the class template FunctionAttributes
+        //! \tparam TDev The device type.
         //! \tparam TDim The dimensionality of the accelerator device properties.
         //! \tparam TIdx The idx type of the accelerator device properties.
         //! \tparam TKernelFn Kernel function object type.
         //! \tparam TArgs Kernel function object argument types as a parameter pack.
-        template<typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
-        struct FunctionAttributes<AccCpuTbbBlocks<TDim, TIdx>, KernelBundle<TKernelFn, TArgs...>>
+        template<typename TDev, typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
+        struct FunctionAttributes<AccCpuTbbBlocks<TDim, TIdx>, TDev, KernelBundle<TKernelFn, TArgs...>>
         {
+            //! \param dev The device instance
             //! \param kernelBundle Kernel bundeled with it's arguments. The function attributes of this kernel will be
             //! determined. Max threads per block is one of the attributes.
             //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
             //! fields. For CPU, the field of max threads allowed by kernel function for the block is 1.
-            ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST static auto getFunctionAttributes(
+                TDev const& dev,
                 [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
                 -> alpaka::KernelFunctionAttributes
             {
                 alpaka::KernelFunctionAttributes kernelFunctionAttributes;
-                using Acc = AccCpuTbbBlocks<TDim, TIdx>;
-                auto const platformAcc = alpaka::Platform<Acc>{};
-                auto const dev = alpaka::getDevByIdx(platformAcc, 0);
-                // set function properties to device properties
-                auto const& props = alpaka::getAccDevProps<Acc>(dev);
+
+                // set function properties for maxThreadsPerBlock to device properties, since API doesn't have function
+                // properties function.
+                auto const& props = alpaka::getAccDevProps<AccCpuTbbBlocks<TDim, TIdx>>(dev);
                 kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
                 return kernelFunctionAttributes;
             }

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -178,6 +178,8 @@ namespace alpaka
                 // properties function.
                 auto const& props = alpaka::getAccDevProps<AccCpuTbbBlocks<TDim, TIdx>>(dev);
                 kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
+                kernelFunctionAttributes.maxDynamicSharedSizeBytes
+                    = static_cast<int>(alpaka::BlockSharedDynMemberAllocKiB * 1024);
                 return kernelFunctionAttributes;
             }
         };

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -20,6 +20,7 @@
 #include "alpaka/kernel/KernelFunctionAttributes.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/meta/NdLoop.hpp"
+#include "alpaka/platform/PlatformCpu.hpp"
 #include "alpaka/workdiv/WorkDivMembers.hpp"
 
 #include <functional>
@@ -165,12 +166,17 @@ namespace alpaka
             //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
             //! fields. For CPU, the field of max threads allowed by kernel function for the block is 1.
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto getFunctionAttributes(
+            ALPAKA_FN_HOST static auto getFunctionAttributes(
                 [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
                 -> alpaka::KernelFunctionAttributes
             {
                 alpaka::KernelFunctionAttributes kernelFunctionAttributes;
-                kernelFunctionAttributes.maxThreadsPerBlock = 1u;
+                using Acc = AccCpuTbbBlocks<TDim, TIdx>;
+                auto const platformAcc = alpaka::Platform<Acc>{};
+                auto const dev = alpaka::getDevByIdx(platformAcc, 0);
+                // set function properties to device properties
+                auto const& props = alpaka::getAccDevProps<Acc>(dev);
+                kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
                 return kernelFunctionAttributes;
             }
         };

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -17,6 +17,8 @@
 #include "alpaka/core/Decay.hpp"
 #include "alpaka/core/ThreadPool.hpp"
 #include "alpaka/dev/DevCpu.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
+#include "alpaka/kernel/KernelFunctionAttributes.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/meta/NdLoop.hpp"
 #include "alpaka/workdiv/WorkDivMembers.hpp"
@@ -200,6 +202,30 @@ namespace alpaka
         {
             using type = TIdx;
         };
+
+        //! \brief Specialisation of the class template FunctionAttributes
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TKernelFn Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
+        template<typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
+        struct FunctionAttributes<AccCpuThreads<TDim, TIdx>, KernelBundle<TKernelFn, TArgs...>>
+        {
+            //! \param kernelBundle Kernel bundeled with it's arguments. The function attributes of this kernel will be
+            //! determined. Max threads per block is one of the attributes.
+            //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
+            //! fields. For CPU, the field of max threads allowed by kernel function for the block is 1.
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_HOST_ACC static auto getFunctionAttributes(
+                [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
+                -> alpaka::KernelFunctionAttributes
+            {
+                alpaka::KernelFunctionAttributes kernelFunctionAttributes;
+                kernelFunctionAttributes.maxThreadsPerBlock = 1u;
+                return kernelFunctionAttributes;
+            }
+        };
+
     } // namespace trait
 } // namespace alpaka
 

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -205,28 +205,29 @@ namespace alpaka
         };
 
         //! \brief Specialisation of the class template FunctionAttributes
+        //! \tparam TDev The device type.
         //! \tparam TDim The dimensionality of the accelerator device properties.
         //! \tparam TIdx The idx type of the accelerator device properties.
         //! \tparam TKernelFn Kernel function object type.
         //! \tparam TArgs Kernel function object argument types as a parameter pack.
-        template<typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
-        struct FunctionAttributes<AccCpuThreads<TDim, TIdx>, KernelBundle<TKernelFn, TArgs...>>
+        template<typename TDev, typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
+        struct FunctionAttributes<AccCpuThreads<TDim, TIdx>, TDev, KernelBundle<TKernelFn, TArgs...>>
         {
+            //! \param dev The device instance
             //! \param kernelBundle Kernel bundeled with it's arguments. The function attributes of this kernel will be
             //! determined. Max threads per block is one of the attributes.
             //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
             //! fields. For CPU, the field of max threads allowed by kernel function for the block is 1.
-            ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST static auto getFunctionAttributes(
+                TDev const& dev,
                 [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
                 -> alpaka::KernelFunctionAttributes
             {
                 alpaka::KernelFunctionAttributes kernelFunctionAttributes;
-                using Acc = AccCpuThreads<TDim, TIdx>;
-                auto const platformAcc = alpaka::Platform<Acc>{};
-                auto const dev = alpaka::getDevByIdx(platformAcc, 0);
-                // set function properties to device properties
-                auto const& props = alpaka::getAccDevProps<Acc>(dev);
+
+                // set function properties for maxThreadsPerBlock to device properties, since API doesn't have function
+                // properties function.
+                auto const& props = alpaka::getAccDevProps<AccCpuThreads<TDim, TIdx>>(dev);
                 kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
                 return kernelFunctionAttributes;
             }

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -229,6 +229,8 @@ namespace alpaka
                 // properties function.
                 auto const& props = alpaka::getAccDevProps<AccCpuThreads<TDim, TIdx>>(dev);
                 kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
+                kernelFunctionAttributes.maxDynamicSharedSizeBytes
+                    = static_cast<int>(alpaka::BlockSharedDynMemberAllocKiB * 1024);
                 return kernelFunctionAttributes;
             }
         };

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -21,6 +21,7 @@
 #include "alpaka/kernel/KernelFunctionAttributes.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/meta/NdLoop.hpp"
+#include "alpaka/platform/PlatformCpu.hpp"
 #include "alpaka/workdiv/WorkDivMembers.hpp"
 
 #include <algorithm>
@@ -216,12 +217,17 @@ namespace alpaka
             //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
             //! fields. For CPU, the field of max threads allowed by kernel function for the block is 1.
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto getFunctionAttributes(
+            ALPAKA_FN_HOST static auto getFunctionAttributes(
                 [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
                 -> alpaka::KernelFunctionAttributes
             {
                 alpaka::KernelFunctionAttributes kernelFunctionAttributes;
-                kernelFunctionAttributes.maxThreadsPerBlock = 1u;
+                using Acc = AccCpuThreads<TDim, TIdx>;
+                auto const platformAcc = alpaka::Platform<Acc>{};
+                auto const dev = alpaka::getDevByIdx(platformAcc, 0);
+                // set function properties to device properties
+                auto const& props = alpaka::getAccDevProps<Acc>(dev);
+                kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
                 return kernelFunctionAttributes;
             }
         };

--- a/include/alpaka/kernel/TaskKernelGenericSycl.hpp
+++ b/include/alpaka/kernel/TaskKernelGenericSycl.hpp
@@ -11,6 +11,8 @@
 #include "alpaka/dev/Traits.hpp"
 #include "alpaka/dim/Traits.hpp"
 #include "alpaka/idx/Traits.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
+#include "alpaka/kernel/KernelFunctionAttributes.hpp"
 #include "alpaka/kernel/SyclSubgroupSize.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/platform/PlatformGenericSycl.hpp"

--- a/include/alpaka/kernel/TaskKernelGenericSycl.hpp
+++ b/include/alpaka/kernel/TaskKernelGenericSycl.hpp
@@ -279,27 +279,27 @@ namespace alpaka::trait
     };
 
     //! \brief Specialisation of the class template FunctionAttributes
+    //! \tparam TDev The device type.
     //! \tparam TDim The dimensionality of the accelerator device properties.
     //! \tparam TIdx The idx type of the accelerator device properties.
     //! \tparam TKernelFn Kernel function object type.
     //! \tparam TArgs Kernel function object argument types as a parameter pack.
-    template<typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
-    struct FunctionAttributes<AccGenericSycl<TDim, TIdx>, KernelBundle<TKernelFn, TArgs...>>
+    template<typename TDev, typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
+    struct FunctionAttributes<AccGenericSycl<TDim, TIdx>, TDev, KernelBundle<TKernelFn, TArgs...>>
     {
+        //! \param dev The device instance
         //! \param kernelBundle Kernel bundeled with it's arguments. The function attributes of this kernel will be
         //! determined. Max threads per block is one of the attributes.
         //! \return KernelFunctionAttributes instance. The default version always returns an instance with zero
         //! fields. For CPU, the field of max threads allowed by kernel function for the block is 1.
-        ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST static auto getFunctionAttributes(
+            TDev const& dev,
             [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle) -> alpaka::KernelFunctionAttributes
         {
             alpaka::KernelFunctionAttributes kernelFunctionAttributes;
-            using Acc = AccGenericSycl<TDim, TIdx>;
-            auto const platformAcc = alpaka::Platform<Acc>{};
-            auto const dev = alpaka::getDevByIdx(platformAcc, 0);
-            // set function properties to device properties
-            auto const& props = alpaka::getAccDevProps<Acc>(dev);
+
+            // set function properties for maxThreadsPerBlock to device properties
+            auto const& props = alpaka::getAccDevProps<AccGenericSycl<TDim, TIdx>>(dev);
             kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(props.m_blockThreadCountMax);
             return kernelFunctionAttributes;
         }

--- a/include/alpaka/kernel/TaskKernelGpuCudaRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuCudaRt.hpp
@@ -11,8 +11,9 @@
 
 namespace alpaka
 {
-    template<typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
-    using TaskKernelGpuCudaRt = TaskKernelGpuUniformCudaHipRt<ApiCudaRt, TAcc, TDim, TIdx, TKernelFnObj, TArgs...>;
+    template<typename TAcc, typename TDev, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
+    using TaskKernelGpuCudaRt
+        = TaskKernelGpuUniformCudaHipRt<ApiCudaRt, TAcc, TDev, TDim, TIdx, TKernelFnObj, TArgs...>;
 } // namespace alpaka
 
 #endif // ALPAKA_ACC_GPU_CUDA_ENABLED

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2022 Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Jan Stephan, Andrea Bocci, Bernhard
- * Manfred Gruber, Antonio Di Pilato
+ * Manfred Gruber, Antonio Di Pilato, Mehmet Yusufoglu
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -17,6 +17,8 @@
 #include "alpaka/dev/Traits.hpp"
 #include "alpaka/dim/Traits.hpp"
 #include "alpaka/idx/Traits.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
+#include "alpaka/kernel/KernelFunctionAttributes.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/platform/Traits.hpp"
 #include "alpaka/queue/QueueUniformCudaHipRtBlocking.hpp"
@@ -64,11 +66,7 @@ namespace alpaka
             TKernelFnObj const kernelFnObj,
             TArgs... args)
         {
-#        if BOOST_ARCH_PTX && (BOOST_ARCH_PTX < BOOST_VERSION_NUMBER(2, 0, 0))
-#            error "Device capability >= 2.0 is required!"
-#        endif
-
-            const TAcc acc(threadElemExtent);
+            TAcc const acc(threadElemExtent);
 
 // with clang it is not possible to query std::result_of for a pure device lambda created on the host side
 #        if !(BOOST_COMP_CLANG_CUDA && BOOST_COMP_CLANG)
@@ -388,6 +386,76 @@ namespace alpaka
                         = std::string{"'execution of kernel: '" + core::demangled<TKernelFnObj> + "' failed with"};
                     ::alpaka::uniform_cuda_hip::detail::rtCheckLastError<TApi, true>(msg.c_str(), __FILE__, __LINE__);
                 }
+            }
+        };
+
+        //! \brief Specialisation of the class template FunctionAttributes
+        //! \tparam TApi The type the API of the GPU accelerator backend. Currently Cuda or Hip.
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TKernelFn Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
+        template<typename TApi, typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
+        struct FunctionAttributes<AccGpuUniformCudaHipRt<TApi, TDim, TIdx>, KernelBundle<TKernelFn, TArgs...>>
+        {
+            //! \param kernelBundle Kernel bundeled with it's arguments. The function attributes of this kernel will be
+            //! determined. Max threads per block is one of the attributes.
+            //! \return KernelFunctionAttributes instance. For GPU backend, all values are set by calling the
+            //! corresponding API functions. The default version always returns an instance with zero fields. For CPU,
+            //! the field of max threads allowed by kernel function for the block is 1.
+            ALPAKA_NO_HOST_ACC_WARNING ALPAKA_FN_HOST_ACC static auto getFunctionAttributes(
+                [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
+                -> alpaka::KernelFunctionAttributes
+            {
+                auto kernelName = alpaka::detail::gpuKernel<
+                    TKernelFn,
+                    TApi,
+                    AccGpuUniformCudaHipRt<TApi, TDim, TIdx>,
+                    TDim,
+                    TIdx,
+                    remove_restrict_t<std::decay_t<TArgs>>...>;
+
+                typename TApi::FuncAttributes_t funcAttrs;
+#        if BOOST_COMP_GNUC
+                // Disable and enable compile warnings for gcc
+#            pragma GCC diagnostic push
+#            pragma GCC diagnostic ignored "-Wconditionally-supported"
+#        endif
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    TApi::funcGetAttributes(&funcAttrs, reinterpret_cast<void const*>(kernelName)));
+#        if BOOST_COMP_GNUC
+#            pragma GCC diagnostic pop
+#        endif
+
+                alpaka::KernelFunctionAttributes kernelFunctionAttributes;
+
+                kernelFunctionAttributes.constSizeBytes = funcAttrs.constSizeBytes;
+                kernelFunctionAttributes.localSizeBytes = funcAttrs.localSizeBytes;
+                kernelFunctionAttributes.sharedSizeBytes = funcAttrs.sharedSizeBytes;
+                kernelFunctionAttributes.maxDynamicSharedSizeBytes = funcAttrs.maxDynamicSharedSizeBytes;
+
+                kernelFunctionAttributes.numRegs = funcAttrs.numRegs;
+                kernelFunctionAttributes.asmVersion = funcAttrs.ptxVersion;
+                kernelFunctionAttributes.maxThreadsPerBlock = funcAttrs.maxThreadsPerBlock;
+
+#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                printf("Kernel Function Attributes: \n");
+                printf("binaryVersion: %d \n", funcAttrs.binaryVersion);
+                printf(
+                    "constSizeBytes: %lu \n localSizeBytes: %lu, sharedSizeBytes %lu  maxDynamicSharedSizeBytes: %d "
+                    "\n",
+                    funcAttrs.constSizeBytes,
+                    funcAttrs.localSizeBytes,
+                    funcAttrs.sharedSizeBytes,
+                    funcAttrs.maxDynamicSharedSizeBytes);
+
+                printf(
+                    "numRegs: %d, ptxVersion: %d \n maxThreadsPerBlock: %d .\n ",
+                    funcAttrs.numRegs,
+                    funcAttrs.ptxVersion,
+                    funcAttrs.maxThreadsPerBlock);
+#        endif
+                return kernelFunctionAttributes;
             }
         };
     } // namespace trait

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -429,12 +429,10 @@ namespace alpaka
 #        endif
 
                 alpaka::KernelFunctionAttributes kernelFunctionAttributes;
-
                 kernelFunctionAttributes.constSizeBytes = funcAttrs.constSizeBytes;
                 kernelFunctionAttributes.localSizeBytes = funcAttrs.localSizeBytes;
                 kernelFunctionAttributes.sharedSizeBytes = funcAttrs.sharedSizeBytes;
                 kernelFunctionAttributes.maxDynamicSharedSizeBytes = funcAttrs.maxDynamicSharedSizeBytes;
-
                 kernelFunctionAttributes.numRegs = funcAttrs.numRegs;
                 kernelFunctionAttributes.asmVersion = funcAttrs.ptxVersion;
                 kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(funcAttrs.maxThreadsPerBlock);

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -403,7 +403,7 @@ namespace alpaka
             //! \return KernelFunctionAttributes instance. For GPU backend, all values are set by calling the
             //! corresponding API functions. The default version always returns an instance with zero fields. For CPU,
             //! the field of max threads allowed by kernel function for the block is 1.
-            ALPAKA_NO_HOST_ACC_WARNING ALPAKA_FN_HOST_ACC static auto getFunctionAttributes(
+            ALPAKA_NO_HOST_ACC_WARNING ALPAKA_FN_HOST static auto getFunctionAttributes(
                 [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
                 -> alpaka::KernelFunctionAttributes
             {
@@ -436,7 +436,7 @@ namespace alpaka
 
                 kernelFunctionAttributes.numRegs = funcAttrs.numRegs;
                 kernelFunctionAttributes.asmVersion = funcAttrs.ptxVersion;
-                kernelFunctionAttributes.maxThreadsPerBlock = funcAttrs.maxThreadsPerBlock;
+                kernelFunctionAttributes.maxThreadsPerBlock = static_cast<int>(funcAttrs.maxThreadsPerBlock);
 
 #        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 printf("Kernel Function Attributes: \n");

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -395,15 +395,16 @@ namespace alpaka
         //! \tparam TIdx The idx type of the accelerator device properties.
         //! \tparam TKernelFn Kernel function object type.
         //! \tparam TArgs Kernel function object argument types as a parameter pack.
-        template<typename TApi, typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
-        struct FunctionAttributes<AccGpuUniformCudaHipRt<TApi, TDim, TIdx>, KernelBundle<TKernelFn, TArgs...>>
+        template<typename TApi, typename TDev, typename TDim, typename TIdx, typename TKernelFn, typename... TArgs>
+        struct FunctionAttributes<AccGpuUniformCudaHipRt<TApi, TDim, TIdx>, TDev, KernelBundle<TKernelFn, TArgs...>>
         {
             //! \param kernelBundle Kernel bundeled with it's arguments. The function attributes of this kernel will be
             //! determined. Max threads per block is one of the attributes.
             //! \return KernelFunctionAttributes instance. For GPU backend, all values are set by calling the
             //! corresponding API functions. The default version always returns an instance with zero fields. For CPU,
             //! the field of max threads allowed by kernel function for the block is 1.
-            ALPAKA_NO_HOST_ACC_WARNING ALPAKA_FN_HOST static auto getFunctionAttributes(
+            ALPAKA_FN_HOST static auto getFunctionAttributes(
+                TDev const&,
                 [[maybe_unused]] KernelBundle<TKernelFn, TArgs...> const& kernelBundle)
                 -> alpaka::KernelFunctionAttributes
             {

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2023 Axel Huebl, Benjamin Worpitz, René Widera, Sergei Bastrakov, Jan Stephan, Bernhard Manfred Gruber,
- *                Andrea Bocci, Aurora Perego
+ *                Andrea Bocci, Aurora Perego, Mehmet Yusufoglu
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -12,6 +12,7 @@
 #include "alpaka/core/OmpSchedule.hpp"
 #include "alpaka/dim/Traits.hpp"
 #include "alpaka/idx/Traits.hpp"
+#include "alpaka/kernel/KernelFunctionAttributes.hpp"
 #include "alpaka/queue/Traits.hpp"
 #include "alpaka/vec/Vec.hpp"
 #include "alpaka/workdiv/Traits.hpp"
@@ -66,6 +67,25 @@ namespace alpaka
                 [[maybe_unused]] TArgs const&... args) -> std::size_t
             {
                 return 0u;
+            }
+        };
+
+        //! \brief The structure template to access to the functions attributes of a kernel function object.
+        //! \tparam TAcc The accelerator type
+        //! \tparam TKernelBundle The kernel object type, which includes the kernel function object and it's invocation
+        //! arguments.
+        template<typename TAcc, typename TKernelBundle>
+        struct FunctionAttributes
+        {
+            //! \param kernelBundle The kernel object instance, which includes the kernel function object and it's
+            //! invocation arguments.
+            //! \return KernelFunctionAttributes data structure instance. The default version always returns the
+            //! instance with fields which are set to zero.
+            ALPAKA_NO_HOST_ACC_WARNING
+            ALPAKA_FN_HOST_ACC static auto getFunctionAttributes([[maybe_unused]] TKernelBundle const& kernelBundle)
+                -> alpaka::KernelFunctionAttributes
+            {
+                return alpaka::KernelFunctionAttributes();
             }
         };
 
@@ -165,6 +185,19 @@ namespace alpaka
             blockThreadExtent,
             threadElemExtent,
             args...);
+    }
+
+    //! \tparam TKernelBundle The kernel object type, which includes the kernel function object and it's invocation
+    //! arguments.
+    //! \return KernelFunctionAttributes instance. Instance is filled with values returned by the accelerator API
+    //! depending on the specific kernel. The default version always returns the instance with fields which are set to
+    //! zero.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAcc, typename TKernelBundle>
+    ALPAKA_FN_HOST_ACC auto getFunctionAttributes(TKernelBundle const& kernelBundle)
+        -> alpaka::KernelFunctionAttributes
+    {
+        return trait::FunctionAttributes<TAcc, TKernelBundle>::getFunctionAttributes(kernelBundle);
     }
 
 #if BOOST_COMP_CLANG

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -82,7 +82,7 @@ namespace alpaka
             //! \return KernelFunctionAttributes data structure instance. The default version always returns the
             //! instance with fields which are set to zero.
             ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST_ACC static auto getFunctionAttributes([[maybe_unused]] TKernelBundle const& kernelBundle)
+            ALPAKA_FN_HOST static auto getFunctionAttributes([[maybe_unused]] TKernelBundle const& kernelBundle)
                 -> alpaka::KernelFunctionAttributes
             {
                 return alpaka::KernelFunctionAttributes();
@@ -187,15 +187,19 @@ namespace alpaka
             args...);
     }
 
+    //! \tparam TAcc The accelerator type.
+    //! \tparam TDev The device type.
     //! \tparam TKernelBundle The kernel object type, which includes the kernel function object and it's invocation
+    //! arguments.
+    //! \param dev The device instance
+    //! \param kernelBundle The kernel object, which includes the kernel function object and it's invocation
     //! arguments.
     //! \return KernelFunctionAttributes instance. Instance is filled with values returned by the accelerator API
     //! depending on the specific kernel. The default version always returns the instance with fields which are set to
     //! zero.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc, typename TKernelBundle>
-    ALPAKA_FN_HOST_ACC auto getFunctionAttributes(TKernelBundle const& kernelBundle)
-        -> alpaka::KernelFunctionAttributes
+    ALPAKA_FN_HOST auto getFunctionAttributes(TKernelBundle const& kernelBundle) -> alpaka::KernelFunctionAttributes
     {
         return trait::FunctionAttributes<TAcc, TKernelBundle>::getFunctionAttributes(kernelBundle);
     }

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -85,7 +85,9 @@ namespace alpaka
                 TDev const&,
                 [[maybe_unused]] TKernelBundle const& kernelBundle) -> alpaka::KernelFunctionAttributes
             {
-                return alpaka::KernelFunctionAttributes();
+                std::string const str
+                    = std::string(__func__) + " function is not specialised for the given arguments.\n";
+                throw std::invalid_argument{str};
             }
         };
 

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -74,16 +74,16 @@ namespace alpaka
         //! \tparam TAcc The accelerator type
         //! \tparam TKernelBundle The kernel object type, which includes the kernel function object and it's invocation
         //! arguments.
-        template<typename TAcc, typename TKernelBundle>
+        template<typename TAcc, typename TDev, typename TKernelBundle>
         struct FunctionAttributes
         {
             //! \param kernelBundle The kernel object instance, which includes the kernel function object and it's
             //! invocation arguments.
             //! \return KernelFunctionAttributes data structure instance. The default version always returns the
             //! instance with fields which are set to zero.
-            ALPAKA_NO_HOST_ACC_WARNING
-            ALPAKA_FN_HOST static auto getFunctionAttributes([[maybe_unused]] TKernelBundle const& kernelBundle)
-                -> alpaka::KernelFunctionAttributes
+            ALPAKA_FN_HOST static auto getFunctionAttributes(
+                TDev const&,
+                [[maybe_unused]] TKernelBundle const& kernelBundle) -> alpaka::KernelFunctionAttributes
             {
                 return alpaka::KernelFunctionAttributes();
             }
@@ -198,10 +198,11 @@ namespace alpaka
     //! depending on the specific kernel. The default version always returns the instance with fields which are set to
     //! zero.
     ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TAcc, typename TKernelBundle>
-    ALPAKA_FN_HOST auto getFunctionAttributes(TKernelBundle const& kernelBundle) -> alpaka::KernelFunctionAttributes
+    template<typename TAcc, typename TDev, typename TKernelBundle>
+    ALPAKA_FN_HOST auto getFunctionAttributes(TDev const& dev, TKernelBundle const& kernelBundle)
+        -> alpaka::KernelFunctionAttributes
     {
-        return trait::FunctionAttributes<TAcc, TKernelBundle>::getFunctionAttributes(kernelBundle);
+        return trait::FunctionAttributes<TAcc, TDev, TKernelBundle>::getFunctionAttributes(dev, kernelBundle);
     }
 
 #if BOOST_COMP_CLANG

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -10,6 +10,9 @@
 #include "alpaka/core/Utility.hpp"
 #include "alpaka/dev/Traits.hpp"
 #include "alpaka/extent/Traits.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
+#include "alpaka/kernel/KernelFunctionAttributes.hpp"
+#include "alpaka/kernel/Traits.hpp"
 #include "alpaka/vec/Vec.hpp"
 #include "alpaka/workdiv/WorkDivMembers.hpp"
 
@@ -113,23 +116,22 @@ namespace alpaka
     //! 2. The requirement of the block thread extent to divide the grid thread extent without remainder
     //! 3. The requirement of the block extent.
     //!
-    //! \param gridElemExtent
-    //!     The full extent of elements in the grid.
-    //! \param threadElemExtent
-    //!     the number of elements computed per thread.
-    //! \param accDevProps
-    //!     The maxima for the work division.
-    //! \param blockThreadMustDivideGridThreadExtent
-    //!     If this is true, the grid thread extent will be multiples of the corresponding block thread extent.
+    //! \param gridElemExtent The full extent of elements in the grid.
+    //! \param threadElemExtent the number of elements computed per thread.
+    //! \param accDevProps The maxima for the work division.
+    //! \param kernelBlockThreadCountMax The maximum number of threads per block. If it is zero this argument is not
+    //! used, device hard limits are used.
+    //! \param blockThreadMustDivideGridThreadExtent If this is true, the grid thread extent will be multiples of the
+    //! corresponding block thread extent.
     //!     NOTE: If this is true and gridThreadExtent is prime (or otherwise bad chosen) in a dimension, the block
     //!     thread extent will be one in this dimension.
-    //! \param gridBlockExtentSubDivRestrictions
-    //!     The grid block extent subdivision restrictions.
+    //! \param gridBlockExtentSubDivRestrictions The grid block extent subdivision restrictions.
     template<typename TDim, typename TIdx>
     ALPAKA_FN_HOST auto subDivideGridElems(
         Vec<TDim, TIdx> const& gridElemExtent,
         Vec<TDim, TIdx> const& threadElemExtent,
         AccDevProps<TDim, TIdx> const& accDevProps,
+        TIdx kernelBlockThreadCountMax = static_cast<TIdx>(0u),
         bool blockThreadMustDivideGridThreadExtent = true,
         GridBlockExtentSubDivRestrictions gridBlockExtentSubDivRestrictions
         = GridBlockExtentSubDivRestrictions::Unrestricted) -> WorkDivMembers<TDim, TIdx>
@@ -148,7 +150,7 @@ namespace alpaka
 
         // Handle threadElemExtent and compute gridThreadExtent. Afterwards, only the blockThreadExtent has to be
         // optimized.
-        auto const clippedThreadElemExtent = elementwise_min(threadElemExtent, gridElemExtent);
+        auto clippedThreadElemExtent = elementwise_min(threadElemExtent, gridElemExtent);
         auto const gridThreadExtent = [&]
         {
             Vec r;
@@ -168,11 +170,27 @@ namespace alpaka
         // For equal block thread extent, restrict it to its minimum component.
         // For example (512, 256, 1024) will get (256, 256, 256).
         if(gridBlockExtentSubDivRestrictions == GridBlockExtentSubDivRestrictions::EqualExtent)
-            blockThreadExtent = Vec::all(blockThreadExtent.min());
+            blockThreadExtent = Vec::all(blockThreadExtent.min() != TIdx(0) ? blockThreadExtent.min() : TIdx(1));
+
+        // Choose kernelBlockThreadCountMax if it is not zero. It is less than the accelerator properties.
+        TIdx const& blockThreadCountMax
+            = (kernelBlockThreadCountMax != 0) ? kernelBlockThreadCountMax : accDevProps.m_blockThreadCountMax;
+
+        // Block thread extent could be {1024,1024,1024} although max threads per block is 1024. Block thread extent
+        // shows the max number of threads along each axis, it is not a measure to get max number of threads per block.
+        // It must be further limited (clipped above) by the kernel limit along each axis, using device limits is not
+        // enough.
+        for(typename TDim::value_type i(0); i < TDim::value; ++i)
+        {
+            blockThreadExtent[i] = std::min(blockThreadExtent[i], blockThreadCountMax);
+        }
 
         // Make the blockThreadExtent product smaller or equal to the accelerator's limit.
-        auto const& blockThreadCountMax = accDevProps.m_blockThreadCountMax;
-        if(blockThreadExtent.prod() > blockThreadCountMax)
+        if(blockThreadCountMax == 1)
+        {
+            blockThreadExtent = Vec::all(core::nthRootFloor(blockThreadCountMax, TIdx{TDim::value}));
+        }
+        else if(blockThreadExtent.prod() > blockThreadCountMax)
         {
             switch(gridBlockExtentSubDivRestrictions)
             {
@@ -204,6 +222,7 @@ namespace alpaka
                 break;
             }
         }
+
 
         // Make the block thread extent divide the grid thread extent.
         if(blockThreadMustDivideGridThreadExtent)
@@ -242,13 +261,15 @@ namespace alpaka
                 [[fallthrough]];
             case GridBlockExtentSubDivRestrictions::Unrestricted:
                 for(DimLoopInd i(0u); i < TDim::value; ++i)
+                {
                     blockThreadExtent[i] = detail::nextDivisorLowerOrEqual(gridThreadExtent[i], blockThreadExtent[i]);
+                }
                 break;
             }
         }
 
         // grid blocks extent = grid thread / block thread extent. quotient is rounded up.
-        auto const gridBlockExtent = [&]
+        auto gridBlockExtent = [&]
         {
             Vec r;
             for(DimLoopInd i = 0; i < TDim::value; ++i)
@@ -256,25 +277,46 @@ namespace alpaka
             return r;
         }();
 
+
+        // Store the maxima allowed for extents of grid, blocks and threads.
+        auto const gridBlockExtentMax = subVecEnd<TDim>(accDevProps.m_gridBlockExtentMax);
+        auto const blockThreadExtentMax = subVecEnd<TDim>(accDevProps.m_blockThreadExtentMax);
+        auto const threadElemExtentMax = subVecEnd<TDim>(accDevProps.m_threadElemExtentMax);
+
+        // Check that the extents for all dimensions are correct.
+        for(typename TDim::value_type i(0); i < TDim::value; ++i)
+        {
+            // Check that the maximum extents are greater or equal 1.
+            if(gridBlockExtentMax[i] < gridBlockExtent[i])
+            {
+                gridBlockExtent[i] = gridBlockExtentMax[i];
+            }
+            if(blockThreadExtentMax[i] < blockThreadExtent[i])
+            {
+                blockThreadExtent[i] = blockThreadExtentMax[i];
+            }
+            if(threadElemExtentMax[i] < threadElemExtent[i])
+            {
+                clippedThreadElemExtent[i] = threadElemExtentMax[i];
+            }
+        }
+
+
         return WorkDivMembers<TDim, TIdx>(gridBlockExtent, blockThreadExtent, clippedThreadElemExtent);
     }
 
     //! \tparam TAcc The accelerator for which this work division has to be valid.
+    //! \tparam TDev The type of the device.
     //! \tparam TGridElemExtent The type of the grid element extent.
     //! \tparam TThreadElemExtent The type of the thread element extent.
-    //! \tparam TDev The type of the device.
-    //! \param dev
-    //!     The device the work division should be valid for.
-    //! \param gridElemExtent
-    //!     The full extent of elements in the grid.
-    //! \param threadElemExtents
-    //!     the number of elements computed per thread.
-    //! \param blockThreadMustDivideGridThreadExtent
-    //!     If this is true, the grid thread extent will be multiples of the corresponding block thread extent.
-    //!     NOTE: If this is true and gridThreadExtent is prime (or otherwise bad chosen) in a dimension, the block
-    //!     thread extent will be one in this dimension.
-    //! \param gridBlockExtentSubDivRestrictions
-    //!     The grid block extent subdivision restrictions.
+    //! \param dev The device the work division should be valid for.
+    //! \param gridElemExtent The full extent of elements in the grid.
+    //! \param threadElemExtents the number of elements computed per thread.
+    //! \param blockThreadMustDivideGridThreadExtent If this is true, the grid thread extent will be multiples of the
+    //! corresponding block thread extent.
+    //!     NOTE: If this is true and gridThreadExtent is prime (or otherwise bad chosen) in a dimension, the
+    //!     block-thread extent will be one in this dimension.
+    //! \param gridBlockExtentSubDivRestrictions The grid block extent subdivision restrictions.
     //! \return The work division.
     template<
         typename TAcc,
@@ -315,6 +357,79 @@ namespace alpaka
                 getExtents(gridElemExtent),
                 getExtents(threadElemExtents),
                 getAccDevProps<TAcc>(dev),
+                static_cast<Idx<TAcc>>(0u),
+                blockThreadMustDivideGridThreadExtent,
+                gridBlockExtentSubDivRestrictions);
+        using V [[maybe_unused]] = Vec<Dim<TGridElemExtent>, Idx<TGridElemExtent>>;
+        ALPAKA_UNREACHABLE(WorkDivMembers<Dim<TGridElemExtent>, Idx<TGridElemExtent>>{V{}, V{}, V{}});
+    }
+
+    //! \tparam TDev The type of the device.
+    //! \tparam TKernelBundle The type of the bundle of kernel and the arguments. Kernel is used to get number of
+    //! threads per block, this number could be less than or equal to the number of threads per block according to
+    //! device properties.
+    //! \tparam TGridElemExtent The type of the grid element extent.
+    //! \tparam TThreadElemExtent The type of the thread element extent.
+    //! \param dev The device the work division should be valid for.
+    //! \param kernelBundle An instance of a class consisting Kernel function and its arguments
+    //! \param gridElemExtent The full extent of elements in the grid.
+    //! \param threadElemExtents the number of elements computed per thread.
+    //! \param blockThreadMustDivideGridThreadExtent If this is true, the grid thread extent will be multiples of the
+    //! corresponding block thread extent.
+    //!     NOTE: If this is true and gridThreadExtent is prime (or otherwise bad chosen) in a dimension, the block
+    //!     thread extent will be one in this dimension.
+    //! \param gridBlockExtentSubDivRestrictions The grid block extent subdivision restrictions.
+    //! \return The work division.
+    template<
+        typename TAcc,
+        typename TDev,
+        typename TKernelBundle,
+        typename TGridElemExtent = Vec<Dim<TAcc>, Idx<TAcc>>,
+        typename TThreadElemExtent = Vec<Dim<TAcc>, Idx<TAcc>>>
+    ALPAKA_FN_HOST auto getValidWorkDivForKernel(
+        [[maybe_unused]] TDev const& dev,
+        TKernelBundle const& kernelBundle,
+        [[maybe_unused]] TGridElemExtent const& gridElemExtent = Vec<Dim<TAcc>, Idx<TAcc>>::ones(),
+        [[maybe_unused]] TThreadElemExtent const& threadElemExtents = Vec<Dim<TAcc>, Idx<TAcc>>::ones(),
+        [[maybe_unused]] bool blockThreadMustDivideGridThreadExtent = true,
+        [[maybe_unused]] GridBlockExtentSubDivRestrictions gridBlockExtentSubDivRestrictions
+        = GridBlockExtentSubDivRestrictions::Unrestricted)
+        -> WorkDivMembers<Dim<TGridElemExtent>, Idx<TGridElemExtent>>
+    {
+        using Acc = TAcc;
+
+        static_assert(
+            Dim<TGridElemExtent>::value == Dim<Acc>::value,
+            "The dimension of Acc and the dimension of TGridElemExtent have to be identical!");
+        static_assert(
+            Dim<TThreadElemExtent>::value == Dim<Acc>::value,
+            "The dimension of Acc and the dimension of TThreadElemExtent have to be identical!");
+        static_assert(
+            std::is_same_v<Idx<TGridElemExtent>, Idx<Acc>>,
+            "The idx type of Acc and the idx type of TGridElemExtent have to be identical!");
+        static_assert(
+            std::is_same_v<Idx<TThreadElemExtent>, Idx<Acc>>,
+            "The idx type of Acc and the idx type of TThreadElemExtent have to be identical!");
+
+        // Get max number of threads per block depending on the kernel function attributes.
+        // For GPU backend; number of registers used by the kernel, local and shared memory usage of the kernel
+        // determines the max number of threads per block. This number could be equal or less than the max number of
+        // threads per block defined by device properties.
+        auto const kernelFunctionAttributes = getFunctionAttributes<Acc>(kernelBundle);
+        auto const threadsPerBlock = kernelFunctionAttributes.maxThreadsPerBlock;
+        if constexpr(Dim<TGridElemExtent>::value == 0)
+        {
+            auto const zero = Vec<DimInt<0>, Idx<Acc>>{};
+            ALPAKA_ASSERT(gridElemExtent == zero);
+            ALPAKA_ASSERT(threadElemExtents == zero);
+            return WorkDivMembers<DimInt<0>, Idx<Acc>>{zero, zero, zero};
+        }
+        else
+            return subDivideGridElems(
+                getExtents(gridElemExtent),
+                getExtents(threadElemExtents),
+                getAccDevProps<Acc>(dev),
+                static_cast<Idx<Acc>>(threadsPerBlock),
                 blockThreadMustDivideGridThreadExtent,
                 gridBlockExtentSubDivRestrictions);
         using V [[maybe_unused]] = Vec<Dim<TGridElemExtent>, Idx<TGridElemExtent>>;
@@ -333,7 +448,7 @@ namespace alpaka
         // Get the extents of grid, blocks and threads of the work division to check.
         auto const gridBlockExtent = getWorkDiv<Grid, Blocks>(workDiv);
         auto const blockThreadExtent = getWorkDiv<Block, Threads>(workDiv);
-        auto const threadElemExtent = getWorkDiv<Block, Threads>(workDiv);
+        auto const threadElemExtent = getWorkDiv<Thread, Elems>(workDiv);
 
         // Check that the maximal counts are satisfied.
         if(accDevProps.m_gridBlockCountMax < gridBlockExtent.prod())
@@ -370,6 +485,89 @@ namespace alpaka
         }
 
         return true;
+    }
+
+    //! \tparam TDim The dimensionality of the accelerator device properties.
+    //! \tparam TIdx The idx type of the accelerator device properties.
+    //! \tparam TKernelBundle The type of the bundle of kernel and the arguments. Kernel is used to get number of
+    //! threads per block, this number could be less than or equal to the number of threads per block according to
+    //! device properties.
+    //! \tparam TWorkDiv The type of the work division.
+    //! \param accDevProps The maxima for the work division.
+    //! \param kernelBundle An instance of a class consisting Kernel function and its arguments.
+    //! \param workDiv The work division to test for validity.
+    //! \return Returns true if the work division is valid for the given accelerator device properties and for the
+    //! given kernel. Otherwise returns false.
+    template<typename TAcc, typename TDim, typename TIdx, typename TKernelBundle, typename TWorkDiv>
+    ALPAKA_FN_HOST auto isValidWorkDivKernel(
+        AccDevProps<TDim, TIdx> const& accDevProps,
+        TKernelBundle const& kernelBundle,
+        TWorkDiv const& workDiv) -> bool
+
+    {
+        // Get the extents of grid, blocks and threads of the work division to check.
+        auto const gridBlockExtent = getWorkDiv<Grid, Blocks>(workDiv);
+        auto const blockThreadExtent = getWorkDiv<Block, Threads>(workDiv);
+        auto const threadElemExtent = getWorkDiv<Thread, Elems>(workDiv);
+        // Use kernel properties to find the max threads per block for the kernel
+        auto const kernelFunctionAttributes = getFunctionAttributes<TAcc>(kernelBundle);
+        auto const threadsPerBlockForKernel = kernelFunctionAttributes.maxThreadsPerBlock;
+        // Select the minimum to find the upper bound for the threads per block
+        auto const allowedThreadsPerBlock = std::min(
+            static_cast<TIdx>(threadsPerBlockForKernel),
+            static_cast<TIdx>(accDevProps.m_blockThreadCountMax));
+        // Check that the maximal counts are satisfied.
+        if(accDevProps.m_gridBlockCountMax < gridBlockExtent.prod())
+        {
+            return false;
+        }
+        if(allowedThreadsPerBlock < blockThreadExtent.prod())
+        {
+            return false;
+        }
+        if(accDevProps.m_threadElemCountMax < threadElemExtent.prod())
+        {
+            return false;
+        }
+
+        // Check that the extents for all dimensions are correct.
+        if constexpr(Dim<TWorkDiv>::value > 0)
+        {
+            // Store the maxima allowed for extents of grid, blocks and threads.
+            auto const gridBlockExtentMax = subVecEnd<Dim<TWorkDiv>>(accDevProps.m_gridBlockExtentMax);
+            auto const blockThreadExtentMax = subVecEnd<Dim<TWorkDiv>>(accDevProps.m_blockThreadExtentMax);
+            auto const threadElemExtentMax = subVecEnd<Dim<TWorkDiv>>(accDevProps.m_threadElemExtentMax);
+
+            for(typename Dim<TWorkDiv>::value_type i(0); i < Dim<TWorkDiv>::value; ++i)
+            {
+                // No extent is allowed to be zero or greater then the allowed maximum.
+                if((gridBlockExtent[i] < 1) || (blockThreadExtent[i] < 1) || (threadElemExtent[i] < 1)
+                   || (gridBlockExtentMax[i] < gridBlockExtent[i]) || (blockThreadExtentMax[i] < blockThreadExtent[i])
+                   || (threadElemExtentMax[i] < threadElemExtent[i]))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    //! \tparam TAcc The accelerator to test the validity on.
+    //! \tparam TDev The type of the device.
+    //! \tparam TKernelBundle The type of the bundle of kernel and the arguments.
+    //! \tparam TWorkDiv The type of work division to test for validity.
+    //! \param dev The device to test the work division for validity on.
+    //! \param kernelBundle An instance of a class consisting Kernel function and its arguments.
+    //! \param workDiv The work division to test for validity.
+    //! \return Returns the value of isValidWorkDivKernel function.
+    template<typename TAcc, typename TDev, typename TKernelBundle, typename TWorkDiv>
+    ALPAKA_FN_HOST auto isValidWorkDivKernel(
+        TDev const& dev,
+        TKernelBundle const& kernelBundle,
+        TWorkDiv const& workDiv) -> bool
+    {
+        return isValidWorkDivKernel<TAcc>(getAccDevProps<TAcc>(dev), kernelBundle, workDiv);
     }
 
     //! \tparam TAcc The accelerator to test the validity on.

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -414,7 +414,7 @@ namespace alpaka
         // For GPU backend; number of registers used by the kernel, local and shared memory usage of the kernel
         // determines the max number of threads per block. This number could be equal or less than the max number of
         // threads per block defined by device properties.
-        auto const kernelFunctionAttributes = getFunctionAttributes<Acc>(kernelBundle);
+        auto const kernelFunctionAttributes = getFunctionAttributes<Acc>(dev, kernelBundle);
         auto const threadsPerBlock = kernelFunctionAttributes.maxThreadsPerBlock;
         // printf("%lu", std::get<0>(kernelBundle.m_args));
         if constexpr(Dim<TGridElemExtent>::value == 0)
@@ -506,12 +506,15 @@ namespace alpaka
         TWorkDiv const& workDiv) -> bool
 
     {
+        auto const platformAcc = alpaka::Platform<TAcc>{};
+        auto const dev = alpaka::getDevByIdx(platformAcc, 0);
+
         // Get the extents of grid, blocks and threads of the work division to check.
         auto const gridBlockExtent = getWorkDiv<Grid, Blocks>(workDiv);
         auto const blockThreadExtent = getWorkDiv<Block, Threads>(workDiv);
         auto const threadElemExtent = getWorkDiv<Thread, Elems>(workDiv);
         // Use kernel properties to find the max threads per block for the kernel
-        auto const kernelFunctionAttributes = getFunctionAttributes<TAcc>(kernelBundle);
+        auto const kernelFunctionAttributes = alpaka::getFunctionAttributes<TAcc>(dev, kernelBundle);
         auto const threadsPerBlockForKernel = kernelFunctionAttributes.maxThreadsPerBlock;
         // Select the minimum to find the upper bound for the threads per block
         auto const allowedThreadsPerBlock = std::min(

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -384,17 +384,16 @@ namespace alpaka
         typename TAcc,
         typename TDev,
         typename TKernelBundle,
-        typename TGridElemExtent = Vec<Dim<TAcc>, Idx<TAcc>>,
-        typename TThreadElemExtent = Vec<Dim<TAcc>, Idx<TAcc>>>
+        typename TGridElemExtent = alpaka::Vec<Dim<TAcc>, Idx<TAcc>>,
+        typename TThreadElemExtent = alpaka::Vec<Dim<TAcc>, Idx<TAcc>>>
     ALPAKA_FN_HOST auto getValidWorkDivForKernel(
         [[maybe_unused]] TDev const& dev,
         TKernelBundle const& kernelBundle,
-        [[maybe_unused]] TGridElemExtent const& gridElemExtent = Vec<Dim<TAcc>, Idx<TAcc>>::ones(),
-        [[maybe_unused]] TThreadElemExtent const& threadElemExtents = Vec<Dim<TAcc>, Idx<TAcc>>::ones(),
+        [[maybe_unused]] TGridElemExtent const& gridElemExtent = alpaka::Vec<Dim<TAcc>, Idx<TAcc>>::ones(),
+        [[maybe_unused]] TThreadElemExtent const& threadElemExtents = alpaka::Vec<Dim<TAcc>, Idx<TAcc>>::ones(),
         [[maybe_unused]] bool blockThreadMustDivideGridThreadExtent = true,
         [[maybe_unused]] GridBlockExtentSubDivRestrictions gridBlockExtentSubDivRestrictions
-        = GridBlockExtentSubDivRestrictions::Unrestricted)
-        -> WorkDivMembers<Dim<TGridElemExtent>, Idx<TGridElemExtent>>
+        = GridBlockExtentSubDivRestrictions::Unrestricted) -> WorkDivMembers<Dim<TAcc>, Idx<TAcc>>
     {
         using Acc = TAcc;
 
@@ -417,6 +416,7 @@ namespace alpaka
         // threads per block defined by device properties.
         auto const kernelFunctionAttributes = getFunctionAttributes<Acc>(kernelBundle);
         auto const threadsPerBlock = kernelFunctionAttributes.maxThreadsPerBlock;
+        // printf("%lu", std::get<0>(kernelBundle.m_args));
         if constexpr(Dim<TGridElemExtent>::value == 0)
         {
             auto const zero = Vec<DimInt<0>, Idx<Acc>>{};
@@ -432,6 +432,7 @@ namespace alpaka
                 static_cast<Idx<Acc>>(threadsPerBlock),
                 blockThreadMustDivideGridThreadExtent,
                 gridBlockExtentSubDivRestrictions);
+
         using V [[maybe_unused]] = Vec<Dim<TGridElemExtent>, Idx<TGridElemExtent>>;
         ALPAKA_UNREACHABLE(WorkDivMembers<Dim<TGridElemExtent>, Idx<TGridElemExtent>>{V{}, V{}, V{}});
     }

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -416,7 +416,7 @@ namespace alpaka
         // threads per block defined by device properties.
         auto const kernelFunctionAttributes = getFunctionAttributes<Acc>(dev, kernelBundle);
         auto const threadsPerBlock = kernelFunctionAttributes.maxThreadsPerBlock;
-        // printf("%lu", std::get<0>(kernelBundle.m_args));
+
         if constexpr(Dim<TGridElemExtent>::value == 0)
         {
             auto const zero = Vec<DimInt<0>, Idx<Acc>>{};

--- a/test/unit/workDiv/CMakeLists.txt
+++ b/test/unit/workDiv/CMakeLists.txt
@@ -12,8 +12,8 @@ alpaka_add_executable(
     ${_FILES_SOURCE})
 
 target_include_directories(
- ${_TARGET_NAME}
- PRIVATE "src")
+    ${_TARGET_NAME}
+    PRIVATE "src")
 
 target_link_libraries(
     ${_TARGET_NAME}

--- a/test/unit/workDiv/src/WorkDivForKernelTest.cpp
+++ b/test/unit/workDiv/src/WorkDivForKernelTest.cpp
@@ -1,0 +1,225 @@
+/* Copyright 2022 Sergei Bastrakov, Jan Stephan, Bernhard Manfred Gruber, Mehmet Yusufoglu
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/acc/AccCpuOmp2Blocks.hpp>
+#include <alpaka/acc/AccCpuOmp2Threads.hpp>
+#include <alpaka/acc/AccCpuSerial.hpp>
+#include <alpaka/acc/AccCpuTbbBlocks.hpp>
+#include <alpaka/acc/AccDevProps.hpp>
+#include <alpaka/acc/AccGpuUniformCudaHipRt.hpp>
+#include <alpaka/kernel/KernelBundle.hpp>
+#include <alpaka/kernel/KernelFunctionAttributes.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
+#include <alpaka/workdiv/WorkDivHelpers.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+struct TestKernelWithManyRegisters
+{
+    template<typename TAcc>
+    [[maybe_unused]] ALPAKA_FN_ACC auto operator()(TAcc const&, std::size_t val) const -> void
+    {
+        double var0 = 1.0;
+        double var1 = 2.0;
+        double var2 = 3.0;
+
+        // Define many variables and use some calculations in order to prevent compiler optimization and make the
+        // kernel use many registers (around 80 on sm_52). Using many registers per SM decreases the max number of
+        // threads per block while this kernel is being run.
+
+        // TODO: Use function templates to parametrize and shorten the code!
+        double var3 = var2 + fmod(var2, 5);
+        double var4 = var3 + fmod(var3, 5);
+        double var5 = var4 + fmod(var4, 5);
+        double var6 = var5 + fmod(var5, 5);
+        double var7 = var6 + fmod(var6, 5);
+        double var8 = var7 + fmod(var7, 5);
+        double var9 = var8 + fmod(var8, 5);
+        double var10 = var9 + fmod(var9, 5);
+        double var11 = var10 + fmod(var10, 5);
+        double var12 = var11 + fmod(var11, 5);
+        double var13 = var12 + fmod(var12, 5);
+        double var14 = var13 + fmod(var13, 5);
+        double var15 = var14 + fmod(var14, 5);
+        double var16 = var15 + fmod(var15, 5);
+        double var17 = var16 + fmod(var16, 5);
+        double var18 = var17 + fmod(var17, 5);
+        double var19 = var18 + fmod(var18, 5);
+        double var20 = var19 + fmod(var19, 5);
+        double var21 = var20 + fmod(var20, 5);
+        double var22 = var21 + fmod(var21, 5);
+        double var23 = var22 + fmod(var22, 5);
+        double var24 = var23 + fmod(var23, 5);
+        double var25 = var24 + fmod(var24, 5);
+        double var26 = var25 + fmod(var25, 5);
+        double var27 = var26 + fmod(var26, 5);
+        double var28 = var27 + fmod(var27, 5);
+        double var29 = var28 + fmod(var28, 5);
+        double var30 = var29 + fmod(var29, 5);
+        double var31 = var30 + fmod(var30, 5);
+        double var32 = var31 + fmod(var31, 5);
+        double var33 = var32 + fmod(var32, 5);
+        double var34 = var33 + fmod(var33, 5);
+        double var35 = var34 + fmod(var34, 5);
+
+        double sum = var0 + var1 + var2 + var3 + var4 + var5 + var6 + var7 + var8 + var9 + var10 + var11 + var12
+                     + var13 + var14 + var15 + var16 + var17 + var18 + var19 + var20 + var21 + var22 + var23 + var24
+                     + var25 + var26 + var27 + var28 + var29 + var30 + var31 + var32 + var33 + var34 + var35;
+        printf("The sum is %5.2f, the argument is %lu ", sum, val);
+    }
+};
+
+using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, std::uint32_t>;
+
+TEMPLATE_LIST_TEST_CASE("getValidWorkDivForKernel.1D", "[workDivKernel]", TestAccs)
+{
+    using Acc = TestType;
+    using Idx = alpaka::Idx<Acc>;
+    using Dim = alpaka::Dim<Acc>;
+    using Vec = alpaka::Vec<Dim, Idx>;
+    using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
+    auto const platform = alpaka::Platform<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
+
+    TestKernelWithManyRegisters kernel;
+    auto const& bundeledKernel = alpaka::KernelBundle(kernel, 200ul);
+
+    // Get hard limits for test
+    auto const& props = alpaka::getAccDevProps<Acc>(dev);
+    Idx const threadsPerGridTestValue = props.m_blockThreadCountMax * props.m_gridBlockCountMax;
+
+    // Test getValidWorkDivForKernel for threadsPerGridTestValue threads per grid
+    auto const workDiv
+        = alpaka::getValidWorkDivForKernel<Acc>(dev, bundeledKernel, Vec{threadsPerGridTestValue}, Vec{1});
+    // Test validity
+    auto const isValid = alpaka::isValidWorkDivKernel<Acc>(dev, bundeledKernel, workDiv);
+    CHECK(isValid == true);
+
+    if constexpr(alpaka::accMatchesTags<Acc, alpaka::TagGpuCudaRt>)
+    {
+        // Get calculated threads per block from the workDiv found by examining kernel function
+        auto const threadsPerBlock = workDiv.m_blockThreadExtent.prod();
+        // Get hard limits
+        auto const threadsPerBlockLimit = props.m_blockThreadCountMax;
+        // Depending on the GPU type or the compiler the test below might fail because threadsPerBlock can be equal to
+        // threadsPerBlockLimit, which is the max device limit.
+        CHECK(threadsPerBlock < static_cast<Idx>(threadsPerBlockLimit));
+    }
+    else if constexpr(alpaka::accMatchesTags<Acc, alpaka::TagGpuHipRt>)
+    {
+        // Get calculated threads per block from the workDiv that was found by examining kernel function
+        auto const threadsPerBlock = workDiv.m_blockThreadExtent.prod();
+        // Get hard limits
+        auto const threadsPerBlockLimit = props.m_blockThreadCountMax;
+        // Depending on the GPU type or the compiler the test below might fail because threadsPerBlock can be equal to
+        // threadsPerBlockLimit, which is the max device limit.
+        CHECK(threadsPerBlock == static_cast<Idx>(threadsPerBlockLimit));
+    }
+    else if constexpr(alpaka::accMatchesTags<
+                          Acc,
+                          alpaka::TagCpuSerial,
+                          alpaka::TagCpuThreads,
+                          alpaka::TagCpuOmp2Threads,
+                          alpaka::TagCpuTbbBlocks>)
+    {
+        // CPU must have only 1 thread per block. In other words, number of blocks is equal to number of threads.
+        CHECK(workDiv == WorkDiv{Vec{threadsPerGridTestValue}, Vec{1}, Vec{1}});
+        // Test a new 1D workdiv. Threads per block can not be larger than 1 for CPU. Hence 2 is not valid.
+        auto const& workDiv1DUsingInitList = WorkDiv{Vec{threadsPerGridTestValue / 2}, Vec{2}, Vec{1}};
+        auto const isWorkDivValidForCpu
+            = alpaka::isValidWorkDivKernel<Acc>(dev, bundeledKernel, workDiv1DUsingInitList);
+        CHECK(isWorkDivValidForCpu == false);
+    }
+}
+
+using TestAccs2D = alpaka::test::EnabledAccs<alpaka::DimInt<2u>, std::uint32_t>;
+
+TEMPLATE_LIST_TEST_CASE("getValidWorkDivForKernel.2D", "[workDivKernel]", TestAccs2D)
+{
+    using Acc = TestType;
+    using Idx = alpaka::Idx<Acc>;
+    using Dim = alpaka::Dim<Acc>;
+    using Vec = alpaka::Vec<Dim, Idx>;
+    using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
+    auto const platform = alpaka::Platform<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
+
+    TestKernelWithManyRegisters kernel;
+    // A random value
+    size_t val(200ul);
+    auto const& bundeledKernel = alpaka::KernelBundle(kernel, val);
+
+    // Get hard limits for test
+    auto const& props = alpaka::getAccDevProps<Acc>(dev);
+    Idx const threadsPerGridTestValue = props.m_blockThreadCountMax * props.m_gridBlockCountMax;
+
+    // Test getValidWorkDivForKernel function for threadsPerGridTestValue threads per grid.
+    auto const workDiv
+        = alpaka::getValidWorkDivForKernel<Acc>(dev, bundeledKernel, Vec{8, threadsPerGridTestValue / 8}, Vec{1, 1});
+
+    // Test isValidWorkDivKernel function
+    auto const isValid = alpaka::isValidWorkDivKernel<Acc>(dev, bundeledKernel, workDiv);
+    CHECK(isValid == true);
+
+    if constexpr(alpaka::accMatchesTags<Acc, alpaka::TagGpuCudaRt>)
+    {
+        // Expected valid workdiv for this kernel. These values might change depending on the GPU type and compiler
+        // therefore commented out. Number of registers used by kernel might limit threads per block value differently
+        // for different GPUs. CHECK(workDiv == WorkDiv{Vec{8, 729444}, Vec{1, 736}, Vec{1, 1}});
+
+        // Get calculated threads per block from the workDiv that was found by examining kernel function
+        auto const threadsPerBlock = workDiv.m_blockThreadExtent.prod();
+        // Get hard limits
+        auto const threadsPerBlockLimit = props.m_blockThreadCountMax;
+
+        // Depending on the GPU type or the compiler the test below might fail because threadsPerBlock can be equal to
+        // threadsPerBlockLimit, which is the max device limit.
+        CHECK(threadsPerBlock < static_cast<Idx>(threadsPerBlockLimit));
+
+        // too many threads per block
+        auto const invalidWorkDiv
+            = WorkDiv{Vec{8, threadsPerGridTestValue / 8}, Vec{2 * threadsPerBlock, 1}, Vec{1, 1}};
+        auto isWorkDivValidForCuda = alpaka::isValidWorkDivKernel<Acc>(dev, bundeledKernel, invalidWorkDiv);
+        CHECK(isWorkDivValidForCuda == false);
+
+        auto const validWorkDiv = WorkDiv{Vec{8, threadsPerGridTestValue / 8}, Vec{1, threadsPerBlock}, Vec{1, 1}};
+        isWorkDivValidForCuda = alpaka::isValidWorkDivKernel<Acc>(dev, bundeledKernel, validWorkDiv);
+        CHECK(isWorkDivValidForCuda == true);
+    }
+    else if constexpr(alpaka::accMatchesTags<Acc, alpaka::TagGpuHipRt>)
+    {
+        // Get calculated threads per block from the workDiv that was found by examining the kernel function
+        auto const threadsPerBlock = workDiv.m_blockThreadExtent.prod();
+        // Get hard limits
+        auto const threadsPerBlockLimit = props.m_blockThreadCountMax;
+        // Depending on the GPU type or the compiler this test might fail because threadsPerBlock can be less than
+        // threadsPerBlockLimit, which is the max device limit.
+        CHECK(threadsPerBlock < static_cast<Idx>(threadsPerBlockLimit));
+
+        // too many threads per block
+        auto const invalidWorkDiv
+            = WorkDiv{Vec{8, threadsPerGridTestValue / 8}, Vec{2 * threadsPerBlock, 1}, Vec{1, 1}};
+        auto isWorkDivValidForHip = alpaka::isValidWorkDivKernel<Acc>(dev, bundeledKernel, invalidWorkDiv);
+        CHECK(isWorkDivValidForHip == false);
+
+        auto const validWorkDiv = WorkDiv{Vec{8, threadsPerGridTestValue / 8}, Vec{1, threadsPerBlock}, Vec{1, 1}};
+        isWorkDivValidForHip = alpaka::isValidWorkDivKernel<Acc>(dev, bundeledKernel, validWorkDiv);
+        CHECK(isWorkDivValidForHip == true);
+    }
+    else if constexpr(alpaka::accMatchesTags<
+                          Acc,
+                          alpaka::TagCpuSerial,
+                          alpaka::TagCpuThreads,
+                          alpaka::TagCpuOmp2Threads,
+                          alpaka::TagCpuTbbBlocks>)
+    {
+        // CPU must have only 1 thread per block. In other words, number of blocks is equal to number of threads.
+        CHECK(workDiv == WorkDiv{Vec{8, threadsPerGridTestValue / 8}, Vec{1, 1}, Vec{1, 1}});
+        // Test a new 2D workdiv. Threads per block can not be larger than 1 for CPU. Hence 2x1 threads is not valid.
+        auto const& invalidWorkDiv2D = WorkDiv{Vec{1, 2048}, Vec{1, 2}, Vec{1, 1}};
+        auto const isWorkDivValidForCpu = alpaka::isValidWorkDivKernel<Acc>(dev, bundeledKernel, invalidWorkDiv2D);
+        CHECK(isWorkDivValidForCpu == false);
+    }
+}

--- a/test/unit/workDiv/src/WorkDivForKernelTest.cpp
+++ b/test/unit/workDiv/src/WorkDivForKernelTest.cpp
@@ -11,6 +11,7 @@
 #include <alpaka/idx/Traits.hpp>
 #include <alpaka/kernel/KernelBundle.hpp>
 #include <alpaka/kernel/KernelFunctionAttributes.hpp>
+#include <alpaka/math/MathStdLib.hpp>
 #include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/workdiv/WorkDivHelpers.hpp>
 
@@ -20,7 +21,7 @@
 struct TestKernelWithManyRegisters
 {
     template<typename TAcc>
-    [[maybe_unused]] ALPAKA_FN_ACC auto operator()(TAcc const&, std::size_t val) const -> void
+    [[maybe_unused]] ALPAKA_FN_ACC auto operator()(TAcc const& acc, std::size_t val) const -> void
     {
         double var0 = 1.0;
         double var1 = 2.0;
@@ -31,39 +32,39 @@ struct TestKernelWithManyRegisters
         // threads per block while this kernel is being run.
 
         // TODO: Use function templates to parametrize and shorten the code!
-        double var3 = var2 + fmod(var2, 5);
-        double var4 = var3 + fmod(var3, 5);
-        double var5 = var4 + fmod(var4, 5);
-        double var6 = var5 + fmod(var5, 5);
-        double var7 = var6 + fmod(var6, 5);
-        double var8 = var7 + fmod(var7, 5);
-        double var9 = var8 + fmod(var8, 5);
-        double var10 = var9 + fmod(var9, 5);
-        double var11 = var10 + fmod(var10, 5);
-        double var12 = var11 + fmod(var11, 5);
-        double var13 = var12 + fmod(var12, 5);
-        double var14 = var13 + fmod(var13, 5);
-        double var15 = var14 + fmod(var14, 5);
-        double var16 = var15 + fmod(var15, 5);
-        double var17 = var16 + fmod(var16, 5);
-        double var18 = var17 + fmod(var17, 5);
-        double var19 = var18 + fmod(var18, 5);
-        double var20 = var19 + fmod(var19, 5);
-        double var21 = var20 + fmod(var20, 5);
-        double var22 = var21 + fmod(var21, 5);
-        double var23 = var22 + fmod(var22, 5);
-        double var24 = var23 + fmod(var23, 5);
-        double var25 = var24 + fmod(var24, 5);
-        double var26 = var25 + fmod(var25, 5);
-        double var27 = var26 + fmod(var26, 5);
-        double var28 = var27 + fmod(var27, 5);
-        double var29 = var28 + fmod(var28, 5);
-        double var30 = var29 + fmod(var29, 5);
-        double var31 = var30 + fmod(var30, 5);
-        double var32 = var31 + fmod(var31, 5);
-        double var33 = var32 + fmod(var32, 5);
-        double var34 = var33 + fmod(var33, 5);
-        double var35 = var34 + fmod(var34, 5);
+        double var3 = var2 + alpaka::math::fmod(acc, var2, 5);
+        double var4 = var3 + alpaka::math::fmod(acc, var3, 5);
+        double var5 = var4 + alpaka::math::fmod(acc, var4, 5);
+        double var6 = var5 + alpaka::math::fmod(acc, var5, 5);
+        double var7 = var6 + alpaka::math::fmod(acc, var6, 5);
+        double var8 = var7 + alpaka::math::fmod(acc, var7, 5);
+        double var9 = var8 + alpaka::math::fmod(acc, var8, 5);
+        double var10 = var9 + alpaka::math::fmod(acc, var9, 5);
+        double var11 = var10 + alpaka::math::fmod(acc, var10, 5);
+        double var12 = var11 + alpaka::math::fmod(acc, var11, 5);
+        double var13 = var12 + alpaka::math::fmod(acc, var12, 5);
+        double var14 = var13 + alpaka::math::fmod(acc, var13, 5);
+        double var15 = var14 + alpaka::math::fmod(acc, var14, 5);
+        double var16 = var15 + alpaka::math::fmod(acc, var15, 5);
+        double var17 = var16 + alpaka::math::fmod(acc, var16, 5);
+        double var18 = var17 + alpaka::math::fmod(acc, var17, 5);
+        double var19 = var18 + alpaka::math::fmod(acc, var18, 5);
+        double var20 = var19 + alpaka::math::fmod(acc, var19, 5);
+        double var21 = var20 + alpaka::math::fmod(acc, var20, 5);
+        double var22 = var21 + alpaka::math::fmod(acc, var21, 5);
+        double var23 = var22 + alpaka::math::fmod(acc, var22, 5);
+        double var24 = var23 + alpaka::math::fmod(acc, var23, 5);
+        double var25 = var24 + alpaka::math::fmod(acc, var24, 5);
+        double var26 = var25 + alpaka::math::fmod(acc, var25, 5);
+        double var27 = var26 + alpaka::math::fmod(acc, var26, 5);
+        double var28 = var27 + alpaka::math::fmod(acc, var27, 5);
+        double var29 = var28 + alpaka::math::fmod(acc, var28, 5);
+        double var30 = var29 + alpaka::math::fmod(acc, var29, 5);
+        double var31 = var30 + alpaka::math::fmod(acc, var30, 5);
+        double var32 = var31 + alpaka::math::fmod(acc, var31, 5);
+        double var33 = var32 + alpaka::math::fmod(acc, var32, 5);
+        double var34 = var33 + alpaka::math::fmod(acc, var33, 5);
+        double var35 = var34 + alpaka::math::fmod(acc, var34, 5);
 
         double sum = var0 + var1 + var2 + var3 + var4 + var5 + var6 + var7 + var8 + var9 + var10 + var11 + var12
                      + var13 + var14 + var15 + var16 + var17 + var18 + var19 + var20 + var21 + var22 + var23 + var24

--- a/test/unit/workDiv/src/WorkDivForKernelTest.cpp
+++ b/test/unit/workDiv/src/WorkDivForKernelTest.cpp
@@ -88,7 +88,7 @@ TEMPLATE_LIST_TEST_CASE("getValidWorkDivForKernel.1D", "[workDivKernel]", TestAc
     auto const& bundeledKernel = alpaka::KernelBundle(kernel, 200ul);
 
     // Get hard limits for test
-    auto const& props = alpaka::getAccDevProps<Acc>(dev);
+    auto const& props = alpaka::getAccDevProps<Acc, decltype(dev)>(dev);
     Idx const threadsPerGridTestValue = props.m_blockThreadCountMax * props.m_gridBlockCountMax;
 
     // Test getValidWorkDivForKernel for threadsPerGridTestValue threads per grid

--- a/test/unit/workDiv/src/WorkDivForKernelTest.cpp
+++ b/test/unit/workDiv/src/WorkDivForKernelTest.cpp
@@ -182,9 +182,8 @@ TEMPLATE_LIST_TEST_CASE("getValidWorkDivForKernel.2D", "[workDivKernel]", TestAc
 
     if constexpr(alpaka::accMatchesTags<Acc, alpaka::TagGpuCudaRt>)
     {
-        // Expected valid workdiv for this kernel. These values might change depending on the GPU type and compiler
-        // therefore commented out. Number of registers used by kernel might limit threads per block value differently
-        // for different GPUs. CHECK(workDiv == WorkDiv{Vec{8, 729444}, Vec{1, 736}, Vec{1, 1}});
+        // Expected valid workdiv values for this kernel might change depending on the GPU type and compiler. Therefore
+        // generated workdiv is not compared to a specific workdiv in this test.
 
         // Get calculated threads per block from the workDiv that was found by examining kernel function
         auto const threadsPerBlock = workDiv.m_blockThreadExtent.prod();


### PR DESCRIPTION
 
`getValidWorkDiv`  has a bug. It only considers device _hard_ properties ( `TApi::getDeviceProperties()`); does not consider the kernel function. Actually kernel function properties can limit number of threads per block. 

In the case of CUDA and ROCm, the function `getValidWorkDiv` should  use  `TApi::funcGetAttributes(&funcAttrs, kernelName)`  together with  `TApi::getDeviceProperties()`.

 I have added 3 functions.  `getFunctionAttributes`,`getValidWorkDivKernel` and `isValidWorkDivKernel`.   One function intrinsic to Alpaka changed: `subDivideGridElems`. Now has an additional argument; "threads per block", if the value is zero the function uses device hard properties as before.

**Next PR:** The 2 functions `getValidWorkDivKernel` and `isValidWorkDivKernel` will be used in Examples and Tests instead of getValidWorkDiv and isValidWorkDiv at the next PR. The names can be determined.

Credits to @psychocoderHPC  for the PR.
**Tests:** The tests for 1D and 2D workdivs were added.