### PR TITLE
change `CreateTaskKernel` interface

### DIFF
--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -16,6 +16,7 @@
 #include "alpaka/idx/bt/IdxBtZero.hpp"
 #include "alpaka/idx/gb/IdxGbRef.hpp"
 #include "alpaka/intrinsic/IntrinsicCpu.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/math/MathStdLib.hpp"
 #include "alpaka/mem/fence/MemFenceOmp2Blocks.hpp"
 #include "alpaka/rand/RandDefault.hpp"
@@ -180,18 +181,20 @@ namespace alpaka
         };
 
         //! The CPU OpenMP 2.0 block accelerator execution task type trait specialization.
+        //!
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TWorkDiv The type of the work division.
+        //! \tparam TKernelFnObj Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-        struct CreateTaskKernel<AccCpuOmp2Blocks<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+        struct CreateTaskKernel<AccCpuOmp2Blocks<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
         {
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
-                TKernelFnObj const& kernelFnObj,
-                TArgs&&... args)
+                KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
             {
-                return TaskKernelCpuOmp2Blocks<TDim, TIdx, TKernelFnObj, TArgs...>(
-                    workDiv,
-                    kernelFnObj,
-                    std::forward<TArgs>(args)...);
+                return TaskKernelCpuOmp2Blocks<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
             }
         };
 

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -15,6 +15,7 @@
 #include "alpaka/idx/bt/IdxBtOmp.hpp"
 #include "alpaka/idx/gb/IdxGbRef.hpp"
 #include "alpaka/intrinsic/IntrinsicCpu.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/math/MathStdLib.hpp"
 #include "alpaka/mem/fence/MemFenceOmp2Threads.hpp"
 #include "alpaka/rand/RandDefault.hpp"
@@ -191,18 +192,20 @@ namespace alpaka
         };
 
         //! The CPU OpenMP 2.0 thread accelerator execution task type trait specialization.
+        //!
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TWorkDiv The type of the work division.
+        //! \tparam TKernelFnObj Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-        struct CreateTaskKernel<AccCpuOmp2Threads<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+        struct CreateTaskKernel<AccCpuOmp2Threads<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
         {
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
-                TKernelFnObj const& kernelFnObj,
-                TArgs&&... args)
+                KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
             {
-                return TaskKernelCpuOmp2Threads<TDim, TIdx, TKernelFnObj, TArgs...>(
-                    workDiv,
-                    kernelFnObj,
-                    std::forward<TArgs>(args)...);
+                return TaskKernelCpuOmp2Threads<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
             }
         };
 

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -15,6 +15,7 @@
 #include "alpaka/idx/bt/IdxBtZero.hpp"
 #include "alpaka/idx/gb/IdxGbRef.hpp"
 #include "alpaka/intrinsic/IntrinsicCpu.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/math/MathStdLib.hpp"
 #include "alpaka/mem/fence/MemFenceCpuSerial.hpp"
 #include "alpaka/rand/RandDefault.hpp"
@@ -174,18 +175,20 @@ namespace alpaka
         };
 
         //! The CPU serial accelerator execution task type trait specialization.
+        //!
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TWorkDiv The type of the work division.
+        //! \tparam TKernelFnObj Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-        struct CreateTaskKernel<AccCpuSerial<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+        struct CreateTaskKernel<AccCpuSerial<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
         {
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
-                TKernelFnObj const& kernelFnObj,
-                TArgs&&... args)
+                KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
             {
-                return TaskKernelCpuSerial<TDim, TIdx, TKernelFnObj, TArgs...>(
-                    workDiv,
-                    kernelFnObj,
-                    std::forward<TArgs>(args)...);
+                return TaskKernelCpuSerial<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
             }
         };
 

--- a/include/alpaka/acc/AccCpuSycl.hpp
+++ b/include/alpaka/acc/AccCpuSycl.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/core/Sycl.hpp"
 #include "alpaka/dev/DevCpuSycl.hpp"
 #include "alpaka/dev/Traits.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/kernel/TaskKernelCpuSycl.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/platform/PlatformCpuSycl.hpp"
@@ -57,15 +58,20 @@ namespace alpaka::trait
     };
 
     //! The CPU SYCL accelerator execution task type trait specialization.
