### PR TITLE
refactor examples/tests + additional `alpaka::exec()` interface

### DIFF
--- a/docs/source/basic/cheatsheet.rst
+++ b/docs/source/basic/cheatsheet.rst
@@ -181,7 +181,7 @@ Prepare Kernel Bundle
 
      HeatEquationKernel heatEqKernel;
      // Arguments of KernelBundle: The kernel instance and the kernel arguments
-     auto const& bundeledKernel = alpaka::KernelBundle(heatEqKernel, pCurrAcc, pNextAcc, numNodesX, dx, dt);
+     auto const& kernelBundle = alpaka::KernelBundle(heatEqKernel, pCurrAcc, pNextAcc, numNodesX, dx, dt);
 
 Automatically select a valid kernel launch configuration
   .. code-block:: c++
@@ -191,7 +191,7 @@ Automatically select a valid kernel launch configuration
 
      auto autoWorkDiv = getValidWorkDivForKernel<Acc>(
        device,
-       bundeledKernel,
+       kernelBundle,
        globalThreadExtent, elementsPerThread,
        false,
        GridBlockExtentSubDivRestrictions::Unrestricted);

--- a/example/complex/src/complex.cpp
+++ b/example/complex/src/complex.cpp
@@ -56,15 +56,14 @@ auto example(TAccTag const&) -> int
     Idx const threadsPerGrid = 1u;
     Idx const elementsPerThread = 1u;
 
-    ComplexKernel complexKernel;
+    alpaka::KernelBundle kernelBundle = ComplexKernel{};
 
-    auto const& bundeledKernel = alpaka::KernelBundle(complexKernel);
     // Let alpaka calculate good block and grid sizes given our full problem extent
     auto const workDiv
-        = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, threadsPerGrid, elementsPerThread);
+        = alpaka::getValidWorkDivForKernel<Acc>(devAcc, kernelBundle, threadsPerGrid, elementsPerThread);
 
     // Run the kernel
-    alpaka::exec<Acc>(queue, workDiv, complexKernel);
+    alpaka::exec<Acc>(queue, workDiv, kernelBundle);
     alpaka::wait(queue);
 
     // Usage of alpaka::Complex<T> on the host side is the same as inside kernels, except math functions are not

--- a/example/conv2DWithMdspan/src/conv2DWithMdspan.cpp
+++ b/example/conv2DWithMdspan/src/conv2DWithMdspan.cpp
@@ -148,24 +148,18 @@ auto example(TAccTag const&) -> int
     ConvolutionKernelMdspan2D convolutionKernel2D;
 
     // Make a bundle
