### PR TITLE
Make all Examples use getValidWorkDivForKernel function [II]

### DIFF
--- a/benchmarks/babelstream/src/AlpakaStream.cpp
+++ b/benchmarks/babelstream/src/AlpakaStream.cpp
@@ -50,7 +50,7 @@ template<typename T>
 void AlpakaStream<T>::init_arrays(T initA, T initB, T initC)
 {
     auto const workdiv = WorkDiv{arraySize / blockSize, blockSize, 1};
-    // auto const workdiv = alpaka::getValidWorkDiv(devAcc, arraySize);
+
     alpaka::exec<
         Acc>(queue, workdiv, InitKernel{}, std::data(d_a), std::data(d_b), std::data(d_c), initA, initB, initC);
     alpaka::wait(queue);
@@ -78,7 +78,7 @@ template<typename T>
 void AlpakaStream<T>::copy()
 {
     auto const workdiv = WorkDiv{arraySize / blockSize, blockSize, 1};
-    // auto const workdiv = alpaka::getValidWorkDiv(devAcc, arraySize);
+
     alpaka::exec<Acc>(queue, workdiv, CopyKernel{}, std::data(d_a), std::data(d_c));
     alpaka::wait(queue);
 }
@@ -98,7 +98,7 @@ template<typename T>
 void AlpakaStream<T>::mul()
 {
     auto const workdiv = WorkDiv{arraySize / blockSize, blockSize, 1};
-    // auto const workdiv = alpaka::getValidWorkDiv(devAcc, arraySize);
+
     alpaka::exec<Acc>(queue, workdiv, MulKernel{}, std::data(d_b), std::data(d_c));
     alpaka::wait(queue);
 }
@@ -117,7 +117,7 @@ template<typename T>
 void AlpakaStream<T>::add()
 {
     auto const workdiv = WorkDiv{arraySize / blockSize, blockSize, 1};
-    // auto const workdiv = alpaka::getValidWorkDiv(devAcc, arraySize);
+
     alpaka::exec<Acc>(queue, workdiv, AddKernel{}, std::data(d_a), std::data(d_b), std::data(d_c));
     alpaka::wait(queue);
 }
@@ -137,7 +137,7 @@ template<typename T>
 void AlpakaStream<T>::triad()
 {
     auto const workdiv = WorkDiv{arraySize / blockSize, blockSize, 1};
-    // auto const workdiv = alpaka::getValidWorkDiv(devAcc, arraySize);
+
     alpaka::exec<Acc>(queue, workdiv, TriadKernel{}, std::data(d_a), std::data(d_b), std::data(d_c));
     alpaka::wait(queue);
 }
@@ -157,7 +157,7 @@ template<typename T>
 void AlpakaStream<T>::nstream()
 {
     auto const workdiv = WorkDiv{arraySize / blockSize, blockSize, 1};
-    // auto const workdiv = alpaka::getValidWorkDiv(devAcc, arraySize);
+
     alpaka::exec<Acc>(queue, workdiv, NstreamKernel{}, std::data(d_a), std::data(d_b), std::data(d_c));
     alpaka::wait(queue);
 }
@@ -197,7 +197,6 @@ template<typename T>
 auto AlpakaStream<T>::dot() -> T
 {
     auto const workdiv = WorkDiv{dotBlockSize, blockSize, 1};
-    // auto const workdiv = alpaka::getValidWorkDiv(devAcc, dotBlockSize * blockSize);
     alpaka::exec<Acc>(queue, workdiv, DotKernel{}, std::data(d_a), std::data(d_b), std::data(d_sum), arraySize);
     alpaka::wait(queue);
 

--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -176,6 +176,12 @@ Enqueue a memory copy from device to host
 
 Kernel Execution
 ----------------
+Prepare Kernel Bundle
+  .. code-block:: c++
+
+     HeatEquationKernel heatEqKernel;
+     // Arguments of KernelBundle: The kernel instance and the kernel arguments
+     auto const& bundeledKernel = alpaka::KernelBundle(heatEqKernel, pCurrAcc, pNextAcc, numNodesX, dx, dt);
 
 Automatically select a valid kernel launch configuration
   .. code-block:: c++
@@ -183,8 +189,9 @@ Automatically select a valid kernel launch configuration
      Vec<Dim, Idx> const globalThreadExtent = vectorValue;
      Vec<Dim, Idx> const elementsPerThread = vectorValue;
 
-     auto autoWorkDiv = getValidWorkDiv<Acc>(
+     auto autoWorkDiv = getValidWorkDivForKernel<Acc>(
        device,
+       bundeledKernel,
        globalThreadExtent, elementsPerThread,
        false,
        GridBlockExtentSubDivRestrictions::Unrestricted);

--- a/example/complex/src/complex.cpp
+++ b/example/complex/src/complex.cpp
@@ -55,15 +55,16 @@ auto example(TAccTag const&) -> int
     // Define the work division
     Idx const threadsPerGrid = 1u;
     Idx const elementsPerThread = 1u;
-    auto const workDiv = alpaka::getValidWorkDiv<Acc>(
-        devAcc,
-        threadsPerGrid,
-        elementsPerThread,
-        false,
-        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
+
+    ComplexKernel complexKernel;
+
+    auto const& bundeledKernel = alpaka::KernelBundle(complexKernel);
+    // Let alpaka calculate good block and grid sizes given our full problem extent
+    auto const workDiv
+        = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, threadsPerGrid, elementsPerThread);
 
     // Run the kernel
-    alpaka::exec<Acc>(queue, workDiv, ComplexKernel{});
+    alpaka::exec<Acc>(queue, workDiv, complexKernel);
     alpaka::wait(queue);
 
     // Usage of alpaka::Complex<T> on the host side is the same as inside kernels, except math functions are not

--- a/example/counterBasedRng/src/counterBasedRng.cpp
+++ b/example/counterBasedRng/src/counterBasedRng.cpp
@@ -131,19 +131,6 @@ auto example(TAccTag const&) -> int
     alpaka::Vec<Dim, Idx> const elementsPerThread = {1, 1, 1};
     alpaka::Vec<Dim, Idx> const elementsPerThreadHost = {1, 1, 8};
 
-    // Let alpaka calculate good block and grid sizes given our full problem extent
-    alpaka::WorkDivMembers<Dim, Idx> const workDivAcc(alpaka::getValidWorkDiv<Acc>(
-        devAcc,
-        extent,
-        elementsPerThread,
-        false,
-        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted));
-    alpaka::WorkDivMembers<Dim, Idx> const workDivHost(alpaka::getValidWorkDiv<AccHost>(
-        devHost,
-        extent,
-        elementsPerThreadHost,
-        false,
-        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted));
 
     // Define the buffer element type
     using Data = std::uint32_t;
@@ -158,6 +145,17 @@ auto example(TAccTag const&) -> int
     // Allocate buffer on the accelerator
     using BufAcc = alpaka::Buf<Acc, Data, Dim, Idx>;
     BufAcc bufAcc(alpaka::allocBuf<Data, Idx>(devAcc, extent));
+
+    CounterBasedRngKernel counterBasedRngKernel;
+    auto const& bundeledKernel
+        = alpaka::KernelBundle(counterBasedRngKernel, alpaka::experimental::getMdSpan(bufAcc), key);
+    auto const& bundeledKernel2
+        = alpaka::KernelBundle(counterBasedRngKernel, alpaka::experimental::getMdSpan(bufHost), key);
+
+    // Let alpaka calculate good block and grid sizes given our full problem extent
+    auto const workDivAcc = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, extent, elementsPerThread);
+    auto const workDivHost
+        = alpaka::getValidWorkDivForKernel<AccHost>(devHost, bundeledKernel2, extent, elementsPerThreadHost);
 
     // Create the kernel execution task.
     auto const taskKernelAcc = alpaka::createTaskKernel<Acc>(

--- a/example/helloWorld/src/helloWorld.cpp
+++ b/example/helloWorld/src/helloWorld.cpp
@@ -127,13 +127,6 @@ auto example(TAccTag const&) -> int
     using Vec = alpaka::Vec<Dim, Idx>;
     auto const elementsPerThread = Vec::all(static_cast<Idx>(1));
     auto const threadsPerGrid = Vec{4, 2, 4};
-    using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
-    WorkDiv const workDiv = alpaka::getValidWorkDiv<Acc>(
-        devAcc,
-        threadsPerGrid,
-        elementsPerThread,
-        false,
-        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
 
     // Instantiate the kernel function object
     //
@@ -141,6 +134,11 @@ auto example(TAccTag const&) -> int
     // callable operator() and takes the accelerator as first
     // argument. So a kernel can be a class or struct, a lambda, etc.
     HelloWorldKernel helloWorldKernel;
+
+    auto const& bundeledKernel = alpaka::KernelBundle(helloWorldKernel);
+    // Let alpaka calculate good block and grid sizes given our full problem extent
+    auto const workDiv
+        = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, threadsPerGrid, elementsPerThread);
 
     // Run the kernel
     //

--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -106,16 +106,16 @@ auto main() -> int
     // Define the work division
     Idx const threadsPerGrid = 16u;
     Idx const elementsPerThread = 1u;
-    auto const workDiv = alpaka::getValidWorkDiv<Acc>(
-        devAcc,
-        threadsPerGrid,
-        elementsPerThread,
-        false,
-        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
+
+    OpenMPScheduleDefaultKernel openMPScheduleDefaultKernel;
+    auto const& bundeledKernel = alpaka::KernelBundle(openMPScheduleDefaultKernel);
+    // Let alpaka calculate good block and grid sizes given our full problem extent
+    auto const workDiv
+        = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, threadsPerGrid, elementsPerThread);
 
     // Run the kernel setting no schedule explicitly.
     std::cout << "OpenMPScheduleDefaultKernel setting no schedule explicitly:\n";
-    alpaka::exec<Acc>(queue, workDiv, OpenMPScheduleDefaultKernel{});
+    alpaka::exec<Acc>(queue, workDiv, openMPScheduleDefaultKernel);
     alpaka::wait(queue);
 
     // Run the kernel setting the schedule via a trait

--- a/example/randomStrategies/src/randomStrategies.cpp
+++ b/example/randomStrategies/src/randomStrategies.cpp
@@ -49,7 +49,7 @@ struct Box
     using BufAccRand = alpaka::Buf<Acc, RandomEngine, Dim, Idx>;
 
     Vec const extentRand; ///< size of the buffer of PRNG states
-    WorkDiv workdivRand; ///< work division for PRNG buffer initialization
+    WorkDiv workdivRand; ///< work division for PRNG buffer initialization // REMOVE THAT!!
     BufHostRand bufHostRand; ///< host side PRNG states buffer (can be used to check the state of the states)
     BufAccRand bufAccRand; ///< device side PRNG states buffer
 
@@ -58,7 +58,7 @@ struct Box
     using BufAcc = alpaka::Buf<Acc, float, Dim, Idx>;
 
     Vec const extentResult; ///< size of the results buffer
-    WorkDiv workdivResult; ///< work division of the result calculation
+    WorkDiv workdivResult; ///< work division of the result calculation // REMOVE THAT!!
     BufHost bufHostResult; ///< host side results buffer
     BufAcc bufAccResult; ///< device side results buffer
 

--- a/example/randomStrategies/src/randomStrategies.cpp
+++ b/example/randomStrategies/src/randomStrategies.cpp
@@ -49,7 +49,8 @@ struct Box
     using BufAccRand = alpaka::Buf<Acc, RandomEngine, Dim, Idx>;
 
     Vec const extentRand; ///< size of the buffer of PRNG states
-    WorkDiv workdivRand; ///< work division for PRNG buffer initialization // REMOVE THAT!!
+    // WorkDiv workdivRand; ///< work division for PRNG buffer initialization // REMOVE THAT!!
+    // WorkDiv workdivResult; ///< work division of the result calculation // REMOVE THAT!!
     BufHostRand bufHostRand; ///< host side PRNG states buffer (can be used to check the state of the states)
     BufAccRand bufAccRand; ///< device side PRNG states buffer
 
@@ -58,28 +59,16 @@ struct Box
     using BufAcc = alpaka::Buf<Acc, float, Dim, Idx>;
 
     Vec const extentResult; ///< size of the results buffer
-    WorkDiv workdivResult; ///< work division of the result calculation // REMOVE THAT!!
+
     BufHost bufHostResult; ///< host side results buffer
     BufAcc bufAccResult; ///< device side results buffer
 
     Box()
         : queue{alpaka::getDevByIdx(accPlatform, 0)}
         , extentRand{static_cast<Idx>(NUM_POINTS)} // One PRNG state per "point".
-        , workdivRand{alpaka::getValidWorkDiv<Acc>(
-              alpaka::getDevByIdx(accPlatform, 0),
-              extentRand,
-              Vec(Idx{1}),
-              false,
-              alpaka::GridBlockExtentSubDivRestrictions::Unrestricted)}
         , bufHostRand{alpaka::allocBuf<RandomEngine, Idx>(alpaka::getDevByIdx(hostPlatform, 0), extentRand)}
         , bufAccRand{alpaka::allocBuf<RandomEngine, Idx>(alpaka::getDevByIdx(accPlatform, 0), extentRand)}
         , extentResult{static_cast<Idx>((NUM_POINTS * NUM_ROLLS))} // Store all "rolls" for each "point"
-        , workdivResult{alpaka::getValidWorkDiv<Acc>(
-              alpaka::getDevByIdx(accPlatform, 0),
-              extentResult,
-              Vec(static_cast<Idx>(NUM_ROLLS)), // One thread per "point"; each performs NUM_ROLLS "rolls"
-              false,
-              alpaka::GridBlockExtentSubDivRestrictions::Unrestricted)}
         , bufHostResult{alpaka::allocBuf<float, Idx>(alpaka::getDevByIdx(hostPlatform, 0), extentResult)}
         , bufAccResult{alpaka::allocBuf<float, Idx>(alpaka::getDevByIdx(accPlatform, 0), extentResult)}
     {
@@ -257,9 +246,26 @@ void runStrategy(Box<TAccTag>& box)
     // of the PRNG buffer and has to be passed in explicitly. Other strategies ignore the last parameter, and deduce
     // the initial parameters solely from the thread index
 
+
+    auto const& bundeledKernel = alpaka::KernelBundle(
+        initRandomKernel,
+        box.extentRand,
+        ptrBufAccRand,
+        static_cast<unsigned>(box.extentResult[0] / box.extentRand[0]));
+
+    // Let alpaka calculate good block and grid sizes given our full problem extent
+    auto const workDivRand = alpaka::getValidWorkDivForKernel<typename Box<TAccTag>::Acc>(
+        alpaka::getDevByIdx(box.accPlatform, 0),
+        bundeledKernel,
+        box.extentRand,
+        typename Box<TAccTag>::Vec(typename Box<TAccTag>::Idx{1}),
+        false,
+        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
+
+
     alpaka::exec<typename Box<TAccTag>::Acc>(
         box.queue,
-        box.workdivRand,
+        workDivRand,
         initRandomKernel,
         box.extentRand,
         ptrBufAccRand,
@@ -284,9 +290,24 @@ void runStrategy(Box<TAccTag>& box)
     // Run the "computation" kernel filling the results buffer with random numbers in parallel
     alpaka::memcpy(box.queue, box.bufAccResult, box.bufHostResult);
     FillKernel fillKernel;
+
+    auto const& bundeledKernelFill
+        = alpaka::KernelBundle(fillKernel, box.extentResult, ptrBufAccRand, ptrBufAccResult);
+
+    // Let alpaka calculate good block and grid sizes given our full problem extent
+    auto const workdivResult = alpaka::getValidWorkDivForKernel<typename Box<TAccTag>::Acc>(
+        alpaka::getDevByIdx(box.accPlatform, 0),
+        bundeledKernelFill,
+        box.extentResult,
+        typename Box<TAccTag>::Vec(static_cast<typename Box<TAccTag>::Idx>(
+            NUM_ROLLS)), // One thread per "point"; each performs NUM_ROLLS "rolls"
+        false,
+        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
+
+
     alpaka::exec<typename Box<TAccTag>::Acc>(
         box.queue,
-        box.workdivResult,
+        workdivResult,
         fillKernel,
         box.extentResult,
         ptrBufAccRand,

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -89,13 +89,6 @@ auto example(TAccTag const&) -> int
     Idx const elementsPerThread(8u);
     alpaka::Vec<Dim, Idx> const extent(numElements);
 
-    // Let alpaka calculate good block and grid sizes given our full problem extent
-    alpaka::WorkDivMembers<Dim, Idx> const workDiv(alpaka::getValidWorkDiv<Acc>(
-        devAcc,
-        extent,
-        elementsPerThread,
-        false,
-        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted));
 
     // Define the buffer element type
     using Data = std::uint32_t;
@@ -136,6 +129,15 @@ auto example(TAccTag const&) -> int
 
     // Instantiate the kernel function object
     VectorAddKernel kernel;
+
+    auto const& bundeledKernel = alpaka::KernelBundle(
+        kernel,
+        alpaka::getPtrNative(bufAccA),
+        alpaka::getPtrNative(bufAccB),
+        alpaka::getPtrNative(bufAccC),
+        numElements);
+    // Let alpaka calculate good block and grid sizes given our full problem extent
+    auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, extent, elementsPerThread);
 
     // Create the kernel execution task.
     auto const taskKernel = alpaka::createTaskKernel<Acc>(

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -112,6 +112,7 @@
 #include "alpaka/idx/gb/IdxGbRef.hpp"
 #include "alpaka/idx/gb/IdxGbUniformCudaHipBuiltIn.hpp"
 // kernel
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp"
 #include "alpaka/kernel/TaskKernelCpuOmp2Threads.hpp"
 #include "alpaka/kernel/TaskKernelCpuSerial.hpp"

--- a/include/alpaka/kernel/KernelBundle.hpp
+++ b/include/alpaka/kernel/KernelBundle.hpp
@@ -20,19 +20,21 @@ namespace alpaka
     class KernelBundle
     {
     public:
-        ALPAKA_FN_HOST KernelBundle(TKernelFn kernelFn, TArgs&&... args)
-            : m_kernelFn(std::move(kernelFn))
-            , m_args(std::make_tuple(std::forward<TArgs>(args)...))
-        {
-        }
-
         //! The function object type
         using KernelFn = TKernelFn;
         //! Tuple type to encapsulate kernel function argument types and argument values
         using ArgTuple = std::tuple<std::remove_const_t<std::remove_reference_t<TArgs>>...>;
 
+        // Constructor
+        KernelBundle(KernelFn kernelFn, TArgs&&... args)
+            : m_kernelFn(std::move(kernelFn))
+            , m_args(std::forward<TArgs>(args)...)
+        {
+        }
+
+    private:
         KernelFn m_kernelFn;
-        ArgTuple m_args;
+        ArgTuple m_args; // Store the argument types without const and reference
     };
 
     //! \brief User defined deduction guide with trailing return type. For CTAD during the construction.

--- a/include/alpaka/kernel/KernelBundle.hpp
+++ b/include/alpaka/kernel/KernelBundle.hpp
@@ -23,7 +23,7 @@ namespace alpaka
         //! The function object type
         using KernelFn = TKernelFn;
         //! Tuple type to encapsulate kernel function argument types and argument values
-        using ArgTuple = std::tuple<std::remove_const_t<std::remove_reference_t<TArgs>>...>;
+        using ArgTuple = std::tuple<std::decay_t<TArgs>...>;
 
         // Constructor
         KernelBundle(KernelFn kernelFn, TArgs&&... args)

--- a/include/alpaka/kernel/KernelBundle.hpp
+++ b/include/alpaka/kernel/KernelBundle.hpp
@@ -29,7 +29,7 @@ namespace alpaka
 #if BOOST_COMP_CLANG
 #    pragma clang diagnostic pop
 #endif
-        KernelBundle(TKernelFn const& kernelFn, TArgs&&... args)
+        ALPAKA_FN_HOST KernelBundle(TKernelFn const& kernelFn, TArgs&&... args)
             : m_kernelFn(kernelFn)
             , m_args(std::forward<TArgs>(args)...)
         {
@@ -60,6 +60,6 @@ namespace alpaka
     //! \return Kernel function bundle. An instance of KernelBundle which consists the kernel function object and its
     //! arguments.
     template<typename TKernelFn, typename... TArgs>
-    KernelBundle(TKernelFn const& kernelFn, TArgs&&... args) -> KernelBundle<TKernelFn, TArgs...>;
+    ALPAKA_FN_HOST KernelBundle(TKernelFn const& kernelFn, TArgs&&... args) -> KernelBundle<TKernelFn, TArgs...>;
 
 } // namespace alpaka

--- a/include/alpaka/kernel/KernelBundle.hpp
+++ b/include/alpaka/kernel/KernelBundle.hpp
@@ -19,26 +19,16 @@ namespace alpaka
     class KernelBundle
     {
     public:
-#if BOOST_COMP_CLANG
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdocumentation" // clang does not support the syntax for variadic template
-                                                       // arguments "args,...". Ignore the error.
-#endif
-        //! \param kernelFn The kernel function-object
-        //! \param args,... The kernel invocation arguments.
-#if BOOST_COMP_CLANG
-#    pragma clang diagnostic pop
-#endif
-        ALPAKA_FN_HOST KernelBundle(TKernelFn const& kernelFn, TArgs&&... args)
-            : m_kernelFn(kernelFn)
-            , m_args(std::forward<TArgs>(args)...)
+        ALPAKA_FN_HOST KernelBundle(TKernelFn kernelFn, TArgs&&... args)
+            : m_kernelFn(std::move(kernelFn))
+            , m_args(std::make_tuple(std::forward<TArgs>(args)...))
         {
         }
 
         //! The function object type
         using KernelFn = TKernelFn;
         //! Tuple type to encapsulate kernel function argument types and argument values
-        using ArgTuple = std::tuple<std::decay_t<TArgs>...>;
+        using ArgTuple = std::tuple<std::remove_const_t<std::remove_reference_t<TArgs>>...>;
 
         KernelFn m_kernelFn;
         ArgTuple m_args;
@@ -60,6 +50,9 @@ namespace alpaka
     //! \return Kernel function bundle. An instance of KernelBundle which consists the kernel function object and its
     //! arguments.
     template<typename TKernelFn, typename... TArgs>
-    ALPAKA_FN_HOST KernelBundle(TKernelFn const& kernelFn, TArgs&&... args) -> KernelBundle<TKernelFn, TArgs...>;
+    ALPAKA_FN_HOST KernelBundle(TKernelFn, TArgs&&...) -> KernelBundle<TKernelFn, TArgs...>;
+    // template<typename TKernelFn, typename... TArgs>
+    // ALPAKA_FN_HOST KernelBundle(TKernelFn kernelFn, TArgs&&... args) -> KernelBundle<std::decay_t<TKernelFn>,
+    // std::decay_t<TArgs>...>;
 
 } // namespace alpaka

--- a/include/alpaka/kernel/KernelBundle.hpp
+++ b/include/alpaka/kernel/KernelBundle.hpp
@@ -38,7 +38,7 @@ namespace alpaka
         //! The function object type
         using KernelFn = TKernelFn;
         //! Tuple type to encapsulate kernel function argument types and argument values
-        using ArgTuple = std::tuple<remove_restrict_t<std::decay_t<TArgs>>...>;
+        using ArgTuple = std::tuple<std::decay_t<TArgs>...>;
 
         KernelFn m_kernelFn;
         ArgTuple m_args;

--- a/include/alpaka/kernel/KernelBundle.hpp
+++ b/include/alpaka/kernel/KernelBundle.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <alpaka/core/Common.hpp>
 #include <alpaka/core/RemoveRestrict.hpp>
 
 #include <tuple>

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -213,7 +213,8 @@ namespace alpaka
 #        endif
 
 #        if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
-                // This checks for a valid work division that is also compliant with the maxima of the accelerator.
+                // This checks for a valid work division that is also compliant with the hardware maxima of the
+                // accelerator.
                 if(!isValidWorkDiv<TAcc>(getDev(queue), task))
                 {
                     throw std::runtime_error(

--- a/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/include/alpaka/test/KernelExecutionFixture.hpp
@@ -39,14 +39,8 @@ namespace alpaka::test
         }
 
         template<typename TExtent>
-        KernelExecutionFixture(TExtent const& extent)
-            : m_queue{m_device}
-            , m_workDiv{getValidWorkDiv<Acc>(
-                  m_device,
-                  extent,
-                  Vec<Dim, Idx>::ones(),
-                  false,
-                  GridBlockExtentSubDivRestrictions::Unrestricted)}
+        KernelExecutionFixture(TExtent const& extent) : m_queue{m_device}
+                                                      , m_extent{extent}
         {
         }
 
@@ -55,23 +49,32 @@ namespace alpaka::test
         }
 
         template<typename TExtent>
-        KernelExecutionFixture(Queue queue, TExtent const& extent)
-            : m_queue{std::move(queue)}
-            , m_workDiv{getValidWorkDiv<Acc>(
-                  m_device,
-                  extent,
-                  Vec<Dim, Idx>::ones(),
-                  false,
-                  GridBlockExtentSubDivRestrictions::Unrestricted)}
+        KernelExecutionFixture(Queue queue, TExtent const& extent) : m_queue{std::move(queue)}
+                                                                   , m_extent{extent}
         {
         }
 
         template<typename TKernelFnObj, typename... TArgs>
-        auto operator()(TKernelFnObj const& kernelFnObj, TArgs&&... args) -> bool
+        auto operator()(TKernelFnObj kernelFnObj, TArgs&&... args) -> bool
         {
             // Allocate the result value
             auto bufAccResult = allocBuf<bool, Idx>(m_device, static_cast<Idx>(1u));
             memset(m_queue, bufAccResult, static_cast<std::uint8_t>(true));
+
+
+            auto bundeledKernel = alpaka::KernelBundle<TKernelFnObj, decltype(getPtrNative(bufAccResult)), TArgs...>(
+                kernelFnObj,
+                getPtrNative(bufAccResult),
+                std::forward<TArgs>(args)...);
+
+
+            // set workdiv if it is not before
+            if(m_workDiv == WorkDiv{Vec<Dim, Idx>::all(0), Vec<Dim, Idx>::all(0), Vec<Dim, Idx>::all(0)})
+                m_workDiv = alpaka::getValidWorkDivForKernel<Acc, Dev<Acc>>(
+                    m_device,
+                    bundeledKernel,
+                    m_extent,
+                    Vec<Dim, Idx>::ones());
 
             exec<Acc>(m_queue, m_workDiv, kernelFnObj, getPtrNative(bufAccResult), std::forward<TArgs>(args)...);
 
@@ -91,7 +94,8 @@ namespace alpaka::test
         Platform m_platform{};
         Device m_device{getDevByIdx(m_platform, 0)};
         Queue m_queue;
-        WorkDiv m_workDiv;
+        WorkDiv m_workDiv{Vec<Dim, Idx>::all(0), Vec<Dim, Idx>::all(0), Vec<Dim, Idx>::all(0)};
+        Vec<Dim, Idx> m_extent;
     };
 
 } // namespace alpaka::test

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -304,65 +304,6 @@ namespace alpaka
         return WorkDivMembers<TDim, TIdx>(gridBlockExtent, blockThreadExtent, clippedThreadElemExtent);
     }
 
-    //! \tparam TAcc The accelerator for which this work division has to be valid.
-    //! \tparam TDev The type of the device.
-    //! \tparam TGridElemExtent The type of the grid element extent.
-    //! \tparam TThreadElemExtent The type of the thread element extent.
-    //! \param dev The device the work division should be valid for.
-    //! \param gridElemExtent The full extent of elements in the grid.
-    //! \param threadElemExtents the number of elements computed per thread.
-    //! \param blockThreadMustDivideGridThreadExtent If this is true, the grid thread extent will be multiples of the
-    //! corresponding block thread extent.
-    //!     NOTE: If this is true and gridThreadExtent is prime (or otherwise bad chosen) in a dimension, the
-    //!     block-thread extent will be one in this dimension.
-    //! \param gridBlockExtentSubDivRestrictions The grid block extent subdivision restrictions.
-    //! \return The work division.
-    template<
-        typename TAcc,
-        typename TDev,
-        typename TGridElemExtent = Vec<Dim<TAcc>, Idx<TAcc>>,
-        typename TThreadElemExtent = Vec<Dim<TAcc>, Idx<TAcc>>>
-    ALPAKA_FN_HOST auto getValidWorkDiv(
-        [[maybe_unused]] TDev const& dev,
-        [[maybe_unused]] TGridElemExtent const& gridElemExtent = Vec<Dim<TAcc>, Idx<TAcc>>::ones(),
-        [[maybe_unused]] TThreadElemExtent const& threadElemExtents = Vec<Dim<TAcc>, Idx<TAcc>>::ones(),
-        [[maybe_unused]] bool blockThreadMustDivideGridThreadExtent = true,
-        [[maybe_unused]] GridBlockExtentSubDivRestrictions gridBlockExtentSubDivRestrictions
-        = GridBlockExtentSubDivRestrictions::Unrestricted)
-        -> WorkDivMembers<Dim<TGridElemExtent>, Idx<TGridElemExtent>>
-    {
-        static_assert(
-            Dim<TGridElemExtent>::value == Dim<TAcc>::value,
-            "The dimension of TAcc and the dimension of TGridElemExtent have to be identical!");
-        static_assert(
-            Dim<TThreadElemExtent>::value == Dim<TAcc>::value,
-            "The dimension of TAcc and the dimension of TThreadElemExtent have to be identical!");
-        static_assert(
-            std::is_same_v<Idx<TGridElemExtent>, Idx<TAcc>>,
-            "The idx type of TAcc and the idx type of TGridElemExtent have to be identical!");
-        static_assert(
-            std::is_same_v<Idx<TThreadElemExtent>, Idx<TAcc>>,
-            "The idx type of TAcc and the idx type of TThreadElemExtent have to be identical!");
-
-        if constexpr(Dim<TGridElemExtent>::value == 0)
-        {
-            auto const zero = Vec<DimInt<0>, Idx<TAcc>>{};
-            ALPAKA_ASSERT(gridElemExtent == zero);
-            ALPAKA_ASSERT(threadElemExtents == zero);
-            return WorkDivMembers<DimInt<0>, Idx<TAcc>>{zero, zero, zero};
-        }
-        else
-            return subDivideGridElems(
-                getExtents(gridElemExtent),
-                getExtents(threadElemExtents),
-                getAccDevProps<TAcc>(dev),
-                static_cast<Idx<TAcc>>(0u),
-                blockThreadMustDivideGridThreadExtent,
-                gridBlockExtentSubDivRestrictions);
-        using V [[maybe_unused]] = Vec<Dim<TGridElemExtent>, Idx<TGridElemExtent>>;
-        ALPAKA_UNREACHABLE(WorkDivMembers<Dim<TGridElemExtent>, Idx<TGridElemExtent>>{V{}, V{}, V{}});
-    }
-
     //! \tparam TDev The type of the device.
     //! \tparam TKernelBundle The type of the bundle of kernel and the arguments. Kernel is used to get number of
     //! threads per block, this number could be less than or equal to the number of threads per block according to

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -301,7 +301,6 @@ namespace alpaka
             }
         }
 
-
         return WorkDivMembers<TDim, TIdx>(gridBlockExtent, blockThreadExtent, clippedThreadElemExtent);
     }
 

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -294,20 +294,6 @@ TEMPLATE_LIST_TEST_CASE("mandelbrot", "[mandelbrot]", TestAccs)
 
     alpaka::Vec<Dim, Idx> const extent(static_cast<Idx>(numRows), static_cast<Idx>(numCols));
 
-    // Let alpaka calculate good block and grid sizes given our full problem extent.
-    alpaka::WorkDivMembers<Dim, Idx> const workDiv(alpaka::getValidWorkDiv<Acc>(
-        devAcc,
-        extent,
-        alpaka::Vec<Dim, Idx>::ones(),
-        false,
-        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted));
-
-    std::cout << "MandelbrotKernel("
-              << " numRows:" << numRows << ", numCols:" << numCols << ", maxIterations:" << maxIterations
-              << ", accelerator: " << alpaka::getAccName<Acc>()
-              << ", kernel: " << alpaka::core::demangled<decltype(kernel)> << ", workDiv: " << workDiv << ")"
-              << std::endl;
-
     // allocate host memory, potentially pinned for faster copy to/from the accelerator.
     auto bufColorHost = alpaka::allocMappedBufIfSupported<Val, Idx>(devHost, platformAcc, extent);
 
@@ -320,6 +306,35 @@ TEMPLATE_LIST_TEST_CASE("mandelbrot", "[mandelbrot]", TestAccs)
     // Create the kernel execution task.
     auto const [rowPitch, _] = alpaka::getPitchesInBytes(bufColorAcc);
     CHECK(rowPitch % sizeof(Val) == 0);
+
+    auto const& bundeledKernel = alpaka::KernelBundle(
+        kernel,
+        std::data(bufColorAcc),
+        numRows,
+        numCols,
+        rowPitch,
+        fMinR,
+        fMaxR,
+        fMinI,
+        fMaxI,
+        maxIterations);
+    // Let alpaka calculate good block and grid sizes given our full problem extent
+    auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(
+        devAcc,
+        bundeledKernel,
+        extent,
+        alpaka::Vec<Dim, Idx>::ones(),
+        false,
+        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
+
+
+    std::cout << "MandelbrotKernel("
+              << " numRows:" << numRows << ", numCols:" << numCols << ", maxIterations:" << maxIterations
+              << ", accelerator: " << alpaka::getAccName<Acc>()
+              << ", kernel: " << alpaka::core::demangled<decltype(kernel)> << ", workDiv: " << workDiv << ")"
+              << std::endl;
+
+
     auto const taskKernel = alpaka::createTaskKernel<Acc>(
         workDiv,
         kernel,

--- a/test/integ/separableCompilation/src/main.cpp
+++ b/test/integ/separableCompilation/src/main.cpp
@@ -90,13 +90,10 @@ TEMPLATE_LIST_TEST_CASE("separableCompilation", "[separableCompilation]", TestAc
     // The data extent.
     alpaka::Vec<alpaka::DimInt<1u>, Idx> const extent(numElements);
 
-    // Let alpaka calculate good block and grid sizes given our full problem extent.
-    alpaka::WorkDivMembers<alpaka::DimInt<1u>, Idx> const workDiv(alpaka::getValidWorkDiv<Acc>(
-        devAcc,
-        extent,
-        static_cast<Idx>(3u),
-        false,
-        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted));
+
+    auto const& bundeledKernel = alpaka::KernelBundle(kernel);
+    // Let alpaka calculate good block and grid sizes given our full problem extent
+    auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, extent, static_cast<Idx>(3u));
 
     std::cout << alpaka::core::demangled<decltype(kernel)> << "("
               << "accelerator: " << alpaka::getAccName<Acc>() << ", workDiv: " << workDiv

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -130,13 +130,20 @@ TEMPLATE_LIST_TEST_CASE("sharedMem", "[sharedMem]", TestAccs)
     // Get a queue on this device.
     QueueAcc queue(devAcc);
 
-    // Set the grid blocks extent.
-    alpaka::WorkDivMembers<Dim, Idx> const workDiv(alpaka::getValidWorkDiv<Acc>(
+
+    auto blockRetValuesDummy = alpaka::allocBuf<Val, Idx>(devAcc, static_cast<Idx>(1));
+    // Kernel input during the runtim of kernel will be different and is chosen to depend on workdiv.
+    // Therefore initially a  workdiv is needed to find the parameter. Therefore in kernel bundle, we can not use the
+    // real input for the buffer pointer.
+    auto const& bundeledKernel = alpaka::KernelBundle(kernel, std::data(blockRetValuesDummy));
+    // Let alpaka calculate good block and grid sizes given our full problem extent
+    auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(
         devAcc,
+        bundeledKernel,
         numElements,
         static_cast<Idx>(1u),
         false,
-        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted));
+        alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
 
     std::cout << "SharedMemKernel("
               << " accelerator: " << alpaka::getAccName<Acc>()

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -108,7 +108,6 @@ using TestAccs = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, std::uint32_t>;
 TEMPLATE_LIST_TEST_CASE("sharedMem", "[sharedMem]", TestAccs)
 {
     using Acc = TestType;
-    using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
     Idx const numElements = 1u << 16u;

--- a/test/unit/math/src/TestTemplate.hpp
+++ b/test/unit/math/src/TestTemplate.hpp
@@ -101,12 +101,18 @@ namespace mathtest
             Args args{devAcc};
             Results results{devAcc};
 
-            WorkDiv const workDiv = alpaka::getValidWorkDiv<TAcc>(
+
+            auto const& bundeledKernel
+                = alpaka::KernelBundle(kernel, results.pDevBuffer, wrappedFunctor, args.pDevBuffer);
+            // Let alpaka calculate good block and grid sizes given our full problem extent
+            auto const workDiv = alpaka::getValidWorkDivForKernel<TAcc>(
                 devAcc,
+                bundeledKernel,
                 sizeExtent,
                 elementsPerThread,
                 false,
                 alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
+
             // SETUP COMPLETED.
 
             // Fill the buffer with random test-numbers.

--- a/test/unit/math/src/TestTemplate.hpp
+++ b/test/unit/math/src/TestTemplate.hpp
@@ -74,9 +74,6 @@ namespace mathtest
             // DevAcc is defined in Buffer.hpp too.
             using DevAcc = alpaka::Dev<TAcc>;
 
-            using Dim = alpaka::DimInt<1u>;
-            using Idx = std::size_t;
-            using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
             using QueueAcc = alpaka::test::DefaultQueue<DevAcc>;
             using TArgsItem = ArgsItem<TData, TFunctor::arity>;
 

--- a/test/unit/workDiv/src/WorkDivHelpersTest.cpp
+++ b/test/unit/workDiv/src/WorkDivHelpersTest.cpp
@@ -12,35 +12,6 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
-namespace
-{
-    template<typename TAcc>
-    auto getWorkDiv()
-    {
-        using Dim = alpaka::Dim<TAcc>;
-        using Idx = alpaka::Idx<TAcc>;
-
-        auto const platform = alpaka::Platform<TAcc>{};
-        auto const dev = alpaka::getDevByIdx(platform, 0);
-        auto const gridThreadExtent = alpaka::Vec<Dim, Idx>::all(10);
-        auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-        auto const workDiv = alpaka::getValidWorkDiv<TAcc>(
-            dev,
-            gridThreadExtent,
-            threadElementExtent,
-            false,
-            alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
-        return workDiv;
-    }
-} // namespace
-
-TEMPLATE_LIST_TEST_CASE("getValidWorkDiv", "[workDiv]", alpaka::test::TestAccs)
-{
-    using Acc = TestType;
-    // Note: getValidWorkDiv() is called inside getWorkDiv
-    std::ignore = getWorkDiv<Acc>();
-}
-
 TEMPLATE_LIST_TEST_CASE("subDivideGridElems.2D.examples", "[workDiv]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
@@ -205,34 +176,6 @@ TEMPLATE_LIST_TEST_CASE("subDivideGridElems.2D.examples", "[workDiv]", alpaka::t
                 alpaka::GridBlockExtentSubDivRestrictions::CloseToEqualExtent)
             == WorkDiv{Vec{63, 38}, Vec{16, 16}, Vec{1, 1}});
     }
-}
-
-TEMPLATE_LIST_TEST_CASE("getValidWorkDiv.1D.withIdx", "[workDiv]", alpaka::test::TestAccs)
-{
-    using Acc = TestType;
-    using Idx = alpaka::Idx<Acc>;
-    using Dim = alpaka::Dim<Acc>;
-    using Vec = alpaka::Vec<Dim, Idx>;
-    if constexpr(Dim::value == 1)
-    {
-        auto const platform = alpaka::Platform<Acc>{};
-        auto const dev = alpaka::getDevByIdx(platform, 0);
-        // test that we can call getValidWorkDiv with the Idx type directly instead of a Vec
-        auto const ref = alpaka::getValidWorkDiv<Acc>(dev, Vec{256}, Vec{13});
-        CHECK(alpaka::getValidWorkDiv<Acc>(dev, Idx{256}, Idx{13}) == ref);
-    }
-}
-
-TEMPLATE_LIST_TEST_CASE("isValidWorkDiv", "[workDiv]", alpaka::test::TestAccs)
-{
-    using Acc = TestType;
-
-    auto const platform = alpaka::Platform<Acc>{};
-    auto const dev = alpaka::getDevByIdx(platform, 0);
-    auto const workDiv = getWorkDiv<Acc>();
-    // Test both overloads
-    REQUIRE(alpaka::isValidWorkDiv(alpaka::getAccDevProps<Acc>(dev), workDiv));
-    REQUIRE(alpaka::isValidWorkDiv<Acc>(dev, workDiv));
 }
 
 //! Test the constructors of WorkDivMembers using 3D extent, 3D extent with zero elements and 2D extents


### PR DESCRIPTION
Replaces the `getValidWorkDiv` function with `getValidWorkDivForKernel` which take into account the kernel in calculating workdiv.

- [x] This PR will be merged after #2251. Includes the changes of #2251.

This PR should be merged together with a Next PR: Change exec and task creation function. They will use KernelBundle as a single argument not KernelObject + Args... Otherwise kernel arguments would be used in kernel bundle and exec 2 times...