### PR TITLE
Let the SYCL queue implement `ConceptCurrentThreadWaitFor`, `ConceptGetDev` and `ConceptQueue`

### DIFF
--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -61,7 +61,7 @@ namespace alpaka
 
     //! True if TDev is a device, i.e. if it implements the ConceptDev concept.
     template<typename TDev>
-    inline constexpr bool isDevice = concepts::ImplementsConcept<ConceptDev, TDev>::value;
+    inline constexpr bool isDevice = concepts::ImplementsConcept<ConceptDev, std::decay_t<TDev>>::value;
 
     //! \return The device this object is bound to.
     template<typename T>

--- a/include/alpaka/queue/Traits.hpp
+++ b/include/alpaka/queue/Traits.hpp
@@ -17,7 +17,7 @@ namespace alpaka
 
     //! True if TQueue is a queue, i.e. if it implements the ConceptQueue concept.
     template<typename TQueue>
-    inline constexpr bool isQueue = concepts::ImplementsConcept<ConceptQueue, TQueue>::value;
+    inline constexpr bool isQueue = concepts::ImplementsConcept<ConceptQueue, std::decay_t<TQueue>>::value;
 
     //! The queue traits.
     namespace trait

--- a/include/alpaka/queue/sycl/QueueGenericSyclBase.hpp
+++ b/include/alpaka/queue/sycl/QueueGenericSyclBase.hpp
@@ -167,6 +167,9 @@ namespace alpaka::detail
 
     template<typename TDev, bool TBlocking>
     class QueueGenericSyclBase
+        : public concepts::Implements<ConceptCurrentThreadWaitFor, QueueGenericSyclBase<TDev, TBlocking>>
+        , public concepts::Implements<ConceptQueue, QueueGenericSyclBase<TDev, TBlocking>>
+        , public concepts::Implements<ConceptGetDev, QueueGenericSyclBase<TDev, TBlocking>>
     {
     public:
         QueueGenericSyclBase(TDev const& dev)

--- a/test/unit/dev/src/DevWarpSizeTest.cpp
+++ b/test/unit/dev/src/DevWarpSizeTest.cpp
@@ -29,3 +29,10 @@ TEMPLATE_LIST_TEST_CASE("getPreferredWarpSize", "[dev]", alpaka::test::TestAccs)
     auto const preferredWarpSize = alpaka::getPreferredWarpSize(dev);
     REQUIRE(preferredWarpSize > 0);
 }
+
+TEMPLATE_LIST_TEST_CASE("isDevice", "[dev]", alpaka::test::TestAccs)
+{
+    auto const platform = alpaka::Platform<TestType>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
+    REQUIRE(alpaka::isDevice<decltype(dev)>);
+}

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -269,3 +269,12 @@ TEMPLATE_LIST_TEST_CASE("enqueueBenchmark", "[queue]", alpaka::test::TestQueues)
         return count.load();
     };
 }
+
+TEMPLATE_LIST_TEST_CASE("isQueue", "[queue]", alpaka::test::TestQueues)
+{
+    using DevQueue = TestType;
+    using Fixture = alpaka::test::QueueTestFixture<DevQueue>;
+    Fixture f;
+
+    REQUIRE(alpaka::isQueue<decltype(f.m_queue)>);
+}


### PR DESCRIPTION
`QueueGenericSyclBase` was not implementing the concepts used by `isQueue` and `isDevice`. As a result, `isQueue<QueueGenericSyclBase<TDev, TBlocking>>` evaluated to `false`.
This PR fixes it by implementing the concepts for the queue and the device as done for `QueueUniformCudaHipRt` for CUDA/HIP.