### PR TITLE
add colored output to the CI scripts

### DIFF
--- a/script/after_failure.sh
+++ b/script/after_failure.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: after_failure>"
+
 if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
 then
   sudo smem

--- a/script/before_install.sh
+++ b/script/before_install.sh
@@ -7,6 +7,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: before_install>"
+
 # because of the strict abort conditions, a variable needs to be defined, if we read from
 # this statement avoids additional checks later in the scripts
 if [ -z "${LD_LIBRARY_PATH+x}" ]

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: ci>"
+
 ./script/print_env.sh
 source ./script/before_install.sh
 if [ -n "$GITHUB_ACTIONS" ] && [ "$ALPAKA_CI_OS_NAME" = "Linux" ]; then

--- a/script/docker_ci.sh
+++ b/script/docker_ci.sh
@@ -16,6 +16,8 @@ set +xv
 source ./script/setup_utilities/set.sh
 source ./script/docker_retry.sh
 
+echo_green "<SCRIPT: docker_ci>"
+
 ALPAKA_CI_BOOST_BRANCH="boost-${ALPAKA_BOOST_VERSION}"
 
 # runtime and compile time options

--- a/script/docker_retry.sh
+++ b/script/docker_retry.sh
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: MPL-2.0
 #
 
-ANSI_RED="\033[31m"
-ANSI_RESET="\033[0m"
 set +xv
 source ./script/setup_utilities.sh
 
