### PR TITLE
fix alpaka_add_library relocatable device code

### DIFF
--- a/cmake/addLibrary.cmake
+++ b/cmake/addLibrary.cmake
@@ -13,10 +13,10 @@
 # Using a macro to stay in the scope (fixes lost assignment of linker command in FindHIP.cmake)
 # https://github.com/ROCm-Developer-Tools/HIP/issues/631
 
-macro(alpaka_add_library libraryName)
+macro(alpaka_add_library In_Name)
     # add_library( <name> [STATIC | SHARED | MODULE] [EXCLUDE_FROM_ALL] [<source>...])
 
-    add_library(${libraryName} ${ARGN})
+    add_library(${In_Name} ${ARGN})
 
     if(alpaka_ACC_GPU_CUDA_ENABLE)
         enable_language(CUDA)


### PR DESCRIPTION
alpaka_add_library did not enable relocatable device code, because the wrong identifier for the library name was used.

I changed the identifier to be consistent with contents of addExecutable.cmake