### PR TITLE
fix usage of Idx to alpaka::Idx

### DIFF
--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -78,7 +78,7 @@ namespace alpaka
                 "The dimensionality of TExtent and the dimensionality of the TDim template parameter have to be "
                 "identical!");
             static_assert(
-                std::is_same_v<TIdx, Idx<TExtent>>,
+                std::is_same_v<TIdx, alpaka::Idx<TExtent>>,
                 "The idx type of TExtent and the TIdx template parameter have to be identical!");
         }
 

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -53,23 +53,23 @@ namespace alpaka
                 "The dev type of TView and the Dev template parameter have to be identical!");
 
             static_assert(
-                std::is_same_v<TIdx, Idx<View>>,
+                std::is_same_v<TIdx, alpaka::Idx<View>>,
                 "The idx type of TView and the TIdx template parameter have to be identical!");
             static_assert(
-                std::is_same_v<TIdx, Idx<TExtent>>,
+                std::is_same_v<TIdx, alpaka::Idx<TExtent>>,
                 "The idx type of TExtent and the TIdx template parameter have to be identical!");
             static_assert(
-                std::is_same_v<TIdx, Idx<TOffsets>>,
+                std::is_same_v<TIdx, alpaka::Idx<TOffsets>>,
                 "The idx type of TOffsets and the TIdx template parameter have to be identical!");
 
             static_assert(
-                std::is_same_v<TDim, Dim<View>>,
+                std::is_same_v<TDim, alpaka::Dim<View>>,
                 "The dim type of TView and the TDim template parameter have to be identical!");
             static_assert(
-                std::is_same_v<TDim, Dim<TExtent>>,
+                std::is_same_v<TDim, alpaka::Dim<TExtent>>,
                 "The dim type of TExtent and the TDim template parameter have to be identical!");
             static_assert(
-                std::is_same_v<TDim, Dim<TOffsets>>,
+                std::is_same_v<TDim, alpaka::Dim<TOffsets>>,
                 "The dim type of TOffsets and the TDim template parameter have to be identical!");
 
             ALPAKA_ASSERT(((m_offsetsElements + m_extentElements) <= getExtents(view)).all());


### PR DESCRIPTION
on windows, the use of Idx resolves differently than alpaka::Idx, thus alpaka::Idx should be used directly.