-    auto const& bundeledKernel = alpaka::KernelBundle(
+    auto const& kernelBundle = alpaka::KernelBundle(
         convolutionKernel2D,
         alpaka::experimental::getMdSpan(bufInputAcc),
         alpaka::experimental::getMdSpan(outputDeviceMemory),
         alpaka::experimental::getMdSpan(bufFilterAcc));
 
     //   Let alpaka calculate good block and grid sizes given our full problem extent.
-    auto const workDiv = alpaka::getValidWorkDivForKernel<DevAcc>(devAcc, bundeledKernel, extent, Vec::ones());
+    auto const workDiv = alpaka::getValidWorkDivForKernel<DevAcc>(devAcc, kernelBundle, extent, Vec::ones());
 
 
     // Run the kernel, pass 3 arrays as 2D mdspans
-    alpaka::exec<DevAcc>(
-        queueAcc,
-        workDiv,
-        convolutionKernel2D,
-        alpaka::experimental::getMdSpan(bufInputAcc),
-        alpaka::experimental::getMdSpan(outputDeviceMemory),
-        alpaka::experimental::getMdSpan(bufFilterAcc));
+    alpaka::exec<DevAcc>(queueAcc, workDiv, kernelBundle);
 
     // Allocate memory on host to receive the resulting matrix as an array
     auto resultGpuHost = alpaka::allocBuf<DataType, Idx>(devHost, extent);

--- a/example/convolution1D/src/convolution1D.cpp
+++ b/example/convolution1D/src/convolution1D.cpp
@@ -140,7 +140,7 @@ auto example(TAccTag const&) -> int
     DataType* nativeInputDeviceMemory = std::data(inputDeviceMemory);
     DataType* nativeOutputDeviceMemory = std::data(outputDeviceMemory);
 
-    auto const& bundeledKernel = alpaka::KernelBundle(
+    auto const& kernelBundle = alpaka::KernelBundle(
         convolutionKernel,
         nativeInputDeviceMemory,
         nativeFilterDeviceMemory,
@@ -150,17 +150,9 @@ auto example(TAccTag const&) -> int
 
     // Let alpaka calculate good block and grid sizes given our full problem extent
     auto const workDiv
-        = alpaka::getValidWorkDivForKernel<DevAcc>(devAcc, bundeledKernel, threadsPerGrid, elementsPerThread);
+        = alpaka::getValidWorkDivForKernel<DevAcc>(devAcc, kernelBundle, threadsPerGrid, elementsPerThread);
     // Run the kernel
-    alpaka::exec<DevAcc>(
-        queue,
-        workDiv,
-        convolutionKernel,
-        nativeInputDeviceMemory,
-        nativeFilterDeviceMemory,
-        nativeOutputDeviceMemory,
-        inputSize,
-        filterSize);
+    alpaka::exec<DevAcc>(queue, workDiv, kernelBundle);
 
     // Allocate memory on host
     auto resultGpuHost = alpaka::allocBuf<DataType, Idx>(devHost, inputSize);

--- a/example/counterBasedRng/src/counterBasedRng.cpp
+++ b/example/counterBasedRng/src/counterBasedRng.cpp
@@ -147,27 +147,19 @@ auto example(TAccTag const&) -> int
     BufAcc bufAcc(alpaka::allocBuf<Data, Idx>(devAcc, extent));
 
     CounterBasedRngKernel counterBasedRngKernel;
-    auto const& bundeledKernel
+    auto const& kernelBundleAcc
         = alpaka::KernelBundle(counterBasedRngKernel, alpaka::experimental::getMdSpan(bufAcc), key);
-    auto const& bundeledKernel2
+    auto const& kernelBundleHost
         = alpaka::KernelBundle(counterBasedRngKernel, alpaka::experimental::getMdSpan(bufHost), key);
 
     // Let alpaka calculate good block and grid sizes given our full problem extent
-    auto const workDivAcc = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, extent, elementsPerThread);
+    auto const workDivAcc = alpaka::getValidWorkDivForKernel<Acc>(devAcc, kernelBundleAcc, extent, elementsPerThread);
     auto const workDivHost
-        = alpaka::getValidWorkDivForKernel<AccHost>(devHost, bundeledKernel2, extent, elementsPerThreadHost);
+        = alpaka::getValidWorkDivForKernel<AccHost>(devHost, kernelBundleHost, extent, elementsPerThreadHost);
 
     // Create the kernel execution task.
-    auto const taskKernelAcc = alpaka::createTaskKernel<Acc>(
-        workDivAcc,
-        CounterBasedRngKernel(),
-        alpaka::experimental::getMdSpan(bufAcc),
-        key);
-    auto const taskKernelHost = alpaka::createTaskKernel<AccHost>(
-        workDivHost,
-        CounterBasedRngKernel(),
-        alpaka::experimental::getMdSpan(bufHost),
-        key);
+    auto const taskKernelAcc = alpaka::createTaskKernel<Acc>(workDivAcc, kernelBundleAcc);
+    auto const taskKernelHost = alpaka::createTaskKernel<AccHost>(workDivHost, kernelBundleHost);
 
     // Enqueue the kernel execution task
     alpaka::enqueue(queueHost, taskKernelHost);

--- a/example/heatEquation/src/heatEquation.cpp
+++ b/example/heatEquation/src/heatEquation.cpp
@@ -134,9 +134,9 @@ auto example(TAccTag const&) -> int
 
     HeatEquationKernel heatEqKernel;
 
-    auto const& bundeledKernel = alpaka::KernelBundle(heatEqKernel, pCurrAcc, pNextAcc, numNodesX, dx, dt);
+    auto const& kernelBundle = alpaka::KernelBundle(heatEqKernel, pCurrAcc, pNextAcc, numNodesX, dx, dt);
     // Let alpaka calculate good block and grid sizes given our full problem extent
-    auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, extent, elemPerThread);
+    auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(devAcc, kernelBundle, extent, elemPerThread);
 
     // Copy host -> device
     alpaka::memcpy(queue, uCurrBufAcc, uCurrBufHost);

--- a/example/helloWorld/src/helloWorld.cpp
+++ b/example/helloWorld/src/helloWorld.cpp
@@ -133,12 +133,11 @@ auto example(TAccTag const&) -> int
     // Kernels can be everything that is trivially copyable, has a
     // callable operator() and takes the accelerator as first
     // argument. So a kernel can be a class or struct, a lambda, etc.
-    HelloWorldKernel helloWorldKernel;
+    alpaka::KernelBundle kernelBundle = HelloWorldKernel{};
 
-    auto const& bundeledKernel = alpaka::KernelBundle(helloWorldKernel);
     // Let alpaka calculate good block and grid sizes given our full problem extent
     auto const workDiv
-        = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, threadsPerGrid, elementsPerThread);
+        = alpaka::getValidWorkDivForKernel<Acc>(devAcc, kernelBundle, threadsPerGrid, elementsPerThread);
 
     // Run the kernel
     //
