### PR TITLE
Update the CUDA/HIP kernel tasks

### DIFF
--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -200,10 +200,10 @@ namespace alpaka
 #        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 // std::size_t printfFifoSize;
                 // TApi::deviceGetLimit(&printfFifoSize, TApi::limitPrintfFifoSize);
-                // std::cout << __func__ << "INFO: printfFifoSize: " << printfFifoSize << std::endl;
+                // std::cout << __func__ << " INFO: printfFifoSize: " << printfFifoSize << std::endl;
                 // TApi::deviceSetLimit(TApi::limitPrintfFifoSize, printfFifoSize*10);
                 // TApi::deviceGetLimit(&printfFifoSize, TApi::limitPrintfFifoSize);
-                // std::cout << __func__ << "INFO: printfFifoSize: " << printfFifoSize << std::endl;
+                // std::cout << __func__ << " INFO: printfFifoSize: " << printfFifoSize << std::endl;
 #        endif
                 auto const gridBlockExtent = getWorkDiv<Grid, Blocks>(task);
                 auto const blockThreadExtent = getWorkDiv<Block, Threads>(task);
@@ -214,8 +214,8 @@ namespace alpaka
                 uniform_cuda_hip::detail::checkVecOnly3Dim(threadElemExtent);
 
 #        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                std::cout << __func__ << "gridDim: (" << gridDim.z << ", " << gridDim.y << ", " << gridDim.x << ")\n";
-                std::cout << __func__ << "blockDim: (" << blockDim.z << ", " << blockDim.y << ", " << blockDim.x
+                std::cout << __func__ << " gridDim: (" << gridDim.z << ", " << gridDim.y << ", " << gridDim.x << ")\n";
+                std::cout << __func__ << " blockDim: (" << blockDim.z << ", " << blockDim.y << ", " << blockDim.x
                           << ")\n";
 #        endif
 

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Jan Stephan, Andrea Bocci, Bernhard
+/* Copyright 2024 Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Jan Stephan, Andrea Bocci, Bernhard
  * Manfred Gruber, Antonio Di Pilato, Mehmet Yusufoglu
  * SPDX-License-Identifier: MPL-2.0
  */
@@ -21,9 +21,8 @@
 #include "alpaka/kernel/KernelFunctionAttributes.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/platform/Traits.hpp"
-#include "alpaka/queue/QueueUniformCudaHipRtBlocking.hpp"
-#include "alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp"
 #include "alpaka/queue/Traits.hpp"
+#include "alpaka/queue/cuda_hip/QueueUniformCudaHipRt.hpp"
 #include "alpaka/workdiv/WorkDivHelpers.hpp"
 #include "alpaka/workdiv/WorkDivMembers.hpp"
 
@@ -178,14 +177,21 @@ namespace alpaka
             using type = TIdx;
         };
 
-        //! The CUDA/HIP non-blocking kernel enqueue trait specialization.
-        template<typename TApi, typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
+        //! The CUDA/HIP kernel enqueue trait specialization.
+        template<
+            typename TApi,
+            bool TBlocking,
+            typename TAcc,
+            typename TDim,
+            typename TIdx,
+            typename TKernelFnObj,
+            typename... TArgs>
         struct Enqueue<
