### PR TITLE
fix gh-pages job

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - develop
+env:
+  ALPAKA_CI_OS_NAME: "Linux"
 
 jobs:
   gh-pages:


### PR DESCRIPTION
With #2323 we broke the github pages CI job.

```
cd ${GITHUB_WORKSPACE}
./script/install_doxygen.sh
./script/setup_utilities/agc-manager.sh: line 3: ALPAKA_CI_OS_NAME: ALPAKA_CI_OS_NAME must be specified
```

@alpaka-group/alpaka-maintainers  The gh-pages CI job is only started when this PR is merged to the dev branch, feel free to merge it before the tests passed!