### PR TITLE
Link `libcudart` even when `libcurand` is not used

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -542,9 +542,12 @@ if(alpaka_ACC_GPU_CUDA_ENABLE)
             endif()
         endif()
 
+        # Link the CUDA Runtime library
+        target_link_libraries(alpaka INTERFACE CUDA::cudart)
+
         if(NOT alpaka_DISABLE_VENDOR_RNG)
             # Use cuRAND random number generators
-            target_link_libraries(alpaka INTERFACE CUDA::cudart CUDA::curand)
+            target_link_libraries(alpaka INTERFACE CUDA::curand)
         endif()
     else()
         message(FATAL_ERROR "Optional alpaka dependency CUDA could not be found!")


### PR DESCRIPTION
Link the CUDA runtime library (`libcudart.so`) when compiling host code that uses CUDA, also when the cuRAND library (`libcurand.so`) is not used.