### PR TITLE
Suppress GCC warning about casting a function to void*

### DIFF
--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -182,7 +182,14 @@ namespace alpaka
         template<typename T>
         static inline Error_t funcGetAttributes(FuncAttributes_t* attr, T* func)
         {
+#    if BOOST_COMP_GNUC
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wconditionally-supported"
+#    endif
             return ::cudaFuncGetAttributes(attr, reinterpret_cast<void const*>(func));
+#    if BOOST_COMP_GNUC
+#        pragma GCC diagnostic pop
+#    endif
         }
 
         static inline Error_t getDeviceCount(int* count)

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -207,7 +207,14 @@ namespace alpaka
         template<typename T>
         static inline Error_t funcGetAttributes(FuncAttributes_t* attr, T* func)
         {
+#    if BOOST_COMP_GNUC
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wconditionally-supported"
+#    endif
             return ::hipFuncGetAttributes(attr, reinterpret_cast<void const*>(func));
+#    if BOOST_COMP_GNUC
+#        pragma GCC diagnostic pop
+#    endif
         }
 
         static inline Error_t getDeviceCount(int* count)


### PR DESCRIPTION
Suppress the `-Wconditionally-supported` GCC warning about

> casting between pointer-to-function and pointer-to-object is conditionally-supported

This is required to be supported by POSIX, and used extensively by dlsym(3).