+    //!
+    //! \tparam TDim The dimensionality of the accelerator device properties.
+    //! \tparam TIdx The idx type of the accelerator device properties.
+    //! \tparam TWorkDiv The type of the work division.
+    //! \tparam TKernelFnObj Kernel function object type.
+    //! \tparam TArgs Kernel function object argument types as a parameter pack.
     template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-    struct CreateTaskKernel<AccCpuSycl<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+    struct CreateTaskKernel<AccCpuSycl<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
     {
-        static auto createTaskKernel(TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST static auto createTaskKernel(
+            TWorkDiv const& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
         {
-            return TaskKernelCpuSycl<TDim, TIdx, TKernelFnObj, TArgs...>{
-                workDiv,
-                kernelFnObj,
-                std::forward<TArgs>(args)...};
+            return TaskKernelCpuSycl<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
         }
     };
 

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -16,6 +16,7 @@
 #include "alpaka/idx/bt/IdxBtZero.hpp"
 #include "alpaka/idx/gb/IdxGbRef.hpp"
 #include "alpaka/intrinsic/IntrinsicCpu.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/math/MathStdLib.hpp"
 #include "alpaka/mem/fence/MemFenceCpu.hpp"
 #include "alpaka/rand/RandDefault.hpp"
@@ -172,18 +173,20 @@ namespace alpaka
         };
 
         //! The CPU TBB block accelerator execution task type trait specialization.
+        //!
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TWorkDiv The type of the work division.
+        //! \tparam TKernelFnObj Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-        struct CreateTaskKernel<AccCpuTbbBlocks<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+        struct CreateTaskKernel<AccCpuTbbBlocks<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
         {
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
-                TKernelFnObj const& kernelFnObj,
-                TArgs&&... args)
+                KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
             {
-                return TaskKernelCpuTbbBlocks<TDim, TIdx, TKernelFnObj, TArgs...>(
-                    workDiv,
-                    kernelFnObj,
-                    std::forward<TArgs>(args)...);
+                return TaskKernelCpuTbbBlocks<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
             }
         };
 

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -14,6 +14,7 @@
 #include "alpaka/idx/bt/IdxBtRefThreadIdMap.hpp"
 #include "alpaka/idx/gb/IdxGbRef.hpp"
 #include "alpaka/intrinsic/IntrinsicCpu.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/math/MathStdLib.hpp"
 #include "alpaka/mem/fence/MemFenceCpu.hpp"
 #include "alpaka/rand/RandDefault.hpp"
@@ -198,19 +199,21 @@ namespace alpaka
             using type = TDim;
         };
 
-        //! The CPU threads accelerator execution task type trait specialization.
+        //! The CPU serial accelerator execution task type trait specialization.
+        //!
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TWorkDiv The type of the work division.
+        //! \tparam TKernelFnObj Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
         template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-        struct CreateTaskKernel<AccCpuThreads<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+        struct CreateTaskKernel<AccCpuThreads<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
         {
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
-                TKernelFnObj const& kernelFnObj,
-                TArgs&&... args)
+                KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
             {
-                return TaskKernelCpuThreads<TDim, TIdx, TKernelFnObj, TArgs...>(
-                    workDiv,
-                    kernelFnObj,
-                    std::forward<TArgs>(args)...);
+                return TaskKernelCpuThreads<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
             }
         };
 

--- a/include/alpaka/acc/AccFpgaSyclIntel.hpp
+++ b/include/alpaka/acc/AccFpgaSyclIntel.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/core/Sycl.hpp"
 #include "alpaka/dev/DevFpgaSyclIntel.hpp"
 #include "alpaka/dev/Traits.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/kernel/TaskKernelFpgaSyclIntel.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/platform/PlatformFpgaSyclIntel.hpp"
@@ -57,15 +58,20 @@ namespace alpaka::trait
     };
 
     //! The Intel FPGA SYCL accelerator execution task type trait specialization.
