### PR TITLE
alpaka CI: set CMAKE_CXX_COMPILER instead using update-alternatives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ concurrency:
 ################################################################################
 # NOTE: Testing the full matrix is not practical.
 # Therefore we aim to have each value been set in at lest one job.
-# CXX                                           : {g++, clang++}
+# ALPAKA_CI_CXX                                 : {g++, clang++}
 #   [g++] ALPAKA_CI_GCC_VER                     : {9, 10, 11, 12, 13}
 #   [clang++] ALPAKA_CI_CLANG_VER               : {9, 10, 11, 12, 13, 14}
 #   [cl.exe] ALPAKA_CI_CL_VER                   : {2022}
-#   ALPAKA_CI_STDLIB                            : {libstdc++, [CXX==clang++]:libc++}
+#   ALPAKA_CI_STDLIB                            : {libstdc++, [ALPAKA_CI_CXX==clang++]:libc++}
 # CMAKE_BUILD_TYPE                              : {Debug, Release}
 # alpaka_CI                                     : {GITHUB}
 # ALPAKA_BOOST_VERSION                          : {1.74.0, 1.75.0, 1.76.0, 1.77.0, 1.78.0, 1.79.0, 1.80.0, 1.81.0, 1.82.0}
@@ -40,7 +40,7 @@ concurrency:
 #   [ON] OMP_NUM_THREADS                        : {1, 2, 3, 4}
 # alpaka_ACC_GPU_CUDA_ENABLE                    : {ON, OFF}
 #   [ON] ALPAKA_CI_CUDA_VERSION                 : {11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 12.0, 12.1, 12.2 12.3}
-#   [ON] CMAKE_CUDA_COMPILER                    : {nvcc, [CXX==clang++]:clang++}
+#   [ON] ALPAKA_CI_CUDA_COMPILER                : {nvcc, [ALPAKA_CI_CXX==clang++]:clang++}
 # alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE             : {ON, OFF}
 # alpaka_ACC_GPU_HIP_ENABLE                     : {ON, OFF}
 #   [ON] ALPAKA_CI_HIP_BRANCH                   : {rocm-4.2}
@@ -108,43 +108,43 @@ jobs:
         ### Analysis builds
         - name: linux_clang-14_cuda-11.2_debug_analysis
           os: ubuntu-20.04
