### PR TITLE
fix forwarding of msvc compiler flag '/Zo'

### DIFF
--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -78,7 +78,7 @@ namespace alpaka
                 "The dimensionality of TExtent and the dimensionality of the TDim template parameter have to be "
                 "identical!");
             static_assert(
-                std::is_same_v<TIdx, Idx<TExtent>>,
+                std::is_same_v<TIdx, alpaka::Idx<TExtent>>,
                 "The idx type of TExtent and the TIdx template parameter have to be identical!");
         }
 

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -78,7 +78,7 @@ namespace alpaka
                 "The dimensionality of TExtent and the dimensionality of the TDim template parameter have to be "
                 "identical!");
             static_assert(
-                std::is_same_v<TIdx, alpaka::Idx<TExtent>>,
+                std::is_same_v<TIdx, Idx<TExtent>>,
                 "The idx type of TExtent and the TIdx template parameter have to be identical!");
         }
 

--- a/test/common/devCompileOptions.cmake
+++ b/test/common/devCompileOptions.cmake
@@ -33,7 +33,7 @@ if(MSVC)
     endif()
     # Improve debugging.
     list(APPEND alpaka_DEV_COMPILE_OPTIONS "$<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CXX>>:SHELL:/Zo>"
-                                           "$<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CUDA>>:-Xcompiler /Zo>")
+                                           "$<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:CUDA>>:SHELL:-Xcompiler /Zo>")
 
     # Flags added in Visual Studio 2013
     list(APPEND alpaka_DEV_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CXX>:SHELL:/Zc:throwingNew>"


### PR DESCRIPTION
Compile log:

```
[build]   Compiling CUDA source file ..\..\..\..\..\test\unit\meta\src\UniqueTest.cpp...
[build]   
[build]   C:\Users\ich\Desktop\hzb\forkalpaka\build\gpu-cuda-nvcc\test\unit\meta>"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\bin\nvcc.exe"  --use-local-env -ccbin "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\bin\HostX64\x64" -x cu   -IC:\Users\ich\Desktop\hzb\forkalpaka\include -IC:\Users\ich\Desktop\hzb\forkalpaka\thirdParty\catch2\src\catch2\.. -I"C:\Users\ich\Desktop\hzb\forkalpaka\build\gpu-cuda-nvcc\thirdParty\catch2\generated-includes" -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\include" -IC:\local\boost_1_84_0 -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\include"  -G   --keep-dir metaTest\x64\Debug  -maxrregcount=0   --machine 64 --compile -cudart static -std=c++17 --generate-code=arch=compute_52,code=[compute_52,sm_52] --Wdefault-stream-launch --Werror default-stream-launch --diag-suppress 177 "-Xcompiler /Zo" --extended-lambda --expt-relaxed-constexpr --display-error-number -Xcompiler="/EHsc -Zi -Ob0 /Zc:throwingNew /Zc:strictStrings /permissive- /wd4996 /bigobj" -g  -D_WINDOWS -DCUDA_API_PER_THREAD_DEFAULT_STREAM -D_USE_MATH_DEFINES -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_DEBUG=0 -DALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB=47 -D"CMAKE_INTDIR=\"Debug\"" -D_MBCS -DWIN32 -D_WINDOWS -DCUDA_API_PER_THREAD_DEFAULT_STREAM -D_USE_MATH_DEFINES -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_DEBUG=0 -DALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB=47 -D"CMAKE_INTDIR=\"Debug\"" -Xcompiler "/EHsc /W4 /nologo /Od /FS /Zi /RTC1 /MDd " -Xcompiler "/FdmetaTest.dir\Debug\vc143.pdb" -o metaTest.dir\Debug\UniqueTest.obj "C:\Users\ich\Desktop\hzb\forkalpaka\test\unit\meta\src\UniqueTest.cpp" 
[build]   nvcc fatal   : Unknown option '-Xcompiler /Zo'
[build] C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\BuildCustomizations\CUDA 12.4.targets(799,9): error MSB3721: The command ""C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\bin\nvcc.exe"  --use-local-env -ccbin "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\bin\HostX64\x64" -x cu   -IC:\Users\ich\Desktop\hzb\forkalpaka\include -IC:\Users\ich\Desktop\hzb\forkalpaka\thirdParty\catch2\src\catch2\.. -I"C:\Users\ich\Desktop\hzb\forkalpaka\build\gpu-cuda-nvcc\thirdParty\catch2\generated-includes" -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\include" -IC:\local\boost_1_84_0 -I"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\include"  -G   --keep-dir metaTest\x64\Debug  -maxrregcount=0   --machine 64 --compile -cudart static -std=c++17 --generate-code=arch=compute_52,code=[compute_52,sm_52] --Wdefault-stream-launch --Werror default-stream-launch --diag-suppress 177 "-Xcompiler /Zo" --extended-lambda --expt-relaxed-constexpr --display-error-number -Xcompiler="/EHsc -Zi -Ob0 /Zc:throwingNew /Zc:strictStrings /permissive- /wd4996 /bigobj" -g  -D_WINDOWS -DCUDA_API_PER_THREAD_DEFAULT_STREAM -D_USE_MATH_DEFINES -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_DEBUG=0 -DALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB=47 -D"CMAKE_INTDIR=\"Debug\"" -D_MBCS -DWIN32 -D_WINDOWS -DCUDA_API_PER_THREAD_DEFAULT_STREAM -D_USE_MATH_DEFINES -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_DEBUG=0 -DALPAKA_BLOCK_SHARED_DYN_MEMBER_ALLOC_KIB=47 -D"CMAKE_INTDIR=\"Debug\"" -Xcompiler "/EHsc /W4 /nologo /Od /FS /Zi /RTC1 /MDd " -Xcompiler "/FdmetaTest.dir\Debug\vc143.pdb" -o metaTest.dir\Debug\UniqueTest.obj "C:\Users\ich\Desktop\hzb\forkalpaka\test\unit\meta\src\UniqueTest.cpp"" exited with code 1. [C:\Users\ich\Desktop\hzb\forkalpaka\build\gpu-cuda-nvcc\test\unit\meta\metaTest.vcxproj]

```