### PR TITLE
ignore `-Wswitch-default` when using `clang`

### DIFF
--- a/include/alpaka/platform/PlatformGenericSycl.hpp
+++ b/include/alpaka/platform/PlatformGenericSycl.hpp
@@ -20,6 +20,11 @@
 
 #ifdef ALPAKA_ACC_SYCL_ENABLED
 
+#    if BOOST_COMP_CLANG
+#        pragma clang diagnostic push
+#        pragma clang diagnostic ignored "-Wswitch-default"
+#    endif
+
 #    include <sycl/sycl.hpp>
 
 namespace alpaka
@@ -719,5 +724,9 @@ namespace alpaka::trait
 #    endif
     };
 } // namespace alpaka::trait
+
+#    if BOOST_COMP_CLANG
+#        pragma clang diagnostic pop
+#    endif
 
 #endif

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -23,6 +23,11 @@
 #include <set>
 #include <type_traits>
 
+#if BOOST_COMP_CLANG
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wswitch-default"
+#endif
+
 //! The alpaka library.
 namespace alpaka
 {
@@ -521,3 +526,7 @@ namespace alpaka
         return isValidWorkDiv(getAccDevProps<TAcc>(dev), workDiv);
     }
 } // namespace alpaka
+
+#if BOOST_COMP_CLANG
+#    pragma clang diagnostic pop
+#endif

--- a/test/unit/math/src/DataGen.hpp
+++ b/test/unit/math/src/DataGen.hpp
@@ -11,6 +11,11 @@
 #include <limits>
 #include <random>
 
+#if BOOST_COMP_CLANG
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wswitch-default"
+#endif
+
 namespace mathtest
 {
     //! Helper to generate random numbers of the given type for testing
@@ -199,3 +204,7 @@ namespace mathtest
         }
     }
 } // namespace mathtest
+
+#if BOOST_COMP_CLANG
+#    pragma clang diagnostic pop
+#endif


### PR DESCRIPTION
This warning is triggered when compiling with oneAPI 2024.2 and the missing `default` causes `warning: 'switch' missing 'default' label [-Wswitch-default]`, while adding it causes `warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]` 🙃 . 