-          env: {CXX: clang++, CC: clang,  ALPAKA_CI_CLANG_VER: 14,     ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.79.0, ALPAKA_CI_CMAKE_VER: 3.23.5, OMP_NUM_THREADS: 4, ALPAKA_CI_ANALYSIS: ON, ALPAKA_CI_RUN_TESTS: OFF, alpaka_DEBUG: 1, alpaka_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "11.2", CMAKE_CUDA_COMPILER: clang++,   alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
+          env: {ALPAKA_CI_CXX: clang++, ALPAKA_CI_CLANG_VER: 14,     ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.79.0, ALPAKA_CI_CMAKE_VER: 3.23.5, OMP_NUM_THREADS: 4, ALPAKA_CI_ANALYSIS: ON, ALPAKA_CI_RUN_TESTS: OFF, alpaka_DEBUG: 1, alpaka_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "11.2", ALPAKA_CI_CUDA_COMPILER : clang++,   alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
           container: ubuntu:20.04
         - name: windows_cl-2022_debug_analysis
           os: windows-2022
-          env: {CXX: cl.exe,  CC: cl.exe, ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.78.0, ALPAKA_CI_CMAKE_VER: 3.23.5,                     ALPAKA_CI_ANALYSIS: ON, alpaka_DEBUG: 2}
+          env: {ALPAKA_CI_CXX: cl.exe,  ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.78.0, ALPAKA_CI_CMAKE_VER: 3.23.5,                     ALPAKA_CI_ANALYSIS: ON, alpaka_DEBUG: 2}
         - name: macos_xcode-14.2_debug_analysis
           os: macos-12
-          env: {CXX: clang++, CC: clang,  ALPAKA_CI_XCODE_VER: 14.2,                                CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.81.0,                                                  ALPAKA_CI_ANALYSIS: ON, alpaka_DEBUG: 2,                                                                                                                                                                             alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: ON, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: ON, ALPAKA_CI_BUILD_JOBS: 3}
+          env: {ALPAKA_CI_CXX: clang++, ALPAKA_CI_XCODE_VER: 14.2,                                CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.81.0,                                                  ALPAKA_CI_ANALYSIS: ON, alpaka_DEBUG: 2,                                                                                                                                                                             alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: ON, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: ON, ALPAKA_CI_BUILD_JOBS: 3}
         - name: linux_gcc-12_debug_analysis
           os: ubuntu-22.04
-          env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 12,       ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.80.0, ALPAKA_CI_CMAKE_VER: 3.23.5, OMP_NUM_THREADS: 4, ALPAKA_CI_ANALYSIS: ON, alpaka_DEBUG: 2}
+          env: {ALPAKA_CI_CXX: g++,    ALPAKA_CI_GCC_VER: 12,       ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.80.0, ALPAKA_CI_CMAKE_VER: 3.23.5, OMP_NUM_THREADS: 4, ALPAKA_CI_ANALYSIS: ON, alpaka_DEBUG: 2}
           container: ubuntu:22.04
 
         ### macOS
         - name: macos_xcode-14.2_release
           os: macos-12
-          env: {CXX: clang++, CC: clang,  ALPAKA_CI_XCODE_VER: 14.2,                                CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.81.0,                                                                                                                                                                                                                                                                       alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: ON, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: ON, ALPAKA_CI_BUILD_JOBS: 3}
+          env: {ALPAKA_CI_CXX: clang++, ALPAKA_CI_XCODE_VER: 14.2,                                CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.81.0,                                                                                                                                                                                                                                                                       alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: ON, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: ON, ALPAKA_CI_BUILD_JOBS: 3}
         - name: macos_xcode-14.3.1_debug
           os: macos-13
-          env: {CXX: clang++, CC: clang,  ALPAKA_CI_XCODE_VER: 14.3.1,                              CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.82.0,                                                                                                                                                                                                                                                                       alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: ON, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: ON, ALPAKA_CI_BUILD_JOBS: 3}
+          env: {ALPAKA_CI_CXX: clang++, ALPAKA_CI_XCODE_VER: 14.3.1,                              CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.82.0,                                                                                                                                                                                                                                                                       alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: ON, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: ON, ALPAKA_CI_BUILD_JOBS: 3}
 
         ### Windows
         - name: windows_cl-2022_release
           os: windows-2022
-          env: {CXX: cl.exe,  CC: cl.exe, ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.79.0, ALPAKA_CI_CMAKE_VER: 3.24.4, OMP_NUM_THREADS: 1}
+          env: {ALPAKA_CI_CXX: cl.exe,  ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.79.0, ALPAKA_CI_CMAKE_VER: 3.24.4, OMP_NUM_THREADS: 1}
         - name: windows_cl-2022_debug
           os: windows-2022
-          env: {CXX: cl.exe,  CC: cl.exe, ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.80.0, ALPAKA_CI_CMAKE_VER: 3.25.1, OMP_NUM_THREADS: 4,                                                                                                                                                                                           alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
+          env: {ALPAKA_CI_CXX: cl.exe,  ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.80.0, ALPAKA_CI_CMAKE_VER: 3.25.1, OMP_NUM_THREADS: 4,                                                                                                                                                                                           alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
 
         ## CUDA 12.1
         # nvcc + MSVC
         # - name: windows_nvcc-12.1_cl-2022_release_cuda-only
         #  os: windows-2022
-        #  env: {CXX: cl.exe,  CC: cl.exe, ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.81.0, ALPAKA_CI_CMAKE_VER: 3.24.4, ALPAKA_CI_RUN_TESTS: OFF,                     alpaka_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "12.1", CMAKE_CUDA_ARCHITECTURES: "50;90", alpaka_ACC_GPU_CUDA_ONLY_MODE: ON,                                                     alpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE: OFF, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
+        #  env: {ALPAKA_CI_CXX: cl.exe,  ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.81.0, ALPAKA_CI_CMAKE_VER: 3.24.4, ALPAKA_CI_RUN_TESTS: OFF,                     alpaka_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "12.1", CMAKE_CUDA_ARCHITECTURES: "50;90", alpaka_ACC_GPU_CUDA_ONLY_MODE: ON,                                                     alpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE: OFF, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
         # - name: windows_nvcc-12.1_cl-2022_debug
         #  os: windows-2022
-        #  env: {CXX: cl.exe,  CC: cl.exe, ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.78.0, ALPAKA_CI_CMAKE_VER: 3.25.1, ALPAKA_CI_RUN_TESTS: OFF,                     alpaka_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "12.1",                                                                                                                           alpaka_ACC_CPU_BT_OMP5_ENABLE: OFF, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF}
+        #  env: {ALPAKA_CI_CXX: cl.exe,  ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.78.0, ALPAKA_CI_CMAKE_VER: 3.25.1, ALPAKA_CI_RUN_TESTS: OFF,                     alpaka_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "12.1",                                                                                                                           alpaka_ACC_CPU_BT_OMP5_ENABLE: OFF, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF}
 
         ### Ubuntu
         ## native
@@ -156,15 +156,15 @@ jobs:
         #  - Ubuntu 22.04
         - name: linux_gcc-9_debug
           os: ubuntu-20.04
-          env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 9,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.74.0, ALPAKA_CI_CMAKE_VER: 3.22.6, OMP_NUM_THREADS: 4, CMAKE_CXX_EXTENSIONS: OFF}
+          env: {ALPAKA_CI_CXX: g++,    ALPAKA_CI_GCC_VER: 9,        ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.74.0, ALPAKA_CI_CMAKE_VER: 3.22.6, OMP_NUM_THREADS: 4, CMAKE_CXX_EXTENSIONS: OFF}
           container: ubuntu:20.04
         - name: linux_gcc-12_release_c++20
           os: ubuntu-22.04
-          env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 12,       ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.80.0, ALPAKA_CI_CMAKE_VER: 3.24.4, OMP_NUM_THREADS: 2, alpaka_CXX_STANDARD: 20, alpaka_USE_MDSPAN: "FETCH"}
+          env: {ALPAKA_CI_CXX: g++,    ALPAKA_CI_GCC_VER: 12,       ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.80.0, ALPAKA_CI_CMAKE_VER: 3.24.4, OMP_NUM_THREADS: 2, alpaka_CXX_STANDARD: 20, alpaka_USE_MDSPAN: "FETCH"}
           container: ubuntu:22.04
         - name: linux_gcc-13_debug
           os: ubuntu-22.04
-          env: {CXX: g++,     CC: gcc,    ALPAKA_CI_GCC_VER: 13,       ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.82.0, ALPAKA_CI_CMAKE_VER: 3.26.4, OMP_NUM_THREADS: 2}
+          env: {ALPAKA_CI_CXX: g++,    ALPAKA_CI_GCC_VER: 13,       ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.82.0, ALPAKA_CI_CMAKE_VER: 3.26.4, OMP_NUM_THREADS: 2}
           container: ubuntu:22.04
 
         # TODO: keep jobs until GitLab CI supports:
@@ -175,24 +175,24 @@ jobs:
         # clang++
         - name: linux_clang-10_release
           os: ubuntu-20.04
-          env: {CXX: clang++, CC: clang,  ALPAKA_CI_CLANG_VER: 10,     ALPAKA_CI_STDLIB: libc++,    CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.75.0, ALPAKA_CI_CMAKE_VER: 3.23.5, OMP_NUM_THREADS: 4, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, CMAKE_CXX_EXTENSIONS: OFF}
+          env: {ALPAKA_CI_CXX: clang++,  ALPAKA_CI_CLANG_VER: 10,     ALPAKA_CI_STDLIB: libc++,    CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.75.0, ALPAKA_CI_CMAKE_VER: 3.23.5, OMP_NUM_THREADS: 4, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, CMAKE_CXX_EXTENSIONS: OFF}
           container: ubuntu:20.04
         # clang-11 tested in GitLab CI
         - name: linux_clang-12_release
           os: ubuntu-20.04
-          env: {CXX: clang++, CC: clang,  ALPAKA_CI_CLANG_VER: 12,     ALPAKA_CI_STDLIB: libc++,    CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.77.0, ALPAKA_CI_CMAKE_VER: 3.24.4, OMP_NUM_THREADS: 4, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, CMAKE_CXX_EXTENSIONS: OFF}
+          env: {ALPAKA_CI_CXX: clang++,  ALPAKA_CI_CLANG_VER: 12,     ALPAKA_CI_STDLIB: libc++,    CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.77.0, ALPAKA_CI_CMAKE_VER: 3.24.4, OMP_NUM_THREADS: 4, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, CMAKE_CXX_EXTENSIONS: OFF}
           container: ubuntu:20.04
         - name: linux_clang-13_debug
           os: ubuntu-22.04
-          env: {CXX: clang++, CC: clang,  ALPAKA_CI_CLANG_VER: 13,     ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.79.0, ALPAKA_CI_CMAKE_VER: 3.23.5, OMP_NUM_THREADS: 3, CMAKE_CXX_EXTENSIONS: OFF}
+          env: {ALPAKA_CI_CXX: clang++,  ALPAKA_CI_CLANG_VER: 13,     ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.79.0, ALPAKA_CI_CMAKE_VER: 3.23.5, OMP_NUM_THREADS: 3, CMAKE_CXX_EXTENSIONS: OFF}
           container: ubuntu:22.04
         - name: linux_clang-16_debug_ubsan
           os: ubuntu-22.04
-          env: {CXX: clang++, CC: clang,  ALPAKA_CI_CLANG_VER: 16,     ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.77.0, ALPAKA_CI_CMAKE_VER: 3.23.5, OMP_NUM_THREADS: 4, CMAKE_CXX_EXTENSIONS: OFF, ALPAKA_CI_SANITIZERS: UBSan}
+          env: {ALPAKA_CI_CXX: clang++,  ALPAKA_CI_CLANG_VER: 16,     ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.77.0, ALPAKA_CI_CMAKE_VER: 3.23.5, OMP_NUM_THREADS: 4, CMAKE_CXX_EXTENSIONS: OFF, ALPAKA_CI_SANITIZERS: UBSan}
           container: ubuntu:22.04
         - name: linux_clang-16_debug_tsan
           os: ubuntu-22.04
-          env: {CXX: clang++, CC: clang,  ALPAKA_CI_CLANG_VER: 16,     ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.77.0, ALPAKA_CI_CMAKE_VER: 3.23.5, OMP_NUM_THREADS: 4, alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, CMAKE_CXX_EXTENSIONS: OFF, ALPAKA_CI_SANITIZERS: TSan}
+          env: {ALPAKA_CI_CXX: clang++,  ALPAKA_CI_CLANG_VER: 16,     ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.77.0, ALPAKA_CI_CMAKE_VER: 3.23.5, OMP_NUM_THREADS: 4, alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, CMAKE_CXX_EXTENSIONS: OFF, ALPAKA_CI_SANITIZERS: TSan}
           container: ubuntu:22.04
 
     steps:

--- a/example/complex/CMakeLists.txt
+++ b/example/complex/CMakeLists.txt
@@ -15,7 +15,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(_TARGET_NAME complexNumbers)
 
-project(${_TARGET_NAME})
+project(${_TARGET_NAME} LANGUAGES CXX)
 
 #-------------------------------------------------------------------------------
 # Find alpaka.

--- a/script/before_install.sh
+++ b/script/before_install.sh
@@ -95,10 +95,15 @@ if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
 then
     if [ "${ALPAKA_CI_STDLIB}" == "libc++" ]
     then
-        if [[ "${CXX}" == "g++"* ]]
+        if [[ "${ALPAKA_CI_CXX}" == "g++"* ]]
         then
             echo "using libc++ with g++ not yet supported."
             exit 1
         fi
     fi
+fi
+
+if [ "$ALPAKA_CI_OS_NAME" = "Windows" ] || [ "$ALPAKA_CI_OS_NAME" = "macOS" ]
+then
+    export CMAKE_CXX_COMPILER=$ALPAKA_CI_CXX
 fi

--- a/script/gitlabci/job_base.yml
+++ b/script/gitlabci/job_base.yml
@@ -18,13 +18,12 @@
   image: ubuntu:${ALPAKA_CI_UBUNTU_VER}
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
-    CC: gcc
-    CXX: g++
+    ALPAKA_CI_CXX: g++
     alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE: "ON"
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "ON"
     alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: "OFF"
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
-    CMAKE_CUDA_COMPILER: nvcc
+    ALPAKA_CI_CUDA_COMPILER: nvcc
     ALPAKA_CI_STDLIB: libstdc++
     # CI contains a Quadro P5000 (sm_61)
     CMAKE_CUDA_ARCHITECTURES: "61"
@@ -51,13 +50,12 @@
   image: ubuntu:${ALPAKA_CI_UBUNTU_VER}
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
-    CC: clang
-    CXX: clang++
+    ALPAKA_CI_CXX: clang++
     alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE: "ON"
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "ON"
     alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: "OFF"
     alpaka_ACC_GPU_CUDA_ENABLE: "ON"
-    CMAKE_CUDA_COMPILER: clang++
+    ALPAKA_CI_CUDA_COMPILER: clang++
     ALPAKA_CI_STDLIB: libstdc++
     # CI contains a Quadro P5000 (sm_61)
     CMAKE_CUDA_ARCHITECTURES: "61"
@@ -87,8 +85,7 @@
   image: ubuntu:${ALPAKA_CI_UBUNTU_VER}
   variables:
     ALPAKA_CI_UBUNTU_VER: "22.04"
-    CC: clang
-    CXX: clang++
+    ALPAKA_CI_CXX: clang++
     ALPAKA_CI_SANITIZERS: ""
     ALPAKA_CI_ANALYSIS: "OFF"
     ALPAKA_CI_TBB_VERSION: 2021.4.0

--- a/script/gitlabci/print_env.sh
+++ b/script/gitlabci/print_env.sh
@@ -39,7 +39,7 @@ fi
 echo -e "2. Run the following export commands in the container to setup enviroment\n"
 
 # take all env variables, filter it and display it with a `export` prefix
-printenv | grep -E 'alpaka_*|ALPAKA_*|CMAKE_*|BOOST_|CC|CXX|CUDA_' | while read -r line ; do
+printenv | grep -E 'alpaka_*|ALPAKA_*|CMAKE_*|BOOST_|CUDA_' | while read -r line ; do
     echo "export $line \\"
 done
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -38,15 +38,13 @@ fi
 
 if [ "${ALPAKA_CI_ANALYSIS}" == "ON" ] ;then source ./script/install_analysis.sh ;fi
 
-# Install CUDA before installing gcc as it installs gcc-4.8 and overwrites our selected compiler
-if [ "${ALPAKA_CI_INSTALL_CUDA}" == "ON" ] ;then source ./script/install_cuda.sh ;fi
 
 if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
 then
-    if [[ "${CXX}" == "g++"* ]] ;then source ./script/install_gcc.sh ;fi
+    if [[ "${ALPAKA_CI_CXX}" == "g++"* ]] ;then source ./script/install_gcc.sh ;fi
     # do not install clang if we use HIP, HIP/ROCm is shipping an own clang version
-    if [[ "${CXX}" == "clang++" ]] && [ "${ALPAKA_CI_INSTALL_HIP}" != "ON" ] ;then source ./script/install_clang.sh ;fi
-    if [[ "${CXX}" == "icpx" ]] ;then source ./script/install_oneapi.sh ;fi
+    if [[ "${ALPAKA_CI_CXX}" == "clang++" ]] && [ "${ALPAKA_CI_INSTALL_HIP}" != "ON" ] ;then source ./script/install_clang.sh ;fi
+    if [[ "${ALPAKA_CI_CXX}" == "icpx" ]] ;then source ./script/install_oneapi.sh ;fi
 elif [ "$ALPAKA_CI_OS_NAME" = "macOS" ]
 then
     echo "### list all applications ###"
@@ -55,8 +53,10 @@ then
     sudo xcode-select -s "/Applications/Xcode_${ALPAKA_CI_XCODE_VER}.app/Contents/Developer"
 fi
 
+if [ "${ALPAKA_CI_INSTALL_CUDA}" == "ON" ] ;then source ./script/install_cuda.sh ;fi
+
 # Don't install TBB for oneAPI runners - it will be installed as part of oneAPI
-if [ "${ALPAKA_CI_INSTALL_TBB}" = "ON" ] && [ "${CXX}" != "icpx" ]
+if [ "${ALPAKA_CI_INSTALL_TBB}" = "ON" ] && [ "${ALPAKA_CI_CXX}" != "icpx" ]
 then
     source ./script/install_tbb.sh
 fi

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -18,8 +18,7 @@ then
     : "${ALPAKA_CI_STDLIB?'ALPAKA_CI_STDLIB must be specified'}"
 fi
 : "${CMAKE_BUILD_TYPE?'CMAKE_BUILD_TYPE must be specified'}"
-: "${CXX?'CXX must be specified'}"
-: "${CC?'CC must be specified'}"
+: "${ALPAKA_CI_CXX?'ALPAKA_CI_CXX must be specified'}"
 : "${ALPAKA_CI_INSTALL_ATOMIC?'ALPAKA_CI_INSTALL_ATOMIC must be specified'}"
 if [ "$ALPAKA_CI_OS_NAME" = "Windows" ]
 then
@@ -31,7 +30,7 @@ then
     ALPAKA_CI_STDLIB=""
 fi
 
-if [ "${CXX}" != "icpc" ] && [ "${ALPAKA_CI_STDLIB}" != "libc++" ]
+if [ "${ALPAKA_CI_CXX}" != "icpc" ] && [ "${ALPAKA_CI_STDLIB}" != "libc++" ]
 then
     if agc-manager -e boost@${ALPAKA_BOOST_VERSION} ; then
         echo_green "<USE: preinstalled BOOST ${ALPAKA_BOOST_VERSION}>"
@@ -71,15 +70,22 @@ then
         TOOLSET="msvc-14.3"
     fi
     # Add new versions as needed
-elif [ "${CXX}" == "icpc" ]
+elif [ "${ALPAKA_CI_CXX}" == "icpc" ]
 then
     TOOLSET="intel-linux"
-elif [ "${CXX}" == "icpx" ]
+elif [ "${ALPAKA_CI_CXX}" == "g++" ]
+then
+    TOOLSET="gcc"
+elif [ "${ALPAKA_CI_CXX}" == "clang++" ]
+then
+    TOOLSET="clang"
+elif [ "${ALPAKA_CI_CXX}" == "icpx" ]
 then
     # icpx is binary compatibly with g++ and ipcx is not supported by b2
     TOOLSET="gcc"
 else
-    TOOLSET="${CC}"
+    echo_red "unknown ALPAKA_CI_CXX: ${ALPAKA_CI_CXX}"
+    exit 1
 fi
 
 # Bootstrap boost.
@@ -151,7 +157,7 @@ then
 
     # Clang is not supported by the FindBoost script.
     # boost (especially old versions) produces too much warnings when using clang (newer versions) so that the 4 MiB log is too short.
-    if [[ "${CXX}" == "clang++"* ]]
+    if [[ "${ALPAKA_CI_CXX}" == "clang++"* ]]
     then
         ALPAKA_BOOST_B2_CXXFLAGS+=" -Wunused-private-field -Wno-unused-local-typedef -Wno-c99-extensions -Wno-variadic-macros"
     fi

--- a/script/install_clang.sh
+++ b/script/install_clang.sh
@@ -12,7 +12,6 @@ echo_green "<SCRIPT: install_clang>"
 
 : "${ALPAKA_CI_CLANG_VER?'ALPAKA_CI_CLANG_VER must be specified'}"
 : "${ALPAKA_CI_STDLIB?'ALPAKA_CI_STDLIB must be specified'}"
-: "${CXX?'CXX must be specified'}"
 
 #TODO(SimeonEhrig): remove this statement, if ppa's are fixed in alpaka-group-container
 if [[ -f "/etc/apt/sources.list.d/llvm.list" ]];
@@ -69,11 +68,14 @@ else
         travis_retry sudo apt-get -y --quiet --allow-unauthenticated --no-install-recommends install "${LIBOMP_PACKAGE}"
     fi
 
-    sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-"${ALPAKA_CI_CLANG_VER}" 50
-    sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-"${ALPAKA_CI_CLANG_VER}" 50
-    sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-"${ALPAKA_CI_CLANG_VER}" 50
-    sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-"${ALPAKA_CI_CLANG_VER}" 50
+    which clang++-${ALPAKA_CI_CLANG_VER}
+    export CMAKE_CXX_COMPILER=$(which clang++-${ALPAKA_CI_CLANG_VER})
+
+    # create soft link clang and clang++ to the actual executable
+    # the boost build script requires that the executable clang++ exist
+    ln -s $(which clang-${ALPAKA_CI_CLANG_VER}) $(dirname $(which clang-${ALPAKA_CI_CLANG_VER}))/clang
+    ln -s $(which clang++-${ALPAKA_CI_CLANG_VER}) $(dirname $(which clang++-${ALPAKA_CI_CLANG_VER}))/clang++
 fi
 
-which "${CXX}"
-${CXX} --version
+which "${CMAKE_CXX_COMPILER}"
+${CMAKE_CXX_COMPILER} --version

--- a/script/install_cuda.sh
+++ b/script/install_cuda.sh
@@ -33,7 +33,7 @@ else
     if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
     then
         : "${ALPAKA_CI_CUDA_DIR?'ALPAKA_CI_CUDA_DIR must be specified'}"
-        : "${CMAKE_CUDA_COMPILER?'CMAKE_CUDA_COMPILER must be specified'}"
+        : "${ALPAKA_CI_CUDA_COMPILER?'ALPAKA_CI_CUDA_COMPILER must be specified'}"
 
         if [[ "$(cat /etc/os-release)" == *"20.04"* ]]
         then
@@ -157,7 +157,7 @@ else
         export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
         export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:$LD_LIBRARY_PATH
 
-        if [ "${CMAKE_CUDA_COMPILER}" == "clang++" ]
+        if [ "${ALPAKA_CI_CUDA_COMPILER}" == "clang++" ]
         then
             travis_retry sudo apt-get -y --quiet --allow-unauthenticated --no-install-recommends install g++-multilib
         fi
@@ -179,4 +179,15 @@ else
         # The 'thrust' package contains the CUDA C++ Core Compute Libraries (CCCL) which are required for cuRAND. The installer doesn't do dependency management so we have to install them manually.
         ./cuda_installer.exe -s "nvcc_${ALPAKA_CI_CUDA_VERSION}" "curand_dev_${ALPAKA_CI_CUDA_VERSION}" "cudart_${ALPAKA_CI_CUDA_VERSION}" "thrust_${ALPAKA_CI_CUDA_VERSION}" "visual_studio_integration_${ALPAKA_CI_CUDA_VERSION}"
     fi
+fi
+
+if [ "${ALPAKA_CI_CUDA_COMPILER}" == "nvcc" ]
+then
+    export CMAKE_CUDA_COMPILER=$(which nvcc)
+elif [ "${ALPAKA_CI_CUDA_COMPILER}" == "clang++" ]
+then
+    export CMAKE_CUDA_COMPILER=$(which clang++-${ALPAKA_CI_CLANG_VER})
+else
+    echo_red "unknown ALPAKA_CI_CUDA_COMPILER: ${ALPAKA_CI_CUDA_COMPILER}"
+    exit 1
 fi

--- a/script/install_hip.sh
+++ b/script/install_hip.sh
@@ -101,3 +101,6 @@ hipconfig
 rocm-smi
 # print newline as previous command does not do this
 echo
+
+# use the clang++ of the HIP SDK as C++ compiler
+export CMAKE_CXX_COMPILER=$(which clang++)

--- a/script/install_oneapi.sh
+++ b/script/install_oneapi.sh
@@ -9,9 +9,6 @@ source ./script/setup_utilities.sh
 
 echo_green "<SCRIPT: install_oneapi>"
 
-: "${CXX?'CXX must be specified'}"
-
-
 if agc-manager -e oneapi
 then
     echo_green "<USE: preinstalled OneAPI ${ALPAKA_CI_ONEAPI_VERSION}>"
@@ -55,10 +52,11 @@ else
         travis_retry sudo apt update
         travis_retry sudo apt install -y --no-install-recommends g++-11
     fi
+
+    # path depends on the SDK version
+    export CMAKE_CXX_COMPILER=$(which icpx)
 fi
 
-which "${CXX}"
-${CXX} --version
-which "${CC}"
-${CC} --version
+which "${CMAKE_CXX_COMPILER}"
+${CMAKE_CXX_COMPILER} --version
 sycl-ls

--- a/script/job_generator/generate_job_yaml.py
+++ b/script/job_generator/generate_job_yaml.py
@@ -296,22 +296,19 @@ def job_variables(job: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
     append_backend_variables(variables, job)
 
     if job[DEVICE_COMPILER][NAME] == GCC:
-        variables["CC"] = "gcc"
-        variables["CXX"] = "g++"
+        variables["ALPAKA_CI_CXX"] = "g++"
         variables["ALPAKA_CI_GCC_VER"] = job[DEVICE_COMPILER][VERSION]
         if ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE in job and job[ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE][VERSION] == ON_VER:
             variables["ALPAKA_CI_TBB_VERSION"] = "2021.10.0"
 
     if job[DEVICE_COMPILER][NAME] == CLANG:
-        variables["CC"] = "clang"
-        variables["CXX"] = "clang++"
+        variables["ALPAKA_CI_CXX"] = "clang++"
         variables["ALPAKA_CI_CLANG_VER"] = job[DEVICE_COMPILER][VERSION]
         if ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE in job and job[ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE][VERSION] == ON_VER:
             variables["ALPAKA_CI_TBB_VERSION"] = "2021.10.0"
 
     if job[DEVICE_COMPILER][NAME] == HIPCC:
-        variables["CC"] = "clang"
-        variables["CXX"] = "clang++"
+        variables["ALPAKA_CI_CXX"] = "clang++"
         variables["CMAKE_HIP_COMPILER"] = "clang++"
         variables["CMAKE_HIP_ARCHITECTURES"] = "${CI_GPU_ARCH}"
         # TODO(SimeonEhrig) check, if we can remove this variable:
@@ -347,17 +344,15 @@ def job_variables(job: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
 
     if job[DEVICE_COMPILER][NAME] == NVCC:
         # general configuration, if nvcc is the CUDA compiler
-        variables["CMAKE_CUDA_COMPILER"] = "nvcc"
+        variables["ALPAKA_CI_CUDA_COMPILER"] = "nvcc"
 
         # configuration, if GCC is the CUDA host compiler
         if job[HOST_COMPILER][NAME] == GCC:
-            variables["CC"] = "gcc"
-            variables["CXX"] = "g++"
+            variables["ALPAKA_CI_CXX"] = "g++"
             variables["ALPAKA_CI_GCC_VER"] = job[HOST_COMPILER][VERSION]
         # configuration, if Clang is the CUDA host compiler
         elif job[HOST_COMPILER][NAME] == CLANG:
-            variables["CC"] = "clang"
-            variables["CXX"] = "clang++"
+            variables["ALPAKA_CI_CXX"] = "clang++"
             variables["ALPAKA_CI_CLANG_VER"] = job[HOST_COMPILER][VERSION]
         else:
             raise RuntimeError(
@@ -365,15 +360,13 @@ def job_variables(job: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
             )
 
     if job[DEVICE_COMPILER][NAME] == CLANG_CUDA:
-        variables["CC"] = "clang"
-        variables["CXX"] = "clang++"
+        variables["ALPAKA_CI_CXX"] = "clang++"
         variables["ALPAKA_CI_CLANG_VER"] = job[DEVICE_COMPILER][VERSION]
-        variables["CMAKE_CUDA_COMPILER"] = "clang++"
+        variables["ALPAKA_CI_CUDA_COMPILER"] = "clang++"
 
     # oneAPI configuration
     if job[DEVICE_COMPILER][NAME] == ICPX:
-        variables["CC"] = "icx"
-        variables["CXX"] = "icpx"
+        variables["ALPAKA_CI_CXX"] = "icpx"
         if job[DEVICE_COMPILER][VERSION] == "2024.0":
             variables["ALPAKA_CI_CLANG_VER"] = "17"
         variables["ALPAKA_CI_STDLIB"] = "libstdc++"

--- a/script/prepare_sanitizers.sh
+++ b/script/prepare_sanitizers.sh
@@ -40,7 +40,7 @@ then
     CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fno-optimize-sibling-calls"
 
     # g++ needs to use a different linker
-    if [[ "${CXX}" == "g++"* ]]
+    if [[ "${ALPAKA_CI_CXX}" == "g++"* ]]
     then
         CMAKE_EXE_LINKER_FLAGS="${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold"
     fi
@@ -50,7 +50,7 @@ then
     then
         CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fsanitize=undefined"
 
-        if [[ "${CXX}" == "clang++"* ]]
+        if [[ "${ALPAKA_CI_CXX}" == "clang++"* ]]
         then
             # Previously 'local-bounds' was part of UBsan but has been removed because it is not a pure front-end check
             CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fsanitize=local-bounds"
@@ -68,7 +68,7 @@ then
             exit 1
         fi
 
-        if ( [ "${alpaka_ACC_GPU_CUDA_ENABLE}" == "ON" ] && [ "${CMAKE_CUDA_COMPILER}" == "clang++" ] )
+        if ( [ "${alpaka_ACC_GPU_CUDA_ENABLE}" == "ON" ] && [ "${ALPAKA_CI_CUDA_COMPILER}" == "clang++" ] )
         then
             # fatal error: error in backend: Module has a nontrivial global ctor, which NVPTX does not support.
             # clang-3.9: error: clang frontend command failed with exit code 70 (use -v to see invocation)
@@ -78,7 +78,7 @@ then
 
         CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fsanitize=address"
 
-        if [[ "${CXX}" != "clang++"* ]]
+        if [[ "${ALPAKA_CI_CXX}" != "clang++"* ]]
         then
             CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fsanitize-address-use-after-scope"
         fi
@@ -99,7 +99,7 @@ then
         fi
 
         CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fsanitize=thread"
-        if [[ "${CXX}" == "g++"* ]]
+        if [[ "${ALPAKA_CI_CXX}" == "g++"* ]]
         then
             CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -pie -fPIE"
             CMAKE_EXE_LINKER_FLAGS="${CMAKE_EXE_LINKER_FLAGS} -ltsan"

--- a/script/run.sh
+++ b/script/run.sh
@@ -21,8 +21,8 @@ then
     : "${ALPAKA_CI_STDLIB?'ALPAKA_CI_STDLIB must be specified'}"
     echo "ALPAKA_CI_STDLIB: ${ALPAKA_CI_STDLIB}"
 fi
-: "${CXX?'CXX must be specified'}"
-echo "CXX: ${CXX}"
+: "${ALPAKA_CI_CXX?'ALPAKA_CI_CXX must be specified'}"
+echo "ALPAKA_CI_CXX: ${ALPAKA_CI_CXX}"
 
 
 if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
@@ -31,7 +31,7 @@ then
     then
         LD_LIBRARY_PATH=
     fi
-    if [[ "${CXX}" = "clang++"* ]]
+    if [[ "${ALPAKA_CI_CXX}" = "clang++"* ]]
     then
         if [ "${ALPAKA_CI_CLANG_VER}" -ge "10" ]
         then
@@ -66,7 +66,7 @@ then
         # We have to explicitly add the stub libcuda.so to CUDA_LIB_PATH because the real one would be installed by the driver (which we can not install).
         export CUDA_LIB_PATH=/usr/local/cuda/lib64/stubs/
 
-        if [ "${CMAKE_CUDA_COMPILER}" == "nvcc" ]
+        if [ "${ALPAKA_CI_CUDA_COMPILER}" == "nvcc" ]
         then
             which nvcc
             nvcc -V
@@ -93,16 +93,16 @@ then
             export CMAKE_CXX_FLAGS=
         fi
 
-        if [[ "${CXX}" == "clang++"* ]]
+        if [[ "${ALPAKA_CI_CXX}" == "clang++"* ]]
         then
             CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -stdlib=libc++"
         fi
     fi
 
-    if [ "${CXX}" == "icpc" ]
+    if [ "${ALPAKA_CI_CXX}" == "icpc" ]
     then
         set +eu
-        which ${CXX} || source /opt/intel/oneapi/setvars.sh
+        which ${ALPAKA_CI_CXX} || source /opt/intel/oneapi/setvars.sh
 
         # exit by default if the command does not return 0
         # can be deactivated by setting the environment variable alpaka_DISABLE_EXIT_FAILURE
@@ -113,8 +113,8 @@ then
         set -u
     fi
 
-    which "${CXX}"
-    ${CXX} --version
+    which "${CMAKE_CXX_COMPILER}"
+    ${CMAKE_CXX_COMPILER} --version
 fi
 
 if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]

--- a/script/run_generate.sh
+++ b/script/run_generate.sh
@@ -10,10 +10,7 @@ source ./script/setup_utilities.sh
 
 echo_green "<SCRIPT: run_generate>"
 
-# TODO(SimeonEhrig): should use CMAKE_C_COMPILER and CMAKE_CXX_COMPILER instead update-alternatives because it
-# is more relastic use case and less error prone approach
-#: "${CMAKE_C_COMPILER?'CMAKE_C_COMPILER must be specified'}"
-#: "${CMAKE_CXX_COMPILER?'CMAKE_CXX_COMPILER must be specified'}"
+: "${CMAKE_CXX_COMPILER?'CMAKE_CXX_COMPILER must be specified'}"
 : "${alpaka_CXX_STANDARD?'alpaka_CXX_STANDARD must be specified'}"
 
 #-------------------------------------------------------------------------------
@@ -42,10 +39,6 @@ function env2cmake()
 if [ ! -z "${CMAKE_CXX_FLAGS+x}" ]
 then
     echo "CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
-fi
-if [ ! -z "${CMAKE_C_COMPILER+x}" ]
-then
-    echo "CMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
 fi
 if [ ! -z "${CMAKE_CXX_COMPILER+x}" ]
 then
@@ -89,7 +82,7 @@ cd build/
 "${ALPAKA_CI_CMAKE_EXECUTABLE}" --log-level=VERBOSE -G "${ALPAKA_CI_CMAKE_GENERATOR}" ${ALPAKA_CI_CMAKE_GENERATOR_PLATFORM}\
     -Dalpaka_BUILD_EXAMPLES=ON -DBUILD_TESTING=ON -Dalpaka_BUILD_BENCHMARKS=ON "$(env2cmake alpaka_ENABLE_WERROR)" \
     "$(env2cmake BOOST_ROOT)" -DBOOST_LIBRARYDIR="${ALPAKA_CI_BOOST_LIB_DIR}/lib" -DBoost_USE_STATIC_LIBS=ON -DBoost_USE_MULTITHREADED=ON -DBoost_USE_STATIC_RUNTIME=OFF -DBoost_ARCHITECTURE="-x64" \
-    "$(env2cmake CMAKE_BUILD_TYPE)" "$(env2cmake CMAKE_CXX_FLAGS)" "$(env2cmake CMAKE_C_COMPILER)" "$(env2cmake CMAKE_CXX_COMPILER)" "$(env2cmake CMAKE_EXE_LINKER_FLAGS)" "$(env2cmake CMAKE_CXX_EXTENSIONS)"\
+    "$(env2cmake CMAKE_BUILD_TYPE)" "$(env2cmake CMAKE_CXX_FLAGS)" "$(env2cmake CMAKE_CXX_COMPILER)" "$(env2cmake CMAKE_EXE_LINKER_FLAGS)" "$(env2cmake CMAKE_CXX_EXTENSIONS)"\
     "$(env2cmake alpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE)" "$(env2cmake alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE)" \
     "$(env2cmake alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE)" \
     "$(env2cmake alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE)" "$(env2cmake alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE)" \


### PR DESCRIPTION
Changing the OS host compiler has dangerous side effects and is not common on productive systems. Therefore our CI should not do it. Instead the CI should use  `CMAKE_CXX_COMPILER` to set the compiler.

- Instead changing the default host compiler, set the compiler via CMAKE_CXX_COMPILER argument at CMake configure.
- Rename environment variable CXX to ALPAKA_CI_CXX, because CXX can cause unexpected side effects.
- The environment variable CMAKE_CXX_COMPILER is created in the scripts depending on the variable ALPAKA_CI_CXX.
- Remove the environment variable CC completely because we do not compile C code.
- Set also CMAKE_CUDA_COMPILER as CMake configure argument manually.

Set `CMAKE_CUDA_COMPILER` as CMake argument was also necessary because of the changed behavior of setting the C++ compiler.