### PR TITLE
Use KernelBundle in exec and task create [KB-III]

### DIFF
--- a/benchmarks/babelstream/src/AlpakaStream.h
+++ b/benchmarks/babelstream/src/AlpakaStream.h
@@ -16,7 +16,6 @@
 
 #include <vector>
 
-inline constexpr auto IMPLEMENTATION_STRING = "alpaka";
 
 using Dim = alpaka::DimInt<1>;
 using Idx = int;

--- a/benchmarks/babelstream/src/main.cpp
+++ b/benchmarks/babelstream/src/main.cpp
@@ -94,7 +94,7 @@ int main(int argc, char* argv[])
     {
         std::cout << "BabelStream" << std::endl
                   << "Version: " << VERSION_STRING << std::endl
-                  << "Implementation: " << IMPLEMENTATION_STRING << std::endl;
+                  << "Implementation: Alpaka " << std::endl;
     }
 
     if(use_float)

--- a/example/complex/src/complex.cpp
+++ b/example/complex/src/complex.cpp
@@ -64,7 +64,7 @@ auto example(TAccTag const&) -> int
         = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, threadsPerGrid, elementsPerThread);
 
     // Run the kernel
-    alpaka::exec<Acc>(queue, workDiv, complexKernel);
+    alpaka::exec<Acc>(queue, workDiv, bundeledKernel);
     alpaka::wait(queue);
 
     // Usage of alpaka::Complex<T> on the host side is the same as inside kernels, except math functions are not

--- a/example/convolution1D/src/convolution1D.cpp
+++ b/example/convolution1D/src/convolution1D.cpp
@@ -152,15 +152,7 @@ auto example(TAccTag const&) -> int
     auto const workDiv
         = alpaka::getValidWorkDivForKernel<DevAcc>(devAcc, bundeledKernel, threadsPerGrid, elementsPerThread);
     // Run the kernel
-    alpaka::exec<DevAcc>(
-        queue,
-        workDiv,
-        convolutionKernel,
-        nativeInputDeviceMemory,
-        nativeFilterDeviceMemory,
-        nativeOutputDeviceMemory,
-        inputSize,
-        filterSize);
+    alpaka::exec<DevAcc>(queue, workDiv, bundeledKernel);
 
     // Allocate memory on host
     auto resultGpuHost = alpaka::allocBuf<DataType, Idx>(devHost, inputSize);

--- a/example/convolution2D/src/convolution2D.cpp
+++ b/example/convolution2D/src/convolution2D.cpp
@@ -320,18 +320,7 @@ auto example(TAccTag const&) -> int
     auto const workDiv = alpaka::getValidWorkDivForKernel<DevAcc>(devAcc, bundeledKernel, extent, Vec::ones());
 
     // Run the kernel
-    alpaka::exec<DevAcc>(
-        queueAcc,
-        workDiv,
-        convolutionKernel2D,
-        std::data(bufInputAcc),
-        std::data(outputDeviceMemory),
-        matrixWidth,
-        matrixHeight,
-        std::data(bufFilterAcc),
-        filterWidth,
-        intputWidthAllocated,
-        filterWidthAllocated);
+    alpaka::exec<DevAcc>(queueAcc, workDiv, bundeledKernel);
 
     // Allocate memory on host to receive the resulting matrix as an array
     auto resultGpuHost = alpaka::allocBuf<DataType, Idx>(devHost, extent1D);

--- a/example/counterBasedRng/src/counterBasedRng.cpp
+++ b/example/counterBasedRng/src/counterBasedRng.cpp
@@ -147,27 +147,20 @@ auto example(TAccTag const&) -> int
     BufAcc bufAcc(alpaka::allocBuf<Data, Idx>(devAcc, extent));
 
     CounterBasedRngKernel counterBasedRngKernel;
-    auto const& bundeledKernel
+    auto const& bundeledKernelAcc
         = alpaka::KernelBundle(counterBasedRngKernel, alpaka::experimental::getMdSpan(bufAcc), key);
-    auto const& bundeledKernel2
+    auto const& bundeledKernelHost
         = alpaka::KernelBundle(counterBasedRngKernel, alpaka::experimental::getMdSpan(bufHost), key);
 
     // Let alpaka calculate good block and grid sizes given our full problem extent
-    auto const workDivAcc = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, extent, elementsPerThread);
+    auto const workDivAcc
+        = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernelAcc, extent, elementsPerThread);
     auto const workDivHost
-        = alpaka::getValidWorkDivForKernel<AccHost>(devHost, bundeledKernel2, extent, elementsPerThreadHost);
+        = alpaka::getValidWorkDivForKernel<AccHost>(devHost, bundeledKernelHost, extent, elementsPerThreadHost);
 
     // Create the kernel execution task.
-    auto const taskKernelAcc = alpaka::createTaskKernel<Acc>(
-        workDivAcc,
-        CounterBasedRngKernel(),
-        alpaka::experimental::getMdSpan(bufAcc),
-        key);
-    auto const taskKernelHost = alpaka::createTaskKernel<AccHost>(
-        workDivHost,
-        CounterBasedRngKernel(),
-        alpaka::experimental::getMdSpan(bufHost),
-        key);
+    auto const taskKernelAcc = alpaka::createTaskKernel<Acc>(workDivAcc, bundeledKernelAcc);
+    auto const taskKernelHost = alpaka::createTaskKernel<AccHost>(workDivHost, bundeledKernelHost);
 
     // Enqueue the kernel execution task
     alpaka::enqueue(queueHost, taskKernelHost);

