### PR TITLE
fix clang9/nvcc11.2 boost bug

### DIFF
--- a/include/alpaka/atomic/AtomicAtomicRef.hpp
+++ b/include/alpaka/atomic/AtomicAtomicRef.hpp
@@ -42,7 +42,7 @@ namespace alpaka
     void isSupportedByAtomicAtomicRef()
     {
         static_assert(
-            std::is_trivially_copyable_v<T> && detail::atomic_ref<T>::required_alignment <= alignof(T),
+            std::is_trivially_copyable_v<T> && alpaka::detail::atomic_ref<T>::required_alignment <= alignof(T),
             "Type not supported by AtomicAtomicRef, please recompile defining "
             "ALPAKA_DISABLE_ATOMIC_ATOMICREF.");
     }
@@ -56,7 +56,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
-                detail::atomic_ref<T> ref(*addr);
+                alpaka::detail::atomic_ref<T> ref(*addr);
                 return ref.fetch_add(value);
             }
         };
@@ -68,7 +68,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
-                detail::atomic_ref<T> ref(*addr);
+                alpaka::detail::atomic_ref<T> ref(*addr);
                 return ref.fetch_sub(value);
             }
         };
@@ -80,7 +80,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
-                detail::atomic_ref<T> ref(*addr);
+                alpaka::detail::atomic_ref<T> ref(*addr);
                 T old = ref;
                 T result = old;
                 result = std::min(result, value);
@@ -100,7 +100,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
-                detail::atomic_ref<T> ref(*addr);
+                alpaka::detail::atomic_ref<T> ref(*addr);
                 T old = ref;
                 T result = old;
                 result = std::max(result, value);
@@ -120,7 +120,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
-                detail::atomic_ref<T> ref(*addr);
+                alpaka::detail::atomic_ref<T> ref(*addr);
                 T old = ref;
                 T result = value;
                 while(!ref.compare_exchange_weak(old, result))
@@ -138,7 +138,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
-                detail::atomic_ref<T> ref(*addr);
+                alpaka::detail::atomic_ref<T> ref(*addr);
                 T old = ref;
                 T result = ((old >= value) ? 0 : static_cast<T>(old + 1));
                 while(!ref.compare_exchange_weak(old, result))
@@ -156,7 +156,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
-                detail::atomic_ref<T> ref(*addr);
+                alpaka::detail::atomic_ref<T> ref(*addr);
                 T old = ref;
                 T result = ((old >= value) ? 0 : static_cast<T>(old - 1));
                 while(!ref.compare_exchange_weak(old, result))
@@ -174,7 +174,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
-                detail::atomic_ref<T> ref(*addr);
+                alpaka::detail::atomic_ref<T> ref(*addr);
                 return ref.fetch_and(value);
             }
         };
@@ -186,7 +186,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
-                detail::atomic_ref<T> ref(*addr);
+                alpaka::detail::atomic_ref<T> ref(*addr);
                 return ref.fetch_or(value);
             }
         };
@@ -198,7 +198,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
-                detail::atomic_ref<T> ref(*addr);
+                alpaka::detail::atomic_ref<T> ref(*addr);
                 return ref.fetch_xor(value);
             }
         };
@@ -214,7 +214,7 @@ namespace alpaka
                 T const& value) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
-                detail::atomic_ref<T> ref(*addr);
+                alpaka::detail::atomic_ref<T> ref(*addr);
                 T old = ref;
                 T result;
                 do

--- a/include/alpaka/atomic/AtomicCpu.hpp
+++ b/include/alpaka/atomic/AtomicCpu.hpp
@@ -6,10 +6,11 @@
 
 #include "alpaka/core/BoostPredef.hpp"
 
-// clang 9 fails at compile time when using boost::atomic_ref
+// clang 9/10/11 together with nvcc<11.6.0 as host compiler fails at compile time when using boost::atomic_ref
 #ifdef BOOST_COMP_CLANG_AVAILABLE
-#    if BOOST_COMP_CLANG < BOOST_VERSION_NUMBER(11, 0, 0)
-#        ifndef ALPAKA_DISABLE_ATOMIC_ATOMICREF
+#    if(BOOST_COMP_CLANG < BOOST_VERSION_NUMBER(12, 0, 0) && BOOST_COMP_NVCC                                          \
+        && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 6, 0))
+#        if !defined(ALPAKA_DISABLE_ATOMIC_ATOMICREF)
 #            define ALPAKA_DISABLE_ATOMIC_ATOMICREF
 #        endif
 #    endif


### PR DESCRIPTION
This PR fix current CI issues with clang + nvcc and disable workarounds for C++20 and newer.

```
/boost/boost/atomic/detail/bitwise_cast.hpp(113): error: type name is not allowed
```

- disable atomic_ref for clang<12&nvcc<11.6

The second commit fixes Windows compile issues those popped up today, maybe due to another MSVC update in the github workflow windows containers.


Issues introduced with #2288 where we enabled atomic ref after we introduced a bug that it was always disabled.