Compile log:
```
[build]   Compiling CUDA source file ..\..\..\..\example\parallelLoopPatterns\src\parallelLoopPatterns.cpp...
[build]   
[build]   C:\Users\ich\Desktop\hzb\forkalpaka\build\gpu-cuda-nvcc\example\parallelLoopPatterns>"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\bin\nvcc.exe"  --use-local-env -ccbin "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\bin\HostX64\x64" -x cu   -IC:\Users\ich\Desktop\hzb\forkalpaka\include -IC:\local\boost_1_84_0 -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\include" -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\include"  -G   --keep-dir parallel.1B88E8CE\x64\Debug  -maxrregcount=0   --machine 64 --compile -cudart static -std=c++17 --generate-code=arch=compute_52,code=[compute_52,sm_52] --extended-lambda --expt-relaxed-constexpr --display-error-number -Xcompiler="/EHsc -Zi -Ob0" -g  -D_WINDOWS -D_USE_MATH_DEFINES -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_DEBUG=0 -DALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB=47 -D"CMAKE_INTDIR=\"Debug\"" -D_MBCS -D"CMAKE_INTDIR=\"Debug\"" -Xcompiler "/EHsc /W1 /nologo /Od /FS /Zi /RTC1 /MDd " -Xcompiler "/FdparallelLoopPatterns.dir\Debug\vc143.pdb" -o parallelLoopPatterns.dir\Debug\parallelLoopPatterns.obj "C:\Users\ich\Desktop\hzb\forkalpaka\example\parallelLoopPatterns\src\parallelLoopPatterns.cpp" 
[build] C:\Users\ich\Desktop\hzb\forkalpaka\include\alpaka/mem/buf/BufUniformCudaHipRt.hpp(81): error : Idx is not a template [C:\Users\ich\Desktop\hzb\forkalpaka\build\gpu-cuda-nvcc\example\parallelLoopPatterns\parallelLoopPatterns.vcxproj]
[build]                     std::is_same_v<TIdx, Idx<TExtent>>,
[build]                                          ^
[build]             detected during:
[build]               instantiation of "alpaka::BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>::BufUniformCudaHipRt(const alpaka::DevUniformCudaHipRt<TApi> &, TElem *, Deleter, const TExtent &, size_t) [with TApi=alpaka::ApiCudaRt, TElem=float, TDim=std::integral_constant<size_t, 1ULL>, TIdx=uint32_t, TExtent=uint32_t, Deleter=lambda [](float *)->void]" at line 268
[build]               instantiation of "auto alpaka::trait::BufAlloc<TElem, Dim, TIdx, alpaka::DevUniformCudaHipRt<TApi>, void>::allocBuf(const alpaka::DevUniformCudaHipRt<TApi> &, const TExtent &)->alpaka::BufUniformCudaHipRt<TApi, TElem, Dim, TIdx> [with TApi=alpaka::ApiCudaRt, TElem=float, Dim=std::integral_constant<size_t, 1ULL>, TIdx=uint32_t, TExtent=uint32_t]" at line 66 of C:\Users\ich\Desktop\hzb\forkalpaka\include\alpaka/mem/buf/Traits.hpp
[build]   
[build] C:\Users\ich\Desktop\hzb\forkalpaka\include\alpaka/mem/buf/BufUniformCudaHipRt.hpp(80): error : static assertion failed with "The idx type of TExtent and the TIdx template parameter have to be identical!" [C:\Users\ich\Desktop\hzb\forkalpaka\build\gpu-cuda-nvcc\example\parallelLoopPatterns\parallelLoopPatterns.vcxproj]
[build]                 static_assert(
[build]                 ^
[build]             detected during:
[build]               instantiation of "alpaka::BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>::BufUniformCudaHipRt(const alpaka::DevUniformCudaHipRt<TApi> &, TElem *, Deleter, const TExtent &, size_t) [with TApi=alpaka::ApiCudaRt, TElem=float, TDim=std::integral_constant<size_t, 1ULL>, TIdx=uint32_t, TExtent=uint32_t, Deleter=lambda [](float *)->void]" at line 268
[build]               instantiation of "auto alpaka::trait::BufAlloc<TElem, Dim, TIdx, alpaka::DevUniformCudaHipRt<TApi>, void>::allocBuf(const alpaka::DevUniformCudaHipRt<TApi> &, const TExtent &)->alpaka::BufUniformCudaHipRt<TApi, TElem, Dim, TIdx> [with TApi=alpaka::ApiCudaRt, TElem=float, Dim=std::integral_constant<size_t, 1ULL>, TIdx=uint32_t, TExtent=uint32_t]" at line 66 of C:\Users\ich\Desktop\hzb\forkalpaka\include\alpaka/mem/buf/Traits.hpp
[build]   
[build]   2 errors detected in the compilation of "C:/Users/ich/Desktop/hzb/forkalpaka/example/parallelLoopPatterns/src/parallelLoopPatterns.cpp".
[build]   parallelLoopPatterns.cpp
[build] C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\BuildCustomizations\CUDA 12.4.targets(799,9): error MSB3721: The command ""C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\bin\nvcc.exe"  --use-local-env -ccbin "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\bin\HostX64\x64" -x cu   -IC:\Users\ich\Desktop\hzb\forkalpaka\include -IC:\local\boost_1_84_0 -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\include" -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\include"  -G   --keep-dir parallel.1B88E8CE\x64\Debug  -maxrregcount=0   --machine 64 --compile -cudart static -std=c++17 --generate-code=arch=compute_52,code=[compute_52,sm_52] --extended-lambda --expt-relaxed-constexpr --display-error-number -Xcompiler="/EHsc -Zi -Ob0" -g  -D_WINDOWS -D_USE_MATH_DEFINES -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_DEBUG=0 -DALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB=47 -D"CMAKE_INTDIR=\"Debug\"" -D_MBCS -D"CMAKE_INTDIR=\"Debug\"" -Xcompiler "/EHsc /W1 /nologo /Od /FS /Zi /RTC1 /MDd " -Xcompiler "/FdparallelLoopPatterns.dir\Debug\vc143.pdb" -o parallelLoopPatterns.dir\Debug\parallelLoopPatterns.obj "C:\Users\ich\Desktop\hzb\forkalpaka\example\parallelLoopPatterns\src\parallelLoopPatterns.cpp"" exited with code 1. [C:\Users\ich\Desktop\hzb\forkalpaka\build\gpu-cuda-nvcc\example\parallelLoopPatterns\parallelLoopPatterns.vcxproj]
```

![Screenshot 2024-05-06 124329](https://github.com/alpaka-group/alpaka/assets/8804937/4535f269-f2e0-4d14-b9c6-13c9fd3551cd)

edit:
msvc: `Microsoft (R) C/C++-Optimierungscompiler Version 19.39.33523 für x64` installed with `Visual Studio 2022`
VSCode: `1.89.0`


