### PR TITLE
Re-enable the `KernelNoTemplateGpu` test

### DIFF
--- a/test/unit/kernel/src/KernelWithoutTemplatedAccParam.cpp
+++ b/test/unit/kernel/src/KernelWithoutTemplatedAccParam.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Axel Huebl, Benjamin Worpitz, Matthias Werner, Bernhard Manfred Gruber, Jan Stephan
+/* Copyright 2024 Axel Huebl, Benjamin Worpitz, Matthias Werner, Bernhard Manfred Gruber, Jan Stephan, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -6,23 +6,6 @@
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
 #include <catch2/catch_test_macros.hpp>
-
-//! It is not possible to use a alpaka kernel function object without a templated operator() when the CUDA accelerator
-//! is hard-coded.
-//!
-//! However, compiling such kernels with a CPU device works fine.
-//!
-//! When the CUDA accelerator is used, the following error is triggered:
-//! /alpaka/include/alpaka/workdiv/Traits.hpp(...): error: calling a __device__ function("getWorkDiv") from a __host__
-//! __device__ function("getWorkDiv") is not allowed The kernel function objects function call operator is attributed
-//! with ALPAKA_FN_ACC which is identical to __host__ __device__. The 'alpaka::getWorkDiv<...>(acc)' function that is
-//! called has the ALPAKA_FN_HOST_ACC attribute (also equal to __host__ __device__). The underlying trait calls the
-//! CUDA specialized method which has the __device__ attribute. Because this call chain does not contain any templates
-//! and therefore no calls depending on input types, everything can be resolved at the first time the template is
-//! parsed which results in the given error.
-//!
-//! Currently, the only possible way to solve this is to make the function call operator a template nonetheless by
-//! providing an unused template parameter.
 
 using Dim = alpaka::DimInt<2u>;
 using Idx = std::uint32_t;
@@ -56,15 +39,11 @@ TEST_CASE("kernelNoTemplateCpu", "[kernel]")
 }
 #endif
 
-/*#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA
-//! DO NOT ENABLE! COMPILATION WILL FAIL!
+#if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
 struct KernelNoTemplateGpu
 {
     ALPAKA_FN_ACC
-    auto operator()(
-        AccGpu const & acc,
-        bool* success) const
-    -> void
+    auto operator()(AccGpu const& acc, bool* success) const -> void
     {
         ALPAKA_CHECK(
             *success,
@@ -74,17 +53,16 @@ struct KernelNoTemplateGpu
 
 TEST_CASE("kernelNoTemplateGpu", "[kernel]")
 {
-    alpaka::test::KernelExecutionFixture<AccGpu> fixture(
-        alpaka::Vec<Dim, Idx>::ones());
+    alpaka::test::KernelExecutionFixture<AccGpu> fixture(alpaka::Vec<Dim, Idx>::ones());
 
     KernelNoTemplateGpu kernel;
 
     REQUIRE(fixture(kernel));
 }
-#endif*/
+#endif
 
 #if defined(ALPAKA_ACC_CPU_SERIAL_ENABLED)
-struct KernelWithoutTemplateParamCpu
+struct KernelUnusedTemplateParamCpu
 {
     template<typename TNotUsed = void>
     ALPAKA_FN_ACC auto operator()(AccCpu const& acc, bool* success) const -> void
@@ -95,18 +73,18 @@ struct KernelWithoutTemplateParamCpu
     }
 };
 
-TEST_CASE("kernelWithoutTemplateParamCpu", "[kernel]")
+TEST_CASE("kernelUnusedTemplateParamCpu", "[kernel]")
 {
     alpaka::test::KernelExecutionFixture<AccCpu> fixture(alpaka::Vec<Dim, Idx>::ones());
 
-    KernelWithoutTemplateParamCpu kernel;
+    KernelUnusedTemplateParamCpu kernel;
 
     REQUIRE(fixture(kernel));
 }
 #endif
 
 #if(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && BOOST_LANG_HIP)
-struct KernelWithoutTemplateParamGpu
+struct KernelUnusedTemplateParamGpu
 {
     template<typename TNotUsed = void>
     ALPAKA_FN_ACC auto operator()(AccGpu const& acc, bool* success) const -> void
@@ -117,11 +95,11 @@ struct KernelWithoutTemplateParamGpu
     }
 };
 
-TEST_CASE("kernelWithoutTemplateParamGpu", "[kernel]")
+TEST_CASE("kernelUnusedTemplateParamGpu", "[kernel]")
 {
     alpaka::test::KernelExecutionFixture<AccGpu> fixture(alpaka::Vec<Dim, Idx>::ones());
 
-    KernelWithoutTemplateParamGpu kernel;
+    KernelUnusedTemplateParamGpu kernel;
 
     REQUIRE(fixture(kernel));
 }


### PR DESCRIPTION
The test compiles and runs successfully with GCC 13 and CUDA 12.5.