### PR TITLE
Fix memcpy warning

### DIFF
--- a/docs/source/basic/install.rst
+++ b/docs/source/basic/install.rst
@@ -113,4 +113,3 @@ If user is going to create her/his own project/example outside the source tree a
   mkdir build && cd build
   cmake -DCMAKE_INSTALL_PREFIX=/install/ ..
   cmake --install .
-

--- a/include/alpaka/core/UniformCudaHip.hpp
+++ b/include/alpaka/core/UniformCudaHip.hpp
@@ -61,7 +61,11 @@ namespace alpaka::uniform_cuda_hip::detail
             if(std::find(std::cbegin(ignoredErrorCodes), std::cend(ignoredErrorCodes), error)
                == std::cend(ignoredErrorCodes))
             {
-                rtCheck<TApi, TThrow>(error, ("'" + std::string(cmd) + "' returned error ").c_str(), file, line);
+                rtCheck<TApi, TThrow>(
+                    error,
+                    (std::string("'") + std::string(cmd) + "' returned error ").c_str(),
+                    file,
+                    line);
             }
             else
             {

--- a/include/alpaka/core/UniformCudaHip.hpp
+++ b/include/alpaka/core/UniformCudaHip.hpp
@@ -61,11 +61,8 @@ namespace alpaka::uniform_cuda_hip::detail
             if(std::find(std::cbegin(ignoredErrorCodes), std::cend(ignoredErrorCodes), error)
                == std::cend(ignoredErrorCodes))
             {
-                rtCheck<TApi, TThrow>(
-                    error,
-                    (std::string("'") + std::string(cmd) + "' returned error ").c_str(),
-                    file,
-                    line);
+                using namespace std::literals;
+                rtCheck<TApi, TThrow>(error, ("'"s + std::string(cmd) + "' returned error "s).c_str(), file, line);
             }
             else
             {


### PR DESCRIPTION
Fixes a compiler warning about `std::string` that apparently happens when a `std::string` is added to a normal C-string. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651. It was also found in https://github.com/cms-sw/cmssw/issues/44096.

Sorry, there are two tiny unrelated formatting changes because pre-commit didn't allow me to push otherwise. 

- [x] rebase against #2294 after V is merged to solve CI issues