### PR TITLE
Fix the device used by `KernelExecutionFixture`

### DIFF
--- a/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/include/alpaka/test/KernelExecutionFixture.hpp
@@ -44,13 +44,20 @@ namespace alpaka::test
         {
         }
 
-        KernelExecutionFixture(Queue queue, WorkDiv workDiv) : m_queue{std::move(queue)}, m_workDiv{std::move(workDiv)}
+        KernelExecutionFixture(Queue queue, WorkDiv workDiv)
+            : m_platform{} // if the platform is not stateless, this is wrong; we ignore it because it is not be used
+            , m_device{alpaka::getDev(queue)}
+            , m_queue{std::move(queue)}
+            , m_workDiv{std::move(workDiv)}
         {
         }
 
         template<typename TExtent>
-        KernelExecutionFixture(Queue queue, TExtent const& extent) : m_queue{std::move(queue)}
-                                                                   , m_extent{extent}
+        KernelExecutionFixture(Queue queue, TExtent const& extent)
+            : m_platform{} // if the platform is not stateless, this is wrong; we ignore it because it is not be used
+            , m_device{alpaka::getDev(queue)}
+            , m_queue{std::move(queue)}
+            , m_extent{extent}
         {
         }
 


### PR DESCRIPTION
When a queue is passed as an argument to a `KernelExecutionFixture`, internally the fixture always uses the first device instead of the device associated to the queue.
This change makes it use the correct device.

Note that, if the `Platform` is not stateless (_e.g._ with SYCL), the platform data member is still wrong. However, there is no way to access the platform associated to a device object. 
Since the platform object will not be used, we ignore this issue for the time being.