### PR TITLE
Implement accelerator traits for single vs multi-threads per block

### DIFF
--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, René Widera, Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2024 Axel Huebl, Benjamin Worpitz, René Widera, Jan Stephan, Bernhard Manfred Gruber, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -114,6 +114,18 @@ namespace alpaka
         struct AccType<AccCpuOmp2Blocks<TDim, TIdx>>
         {
             using type = AccCpuOmp2Blocks<TDim, TIdx>;
+        };
+
+        //! The CPU OpenMP 2.0 block single thread accelerator type trait specialization.
+        template<typename TDim, typename TIdx>
+        struct IsSingleThreadAcc<AccCpuOmp2Blocks<TDim, TIdx>> : std::true_type
+        {
+        };
+
+        //! The CPU OpenMP 2.0 block multi thread accelerator type trait specialization.
+        template<typename TDim, typename TIdx>
+        struct IsMultiThreadAcc<AccCpuOmp2Blocks<TDim, TIdx>> : std::false_type
+        {
         };
 
         //! The CPU OpenMP 2.0 block accelerator device properties get trait specialization.

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, René Widera, Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2024 Axel Huebl, Benjamin Worpitz, René Widera, Jan Stephan, Bernhard Manfred Gruber, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -119,6 +119,18 @@ namespace alpaka
         struct AccType<AccCpuOmp2Threads<TDim, TIdx>>
         {
             using type = AccCpuOmp2Threads<TDim, TIdx>;
+        };
+
+        //! The CPU OpenMP 2.0 thread single thread accelerator type trait specialization.
+        template<typename TDim, typename TIdx>
+        struct IsSingleThreadAcc<AccCpuOmp2Threads<TDim, TIdx>> : std::false_type
+        {
+        };
+
+        //! The CPU OpenMP 2.0 thread multi thread accelerator type trait specialization.
+        template<typename TDim, typename TIdx>
+        struct IsMultiThreadAcc<AccCpuOmp2Threads<TDim, TIdx>> : std::true_type
+        {
         };
 
         //! The CPU OpenMP 2.0 thread accelerator device properties get trait specialization.

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, René Widera, Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2024 Axel Huebl, Benjamin Worpitz, René Widera, Jan Stephan, Bernhard Manfred Gruber, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -108,6 +108,18 @@ namespace alpaka
         struct AccType<AccCpuSerial<TDim, TIdx>>
         {
             using type = AccCpuSerial<TDim, TIdx>;
+        };
+
+        //! The CPU serial single thread accelerator type trait specialization.
+        template<typename TDim, typename TIdx>
+        struct IsSingleThreadAcc<AccCpuSerial<TDim, TIdx>> : std::true_type
+        {
+        };
+
+        //! The CPU serial multi thread accelerator type trait specialization.
+        template<typename TDim, typename TIdx>
+        struct IsMultiThreadAcc<AccCpuSerial<TDim, TIdx>> : std::false_type
+        {
         };
 
         //! The CPU serial accelerator device properties get trait specialization.

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Erik Zenker, René Widera, Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2024 Axel Huebl, Benjamin Worpitz, Erik Zenker, René Widera, Jan Stephan, Bernhard Manfred Gruber,
+ *                Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -105,6 +106,18 @@ namespace alpaka
         struct AccType<AccCpuTbbBlocks<TDim, TIdx>>
         {
             using type = AccCpuTbbBlocks<TDim, TIdx>;
+        };
+
+        //! The CPU TBB block single thread accelerator type trait specialization.
+        template<typename TDim, typename TIdx>
+        struct IsSingleThreadAcc<AccCpuTbbBlocks<TDim, TIdx>> : std::true_type
+        {
+        };
+
+        //! The CPU TBB block multi thread accelerator type trait specialization.
+        template<typename TDim, typename TIdx>
+        struct IsMultiThreadAcc<AccCpuTbbBlocks<TDim, TIdx>> : std::false_type
+        {
         };
 
         //! The CPU TBB block accelerator device properties get trait specialization.

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, René Widera, Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2024 Axel Huebl, Benjamin Worpitz, René Widera, Jan Stephan, Bernhard Manfred Gruber, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -122,6 +122,18 @@ namespace alpaka
         struct AccType<AccCpuThreads<TDim, TIdx>>
         {
             using type = AccCpuThreads<TDim, TIdx>;
+        };
+
+        //! The CPU threads single thread accelerator type trait specialization.
+        template<typename TDim, typename TIdx>
+        struct IsSingleThreadAcc<AccCpuThreads<TDim, TIdx>> : std::false_type
+        {
+        };
+
+        //! The CPU threads multi thread accelerator type trait specialization.
+        template<typename TDim, typename TIdx>
+        struct IsMultiThreadAcc<AccCpuThreads<TDim, TIdx>> : std::true_type
+        {
         };
 
         //! The CPU threads accelerator device properties get trait specialization.