@@ -149,11 +148,7 @@ auto example(TAccTag const&) -> int
     // The queue can be blocking or non-blocking
     // depending on the chosen queue type (see type definitions above).
     // Here it is synchronous which means that the kernel is directly executed.
-    alpaka::exec<Acc>(
-        queue,
-        workDiv,
-        helloWorldKernel
-        /* put kernel arguments here */);
+    alpaka::exec<Acc>(queue, workDiv, kernelBundle);
     alpaka::wait(queue);
 
     return EXIT_SUCCESS;

--- a/example/helloWorldLambda/src/helloWorldLambda.cpp
+++ b/example/helloWorldLambda/src/helloWorldLambda.cpp
@@ -117,12 +117,12 @@ auto example(TAccTag const&) -> int
         printf("\n");
     };
 
-    auto const& bundeledKernel = alpaka::KernelBundle(kernelLambda, nExclamationMarks);
+    auto const& kernelBundle = alpaka::KernelBundle(kernelLambda, nExclamationMarks);
     // Let alpaka calculate good block and grid sizes given our full problem extent
     auto const workDiv
-        = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, threadsPerGrid, elementsPerThread);
+        = alpaka::getValidWorkDivForKernel<Acc>(devAcc, kernelBundle, threadsPerGrid, elementsPerThread);
 
-    alpaka::exec<Acc>(queue, workDiv, kernelLambda, nExclamationMarks);
+    alpaka::exec<Acc>(queue, workDiv, kernelBundle);
     alpaka::wait(queue);
 
     return EXIT_SUCCESS;

--- a/example/kernelSpecialization/src/kernelSpecialization.cpp
+++ b/example/kernelSpecialization/src/kernelSpecialization.cpp
@@ -79,15 +79,14 @@ auto example(TAccTag const&) -> int
     // Define the work division
     std::size_t const threadsPerGrid = 16u;
     std::size_t const elementsPerThread = 1u;
-    Kernel kernel;
+    alpaka::KernelBundle kernelBundle = Kernel{};
 
-    auto const& bundeledKernel = alpaka::KernelBundle(kernel);
     // Let alpaka calculate good block and grid sizes given our full problem extent
     auto const workDiv
-        = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, threadsPerGrid, elementsPerThread);
+        = alpaka::getValidWorkDivForKernel<Acc>(devAcc, kernelBundle, threadsPerGrid, elementsPerThread);
 
     // Run the kernel
-    alpaka::exec<Acc>(queue, workDiv, kernel);
+    alpaka::exec<Acc>(queue, workDiv, kernelBundle);
     alpaka::wait(queue);
 
     return EXIT_SUCCESS;

--- a/example/matrixMulWithMdspan/src/matrixMulMdSpan.cpp
+++ b/example/matrixMulWithMdspan/src/matrixMulMdSpan.cpp
@@ -147,19 +147,19 @@ auto example(TAccTag const&) -> int
     auto mdDevC = alpaka::experimental::getMdSpan(bufDevC);
 
     MatrixMulKernel kernel;
