### PR TITLE
Additions to readthedocs documentation

### DIFF
--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -115,6 +115,7 @@ Create a CPU device for memory allocation on the host side
 
 Allocate a buffer in host memory
   .. code-block:: c++
+
      // Use alpaka vector as a static array for the extents
      alpaka::Vec<Dim, Idx> extent = value;
      // Allocate memory for the alpaka buffer, which is a dynamic array
@@ -161,6 +162,7 @@ Allocate a buffer in device memory
 Enqueue a memory copy from host to device
   .. code-block:: c++
 
+     // arguments can be also alpaka::View instances instead of alpaka::Buf
      memcpy(queue, bufDevice, bufHost, extent);
 
 Enqueue a memory copy from device to host

--- a/docs/source/basic/install.rst
+++ b/docs/source/basic/install.rst
@@ -3,17 +3,60 @@
 Installation
 ============
 
+**Installing dependencies**
+
+alpaka requires **Boost** and a modern C++ compiler (g++, clang++, Visual C++, …). In order to install **Boost**:
+
+On Linux:
+
 .. code-block::
 
-  # Clone alpaka from github.com
-  git clone --branch 0.9.0 https://github.com/alpaka-group/alpaka.git
-  cd alpaka
-  mkdir build && cd build
-  cmake -DCMAKE_INSTALL_PREFIX=/install/ ..
-  cmake --install .
+  # RPM
+  sudo dnf install boost-devel
+  # DEB
+  sudo apt install libboost-all-dev
+
+On macOS:
+
+.. code-block::
+
+  # Using Homebrew, https://brew.sh
+  brew install boost
+  # Using MacPorts, https://macports.org
+  sudo port install boost
+
+On Windows:
+
+.. code-block::
+
+  # Using vcpkg, https://github.com/microsoft/vcpkg
+  vcpkg install boost
+
+**CMake** is the preferred system for configuration the build tree, building and installing. In order to install **CMake**:
+
+On Linux:
+
+.. code-block::
+
+  # RPM
+  sudo dnf install cmake
+  # DEB
+  sudo apt install cmake
+
+On macOS or Windows:
+
+Download the installer from https://cmake.org/download/
+
+**Dependencies to use specific backends**: Depending on your target platform you may need additional packages to compile and run alpaka.
+
+- NVIDIA GPUs: CUDA Toolkit (https://developer.nvidia.com/cuda-toolkit)
+- AMD GPUs: ROCm / HIP (https://rocmdocs.amd.com/en/latest/index.html)
+- Intel GPUs: OneAPI Toolkit (https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html#gs.9x3lnh)
 
 Tests and Examples
 ++++++++++++++++++
+
+The examples and tests can be compiled without installing alpaka. They will use alpaka headers from the source directory.
 
 **Build and run examples:**
 
@@ -56,3 +99,18 @@ In the overview of :doc:`cmake arguments </advanced/cmake>` you will find all CM
 .. hint::
 
   When the test or examples are activated, the alpaka build system automatically activates the ``serial backend``, as it is needed for many tests. Therefore, the tests are run with the ``serial backend`` by default. If you want to test another backend, you have to activate it at CMake configuration time, for example the ``HIP`` backend: ``cmake .. -DBUILD_TESTING=ON -Dalpaka_ACC_GPU_HIP_ENABLE=ON``. Some alpaka tests use a selector algorithm to choose a specific accelerator for the test cases. The selector works with accelerator priorities. Therefore, it is recommended to enable only one accelerator for a build to make sure that the right one is used.
+
+
+**Installing alpaka**
+
+If user is going to create her/his own project/example outside the source tree alpaka should be installed. Since alpaka is a header only library compilation is not needed before installation.
+
+.. code-block::
+
+  # Clone alpaka from github.com
+  git clone --branch 1.1.0 https://github.com/alpaka-group/alpaka.git
+  cd alpaka
+  mkdir build && cd build
+  cmake -DCMAKE_INSTALL_PREFIX=/install/ ..
+  cmake --install .
+

--- a/docs/source/basic/library.rst
+++ b/docs/source/basic/library.rst
@@ -213,7 +213,9 @@ The memory allocation function of the *alpaka* library (``alpaka::allocBuf<TElem
 It does not return raw pointers but reference counted memory buffer objects that remove the necessity for manual freeing and the possibility of memory leaks.
 Additionally, the memory buffer objects know their extents, their pitches as well as the device they reside on.
 Due to padding, the allocated number of bytes may be more than the required storage; the pitch value gives the correct stride for each dimension for row-major access.
-This allows buffers that possibly reside on different devices with different pitches to be copied only by providing the buffer objects as well as the extents of the region to copy (``alpaka::memcpy(bufDevA, bufDevB, copyExtents``).
+This allows buffers that possibly reside on different devices with different pitches to be copied by providing the buffer objects as well as the extents of the region to copy (``alpaka::memcpy(queue, bufDevA, bufDevB, copyExtents``).
+
+If the data is already in a contiguous STL container on the host; the container can be converted to a View to be used in ``alpaka::memcpy`` function. The data structure ``alpaka::View`` knows the the extent and the device of the data; therefore can be used in memcpy. (``alpaka::memcpy(queue, bufDevA, viewDevB, copyExtents``).
 
 Kernel Execution
 ````````````````


### PR DESCRIPTION
Documentation at readthedocs is changed.

- Explanation for installing dependencies before installation is added into `install.rst`
- using alpaka:: View instances in memcpy is also possible, add info about that into the documents  `cheatsheet.rst `and` library.rst.    `