-            QueueUniformCudaHipRtNonBlocking<TApi>,
+            uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>,
             TaskKernelGpuUniformCudaHipRt<TApi, TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
         {
             ALPAKA_FN_HOST static auto enqueue(
-                QueueUniformCudaHipRtNonBlocking<TApi>& queue,
+                uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>& queue,
                 TaskKernelGpuUniformCudaHipRt<TApi, TAcc, TDim, TIdx, TKernelFnObj, TArgs...> const& task) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -208,8 +214,9 @@ namespace alpaka
                 uniform_cuda_hip::detail::checkVecOnly3Dim(threadElemExtent);
 
 #        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                std::cout << __func__ << " gridDim: " << gridDim.z << " " << gridDim.y << " " << gridDim.x
-                          << " blockDim: " << blockDim.z << " " << blockDim.y << " " << blockDim.x << std::endl;
+                std::cout << __func__ << "gridDim: (" << gridDim.z << ", " << gridDim.y << ", " << gridDim.x << ")\n";
+                std::cout << __func__ << "blockDim: (" << blockDim.z << ", " << blockDim.y << ", " << blockDim.x
+                          << ")\n";
 #        endif
 
 #        if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
@@ -238,6 +245,7 @@ namespace alpaka
                 std::cout << __func__ << " BlockSharedMemDynSizeBytes: " << blockSharedMemDynSizeBytes << " B"
                           << std::endl;
 #        endif
+
                 auto kernelName = alpaka::detail::
                     gpuKernel<TKernelFnObj, TApi, TAcc, TDim, TIdx, remove_restrict_t<std::decay_t<TArgs>>...>;
 
@@ -255,6 +263,7 @@ namespace alpaka
 
                 // Set the current device.
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(queue.m_spQueueImpl->m_dev.getNativeHandle()));
+
                 // Enqueue the kernel execution.
                 // \NOTE: No const reference (const &) is allowed as the parameter type because the kernel launch
                 // language extension expects the arguments by value. This forces the type of a float argument given
@@ -272,118 +281,17 @@ namespace alpaka
                     },
                     task.m_args);
 
-                if constexpr(ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL)
+                if constexpr(TBlocking || ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL)
                 {
                     // Wait for the kernel execution to finish but do not check error return of this call.
                     // Do not use the alpaka::wait method because it checks the error itself but we want to give a
                     // custom error message.
                     std::ignore = TApi::streamSynchronize(queue.getNativeHandle());
-                    auto const msg = std::string{
-                        "'execution of kernel: '" + std::string{core::demangled<TKernelFnObj>} + "' failed with"};
-                    ::alpaka::uniform_cuda_hip::detail::rtCheckLastError<TApi, true>(msg.c_str(), __FILE__, __LINE__);
                 }