--- a/example/heatEquation/src/heatEquation.cpp
+++ b/example/heatEquation/src/heatEquation.cpp
@@ -146,8 +146,10 @@ auto example(TAccTag const&) -> int
 
     for(uint32_t step = 0; step < numTimeSteps; step++)
     {
+        auto const& tempBundeledKernel = alpaka::KernelBundle(heatEqKernel, pCurrAcc, pNextAcc, numNodesX, dx, dt);
+
         // Compute next values
-        alpaka::exec<Acc>(queue, workDiv, heatEqKernel, pCurrAcc, pNextAcc, numNodesX, dx, dt);
+        alpaka::exec<Acc>(queue, workDiv, tempBundeledKernel);
 
         // We assume the boundary conditions are constant and so these values
         // do not need to be updated.

--- a/example/helloWorld/src/helloWorld.cpp
+++ b/example/helloWorld/src/helloWorld.cpp
@@ -149,11 +149,18 @@ auto example(TAccTag const&) -> int
     // The queue can be blocking or non-blocking
     // depending on the chosen queue type (see type definitions above).
     // Here it is synchronous which means that the kernel is directly executed.
-    alpaka::exec<Acc>(
-        queue,
-        workDiv,
-        helloWorldKernel
-        /* put kernel arguments here */);
+    alpaka::exec<Acc>(queue, workDiv, bundeledKernel);
+
+    // Alternative way for kernel execution (commented out deliberately)
+    // exec function can be called by directly using kernel instance and kernel arguments without bundling kernel in a
+    // KernelBundle. This might be usefull if getValidWorkDivForKernel is not needed before kernel execution and
+    // workdiv is determined directly instantiating the WorkDivMembers class with predetermined values.
+    // alpaka::exec<Acc>(
+    //     queue,
+    //     workDiv,
+    //     helloWorldKernel,
+    //     /* put kernel arguments here*/);
+
     alpaka::wait(queue);
 
     return EXIT_SUCCESS;

--- a/example/helloWorldLambda/src/helloWorldLambda.cpp
+++ b/example/helloWorldLambda/src/helloWorldLambda.cpp
@@ -122,7 +122,7 @@ auto example(TAccTag const&) -> int
     auto const workDiv
         = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, threadsPerGrid, elementsPerThread);
 
-    alpaka::exec<Acc>(queue, workDiv, kernelLambda, nExclamationMarks);
+    alpaka::exec<Acc>(queue, workDiv, bundeledKernel);
     alpaka::wait(queue);
 
     return EXIT_SUCCESS;

--- a/example/monteCarloIntegration/src/monteCarloIntegration.cpp
+++ b/example/monteCarloIntegration/src/monteCarloIntegration.cpp
@@ -121,7 +121,7 @@ auto example(TAccTag const&) -> int
         Vec(numThreads),
         Vec(numAlpakaElementsPerThread));
 
-    alpaka::exec<Acc>(queue, workDiv, kernel, numPoints, ptrBufAcc, Function{});
+    alpaka::exec<Acc>(queue, workDiv, bundeledKernel);
     alpaka::memcpy(queue, bufHost, bufAcc);
     alpaka::wait(queue);
 

--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -115,7 +115,7 @@ auto main() -> int
 
     // Run the kernel setting no schedule explicitly.
     std::cout << "OpenMPScheduleDefaultKernel setting no schedule explicitly:\n";
-    alpaka::exec<Acc>(queue, workDiv, openMPScheduleDefaultKernel);
+    alpaka::exec<Acc>(queue, workDiv, bundeledKernel);
     alpaka::wait(queue);
 
     // Run the kernel setting the schedule via a trait

--- a/example/parallelLoopPatterns/src/parallelLoopPatterns.cpp
+++ b/example/parallelLoopPatterns/src/parallelLoopPatterns.cpp
@@ -114,7 +114,9 @@ void naiveCudaStyle(TDev& dev, TQueue& queue, TBufAcc& bufAcc)
     std::cout << "\nNaive CUDA style processing - each thread processes one data point:\n";
     std::cout << "   " << blocksPerGrid << " blocks, " << threadsPerBlock << " threads per block, "
               << "alpaka element layer not used\n";
-    alpaka::exec<TAcc>(queue, workDiv, NaiveCudaStyleKernel{}, std::data(bufAcc), n);
+
+    NaiveCudaStyleKernel naiveCudaStyleKernel;
+    alpaka::exec<TAcc>(queue, workDiv, naiveCudaStyleKernel, std::data(bufAcc), n);
     testResult(queue, bufAcc);
 }
 
@@ -177,7 +179,11 @@ void gridStridedLoop(TDev& dev, TQueue& queue, TBufAcc& bufAcc)
     std::cout << "\nGrid strided loop processing - fixed number of threads and blocks:\n";
     std::cout << "   " << blocksPerGrid << " blocks, " << threadsPerBlock << " threads per block, "
               << "alpaka element layer not used\n";
-    alpaka::exec<TAcc>(queue, workDiv, GridStridedLoopKernel{}, std::data(bufAcc), n);
+
+    GridStridedLoopKernel gridStridedLoopKernel;
+    auto bufAccPtr = std::data(bufAcc);
+    auto const& bundeledKernel = alpaka::KernelBundle(gridStridedLoopKernel, bufAccPtr, n);
+    alpaka::exec<TAcc>(queue, workDiv, bundeledKernel);
     testResult(queue, bufAcc);
 }
 
@@ -252,7 +258,11 @@ void chunkedGridStridedLoop(TDev& dev, TQueue& queue, TBufAcc& bufAcc)
     std::cout << "\nChunked grid strided loop processing - fixed number of threads and blocks:\n";
     std::cout << "   " << blocksPerGrid << " blocks, " << threadsPerBlock << " threads per block, "
               << elementsPerThread << " alpaka elements per thread\n";
-    alpaka::exec<TAcc>(queue, workDiv, ChunkedGridStridedLoopKernel{}, std::data(bufAcc), n);
+
+    ChunkedGridStridedLoopKernel chunkedGridStridedLoopKernel;
+    auto const& bundeledKernel = alpaka::KernelBundle(chunkedGridStridedLoopKernel, std::data(bufAcc), n);
+    alpaka::exec<TAcc>(queue, workDiv, bundeledKernel);
+
     testResult(queue, bufAcc);
 }
 