-    auto const& bundeledKernel = alpaka::KernelBundle(kernel, mdDevA, mdDevB, mdDevC);
+    auto const& kernelBundle = alpaka::KernelBundle(kernel, mdDevA, mdDevB, mdDevC);
 
     // Let alpaka calculate good block and grid sizes given our full problem extent
     auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(
         devAcc,
-        bundeledKernel,
+        kernelBundle,
         extentC,
         Vec::ones(),
         false,
         alpaka::GridBlockExtentSubDivRestrictions::Unrestricted);
 
     // Execute the kernel
-    alpaka::exec<Acc>(queue, workDiv, MatrixMulKernel{}, mdDevA, mdDevB, mdDevC);
+    alpaka::exec<Acc>(queue, workDiv, kernelBundle);
 
     // Copy result back to host
     alpaka::memcpy(queue, bufHostC, bufDevC);

--- a/example/monteCarloIntegration/src/monteCarloIntegration.cpp
+++ b/example/monteCarloIntegration/src/monteCarloIntegration.cpp
@@ -113,15 +113,15 @@ auto example(TAccTag const&) -> int
     alpaka::memcpy(queue, bufAcc, bufHost);
 
     Kernel kernel;
-    auto const& bundeledKernel = alpaka::KernelBundle(kernel, numPoints, ptrBufAcc, Function{});
+    auto const& kernelBundle = alpaka::KernelBundle(kernel, numPoints, ptrBufAcc, Function{});
     // Let alpaka calculate good block and grid sizes given our full problem extent
     auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(
         devAcc,
-        bundeledKernel,
+        kernelBundle,
         Vec(numThreads),
         Vec(numAlpakaElementsPerThread));
 
-    alpaka::exec<Acc>(queue, workDiv, kernel, numPoints, ptrBufAcc, Function{});
+    alpaka::exec<Acc>(queue, workDiv, kernelBundle);
     alpaka::memcpy(queue, bufHost, bufAcc);
     alpaka::wait(queue);
 

--- a/example/openMPSchedule/src/openMPSchedule.cpp
+++ b/example/openMPSchedule/src/openMPSchedule.cpp
@@ -107,25 +107,25 @@ auto main() -> int
     Idx const threadsPerGrid = 16u;
     Idx const elementsPerThread = 1u;
 
-    OpenMPScheduleDefaultKernel openMPScheduleDefaultKernel;
-    auto const& bundeledKernel = alpaka::KernelBundle(openMPScheduleDefaultKernel);
+    alpaka::KernelBundle kernelBundle = OpenMPScheduleDefaultKernel{};
+
     // Let alpaka calculate good block and grid sizes given our full problem extent
     auto const workDiv
-        = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, threadsPerGrid, elementsPerThread);
+        = alpaka::getValidWorkDivForKernel<Acc>(devAcc, kernelBundle, threadsPerGrid, elementsPerThread);
 
     // Run the kernel setting no schedule explicitly.
     std::cout << "OpenMPScheduleDefaultKernel setting no schedule explicitly:\n";
-    alpaka::exec<Acc>(queue, workDiv, openMPScheduleDefaultKernel);
+    alpaka::exec<Acc>(queue, workDiv, kernelBundle);
     alpaka::wait(queue);
 
     // Run the kernel setting the schedule via a trait
     std::cout << "\n\nOpenMPScheduleMemberKernel setting the schedule via a static member:\n";
-    alpaka::exec<Acc>(queue, workDiv, OpenMPScheduleMemberKernel{});
+    alpaka::exec<Acc>(queue, workDiv, kernelBundle);
     alpaka::wait(queue);
 
     // Run the kernel setting the schedule via a trait
     std::cout << "\n\nOpenMPScheduleTraitKernel setting the schedule via trait:\n";
-    alpaka::exec<Acc>(queue, workDiv, OpenMPScheduleTraitKernel{});
+    alpaka::exec<Acc>(queue, workDiv, kernelBundle);
     alpaka::wait(queue);
 
     return EXIT_SUCCESS;

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -130,23 +130,17 @@ auto example(TAccTag const&) -> int
     // Instantiate the kernel function object
     VectorAddKernel kernel;
 
