### PR TITLE
refactor template order `allocMappedBuf`

### DIFF
--- a/docs/source/dev/backends.rst
+++ b/docs/source/dev/backends.rst
@@ -195,7 +195,7 @@ Depending on the cmake argument ``ALPAKA_ACC_GPU_CUDA_ONLY_MODE`` the function a
     +----------+-------------------------------------+
     | CUDA     | alpaka                              |
     +==========+=====================================+
-    | ``dim3`` | ``alpaka::Vec< TDim, TVal >``  |
+    | ``dim3`` | ``alpaka::Vec< TDim, TVal >``       |
     +----------+-------------------------------------+
 
 
@@ -353,7 +353,7 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaFreeAsync              | n/a (automatic memory management with reference counted memory handles)                    |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaFreeHost               | n/a (automatic memory management with reference counted memory handles)                                                                                       |
+    | cudaFreeHost               | n/a (automatic memory management with reference counted memory handles)                    |
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaFreeMipmappedArray     | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
@@ -363,7 +363,7 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaGetSymbolSize          | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaHostAlloc              | alpaka::allocMappedBuf<TPlatform, TElement>(host, extents) 1D, 2D, 3D supported!           |
+    | cudaHostAlloc              | alpaka::allocMappedBuf<TElement, TIdx>(host, platform, extents) 1D, 2D, 3D supported! [1]  |
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaHostGetDevicePointer   | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
@@ -383,7 +383,7 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMallocAsync            | alpaka::allocAsyncBuf<TElement>(queue, extents1D)                                          |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMallocHost             | alpaka::allocMappedBuf<TPlatform, TElement>(host, extents) 1D, 2D, 3D supported!           |
+    | cudaMallocHost             | alpaka::allocMappedBuf<TElement, TIdx>(host, platform, extents) 1D, 2D, 3D supported! [1]  |
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMallocManaged          | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
@@ -473,6 +473,7 @@ The following tables list the functions available in the `CUDA Runtime API <http
     | cudaMemcpyDeviceToHost     | n/a (direction of copy is determined automatically)                                        |
     +----------------------------+--------------------------------------------------------------------------------------------+
 
+[1] Not every platform supports mapped buffers, so `alpaka::allocMappedBufIfSupported<TElement, TIdx>(host, platform, extents)` should be used instead to support these platforms as well.
 
 *Execution Control*
 

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -127,14 +127,14 @@ namespace alpaka
 
     //! Allocates pinned/mapped host memory, accessible by all devices in the given platform.
     //!
-    //! \tparam TPlatform The platform from which the buffer is accessible.
     //! \tparam TElem The element type of the returned buffer.
     //! \tparam TIdx The linear index type of the buffer.
     //! \tparam TExtent The extent type of the buffer.
+    //! \tparam TPlatform The platform from which the buffer is accessible.
     //! \param host The host device to allocate the buffer on.
     //! \param extent The extent of the buffer.
     //! \return The newly allocated buffer.
-    template<typename TPlatform, typename TElem, typename TIdx, typename TExtent>
+    template<typename TElem, typename TIdx, typename TExtent, typename TPlatform>
     ALPAKA_FN_HOST auto allocMappedBuf(
         DevCpu const& host,
         TPlatform const& platform,
@@ -180,7 +180,7 @@ namespace alpaka
         using Platform = alpaka::Platform<TPlatform>;
         if constexpr(hasMappedBufSupport<Platform>)
         {
-            return allocMappedBuf<Platform, TElem, TIdx>(host, platform, extent);
+            return allocMappedBuf<TElem, TIdx>(host, platform, extent);
         }
         else
         {


### PR DESCRIPTION
Move template TPlatform as the last template. There is no need to provide the platform template signature if we pass the platform as an instance.

follow up of #2162