### PR TITLE
fix complex math pow test

### DIFF
--- a/test/unit/math/src/TestTemplate.hpp
+++ b/test/unit/math/src/TestTemplate.hpp
@@ -177,7 +177,7 @@ namespace mathtest
             if(!isFinite(a) && !isFinite(b))
                 return true;
             // For the same reason use relative difference comparison with a large margin
-            auto const scalingFactor = static_cast<T>(std::is_same_v<T, float> ? 1.1e4 : 1.1e6);
+            auto const scalingFactor = static_cast<T>(std::is_same_v<T, float> ? 1.5e4 : 1.1e6);
             auto const marginValue = scalingFactor * std::numeric_limits<T>::epsilon();
             return (a.real() == Catch::Approx(b.real()).margin(marginValue).epsilon(marginValue))
                    && (a.imag() == Catch::Approx(b.imag()).margin(marginValue).epsilon(marginValue));


### PR DESCRIPTION
Increase the margin for results comparison for single precision floating point operations due to high computing error compared to `std::pow`.

With the seed `2913388561` for the pow complex math tests I was able to reproduce the reported issue. In general the calculation is correct but is slidly more off than our old margins allows.

fix issues seen here: https://github.com/alpaka-group/alpaka/pull/2327#issuecomment-2257873170