-    auto const& bundeledKernel = alpaka::KernelBundle(
+    auto const& kernelBundle = alpaka::KernelBundle(
         kernel,
         alpaka::getPtrNative(bufAccA),
         alpaka::getPtrNative(bufAccB),
         alpaka::getPtrNative(bufAccC),
         numElements);
     // Let alpaka calculate good block and grid sizes given our full problem extent
-    auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, extent, elementsPerThread);
+    auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(devAcc, kernelBundle, extent, elementsPerThread);
 
     // Create the kernel execution task.
-    auto const taskKernel = alpaka::createTaskKernel<Acc>(
-        workDiv,
-        kernel,
-        std::data(bufAccA),
-        std::data(bufAccB),
-        std::data(bufAccC),
-        numElements);
+    auto const& taskKernel = alpaka::createTaskKernel<Acc>(workDiv, kernelBundle);
 
     // Enqueue the kernel execution task
     {

--- a/include/alpaka/kernel/KernelBundle.hpp
+++ b/include/alpaka/kernel/KernelBundle.hpp
@@ -32,7 +32,6 @@ namespace alpaka
         {
         }
 
-    private:
         KernelFn m_kernelFn;
         ArgTuple m_args; // Store the argument types without const and reference
     };

--- a/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/include/alpaka/test/KernelExecutionFixture.hpp
@@ -69,21 +69,22 @@ namespace alpaka::test
             memset(m_queue, bufAccResult, static_cast<std::uint8_t>(true));
 
 
-            auto bundeledKernel = alpaka::KernelBundle<TKernelFnObj, decltype(getPtrNative(bufAccResult)), TArgs...>(
-                kernelFnObj,
-                getPtrNative(bufAccResult),
-                std::forward<TArgs>(args)...);
+            auto const& kernelBundle
+                = alpaka::KernelBundle<TKernelFnObj, decltype(getPtrNative(bufAccResult)), TArgs...>(
+                    kernelFnObj,
+                    getPtrNative(bufAccResult),
+                    std::forward<TArgs>(args)...);
 
 
             // set workdiv if it is not before
             if(m_workDiv == WorkDiv{Vec<Dim, Idx>::all(0), Vec<Dim, Idx>::all(0), Vec<Dim, Idx>::all(0)})
                 m_workDiv = alpaka::getValidWorkDivForKernel<Acc, Dev<Acc>>(
                     m_device,
-                    bundeledKernel,
+                    kernelBundle,
                     m_extent,
                     Vec<Dim, Idx>::ones());
 
-            exec<Acc>(m_queue, m_workDiv, kernelFnObj, getPtrNative(bufAccResult), std::forward<TArgs>(args)...);
+            exec<Acc>(m_queue, m_workDiv, kernelBundle);
 
             // Copy the result value to the host
             auto bufHostResult = allocBuf<bool, Idx>(m_devHost, static_cast<Idx>(1u));

--- a/test/integ/axpy/src/axpy.cpp
+++ b/test/integ/axpy/src/axpy.cpp
@@ -91,7 +91,6 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
 
     // Get a queue on this device.
     QueueAcc queue(devAcc);
-
     alpaka::Vec<Dim, Idx> const extent(numElements);
 
     // Allocate host memory buffers in pinned memory.
@@ -146,13 +145,12 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
     std::cout << std::endl;
 #endif
 