@@ -318,7 +328,11 @@ void naiveOpenMPStyle(TDev& dev, TQueue& queue, TBufAcc& bufAcc)
     std::cout << "\nNaive OpenMP style processing - each thread processes a single consecutive range of elements:\n";
     std::cout << "   " << blocksPerGrid << " blocks, " << threadsPerBlock << " threads per block, "
               << "alpaka element layer not used\n";
-    alpaka::exec<TAcc>(queue, workDiv, NaiveOpenMPStyleKernel{}, std::data(bufAcc), n);
+
+    NaiveOpenMPStyleKernel naiveOpenMPStyleKernel;
+    auto const& bundeledKernel = alpaka::KernelBundle(naiveOpenMPStyleKernel, std::data(bufAcc), n);
+
+    alpaka::exec<TAcc>(queue, workDiv, bundeledKernel);
     testResult(queue, bufAcc);
 }
 
@@ -396,7 +410,11 @@ void openMPSimdStyle(TDev& dev, TQueue& queue, TBufAcc& bufAcc)
     std::cout << "\nOpenMP SIMD style processing - each thread processes a single consecutive range of elements:\n";
     std::cout << "   " << blocksPerGrid << " blocks, " << threadsPerBlock << " threads per block, "
               << elementsPerThread << " alpaka elements per thread\n";
-    alpaka::exec<TAcc>(queue, workDiv, OpenMPSimdStyleKernel{}, std::data(bufAcc), n);
+
+    OpenMPSimdStyleKernel openMPSimdStyleKernel;
+    auto const& bundeledKernel = alpaka::KernelBundle(openMPSimdStyleKernel, std::data(bufAcc), n);
+
+    alpaka::exec<TAcc>(queue, workDiv, bundeledKernel);
     testResult(queue, bufAcc);
 }
 

--- a/example/randomCells2D/src/randomCells2D.cpp
+++ b/example/randomCells2D/src/randomCells2D.cpp
@@ -211,6 +211,7 @@ auto example(TAccTag const&) -> int
     alpaka::exec<Acc>(queue, workDivInitRandom, initRandomKernel, extent, ptrBufAccRandS, pitchBufAccRandS);
     alpaka::wait(queue);
 
+    // execute the same kernel with different pointers
     alpaka::exec<Acc>(queue, workDivInitRandom, initRandomKernel, extent, ptrBufAccRandV, pitchBufAccRandV);
     alpaka::wait(queue);
 

--- a/example/randomStrategies/src/randomStrategies.cpp
+++ b/example/randomStrategies/src/randomStrategies.cpp
@@ -29,7 +29,7 @@ template<typename TAccTag>
 struct Box
 {
     // accelerator, queue, and work division typedefs
-    using Dim = alpaka::DimInt<1>;
+    using Dim = alpaka::DimInt<1u>;
     using Idx = std::size_t;
     using Vec = alpaka::Vec<Dim, Idx>;
     using Acc = alpaka::TagToAcc<TAccTag, Dim, Idx>;
@@ -266,11 +266,7 @@ void runStrategy(Box<TAccTag>& box)
     alpaka::exec<typename Box<TAccTag>::Acc>(
         box.queue,
         workDivRand,
-        initRandomKernel,
-        box.extentRand,
-        ptrBufAccRand,
-        static_cast<unsigned>(
-            box.extentResult[0] / box.extentRand[0])); // == NUM_ROLLS; amount of work to be performed by each thread
+        bundeledKernel); // == NUM_ROLLS; amount of work to be performed by each thread
 
     alpaka::wait(box.queue);
 
@@ -305,13 +301,7 @@ void runStrategy(Box<TAccTag>& box)
         alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
 
 
-    alpaka::exec<typename Box<TAccTag>::Acc>(
-        box.queue,
-        workdivResult,
-        fillKernel,
-        box.extentResult,
-        ptrBufAccRand,
-        ptrBufAccResult);
+    alpaka::exec<typename Box<TAccTag>::Acc>(box.queue, workdivResult, bundeledKernelFill);
     alpaka::memcpy(box.queue, box.bufHostResult, box.bufAccResult);
     alpaka::wait(box.queue);
 

--- a/example/reduce/src/reduce.cpp
+++ b/example/reduce/src/reduce.cpp
@@ -75,27 +75,24 @@ auto reduce(
     WorkDiv workDiv1{static_cast<Extent>(blockCount), static_cast<Extent>(blockSize), static_cast<Extent>(1)};
     WorkDiv workDiv2{static_cast<Extent>(1), static_cast<Extent>(blockSize), static_cast<Extent>(1)};
 
-    // create main reduction kernel execution task
-    auto const taskKernelReduceMain = alpaka::createTaskKernel<Acc>(
+    //  main reduction kernel execution
+    alpaka::exec<Acc>(
+        queue,
         workDiv1,
         kernel1,
         std::data(sourceDeviceMemory),
         std::data(destinationDeviceMemory),
         n,
         func);
-
-    // create last block reduction kernel execution task
-    auto const taskKernelReduceLastBlock = alpaka::createTaskKernel<Acc>(
+    // last block reduction kernel execution
+    alpaka::exec<Acc>(
+        queue,
         workDiv2,
         kernel2,
         std::data(destinationDeviceMemory),
         std::data(destinationDeviceMemory),
         blockCount,
         func);
-
-    // enqueue both kernel execution tasks
-    alpaka::enqueue(queue, taskKernelReduceMain);
-    alpaka::enqueue(queue, taskKernelReduceLastBlock);
 
     //  download result from GPU
     T resultGpuHost;

--- a/example/tagSpecialization/src/tagSpecialization.cpp
+++ b/example/tagSpecialization/src/tagSpecialization.cpp
@@ -109,10 +109,11 @@ auto example(TAccTag const&) -> int
         static_cast<std::size_t>(1),
         static_cast<std::size_t>(1)};
 
+    WrapperKernel wrapperKernel;
     // Run the wrapper kernel, which calls the actual specialized
     // Specializing the entry kernel with tags is not possible. Therefore pre processor guards are required, see
     // kernelSpecialization example.
-    alpaka::exec<Acc>(queue, workDiv, WrapperKernel{});
+    alpaka::exec<Acc>(queue, workDiv, wrapperKernel);
     alpaka::wait(queue);
     return EXIT_SUCCESS;
 }

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -140,13 +140,7 @@ auto example(TAccTag const&) -> int
     auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, extent, elementsPerThread);
 
     // Create the kernel execution task.