+    //!
+    //! \tparam TDim The dimensionality of the accelerator device properties.
+    //! \tparam TIdx The idx type of the accelerator device properties.
+    //! \tparam TWorkDiv The type of the work division.
+    //! \tparam TKernelFnObj Kernel function object type.
+    //! \tparam TArgs Kernel function object argument types as a parameter pack.
     template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-    struct CreateTaskKernel<AccFpgaSyclIntel<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+    struct CreateTaskKernel<AccFpgaSyclIntel<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
     {
-        static auto createTaskKernel(TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST static auto createTaskKernel(
+            TWorkDiv const& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
         {
-            return TaskKernelFpgaSyclIntel<TDim, TIdx, TKernelFnObj, TArgs...>{
-                workDiv,
-                kernelFnObj,
-                std::forward<TArgs>(args)...};
+            return TaskKernelFpgaSyclIntel<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
         }
     };
 

--- a/include/alpaka/acc/AccGpuSyclIntel.hpp
+++ b/include/alpaka/acc/AccGpuSyclIntel.hpp
@@ -11,6 +11,7 @@
 #include "alpaka/core/Sycl.hpp"
 #include "alpaka/dev/DevGpuSyclIntel.hpp"
 #include "alpaka/dev/Traits.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/kernel/TaskKernelGpuSyclIntel.hpp"
 #include "alpaka/kernel/Traits.hpp"
 #include "alpaka/platform/PlatformGpuSyclIntel.hpp"
@@ -57,15 +58,20 @@ namespace alpaka::trait
     };
 
     //! The Intel GPU SYCL accelerator execution task type trait specialization.
+    //!
+    //! \tparam TDim The dimensionality of the accelerator device properties.
+    //! \tparam TIdx The idx type of the accelerator device properties.
+    //! \tparam TWorkDiv The type of the work division.
+    //! \tparam TKernelFnObj Kernel function object type.
+    //! \tparam TArgs Kernel function object argument types as a parameter pack.
     template<typename TDim, typename TIdx, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
-    struct CreateTaskKernel<AccGpuSyclIntel<TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+    struct CreateTaskKernel<AccGpuSyclIntel<TDim, TIdx>, TWorkDiv, KernelBundle<TKernelFnObj, TArgs...>>
     {
-        static auto createTaskKernel(TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST static auto createTaskKernel(
+            TWorkDiv const& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
         {
-            return TaskKernelGpuSyclIntel<TDim, TIdx, TKernelFnObj, TArgs...>{
-                workDiv,
-                kernelFnObj,
-                std::forward<TArgs>(args)...};
+            return TaskKernelGpuSyclIntel<TDim, TIdx, TKernelFnObj, TArgs...>(workDiv, kernelBundle);
         }
     };
 

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -14,6 +14,7 @@
 #include "alpaka/idx/bt/IdxBtUniformCudaHipBuiltIn.hpp"
 #include "alpaka/idx/gb/IdxGbUniformCudaHipBuiltIn.hpp"
 #include "alpaka/intrinsic/IntrinsicUniformCudaHipBuiltIn.hpp"
+#include "alpaka/kernel/KernelBundle.hpp"
 #include "alpaka/math/MathUniformCudaHipBuiltIn.hpp"
 #include "alpaka/mem/fence/MemFenceUniformCudaHipBuiltIn.hpp"
 #include "alpaka/rand/RandDefault.hpp"
@@ -264,6 +265,13 @@ namespace alpaka
     namespace trait
     {
         //! The GPU CUDA accelerator execution task type trait specialization.
+        //!
+        //! \tparam TApi The type the API of the GPU accelerator backend. Currently Cuda or Hip.
+        //! \tparam TDim The dimensionality of the accelerator device properties.
+        //! \tparam TIdx The idx type of the accelerator device properties.
+        //! \tparam TWorkDiv The type of the work division.
+        //! \tparam TKernelFnObj Kernel function object type.
+        //! \tparam TArgs Kernel function object argument types as a parameter pack.
         template<
             typename TApi,
             typename TDim,
@@ -271,12 +279,15 @@ namespace alpaka
             typename TWorkDiv,
             typename TKernelFnObj,
             typename... TArgs>
-        struct CreateTaskKernel<AccGpuUniformCudaHipRt<TApi, TDim, TIdx>, TWorkDiv, TKernelFnObj, TArgs...>
+        struct CreateTaskKernel<
+            AccGpuUniformCudaHipRt<TApi, TDim, TIdx>,
+            TWorkDiv,
+            KernelBundle<TKernelFnObj, TArgs...>>
         {
             ALPAKA_FN_HOST static auto createTaskKernel(
                 TWorkDiv const& workDiv,
-                TKernelFnObj const& kernelFnObj,
-                TArgs&&... args)
+
+                KernelBundle<TKernelFnObj, TArgs...> const& kernelBundle)
             {
                 return TaskKernelGpuUniformCudaHipRt<
                     TApi,
@@ -284,7 +295,7 @@ namespace alpaka
                     TDim,
                     TIdx,
                     TKernelFnObj,
-                    TArgs...>(workDiv, kernelFnObj, std::forward<TArgs>(args)...);
+                    TArgs...>(workDiv, kernelBundle);
             }
         };
 

--- a/include/alpaka/kernel/KernelBundle.hpp
+++ b/include/alpaka/kernel/KernelBundle.hpp
@@ -32,7 +32,6 @@ namespace alpaka
         {
         }
 
-    private:
         KernelFn m_kernelFn;
         ArgTuple m_args; // Store the argument types without const and reference
     };

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -789,10 +789,12 @@ namespace alpaka
     {
     public:
         template<typename TWorkDiv>
-        ALPAKA_FN_HOST TaskKernelCpuOmp2Blocks(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST TaskKernelCpuOmp2Blocks(
+            TWorkDiv&& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& KernelBundle)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj(kernelFnObj)
-            , m_args(std::forward<TArgs>(args)...)
+            , m_kernelFnObj(KernelBundle.m_kernelFn)
+            , m_args(KernelBundle.m_args)
         {
             static_assert(
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Threads.hpp
@@ -46,10 +46,12 @@ namespace alpaka
     {
     public:
         template<typename TWorkDiv>
-        ALPAKA_FN_HOST TaskKernelCpuOmp2Threads(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST TaskKernelCpuOmp2Threads(
+            TWorkDiv&& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& KernelBundle)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj(kernelFnObj)
-            , m_args(std::forward<TArgs>(args)...)
+            , m_kernelFnObj(KernelBundle.m_kernelFn)
+            , m_args(KernelBundle.m_args)
         {
             static_assert(
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -40,10 +40,12 @@ namespace alpaka
     {
     public:
         template<typename TWorkDiv>
-        ALPAKA_FN_HOST TaskKernelCpuSerial(TWorkDiv&& workDiv, TKernelFnObj kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST TaskKernelCpuSerial(
+            TWorkDiv&& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& KernelBundle)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj(std::move(kernelFnObj))
-            , m_args(std::forward<TArgs>(args)...)
+            , m_kernelFnObj(KernelBundle.m_kernelFn)
+            , m_args(KernelBundle.m_args)
         {
             static_assert(
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -45,10 +45,12 @@ namespace alpaka
     {
     public:
         template<typename TWorkDiv>
-        ALPAKA_FN_HOST TaskKernelCpuTbbBlocks(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST TaskKernelCpuTbbBlocks(
+            TWorkDiv&& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& KernelBundle)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj(kernelFnObj)
-            , m_args(std::forward<TArgs>(args)...)
+            , m_kernelFnObj(KernelBundle.m_kernelFn)
+            , m_args(KernelBundle.m_args)
         {
             static_assert(
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,

--- a/include/alpaka/kernel/TaskKernelCpuThreads.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuThreads.hpp
@@ -51,11 +51,12 @@ namespace alpaka
 
     public:
         template<typename TWorkDiv>
-        ALPAKA_FN_HOST TaskKernelCpuThreads(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        ALPAKA_FN_HOST TaskKernelCpuThreads(
+            TWorkDiv&& workDiv,
+            KernelBundle<TKernelFnObj, TArgs...> const& KernelBundle)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj(kernelFnObj)
-            , m_args(std::forward<TArgs>(
-                  args)...) // FIXME(bgruber): this does not forward, since TArgs is not a deduced template parameter
+            , m_kernelFnObj(KernelBundle.m_kernelFn)
+            , m_args(KernelBundle.m_args)
         {
             static_assert(
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,

--- a/include/alpaka/kernel/TaskKernelGenericSycl.hpp
+++ b/include/alpaka/kernel/TaskKernelGenericSycl.hpp
@@ -78,10 +78,10 @@ namespace alpaka
         static_assert(TDim::value > 0 && TDim::value <= 3, "Invalid kernel dimensionality");
 
         template<typename TWorkDiv>
-        TaskKernelGenericSycl(TWorkDiv&& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        TaskKernelGenericSycl(TWorkDiv&& workDiv, KernelBundle<TKernelFnObj, TArgs...> const& KernelBundle)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj{kernelFnObj}
-            , m_args{std::forward<TArgs>(args)...}
+            , m_kernelFnObj(KernelBundle.m_kernelFn)
+            , m_args(KernelBundle.m_args)
         {
         }
 

--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -125,11 +125,10 @@ namespace alpaka
         template<typename TWorkDiv>
         ALPAKA_FN_HOST TaskKernelGpuUniformCudaHipRt(
             TWorkDiv&& workDiv,
-            TKernelFnObj const& kernelFnObj,
-            TArgs&&... args)
+            KernelBundle<TKernelFnObj, TArgs...> const& KernelBundle)
             : WorkDivMembers<TDim, TIdx>(std::forward<TWorkDiv>(workDiv))
-            , m_kernelFnObj(kernelFnObj)
-            , m_args(std::forward<TArgs>(args)...)
+            , m_kernelFnObj(KernelBundle.m_kernelFn)
+            , m_args(KernelBundle.m_args)
         {
             static_assert(
                 Dim<std::decay_t<TWorkDiv>>::value == TDim::value,


### PR DESCRIPTION
Use `KernelBundle` for task kernel creation.

This is the first part of the split PR #2318