-
-    auto const& bundeledKernel
+    auto const& kernelBundle
         = alpaka::KernelBundle(kernel, numElements, alpha, std::data(memBufAccX), std::data(memBufAccY));
     // Let alpaka calculate good block and grid sizes given our full problem extent
     auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(
         devAcc,
-        bundeledKernel,
+        kernelBundle,
         extent,
         static_cast<Idx>(3u),
         false,
@@ -164,13 +162,7 @@ TEMPLATE_LIST_TEST_CASE("axpy", "[axpy]", TestAccs)
               << std::endl;
 
     // Create the kernel execution task.
-    auto const taskKernel = alpaka::createTaskKernel<Acc>(
-        workDiv,
-        kernel,
-        numElements,
-        alpha,
-        std::data(memBufAccX),
-        std::data(memBufAccY));
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(workDiv, kernelBundle);
 
     // Profile the kernel execution.
     std::cout << "Execution time: " << alpaka::test::integ::measureTaskRunTimeMs(queue, taskKernel) << " ms"

--- a/test/integ/mandelbrot/src/mandelbrot.cpp
+++ b/test/integ/mandelbrot/src/mandelbrot.cpp
@@ -307,7 +307,7 @@ TEMPLATE_LIST_TEST_CASE("mandelbrot", "[mandelbrot]", TestAccs)
     auto const [rowPitch, _] = alpaka::getPitchesInBytes(bufColorAcc);
     CHECK(rowPitch % sizeof(Val) == 0);
 
-    auto const& bundeledKernel = alpaka::KernelBundle(
+    auto const& kernelBundle = alpaka::KernelBundle(
         kernel,
         std::data(bufColorAcc),
         numRows,
@@ -321,7 +321,7 @@ TEMPLATE_LIST_TEST_CASE("mandelbrot", "[mandelbrot]", TestAccs)
     // Let alpaka calculate good block and grid sizes given our full problem extent
     auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(
         devAcc,
-        bundeledKernel,
+        kernelBundle,
         extent,
         alpaka::Vec<Dim, Idx>::ones(),
         false,
@@ -334,19 +334,7 @@ TEMPLATE_LIST_TEST_CASE("mandelbrot", "[mandelbrot]", TestAccs)
               << ", kernel: " << alpaka::core::demangled<decltype(kernel)> << ", workDiv: " << workDiv << ")"
               << std::endl;
 
-
-    auto const taskKernel = alpaka::createTaskKernel<Acc>(
-        workDiv,
-        kernel,
-        std::data(bufColorAcc),
-        numRows,
-        numCols,
-        rowPitch,
-        fMinR,
-        fMaxR,
-        fMinI,
-        fMaxI,
-        maxIterations);
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(workDiv, kernelBundle);
 
     // Profile the kernel execution.
     std::cout << "Execution time: " << alpaka::test::integ::measureTaskRunTimeMs(queue, taskKernel) << " ms"

--- a/test/integ/matMul/src/matMul.cpp
+++ b/test/integ/matMul/src/matMul.cpp
@@ -244,7 +244,7 @@ TEMPLATE_LIST_TEST_CASE("matMul", "[matMul]", TestAccs)
     std::cout << "pitchesC " << alpaka::getPitchesInBytes(bufCAcc) << " ldc: " << ldc << "\n";
 
 
-    auto const& bundeledKernel = alpaka::KernelBundle(
+    auto const& kernelBundle = alpaka::KernelBundle(
         kernel,
         m,
         n,
@@ -260,7 +260,7 @@ TEMPLATE_LIST_TEST_CASE("matMul", "[matMul]", TestAccs)
     // Let alpaka calculate good block and grid sizes given our full problem extent
     auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(
         devAcc,
-        bundeledKernel,
+        kernelBundle,
         extentC,
         alpaka::Vec<Dim, Idx>::ones(),
         false,
@@ -272,22 +272,8 @@ TEMPLATE_LIST_TEST_CASE("matMul", "[matMul]", TestAccs)
               << ", kernel: " << alpaka::core::demangled<decltype(kernel)> << ", workDiv: " << workDiv << ")"
               << std::endl;
 
-
     // Create the kernel execution task.
-    auto const taskKernel = alpaka::createTaskKernel<Acc>(
-        workDiv,
-        kernel,
-        m,
-        n,
-        k,
-        static_cast<Val>(1),
-        std::data(bufAAcc),
-        lda,
-        std::data(bufBAcc),
-        ldb,
-        static_cast<Val>(1),
-        std::data(bufCAcc),
-        ldc);
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(workDiv, kernelBundle);
 
     // Profile the kernel execution.
     std::cout << "Execution time:   " << alpaka::test::integ::measureTaskRunTimeMs(queueAcc, taskKernel) << " ms"

--- a/test/integ/separableCompilation/src/main.cpp
+++ b/test/integ/separableCompilation/src/main.cpp
@@ -111,23 +111,21 @@ TEMPLATE_LIST_TEST_CASE("separableCompilation", "[separableCompilation]", TestAc
     alpaka::memcpy(queueAcc, memBufAccA, memBufHostA);
     alpaka::memcpy(queueAcc, memBufAccB, memBufHostB);
 
-    auto const& bundeledKernel
-        = alpaka::KernelBundle(kernel, memBufAccA.data(), memBufAccB.data(), memBufAccC.data(), numElements);
+    auto const& kernelBundle = alpaka::KernelBundle(
+        kernel,
+        std::data(memBufAccA),
+        std::data(memBufAccB),
+        std::data(memBufAccC),
+        numElements);
     // Let alpaka calculate good block and grid sizes given our full problem extent
-    auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(devAcc, bundeledKernel, extent, static_cast<Idx>(3u));
+    auto const workDiv = alpaka::getValidWorkDivForKernel<Acc>(devAcc, kernelBundle, extent, static_cast<Idx>(3u));
 
     std::cout << alpaka::core::demangled<decltype(kernel)> << "("
               << "accelerator: " << alpaka::getAccName<Acc>() << ", workDiv: " << workDiv
               << ", numElements:" << numElements << ")" << std::endl;
 
     // Create the executor task.
-    auto const taskKernel = alpaka::createTaskKernel<Acc>(
-        workDiv,
-        kernel,
-        memBufAccA.data(),
-        memBufAccB.data(),
-        memBufAccC.data(),
-        numElements);
+    auto const taskKernel = alpaka::createTaskKernel<Acc>(workDiv, kernelBundle);
 
     // Profile the kernel execution.
     std::cout << "Execution time: " << alpaka::test::integ::measureTaskRunTimeMs(queueAcc, taskKernel) << " ms"

--- a/test/unit/math/src/TestTemplate.hpp
+++ b/test/unit/math/src/TestTemplate.hpp
@@ -73,7 +73,6 @@ namespace mathtest
             // SETUP (defines and initialising)
             // DevAcc is defined in Buffer.hpp too.
             using DevAcc = alpaka::Dev<TAcc>;
-
             using QueueAcc = alpaka::test::DefaultQueue<DevAcc>;
             using TArgsItem = ArgsItem<TData, TFunctor::arity>;
 
@@ -99,12 +98,12 @@ namespace mathtest
             Results results{devAcc};
 
 
-            auto const& bundeledKernel
+            auto const& kernelBundle
                 = alpaka::KernelBundle(kernel, results.pDevBuffer, wrappedFunctor, args.pDevBuffer);
             // Let alpaka calculate good block and grid sizes given our full problem extent
             auto const workDiv = alpaka::getValidWorkDivForKernel<TAcc>(
                 devAcc,
-                bundeledKernel,
+                kernelBundle,
                 sizeExtent,
                 elementsPerThread,
                 false,
@@ -123,8 +122,7 @@ namespace mathtest
             results.copyToDevice(queue);
 
             // Enqueue the kernel execution task.
-            auto const taskKernel
-                = alpaka::createTaskKernel<TAcc>(workDiv, kernel, results.pDevBuffer, wrappedFunctor, args.pDevBuffer);
+            auto const taskKernel = alpaka::createTaskKernel<TAcc>(workDiv, kernelBundle);
             alpaka::enqueue(queue, taskKernel);
 
             // Copy back the results (encapsulated in the buffer class).


### PR DESCRIPTION
# new interface
- add new interface `exec(queue, workDiv, kernelBundle)`
- add new interface `createKernelTask(workDiv, kernelBundle)`

We observed a tiny overhead when we start kernel with 100 arguments or an 1000 byte array as argument, see https://github.com/alpaka-group/alpaka/pull/2339#issuecomment-2268504326
Overhead is <1ms for `10000` kernel invocations.

# refactoring
- rename `bundeledKernelFill` into `kernelBundle`
- use the kernel bundle everywhere where we already have this object for the valid work division creation


This PR replaces #2339. Due to performance issues observed in #2339 the `TaskKernel` objects will keep the kernel instances and arguments separately and will not use `KernelBundle`

changes coming from PR https://github.com/alpaka-group/alpaka/pull/2318