### PR TITLE
CI jobs: allow to disable exit on error

### DIFF
--- a/script/gitlabci/print_env.sh
+++ b/script/gitlabci/print_env.sh
@@ -7,7 +7,9 @@
 
 # set exit on error manually instead using setup_utilities because
 # otherwise the begin of the job log looks not helpful
-set -e
+if [ -z ${alpaka_DISABLE_EXIT_FAILURE+x} ]; then
+    set -e
+fi
 
 # display output with yellow color
 echo -e "\033[0;33mSteps to setup containter locally"
@@ -41,6 +43,8 @@ printenv | grep -E 'alpaka_*|ALPAKA_*|CMAKE_*|BOOST_|CC|CXX|CUDA_' | while read 
     echo "export $line \\"
 done
 
+# the variable is not set, but should be set if a job is debugged locally in a container
+echo 'export alpaka_DISABLE_EXIT_FAILURE=true \'
 echo 'export GITLAB_CI=true'
 echo ""
 

--- a/script/run.sh
+++ b/script/run.sh
@@ -103,7 +103,14 @@ then
     then
         set +eu
         which ${CXX} || source /opt/intel/oneapi/setvars.sh
-        set -eu
+
+        # exit by default if the command does not return 0
+        # can be deactivated by setting the environment variable alpaka_DISABLE_EXIT_FAILURE
+        # for example for local debugging in a Docker container
+        if [ -z ${alpaka_DISABLE_EXIT_FAILURE+x} ]; then
+            set -e
+        fi
+        set -u
     fi
 
     which "${CXX}"

--- a/script/setup_utilities.sh
+++ b/script/setup_utilities.sh
@@ -7,7 +7,12 @@
 # if a bash script is normal called, self defined bash functions are not avaible from the calling bash instance
 
 
-set -e
+# exit by default if the command does not return 0
+# can be deactivated by setting the environment variable alpaka_DISABLE_EXIT_FAILURE
+# for example for local debugging in a Docker container
+if [ -z ${alpaka_DISABLE_EXIT_FAILURE+x} ]; then
+    set -e
+fi
 
 # disable command traces for the following scripts to avoid useless noise in the job output
 source ./script/setup_utilities/color_echo.sh

--- a/script/setup_utilities/set.sh
+++ b/script/setup_utilities/set.sh
@@ -11,4 +11,12 @@
 # -u: treat unset variables as an error
 # -v: Print shell input lines as they are read
 # -x: Print command traces before executing command
-set -eouvx pipefail
+
+# exit by default if the command does not return 0
+# can be deactivated by setting the environment variable alpaka_DISABLE_EXIT_FAILURE
+# for example for local debugging in a Docker container
+if [ -z ${alpaka_DISABLE_EXIT_FAILURE+x} ]; then
+    set -e
+fi
+
+set -ouvx pipefail


### PR DESCRIPTION
The CI jobs exit on a failure by default. Otherwise the tests would not work. If you try to debug an error locally in a docker container, the behavior is annoying. Therefore it can be disable if the environment variable `alpaka_DISABLE_EXIT_FAILURE` is set, before the scripts are executed.

There is no way mechanism to disable exit on failure in the GitLab CI e.g. via git commit message. The feature is only designed for local usage.