-    auto const taskKernel = alpaka::createTaskKernel<Acc>(
-        workDiv,
-        kernel,
-        std::data(bufAccA),
-        std::data(bufAccB),
-        std::data(bufAccC),
-        numElements);
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(workDiv, bundeledKernel);
 
     // Enqueue the kernel execution task
     {

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -16,6 +16,7 @@
 #include "alpaka/idx/bt/IdxBtZero.hpp"
 #include "alpaka/idx/gb/IdxGbRef.hpp"
 #include "alpaka/intrinsic/IntrinsicCpu.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/math/MathStdLib.hpp"
 #include "alpaka/mem/fence/MemFenceOmp2Blocks.hpp"
 #include "alpaka/rand/RandDefault.hpp"
@@ -180,18 +181,20 @@ namespace alpaka
         };
 
         //! The CPU OpenMP 2.0 block accelerator execution task type trait specialization.
+        //!
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TWorkDiv The type of the work division.
+        //! \tparam TKernelFnObj Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-        struct CreateTaskKernel<AccCpuOmp2Blocks<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+        struct CreateTaskKernel<AccCpuOmp2Blocks<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
         {
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
-                TKernelFnObj const& kernelFnObj,
-                TArgs&&... args)
+                KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
             {
-                return TaskKernelCpuOmp2Blocks<TDim, TIdx, TKernelFnObj, TArgs...>(
-                    workDiv,
-                    kernelFnObj,
-                    std::forward<TArgs>(args)...);
+                return TaskKernelCpuOmp2Blocks<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
             }
         };
 

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -15,6 +15,7 @@
 #include "alpaka/idx/bt/IdxBtOmp.hpp"
 #include "alpaka/idx/gb/IdxGbRef.hpp"
 #include "alpaka/intrinsic/IntrinsicCpu.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/math/MathStdLib.hpp"
 #include "alpaka/mem/fence/MemFenceOmp2Threads.hpp"
 #include "alpaka/rand/RandDefault.hpp"
@@ -191,18 +192,20 @@ namespace alpaka
         };
 
         //! The CPU OpenMP 2.0 thread accelerator execution task type trait specialization.
+        //!
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TWorkDiv The type of the work division.
+        //! \tparam TKernelFnObj Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-        struct CreateTaskKernel<AccCpuOmp2Threads<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+        struct CreateTaskKernel<AccCpuOmp2Threads<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
         {
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
-                TKernelFnObj const& kernelFnObj,
-                TArgs&&... args)
+                KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
             {
-                return TaskKernelCpuOmp2Threads<TDim, TIdx, TKernelFnObj, TArgs...>(
-                    workDiv,
-                    kernelFnObj,
-                    std::forward<TArgs>(args)...);
+                return TaskKernelCpuOmp2Threads<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
             }
         };
 

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -15,6 +15,7 @@
 #include "alpaka/idx/bt/IdxBtZero.hpp"
 #include "alpaka/idx/gb/IdxGbRef.hpp"
 #include "alpaka/intrinsic/IntrinsicCpu.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/math/MathStdLib.hpp"
 #include "alpaka/mem/fence/MemFenceCpuSerial.hpp"
 #include "alpaka/rand/RandDefault.hpp"
@@ -174,18 +175,20 @@ namespace alpaka
         };
 
         //! The CPU serial accelerator execution task type trait specialization.
+        //!
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TWorkDiv The type of the work division.
+        //! \tparam TKernelFnObj Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-        struct CreateTaskKernel<AccCpuSerial<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+        struct CreateTaskKernel<AccCpuSerial<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
         {
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
-                TKernelFnObj const& kernelFnObj,
-                TArgs&&... args)
+                KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
             {
-                return TaskKernelCpuSerial<TDim, TIdx, TKernelFnObj, TArgs...>(
-                    workDiv,
-                    kernelFnObj,
-                    std::forward<TArgs>(args)...);
+                return TaskKernelCpuSerial<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
             }
         };
 

--- a/include/alpaka/acc/AccCpuSycl.hpp
+++ b/include/alpaka/acc/AccCpuSycl.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/core/Sycl.hpp"
 #include "alpaka/dev/DevCpuSycl.hpp"
 #include "alpaka/dev/Traits.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/kernel/TaskKernelCpuSycl.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/platform/PlatformCpuSycl.hpp"
@@ -57,15 +58,20 @@ namespace alpaka::trait
     };
 
     //! The CPU SYCL accelerator execution task type trait specialization.
