### PR TITLE
Add missing #include

### DIFF
--- a/include/alpaka/mem/global/DeviceGlobalGenericSycl.hpp
+++ b/include/alpaka/mem/global/DeviceGlobalGenericSycl.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/elem/Traits.hpp"
 #include "alpaka/mem/global/Traits.hpp"
 #include "alpaka/queue/sycl/QueueGenericSyclBase.hpp"
 


### PR DESCRIPTION
Needed to use `alpaka::Elem<...>`.