--- a/include/alpaka/acc/AccGenericSycl.hpp
+++ b/include/alpaka/acc/AccGenericSycl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Jan Stephan, Antonio Di Pilato, Andrea Bocci, Luca Ferragina, Aurora Perego
+/* Copyright 2024 Jan Stephan, Antonio Di Pilato, Andrea Bocci, Luca Ferragina, Aurora Perego
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -100,6 +100,22 @@ namespace alpaka::trait
     struct AccType<TAcc<TDim, TIdx>, std::enable_if_t<std::is_base_of_v<AccGenericSycl<TDim, TIdx>, TAcc<TDim, TIdx>>>>
     {
         using type = TAcc<TDim, TIdx>;
+    };
+
+    //! The SYCL single thread accelerator type trait specialization.
+    template<template<typename, typename> typename TAcc, typename TDim, typename TIdx>
+    struct IsSingleThreadAcc<
+        TAcc<TDim, TIdx>,
+        std::enable_if_t<std::is_base_of_v<AccGenericSycl<TDim, TIdx>, TAcc<TDim, TIdx>>>> : std::false_type
+    {
+    };
+
+    //! The SYCL multi thread accelerator type trait specialization.
+    template<template<typename, typename> typename TAcc, typename TDim, typename TIdx>
+    struct IsMultiThreadAcc<
+        TAcc<TDim, TIdx>,
+        std::enable_if_t<std::is_base_of_v<AccGenericSycl<TDim, TIdx>, TAcc<TDim, TIdx>>>> : std::true_type
+    {
     };
 
     //! The SYCL accelerator device properties get trait specialization.

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, René Widera, Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber, Antonio Di Pilato
+/* Copyright 2024 Benjamin Worpitz, René Widera, Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber, Antonio Di Pilato
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -92,6 +92,18 @@ namespace alpaka
         struct AccType<AccGpuUniformCudaHipRt<TApi, TDim, TIdx>>
         {
             using type = AccGpuUniformCudaHipRt<TApi, TDim, TIdx>;
+        };
+
+        //! The GPU CUDA single thread accelerator type trait specialization.
+        template<typename TApi, typename TDim, typename TIdx>
+        struct IsSingleThreadAcc<AccGpuUniformCudaHipRt<TApi, TDim, TIdx>> : std::false_type
+        {
+        };
+
+        //! The GPU CUDA multi thread accelerator type trait specialization.
+        template<typename TApi, typename TDim, typename TIdx>
+        struct IsMultiThreadAcc<AccGpuUniformCudaHipRt<TApi, TDim, TIdx>> : std::true_type
+        {
         };
 
         //! The GPU CUDA accelerator device properties get trait specialization.

--- a/include/alpaka/acc/Traits.hpp
+++ b/include/alpaka/acc/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Bernhard Manfred Gruber
+/* Copyright 2024 Benjamin Worpitz, Bernhard Manfred Gruber, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -36,6 +36,26 @@ namespace alpaka
         template<typename T, typename TSfinae = void>
         struct AccType;
 
+        //! The single thread accelerator trait.
+        //!
+        //! If TAcc is an accelerator that supports only a single thread per block, inherit from std::true_type.
+        //! If TAcc is not an accelerator, or an accelerator that supports multiple threads per block, inherit from
+        //! std::false_type.
+        template<typename TAcc, typename TSfinae = void>
+        struct IsSingleThreadAcc : std::false_type
+        {
+        };
+
+        //! The multi thread accelerator trait.
+        //!
+        //! If TAcc is an accelerator that supports multiple threads per block, inherit from std::true_type.
+        //! If TAcc is not an accelerator, or an accelerator that supports only a single thread per block, inherit from
+        //! std::false_type.
+        template<typename TAcc, typename TSfinae = void>
+        struct IsMultiThreadAcc : std::false_type
+        {
+        };
+
         //! The device properties get trait.
         template<typename TAcc, typename TSfinae = void>
         struct GetAccDevProps;
@@ -56,6 +76,14 @@ namespace alpaka
     //! The accelerator type trait alias template to remove the ::type.
     template<typename T>
     using Acc = typename trait::AccType<T>::type;
+
+    //! True if TAcc is an accelerator that supports only a single thread per block, false otherwise.
+    template<typename TAcc>
+    inline constexpr bool isSingleThreadAcc = trait::IsSingleThreadAcc<TAcc>::value;
+
+    //! True if TAcc is an accelerator that supports multiple threads per block, false otherwise.
+    template<typename TAcc>
+    inline constexpr bool isMultiThreadAcc = trait::IsMultiThreadAcc<TAcc>::value;
 
     //! \return The acceleration properties on the given device.
     template<typename TAcc, typename TDev>
@@ -81,5 +109,7 @@ namespace alpaka
         {
             using type = typename QueueType<typename alpaka::trait::PlatformType<TAcc>::type, TProperty>::type;
         };
+
     } // namespace trait
+
 } // namespace alpaka

--- a/test/unit/acc/src/AccTraitTest.cpp
+++ b/test/unit/acc/src/AccTraitTest.cpp
@@ -1,0 +1,35 @@
+/* Copyright 2024 Andrea Bocci
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/acc/Traits.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+TEMPLATE_LIST_TEST_CASE("isSingleThreadAcc", "[acc]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+
+    // Check that both traits are defined, and that only one is true.
+    REQUIRE(alpaka::isSingleThreadAcc<Acc> != alpaka::isMultiThreadAcc<Acc>);
+
+    auto const platform = alpaka::Platform<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
+    auto const devProps = alpaka::getAccDevProps<Acc>(dev);
+
+    // Compare the runtime properties with the compile time trait.
+    INFO("Accelerator: " << alpaka::core::demangled<Acc>);
+    if constexpr(alpaka::isSingleThreadAcc<Acc>)
+    {
+        // Require a single thread per block.
+        REQUIRE(devProps.m_blockThreadCountMax == 1);
+    }
+    else
+    {
+        // Assume multiple threads per block, but allow a single thread per block.
+        // For example, the AccCpuOmp2Threads accelerator may report a single thread on a single core system.
+        REQUIRE(devProps.m_blockThreadCountMax >= 1);
+    }
+}


### PR DESCRIPTION
`alpaka::isSingleThreadAccelerator<T>` evaluates to `true` if the given type is an accelerator that supports only one thread per block, and to to `false` if it supports multiple threads per block.

`alpaka::isMultiThreadAccelerator<T>` evaluates to `true` if the given type is an accelerator that supports multiple threads per block, and to to `false` if it supports only one thread per block.

If the given type is not an accelerator, the constants are not defined.

Implement a unit test for `alpaka::isSingleThreadAccelerator<T>` and `alpaka::isMultiThreadAccelerator<T>`.