### PR TITLE
fix `BufFpgaSyclIntel` template arguments

### DIFF
--- a/include/alpaka/mem/buf/BufFpgaSyclIntel.hpp
+++ b/include/alpaka/mem/buf/BufFpgaSyclIntel.hpp
@@ -12,7 +12,7 @@
 namespace alpaka
 {
     template<typename TElem, typename TDim, typename TIdx>
-    using BufFpgaSyclIntel = BufGenericSycl<TElem, TDim, TIdx, DevFpgaSyclIntel>;
+    using BufFpgaSyclIntel = BufGenericSycl<TElem, TDim, TIdx, PlatformFpgaSyclIntel>;
 } // namespace alpaka
 
 #endif


### PR DESCRIPTION
`BufGenericSycl` is templated on the `Platform`, while `BufFpgaSyclIntel` was specialized with the device.

I'm afraid the `using ...` is not tested anywhere in our tests.