@@ -18,7 +16,7 @@ docker_retry() {
   local count=1
   while [ $count -le 3 ]; do
     [ $result -eq 125 ] && {
-      echo -e "\n${ANSI_RED}The command \"$*\" failed. Retrying, $count of 3.${ANSI_RESET}\n" >&2
+    echo_red "\nThe command \"$*\" failed. Retrying, $count of 3.\n" >&2
     }
     "$@"
     result=$?
@@ -27,7 +25,7 @@ docker_retry() {
     sleep 30
   done
   [ $count -gt 3 ] && {
-    echo -e "\n${ANSI_RED}The command \"$*\" failed 3 times.${ANSI_RESET}\n" >&2
+    echo_red "\nThe command \"$*\" failed 3 times.\n" >&2
   }
   return $result
 }

--- a/script/install.sh
+++ b/script/install.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: install>"
+
 : ${ALPAKA_CI_ANALYSIS?"ALPAKA_CI_ANALYSIS must be specified"}
 : ${ALPAKA_CI_INSTALL_CUDA?"ALPAKA_CI_INSTALL_CUDA must be specified"}
 : ${ALPAKA_CI_INSTALL_HIP?"ALPAKA_CI_INSTALL_HIP must be specified"}

--- a/script/install_analysis.sh
+++ b/script/install_analysis.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: install_analysis>"
+
 if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
 then
     #-------------------------------------------------------------------------------

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: install boost>"
+
 : "${BOOST_ROOT?'BOOST_ROOT must be specified'}"
 : "${ALPAKA_BOOST_VERSION?'ALPAKA_BOOST_VERSION must be specified'}"
 : "${ALPAKA_CI_BOOST_LIB_DIR?'ALPAKA_CI_BOOST_LIB_DIR must be specified'}"

--- a/script/install_clang.sh
+++ b/script/install_clang.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: install_clang>"
+
 : "${ALPAKA_CI_CLANG_VER?'ALPAKA_CI_CLANG_VER must be specified'}"
 : "${ALPAKA_CI_STDLIB?'ALPAKA_CI_STDLIB must be specified'}"
 : "${CXX?'CXX must be specified'}"

--- a/script/install_cmake.sh
+++ b/script/install_cmake.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: install_cmake>"
+
 : "${ALPAKA_CI_CMAKE_DIR?'ALPAKA_CI_CMAKE_DIR must be specified'}"
 : "${ALPAKA_CI_CMAKE_VER?'ALPAKA_CI_CMAKE_VER must be specified'}"
 

--- a/script/install_cuda.sh
+++ b/script/install_cuda.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: install_cuda>"
+
 : "${ALPAKA_CI_CUDA_VERSION?'ALPAKA_CI_CUDA_VERSION must be specified'}"
 
 ALPAKA_CUDA_VER_SEMANTIC=( ${ALPAKA_CI_CUDA_VERSION//./ } )

--- a/script/install_doxygen.sh
+++ b/script/install_doxygen.sh
@@ -8,4 +8,6 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: install_doxygen>"
+
 travis_retry sudo apt-get -y --quiet install --no-install-recommends doxygen graphviz

--- a/script/install_gcc.sh
+++ b/script/install_gcc.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: install_gcc>"
+
 : "${ALPAKA_CI_GCC_VER?'ALPAKA_CI_GCC_VER must be specified'}"
 : "${ALPAKA_CI_SANITIZERS?'ALPAKA_CI_SANITIZERS must be specified'}"
 : "${CXX?'CXX must be specified'}"

--- a/script/install_hip.sh
+++ b/script/install_hip.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: install_hip>"
+
 : "${ALPAKA_CI_HIP_ROOT_DIR?'ALPAKA_CI_HIP_ROOT_DIR must be specified'}"
 : "${ALPAKA_CI_HIP_VERSION?'ALPAKA_CI_HIP_VERSION must be specified'}"
 

--- a/script/install_omp.sh
+++ b/script/install_omp.sh
@@ -7,6 +7,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: install_omp>"
+
 if [ "$ALPAKA_CI_OS_NAME" = "macOS" ]
 then
     # workaround to avoid link issues from python 2 to 3 during libomp dependency installation

--- a/script/install_oneapi.sh
+++ b/script/install_oneapi.sh
@@ -7,6 +7,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: install_oneapi>"
+
 : "${CXX?'CXX must be specified'}"
 
 

--- a/script/install_tbb.sh
+++ b/script/install_tbb.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: install_tbb>"
+
 : "${ALPAKA_CI_TBB_VERSION?'ALPAKA_CI_TBB_VERSION must be specified'}"
 
 if ! agc-manager -e tbb@${ALPAKA_CI_TBB_VERSION}

--- a/script/prepare_sanitizers.sh
+++ b/script/prepare_sanitizers.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: prepare_sanitizers>"
+
 #-------------------------------------------------------------------------------
 # Exports the CMAKE_CXX_FLAGS and CMAKE_EXE_LINKER_FLAGS to enable the sanitizers listed in ALPAKA_CI_SANITIZERS.
 if [ -z "${CMAKE_CXX_FLAGS+x}" ]

--- a/script/print_env.sh
+++ b/script/print_env.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: print_env>"
+
 #-------------------------------------------------------------------------------
 if [ "$alpaka_CI" = "GITHUB" ]
 then

--- a/script/push_doc.sh
+++ b/script/push_doc.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: push_doc>"
+
 cd docs/doxygen/html
 
 git config --global user.email "action@github.com"

--- a/script/run.sh
+++ b/script/run.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: run>"
+
 : "${ALPAKA_CI_CMAKE_DIR?'ALPAKA_CI_CMAKE_DIR must be specified'}"
 echo "ALPAKA_CI_CMAKE_DIR: ${ALPAKA_CI_CMAKE_DIR}"
 : "${ALPAKA_CI_ANALYSIS?'ALPAKA_CI_ANALYSIS must be specified'}"

--- a/script/run_analysis.sh
+++ b/script/run_analysis.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: run_analysis>"
+
 if [ "$ALPAKA_CI_OS_NAME" = "Linux" ] || [ "$ALPAKA_CI_OS_NAME" = "macOS" ]
 then
     #-------------------------------------------------------------------------------

--- a/script/run_build.sh
+++ b/script/run_build.sh
@@ -7,6 +7,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: run_build>"
+
 cd build/
 
 if [ -z "${ALPAKA_CI_BUILD_JOBS+x}" ]

--- a/script/run_doxygen.sh
+++ b/script/run_doxygen.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: run_doxygen>"
+
 #To deploy the doxygen documentation a copy of the repository is created inside the deployed folder.
 #This copy is always in the gh-pages branch consisting only of the containing files.
 #This folder is ignored in all other branches.

--- a/script/run_generate.sh
+++ b/script/run_generate.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: run_generate>"
+
 # TODO(SimeonEhrig): should use CMAKE_C_COMPILER and CMAKE_CXX_COMPILER instead update-alternatives because it
 # is more relastic use case and less error prone approach
 #: "${CMAKE_C_COMPILER?'CMAKE_C_COMPILER must be specified'}"

--- a/script/run_install.sh
+++ b/script/run_install.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: run_install>"
+
 ALPAKA_CI_CMAKE_EXECUTABLE=cmake
 if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
 then

--- a/script/run_tests.sh
+++ b/script/run_tests.sh
@@ -8,6 +8,8 @@
 set +xv
 source ./script/setup_utilities.sh
 
+echo_green "<SCRIPT: run_tests>"
+
 : "${alpaka_ACC_GPU_CUDA_ENABLE?'alpaka_ACC_GPU_CUDA_ENABLE must be specified'}"
 : "${alpaka_ACC_GPU_HIP_ENABLE?'alpaka_ACC_GPU_HIP_ENABLE must be specified'}"
 

--- a/script/setup_utilities.sh
+++ b/script/setup_utilities.sh
@@ -10,6 +10,7 @@
 set -e
 
 # disable command traces for the following scripts to avoid useless noise in the job output
+source ./script/setup_utilities/color_echo.sh
 source ./script/setup_utilities/travis_retry.sh
 source ./script/setup_utilities/sudo.sh
 source ./script/setup_utilities/agc-manager.sh

--- a/script/setup_utilities/agc-manager.sh
+++ b/script/setup_utilities/agc-manager.sh
@@ -8,7 +8,7 @@
 if [ "$ALPAKA_CI_OS_NAME" != "Linux" ] || [ ! -f "/usr/bin/agc-manager" ]; then
     # display message only one time not everytime the script is sourced
     if [ -z ${PRINT_INSTALL_AGC_MANAGER+x} ]; then
-        echo "install fake agc-manager"
+        echo_yellow "install fake agc-manager"
         export PRINT_INSTALL_AGC_MANAGER=true
     fi
 
@@ -25,14 +25,14 @@ if [ "$ALPAKA_CI_OS_NAME" != "Linux" ] || [ ! -f "/usr/bin/agc-manager" ]; then
         sudo chmod +x agc-manager
         sudo mv agc-manager /usr/local/bin
     else
-        echo "installing agc-manager: " \
+        echo_red "installing agc-manager: " \
         "unknown operation system: ${ALPAKA_CI_OS_NAME}"
         exit 1
     fi
 else
     # display message only one time not everytime the script is sourced
     if [ -z ${PRINT_INSTALL_AGC_MANAGER+x} ]; then
-        echo "found agc-manager"
+        echo_green "found agc-manager"
         export PRINT_INSTALL_AGC_MANAGER=true
     fi
 fi

--- a/script/setup_utilities/color_echo.sh
+++ b/script/setup_utilities/color_echo.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: MPL-2.0
+
+# colored output
+
+# display a message in green
+echo_green() {
+    # macOS uses bash 3, therefor \e is not working \033 needs to be used
+    # https://stackoverflow.com/questions/28782394/how-to-get-osx-shell-script-to-show-colors-in-echo
+    echo -e "\033[1;32m$1\033[0m"
+}
+
+# display a message in yellow
+echo_yellow() {
+    echo -e "\033[1;33m$1\033[0m"
+}
+
+# display a message in red
+echo_red() {
+    echo -e "\033[1;31m$1\033[0m"
+}

--- a/script/setup_utilities/sudo.sh
+++ b/script/setup_utilities/sudo.sh
@@ -6,7 +6,7 @@ if ! command -v sudo &>/dev/null; then
     if [ "$ALPAKA_CI_OS_NAME" == "Linux" ]; then
         # display message only one time not everytime the script is sourced
         if [ -z ${PRINT_INSTALL_SUDO+x} ]; then
-            echo "install sudo"
+            echo_yellow "install sudo"
             export PRINT_INSTALL_SUDO=true
         fi
 


### PR DESCRIPTION
The `echo_green "<SCRIPT: script_name>"` at the begin of the script looks redundant, because the trace option of bash displays all scripts, which was sourced but there are two benefits of it.

1. You see which script causes problems, without using the browser search.
2. You can search or grep for `<SCRIPT:` to easily find all major scripts, involved in the CI job. Helper scripts, which are be redundant sourced will be not displayed. 