### PR TITLE
fix `set +euo pipefail` in travis_retry and docker_retry

### DIFF
--- a/script/gitlabci/job_cuda.yml
+++ b/script/gitlabci/job_cuda.yml
@@ -1,26 +1,26 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # nvcc + g++
-linux_nvcc12.0_gcc12_debug_relocatable_device_code_compile_only:
+linux_nvcc12.0_gcc11_debug_relocatable_device_code_compile_only:
   extends: .base_cuda_gcc_compile_only
   image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu20.04-cuda110-gcc:3.2
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "12.0"
-    ALPAKA_CI_GCC_VER: 12
+    ALPAKA_CI_GCC_VER: 11
     CMAKE_BUILD_TYPE: Debug
     ALPAKA_BOOST_VERSION: 1.81.0
     ALPAKA_CI_CMAKE_VER: 3.26.5
     alpaka_CXX_STANDARD: 17
     alpaka_RELOCATABLE_DEVICE_CODE: "ON"
 
-linux_nvcc12.0_gcc12_release_extended_lambda_off_compile_only:
+linux_nvcc12.0_gcc11_release_extended_lambda_off_compile_only:
   extends: .base_cuda_gcc_compile_only
   image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu20.04-cuda110-gcc:3.2
   variables:
     ALPAKA_CI_UBUNTU_VER: "20.04"
     ALPAKA_CI_CUDA_VERSION: "12.0"
-    ALPAKA_CI_GCC_VER: 12
+    ALPAKA_CI_GCC_VER: 11
     CMAKE_BUILD_TYPE: Release
     ALPAKA_BOOST_VERSION: 1.82.0
     ALPAKA_CI_CMAKE_VER: 3.27.1

--- a/script/install_cuda.sh
+++ b/script/install_cuda.sh
@@ -16,6 +16,11 @@ ALPAKA_CUDA_VER_SEMANTIC=( ${ALPAKA_CI_CUDA_VERSION//./ } )
 ALPAKA_CUDA_VER_MAJOR="${ALPAKA_CUDA_VER_SEMANTIC[0]}"
 echo ALPAKA_CUDA_VER_MAJOR: "${ALPAKA_CUDA_VER_MAJOR}"
 
+# if LD_LIBRARY_PATH is not set, the following statement will throw an unbound variable error
+# export LD_LIBRARY_PATH=/path/to/lib:${LD_LIBRARY_PATH} 
+if [ -z ${LD_LIBRARY_PATH+x} ]; then
+    export LD_LIBRARY_PATH=""
+fi
 
 if agc-manager -e cuda@${ALPAKA_CI_CUDA_VERSION}
 then

--- a/script/setup_utilities/travis_retry.sh
+++ b/script/setup_utilities/travis_retry.sh
@@ -25,22 +25,26 @@ ANSI_RED="\033[31m"
 ANSI_RESET="\033[0m"
 
 travis_retry() {
-  set +euo pipefail
-  local result=0
-  local count=1
-  local max=666
-  while [ $count -le $max ]; do
-    [ $result -ne 0 ] && {
-      echo -e "\n${ANSI_RED}The command \"$*\" failed. Retrying, $count of $max.${ANSI_RESET}\n" >&2
+  # apply `set +euo pipefail` in a local scope so that the following script is not affected and 
+  # e.g. exit on failure is not deactivated
+  (
+    set +euo pipefail
+    local result=0
+    local count=1
+    local max=666
+    while [ $count -le $max ]; do
+      [ $result -ne 0 ] && {
+        echo -e "\n${ANSI_RED}The command \"$*\" failed. Retrying, $count of $max.${ANSI_RESET}\n" >&2
+      }
+      "$@"
+      result=$?
+      [ $result -eq 0 ] && break
+      count=$((count + 1))
+      sleep 1
+    done
+    [ $count -gt $max ] && {
+      echo -e "\n${ANSI_RED}The command \"$*\" failed $max times.${ANSI_RESET}\n" >&2
     }
-    "$@"
-    result=$?
-    [ $result -eq 0 ] && break
-    count=$((count + 1))
-    sleep 1
-  done
-  [ $count -gt $max ] && {
-    echo -e "\n${ANSI_RED}The command \"$*\" failed $max times.${ANSI_RESET}\n" >&2
-  }
-  return $result
+    return $result
+  )
 }


### PR DESCRIPTION
If the functions was called the changed bash behavior was still working after the function call.

~Maybe fixes: #2357~
Does not solve #2357, see test PR: https://github.com/alpaka-group/alpaka/pull/2356

The PR fixes also two bugs in the CI scripts:

- use unbound variable LD_LIBRARY_PATH in install_cuda.sh
- use g++-12 in custom jobs, which is not available on Ubuntu 20.04