+    //!
+    //! \tparam TDim The dimensionality of the accelerator device properties.
+    //! \tparam TIdx The idx type of the accelerator device properties.
+    //! \tparam TWorkDiv The type of the work division.
+    //! \tparam TKernelFnObj Kernel function object type.
+    //! \tparam TArgs Kernel function object argument types as a parameter pack.
     template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-    struct CreateTaskKernel<AccCpuSycl<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+    struct CreateTaskKernel<AccCpuSycl<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
     {
-        static auto createTaskKernel(TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST static auto createTaskKernel(
+            TWorkDiv const& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
         {
-            return TaskKernelCpuSycl<TDim, TIdx, TKernelFnObj, TArgs...>{
-                workDiv,
-                kernelFnObj,
-                std::forward<TArgs>(args)...};
+            return TaskKernelCpuSycl<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
         }
     };
 

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -16,6 +16,7 @@
 #include "alpaka/idx/bt/IdxBtZero.hpp"
 #include "alpaka/idx/gb/IdxGbRef.hpp"
 #include "alpaka/intrinsic/IntrinsicCpu.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/math/MathStdLib.hpp"
 #include "alpaka/mem/fence/MemFenceCpu.hpp"
 #include "alpaka/rand/RandDefault.hpp"
@@ -172,18 +173,20 @@ namespace alpaka
         };
 
         //! The CPU TBB block accelerator execution task type trait specialization.
+        //!
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TWorkDiv The type of the work division.
+        //! \tparam TKernelFnObj Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-        struct CreateTaskKernel<AccCpuTbbBlocks<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+        struct CreateTaskKernel<AccCpuTbbBlocks<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
         {
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
-                TKernelFnObj const& kernelFnObj,
-                TArgs&&... args)
+                KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
             {
-                return TaskKernelCpuTbbBlocks<TDim, TIdx, TKernelFnObj, TArgs...>(
-                    workDiv,
-                    kernelFnObj,
-                    std::forward<TArgs>(args)...);
+                return TaskKernelCpuTbbBlocks<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
             }
         };
 

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -14,6 +14,7 @@
 #include "alpaka/idx/bt/IdxBtRefThreadIdMap.hpp"
 #include "alpaka/idx/gb/IdxGbRef.hpp"
 #include "alpaka/intrinsic/IntrinsicCpu.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/math/MathStdLib.hpp"
 #include "alpaka/mem/fence/MemFenceCpu.hpp"
 #include "alpaka/rand/RandDefault.hpp"
@@ -198,19 +199,21 @@ namespace alpaka
             using type = TDim;
         };
 
-        //! The CPU threads accelerator execution task type trait specialization.
+        //! The CPU serial accelerator execution task type trait specialization.
+        //!
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TWorkDiv The type of the work division.
+        //! \tparam TKernelFnObj Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-        struct CreateTaskKernel<AccCpuThreads<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+        struct CreateTaskKernel<AccCpuThreads<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
         {
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
-                TKernelFnObj const& kernelFnObj,
-                TArgs&&... args)
+                KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
             {
-                return TaskKernelCpuThreads<TDim, TIdx, TKernelFnObj, TArgs...>(
-                    workDiv,
-                    kernelFnObj,
-                    std::forward<TArgs>(args)...);
+                return TaskKernelCpuThreads<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
             }
         };
 

--- a/include/alpaka/acc/AccFpgaSyclIntel.hpp
+++ b/include/alpaka/acc/AccFpgaSyclIntel.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/core/Sycl.hpp"
 #include "alpaka/dev/DevFpgaSyclIntel.hpp"
 #include "alpaka/dev/Traits.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/kernel/TaskKernelFpgaSyclIntel.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/platform/PlatformFpgaSyclIntel.hpp"
@@ -57,15 +58,20 @@ namespace alpaka::trait
     };
 
     //! The Intel FPGA SYCL accelerator execution task type trait specialization.
