### PR TITLE
document cmake flag to build alpaka benchmarks

### DIFF
--- a/docs/source/advanced/cmake.rst
+++ b/docs/source/advanced/cmake.rst
@@ -117,6 +117,11 @@ alpaka_BUILD_EXAMPLES
 
      Build the examples.
 
+alpaka_BUILD_BENCHMARKS
+  .. code-block::
+
+     Build the benchmarks.
+
 BUILD_TESTING
   .. code-block::
 


### PR DESCRIPTION
missing cmake documentation for PR #2237 