-            }
-        };
-
-        //! The CUDA/HIP synchronous kernel enqueue trait specialization.
-        template<typename TApi, typename TAcc, typename TDim, typename TIdx, typename TKernelFnObj, typename... TArgs>
-        struct Enqueue<
-            QueueUniformCudaHipRtBlocking<TApi>,
-            TaskKernelGpuUniformCudaHipRt<TApi, TAcc, TDim, TIdx, TKernelFnObj, TArgs...>>
-        {
-            ALPAKA_FN_HOST static auto enqueue(
-                QueueUniformCudaHipRtBlocking<TApi>& queue,
-                TaskKernelGpuUniformCudaHipRt<TApi, TAcc, TDim, TIdx, TKernelFnObj, TArgs...> const& task) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-                // TODO: Check that (sizeof(TKernelFnObj) * m_3uiBlockThreadExtent.prod()) < available memory idx
-
-#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                // std::size_t printfFifoSize;
-                // TApi::deviceGetLimit(&printfFifoSize, TApi::limitPrintfFifoSize);
-                // std::cout << __func__ << "INFO: printfFifoSize: " << printfFifoSize << std::endl;
-                // TApi::deviceSetLimit(TApi::limitPrintfFifoSize, printfFifoSize*10);
-                // TApi::deviceGetLimit(&printfFifoSize, TApi::limitPrintfFifoSize);
-                // std::cout << __func__ << "INFO: printfFifoSize: " << printfFifoSize << std::endl;
-#        endif
-                auto const gridBlockExtent = getWorkDiv<Grid, Blocks>(task);
-                auto const blockThreadExtent = getWorkDiv<Block, Threads>(task);
-                auto const threadElemExtent = getWorkDiv<Thread, Elems>(task);
-
-                dim3 const gridDim = uniform_cuda_hip::detail::convertVecToUniformCudaHipDim(gridBlockExtent);
-                dim3 const blockDim = uniform_cuda_hip::detail::convertVecToUniformCudaHipDim(blockThreadExtent);
-                uniform_cuda_hip::detail::checkVecOnly3Dim(threadElemExtent);
-
-#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                std::cout << __func__ << "gridDim: " << gridDim.z << " " << gridDim.y << " " << gridDim.x << std::endl;
-                std::cout << __func__ << "blockDim: " << blockDim.z << " " << blockDim.y << " " << blockDim.x
-                          << std::endl;
-#        endif
-
-#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
-                // This checks for a valid work division that is also compliant with the maxima of the accelerator.
-                if(!isValidWorkDiv<TAcc>(getDev(queue), task))
-                {
-                    throw std::runtime_error(
-                        "The given work division is not valid or not supported by the device of type "
-                        + getAccName<AccGpuUniformCudaHipRt<TApi, TDim, TIdx>>() + "!");
-                }
-#        endif
-
-                // Get the size of the block shared dynamic memory.
-                auto const blockSharedMemDynSizeBytes = std::apply(
-                    [&](remove_restrict_t<std::decay_t<TArgs>> const&... args) {
-                        return getBlockSharedMemDynSizeBytes<TAcc>(
-                            task.m_kernelFnObj,
-                            blockThreadExtent,
-                            threadElemExtent,
-                            args...);
-                    },
-                    task.m_args);
-
-#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                // Log the block shared memory idx.
-                std::cout << __func__ << " BlockSharedMemDynSizeBytes: " << blockSharedMemDynSizeBytes << " B"
-                          << std::endl;
-#        endif
-
-                auto kernelName = alpaka::detail::
-                    gpuKernel<TKernelFnObj, TApi, TAcc, TDim, TIdx, remove_restrict_t<std::decay_t<TArgs>>...>;
-#        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                // Log the function attributes.
-                typename TApi::FuncAttributes_t funcAttrs;
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::funcGetAttributes(&funcAttrs, kernelName));
-                std::cout << __func__ << " binaryVersion: " << funcAttrs.binaryVersion
-                          << " constSizeBytes: " << funcAttrs.constSizeBytes << " B"
-                          << " localSizeBytes: " << funcAttrs.localSizeBytes << " B"
-                          << " maxThreadsPerBlock: " << funcAttrs.maxThreadsPerBlock
-                          << " numRegs: " << funcAttrs.numRegs << " ptxVersion: " << funcAttrs.ptxVersion
-                          << " sharedSizeBytes: " << funcAttrs.sharedSizeBytes << " B" << std::endl;
-#        endif
-
-                // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(queue.m_spQueueImpl->m_dev.getNativeHandle()));
-
-                // Enqueue the kernel execution.
-                std::apply(
-                    [&](remove_restrict_t<std::decay_t<TArgs>> const&... args)
-                    {
-                        kernelName<<<
-                            gridDim,
-                            blockDim,
-                            static_cast<std::size_t>(blockSharedMemDynSizeBytes),
-                            queue.getNativeHandle()>>>(threadElemExtent, task.m_kernelFnObj, args...);
-                    },
-                    task.m_args);
-
-                // Wait for the kernel execution to finish but do not check error return of this call.
-                // Do not use the alpaka::wait method because it checks the error itself but we want to give a custom
-                // error message.
-                std::ignore = TApi::streamSynchronize(queue.getNativeHandle());
                 if constexpr(ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL)
                 {
                     auto const msg
-                        = std::string{"'execution of kernel: '" + core::demangled<TKernelFnObj> + "' failed with"};
+                        = std::string{"execution of kernel '" + core::demangled<TKernelFnObj> + "' failed with"};
                     ::alpaka::uniform_cuda_hip::detail::rtCheckLastError<TApi, true>(msg.c_str(), __FILE__, __LINE__);
                 }
             }


### PR DESCRIPTION
Reduce code duplication in CUDA/HIP kernel launch: use a boolean template parameter to distinguish blocking (sync) and non-blocking (async) queues, instead of writing two almost identical copies of the enqueue function.

Add missing white space in enqueue log messages.