+    //!
+    //! \tparam TDim The dimensionality of the accelerator device properties.
+    //! \tparam TIdx The idx type of the accelerator device properties.
+    //! \tparam TWorkDiv The type of the work division.
+    //! \tparam TKernelFnObj Kernel function object type.
+    //! \tparam TArgs Kernel function object argument types as a parameter pack.
     template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-    struct CreateTaskKernel<AccFpgaSyclIntel<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+    struct CreateTaskKernel<AccFpgaSyclIntel<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
     {
-        static auto createTaskKernel(TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST static auto createTaskKernel(
+            TWorkDiv const& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
         {
-            return TaskKernelFpgaSyclIntel<TDim, TIdx, TKernelFnObj, TArgs...>{
-                workDiv,
-                kernelFnObj,
-                std::forward<TArgs>(args)...};
+            return TaskKernelFpgaSyclIntel<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
         }
     };
 

--- a/include/alpaka/acc/AccGpuSyclIntel.hpp
+++ b/include/alpaka/acc/AccGpuSyclIntel.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/core/Sycl.hpp"
 #include "alpaka/dev/DevGpuSyclIntel.hpp"
 #include "alpaka/dev/Traits.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/kernel/TaskKernelGpuSyclIntel.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/platform/PlatformGpuSyclIntel.hpp"
@@ -57,15 +58,20 @@ namespace alpaka::trait
     };
 
     //! The Intel GPU SYCL accelerator execution task type trait specialization.
+    //!
+    //! \tparam TDim The dimensionality of the accelerator device properties.
+    //! \tparam TIdx The idx type of the accelerator device properties.
+    //! \tparam TWorkDiv The type of the work division.
+    //! \tparam TKernelFnObj Kernel function object type.
+    //! \tparam TArgs Kernel function object argument types as a parameter pack.
     template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-    struct CreateTaskKernel<AccGpuSyclIntel<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+    struct CreateTaskKernel<AccCpuSyclIntel<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
     {
-        static auto createTaskKernel(TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST static auto createTaskKernel(
+            TWorkDiv const& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
         {
-            return TaskKernelGpuSyclIntel<TDim, TIdx, TKernelFnObj, TArgs...>{
-                workDiv,
-                kernelFnObj,
-                std::forward<TArgs>(args)...};
+            return TaskKernelCpuSyclIntel<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
         }
     };
 

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -14,6 +14,7 @@
 #include "alpaka/idx/bt/IdxBtUniformCudaHipBuiltIn.hpp"
 #include "alpaka/idx/gb/IdxGbUniformCudaHipBuiltIn.hpp"
 #include "alpaka/intrinsic/IntrinsicUniformCudaHipBuiltIn.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/math/MathUniformCudaHipBuiltIn.hpp"
 #include "alpaka/mem/fence/MemFenceUniformCudaHipBuiltIn.hpp"
 #include "alpaka/rand/RandDefault.hpp"
@@ -264,6 +265,13 @@ namespace alpaka
     namespace trait
     {
         //! The GPU CUDA accelerator execution task type trait specialization.
+        //!
+        //! \tparam TApi The type the API of the GPU accelerator backend. Currently Cuda or Hip.
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TWorkDiv The type of the work division.
+        //! \tparam TKernelFnObj Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
         template<
             typename TApi,
             typename TDim,
@@ -271,12 +279,15 @@ namespace alpaka
             typename TWorkDiv,
             typename TKernelFnObj,
             typename... TArgs>
-        struct CreateTaskKernel<AccGpuUniformCudaHipRt<TApi, TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+        struct CreateTaskKernel<
+            AccGpuUniformCudaHipRt<TApi, TDim, TIdx>,
+            TWorkDiv,
+            KernelBundle<TKernelFnObj, TArgs...>>
         {
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
-                TKernelFnObj const& kernelFnObj,
-                TArgs&&... args)
+
+                KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
             {
                 return TaskKernelGpuUniformCudaHipRt<
                     TApi,
@@ -284,7 +295,7 @@ namespace alpaka
                     TDim,
                     TIdx,
                     TKernelFnObj,
-                    TArgs...>(workDiv, kernelFnObj, std::forward<TArgs>(args)...);
+                    TArgs...>(workDiv, kernelBundle);
             }
         };
 

--- a/include/alpaka/kernel/KernelBundle.hpp
+++ b/include/alpaka/kernel/KernelBundle.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/DemangleTypeNames.hpp>
 #include <alpaka/core/RemoveRestrict.hpp>
 
 #include <tuple>
@@ -12,6 +13,38 @@
 
 namespace alpaka
 {
+    namespace detail
+    {
+        //! Check if a type used as kernel argument is trivially copyable
+        //!
+        //! \attention In case this trait is specialized for a user type the user should be sure that the result of
+        //! calling the copy constructor is equal to use memcpy to duplicate the object. An existing destructor should
+        //! be free of side effects.
+        //!
+        //! It's implementation defined whether the closure type of a lambda is trivially copyable.
+        //! Therefor the default implementation is true for trivially copyable or empty (stateless) types.
+        //!
+        //! @tparam T type to check
+        //! @{
+        template<typename T, typename = void>
+        struct IsKernelArgumentTriviallyCopyable
+            : std::bool_constant<std::is_empty_v<T> || std::is_trivially_copyable_v<T>>
+        {
+        };
+
+        template<typename T>
+        inline constexpr bool isKernelArgumentTriviallyCopyable = IsKernelArgumentTriviallyCopyable<T>::value;
+
+        // asserts that T is trivially copyable. We put this in a separate function so we can see which T would fail
+        // the test, when called from a fold expression.
+        template<typename T>
+        inline void assertKernelArgIsTriviallyCopyable()
+        {
+            static_assert(isKernelArgumentTriviallyCopyable<T>, "The kernel argument T must be trivially copyable!");
+        }
+
+    } // namespace detail
+
     //! \brief The class used to bind kernel function object and arguments together. Once an instance of this class is
     //! created, arguments are not needed to be separately given to functions who need kernel function and arguments.
     //! \tparam TKernelFn The kernel function object type.
@@ -30,9 +63,21 @@ namespace alpaka
             : m_kernelFn(std::move(kernelFn))
             , m_args(std::forward<TArgs>(args)...)
         {
+#if BOOST_COMP_NVCC
+            static_assert(
+                std::is_trivially_copyable_v<TKernelFn> || __nv_is_extended_device_lambda_closure_type(TKernelFn)
+                    || __nv_is_extended_host_device_lambda_closure_type(TKernelFn),
+                "Kernels must be trivially copyable or an extended CUDA lambda expression!");
+#else
+            static_assert(std::is_trivially_copyable_v<TKernelFn>, "Kernels must be trivially copyable!");
+#endif
+            (detail::assertKernelArgIsTriviallyCopyable<std::decay_t<TArgs>>(), ...);
+
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+            std::cout << __func__ << ", kernelFnObj: " << core::demangled<decltype(m_kernelFn)> << std::endl;
+#endif
         }
 
-    private:
         KernelFn m_kernelFn;
         ArgTuple m_args; // Store the argument types without const and reference
     };
@@ -54,5 +99,4 @@ namespace alpaka
     //! arguments.
     template<typename TKernelFn, typename... TArgs>
     ALPAKA_FN_HOST KernelBundle(TKernelFn, TArgs&&...) -> KernelBundle<TKernelFn, TArgs...>;
-
 } // namespace alpaka

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -789,10 +789,12 @@ namespace alpaka
     {
     public:
         template<typename TWorkDiv>
-        ALPAKA_FN_HOST TaskKernelCpuOmp2Blocks(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST TaskKernelCpuOmp2Blocks(
+            TWorkDiv&& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& KernelBundle)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj(kernelFnObj)
-            , m_args(std::forward<TArgs>(args)...)
+            , m_kernelFnObj(KernelBundle.m_kernelFn)
+            , m_args(KernelBundle.m_args)
         {
             static_assert(
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -46,10 +46,12 @@ namespace alpaka
     {
     public:
         template<typename TWorkDiv>
-        ALPAKA_FN_HOST TaskKernelCpuOmp2Threads(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST TaskKernelCpuOmp2Threads(
+            TWorkDiv&& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& KernelBundle)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj(kernelFnObj)
-            , m_args(std::forward<TArgs>(args)...)
+            , m_kernelFnObj(KernelBundle.m_kernelFn)
+            , m_args(KernelBundle.m_args)
         {
             static_assert(
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -40,10 +40,12 @@ namespace alpaka
     {
     public:
         template<typename TWorkDiv>
-        ALPAKA_FN_HOST TaskKernelCpuSerial(TWorkDiv&& workDiv, TKernelFnObj kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST TaskKernelCpuSerial(
+            TWorkDiv&& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& KernelBundle)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj(std::move(kernelFnObj))
-            , m_args(std::forward<TArgs>(args)...)
+            , m_kernelFnObj(KernelBundle.m_kernelFn)
+            , m_args(KernelBundle.m_args)
         {
             static_assert(
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -45,10 +45,12 @@ namespace alpaka
     {
     public:
         template<typename TWorkDiv>
-        ALPAKA_FN_HOST TaskKernelCpuTbbBlocks(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST TaskKernelCpuTbbBlocks(
+            TWorkDiv&& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& KernelBundle)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj(kernelFnObj)
-            , m_args(std::forward<TArgs>(args)...)
+            , m_kernelFnObj(KernelBundle.m_kernelFn)
+            , m_args(KernelBundle.m_args)
         {
             static_assert(
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -51,11 +51,13 @@ namespace alpaka
 
     public:
         template<typename TWorkDiv>
-        ALPAKA_FN_HOST TaskKernelCpuThreads(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST TaskKernelCpuThreads(
+            TWorkDiv&& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& KernelBundle)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj(kernelFnObj)
-            , m_args(std::forward<TArgs>(
-                  args)...) // FIXME(bgruber): this does not forward, since TArgs is not a deduced template parameter
+            , m_kernelFnObj(KernelBundle.m_kernelFn)
+            , m_args(KernelBundle.m_args) // FIXME(bgruber): this does not forward, since TArgs is not a deduced
+                                          // template parameter
         {
             static_assert(
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,

--- a/include/alpaka/kernel/TaskKernelGenericSycl.hpp
+++ b/include/alpaka/kernel/TaskKernelGenericSycl.hpp
@@ -79,10 +79,10 @@ namespace alpaka
         static_assert(TDim::value > 0 && TDim::value <= 3, "Invalid kernel dimensionality");
 
         template<typename TWorkDiv>
-        TaskKernelGenericSycl(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        TaskKernelGenericSycl(TWorkDiv&& workDiv, KernelBundle<TKernelFnObj, TArgs...> const& KernelBundle)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj{kernelFnObj}
-            , m_args{std::forward<TArgs>(args)...}
+            , m_kernelFnObj(KernelBundle.m_kernelFn)
+            , m_args(KernelBundle.m_args)
         {
         }
 

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -125,11 +125,10 @@ namespace alpaka
         template<typename TWorkDiv>
         ALPAKA_FN_HOST TaskKernelGpuUniformCudaHipRt(
             TWorkDiv&& workDiv,
-            TKernelFnObj const& kernelFnObj,
-            TArgs&&... args)
+            KernelBundle<TKernelFnObj, TArgs...> const& KernelBundle)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj(kernelFnObj)
-            , m_args(std::forward<TArgs>(args)...)
+            , m_kernelFnObj(KernelBundle.m_kernelFn)
+            , m_args(KernelBundle.m_args)
         {
             static_assert(
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,

--- a/test/integ/axpy/src/axpy.cpp
+++ b/test/integ/axpy/src/axpy.cpp
@@ -91,7 +91,6 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
 
     // Get a queue on this device.
     QueueAcc queue(devAcc);
-
     alpaka::Vec<Dim, Idx> const extent(numElements);
 
     // Allocate host memory buffers in pinned memory.
@@ -146,7 +145,6 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
     std::cout << std::endl;
 #endif
 
-
     auto const& bundeledKernel
         = alpaka::KernelBundle(kernel, numElements, alpha, std::data(memBufAccX), std::data(memBufAccY));
     // Let alpaka calculate good block and grid sizes given our full problem extent
@@ -163,14 +161,9 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
               << ", kernel: " << alpaka::core::demangled<decltype(kernel)> << ", workDiv: " << workDiv << ")"
               << std::endl;
 
+
     // Create the kernel execution task.
-    auto const taskKernel = alpaka::createTaskKernel<Acc>(
-        workDiv,
-        kernel,
-        numElements,
-        alpha,
-        std::data(memBufAccX),
-        std::data(memBufAccY));
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(workDiv, bundeledKernel);
 
     // Profile the kernel execution.
     std::cout << "Execution time: " << alpaka::test::integ::measureTaskRunTimeMs(queue, taskKernel) << " ms"

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -334,19 +334,7 @@ TEMPLATE_LIST_TEST_CASE("mandelbrot", "[mandelbrot]", TestAccs)
               << ", kernel: " << alpaka::core::demangled<decltype(kernel)> << ", workDiv: " << workDiv << ")"
               << std::endl;
 
-
-    auto const taskKernel = alpaka::createTaskKernel<Acc>(
-        workDiv,
-        kernel,
-        std::data(bufColorAcc),
-        numRows,
-        numCols,
-        rowPitch,
-        fMinR,
-        fMaxR,
-        fMinI,
-        fMaxI,
-        maxIterations);
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(workDiv, bundeledKernel);
 
     // Profile the kernel execution.
     std::cout << "Execution time: " << alpaka::test::integ::measureTaskRunTimeMs(queue, taskKernel) << " ms"

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -272,22 +272,8 @@ TEMPLATE_LIST_TEST_CASE("matMul", "[matMul]", TestAccs)
               << ", kernel: " << alpaka::core::demangled<decltype(kernel)> << ", workDiv: " << workDiv << ")"
               << std::endl;
 
-
     // Create the kernel execution task.
-    auto const taskKernel = alpaka::createTaskKernel<Acc>(
-        workDiv,
-        kernel,
-        m,
-        n,
-        k,
-        static_cast<Val>(1),
-        std::data(bufAAcc),
-        lda,
-        std::data(bufBAcc),
-        ldb,
-        static_cast<Val>(1),
-        std::data(bufCAcc),
-        ldc);
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(workDiv, bundeledKernel);
 
     // Profile the kernel execution.
     std::cout << "Execution time:   " << alpaka::test::integ::measureTaskRunTimeMs(queueAcc, taskKernel) << " ms"

--- a/test/integ/separableCompilation/src/main.cpp
+++ b/test/integ/separableCompilation/src/main.cpp
@@ -111,8 +111,12 @@ TEMPLATE_LIST_TEST_CASE("separableCompilation", "[separableCompilation]", TestAc
     alpaka::memcpy(queueAcc, memBufAccA, memBufHostA);
     alpaka::memcpy(queueAcc, memBufAccB, memBufHostB);
 
-    auto const& bundeledKernel
-        = alpaka::KernelBundle(kernel, memBufAccA.data(), memBufAccB.data(), memBufAccC.data(), numElements);
+    auto const& bundeledKernel = alpaka::KernelBundle(
+        kernel,
+        std::data(memBufAccA),
+        std::data(memBufAccB),
+        std::data(memBufAccC),
+        numElements);
     // Let alpaka calculate good block and grid sizes given our full problem extent
     auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, extent, static_cast<Idx>(3u));
 
@@ -121,13 +125,7 @@ TEMPLATE_LIST_TEST_CASE("separableCompilation", "[separableCompilation]", TestAc
               << ", numElements:" << numElements << ")" << std::endl;
 
     // Create the executor task.
-    auto const taskKernel = alpaka::createTaskKernel<Acc>(
-        workDiv,
-        kernel,
-        memBufAccA.data(),
-        memBufAccB.data(),
-        memBufAccC.data(),
-        numElements);
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(workDiv, bundeledKernel);
 
     // Profile the kernel execution.
     std::cout << "Execution time: " << alpaka::test::integ::measureTaskRunTimeMs(queueAcc, taskKernel) << " ms"

--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -131,7 +131,7 @@ TEMPLATE_LIST_TEST_CASE("sharedMem", "[sharedMem]", TestAccs)
 
 
     auto blockRetValuesDummy = alpaka::allocBuf<Val, Idx>(devAcc, static_cast<Idx>(1));
-    // Kernel input during the runtim of kernel will be different and is chosen to depend on workdiv.
+    // Kernel input during the runtime of kernel will be different and is chosen to depend on workdiv.
     // Therefore initially a  workdiv is needed to find the parameter. Therefore in kernel bundle, we can not use the
     // real input for the buffer pointer.
     auto const& bundeledKernel = alpaka::KernelBundle(kernel, std::data(blockRetValuesDummy));
@@ -149,6 +149,7 @@ TEMPLATE_LIST_TEST_CASE("sharedMem", "[sharedMem]", TestAccs)
               << ", kernel: " << alpaka::core::demangled<decltype(kernel)> << ", workDiv: " << workDiv << ")"
               << std::endl;
 
+    // Data size depends on workdiv
     Idx const gridBlocksCount(alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(workDiv)[0u]);
     Idx const blockThreadCount(alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(workDiv)[0u]);
 
@@ -160,8 +161,11 @@ TEMPLATE_LIST_TEST_CASE("sharedMem", "[sharedMem]", TestAccs)
     auto blockRetValsAcc = alpaka::allocBuf<Val, Idx>(devAcc, resultElemCount);
     alpaka::memcpy(queue, blockRetValsAcc, blockRetVals, resultElemCount);
 
-    // Create the kernel execution task.
-    auto const taskKernel = alpaka::createTaskKernel<Acc>(workDiv, kernel, std::data(blockRetValsAcc));
+
+    // Create the kernel execution task using the real data.
+    auto const& bundeledKernel2 = alpaka::KernelBundle(kernel, std::data(blockRetValsAcc));
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(workDiv, bundeledKernel2);
+
 
     // Profile the kernel execution.
     std::cout << "Execution time: " << alpaka::test::integ::measureTaskRunTimeMs(queue, taskKernel) << " ms"

--- a/test/unit/math/src/TestTemplate.hpp
+++ b/test/unit/math/src/TestTemplate.hpp
@@ -73,7 +73,6 @@ namespace mathtest
             // SETUP (defines and initialising)
             // DevAcc is defined in Buffer.hpp too.
             using DevAcc = alpaka::Dev<TAcc>;
-
             using QueueAcc = alpaka::test::DefaultQueue<DevAcc>;
             using TArgsItem = ArgsItem<TData, TFunctor::arity>;
 
@@ -123,8 +122,7 @@ namespace mathtest
             results.copyToDevice(queue);
 
             // Enqueue the kernel execution task.
-            auto const taskKernel
-                = alpaka::createTaskKernel<TAcc>(workDiv, kernel, results.pDevBuffer, wrappedFunctor, args.pDevBuffer);
+            auto const taskKernel = alpaka::createTaskKernel<TAcc>(workDiv, bundeledKernel);
             alpaka::enqueue(queue, taskKernel);
 
             // Copy back the results (encapsulated in the buffer class).


### PR DESCRIPTION
Add an overload to `exec` and change `createTaskKernel` functions so that they will take the kernel and arguments as a single argument of type `KernelBundle` .  Once `KernelBundle` instance is created to be used in `GetValidWorkDivForKernel`; using it again for `exec` (and in createTaskKernel) is needed because it already bundles the arguments with the kernel object hence exec does not need seperate kernel arguments.

This is the **3rd PR** of `KernelBundle` related tasks. Previous ones were #2251 (merged) and #2261.

- `CreateTaskKernel` has a KernelBundle argument
- `isKernelArgumentTriviallyCopyable` is moved to `KernelBundle` since it is not used anywhere else and better to check there. Because KernelBundle is used if the kernel is executed somehow; either before exec or inside the overloaded exec.
-  kernel return type check traits changed; now a `KernelBundle` argument can be used directly to check the kernel return type
-  Debug log about kernel object starting with `#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL ...` moved into the `KernelBundle`. 


- [x] This PR will be merged after #2261.
- [x]  must be squashed before merge