### PR TITLE
fix missing C++20 STL for ICPX in the CI

### DIFF
--- a/script/install_oneapi.sh
+++ b/script/install_oneapi.sh
@@ -41,6 +41,15 @@ then
     set +eu
     source /opt/intel/oneapi/setvars.sh
     set -eu
+
+    # Workaround if icpx uses the stdlibc++. The stdlibc++-9 does not support C++20, therefore we install the stdlibc++-11. Clang automatically uses the latest stdlibc++ version.
+    if [[ "$(cat /etc/os-release)" =~ "20.04" ]] && [ "${alpaka_CXX_STANDARD}" == "20" ];
+    then
+        travis_retry sudo apt install -y --no-install-recommends software-properties-common
+        sudo apt-add-repository ppa:ubuntu-toolchain-r/test -y
+        travis_retry sudo apt update
+        travis_retry sudo apt install -y --no-install-recommends g++-11
+    fi
 fi
 
 which "${CXX}"


### PR DESCRIPTION
fix #2321 