### PR TITLE
enable support for mapped memory allocation for the SYCL backend

### DIFF
--- a/include/alpaka/mem/buf/BufGenericSycl.hpp
+++ b/include/alpaka/mem/buf/BufGenericSycl.hpp
@@ -237,6 +237,12 @@ namespace alpaka::trait
         }
     };
 
+    //! The pinned/mapped memory allocation capability trait specialization.
+    template<typename TTag>
+    struct HasMappedBufSupport<PlatformGenericSycl<TTag>> : public std::true_type
+    {
+    };
+
     //! The BufGenericSycl idx type trait specialization.
     template<typename TElem, typename TDim, typename TIdx, typename TPlatform>
     struct IdxType<BufGenericSycl<TElem, TDim, TIdx, TPlatform>>

--- a/test/unit/math/src/Buffer.hpp
+++ b/test/unit/math/src/Buffer.hpp
@@ -38,12 +38,10 @@ namespace mathtest
         using PlatformAcc = alpaka::Platform<DevAcc>;
         using BufAcc = alpaka::Buf<DevAcc, TData, Dim, Idx>;
 
-        PlatformHost platformHost;
         DevHost devHost;
 
         BufHost hostBuffer;
         BufAcc devBuffer;
-        PlatformAcc platformAcc;
 
         // Native pointer to access buffer.
         TData* const pHostBuffer;
@@ -54,7 +52,7 @@ namespace mathtest
         Buffer() = delete;
 
         // Constructor needs to initialize all Buffer.
-        Buffer(DevAcc const& devAcc)
+        Buffer(DevAcc const& devAcc, PlatformHost const& platformHost, PlatformAcc const& platformAcc)
             : devHost{alpaka::getDevByIdx(platformHost, 0)}
             , hostBuffer{alpaka::allocMappedBufIfSupported<TData, Idx>(devHost, platformAcc, Tcapacity)}
             , devBuffer{alpaka::allocBuf<TData, Idx>(devAcc, Tcapacity)}

--- a/test/unit/math/src/TestTemplate.hpp
+++ b/test/unit/math/src/TestTemplate.hpp
@@ -95,8 +95,8 @@ namespace mathtest
 
             TestKernel<capacity> kernel;
             TFunctor functor;
-            Args args{devAcc};
-            Results results{devAcc};
+            Args args{devAcc, platformHost, platformAcc};
+            Results results{devAcc, platformHost, platformAcc};
 
             // Let alpaka calculate good block and grid sizes given our full problem extent
             alpaka::KernelCfg<TAcc> const kernelCfg


### PR DESCRIPTION
The `allocMappedBuf` method was already there, but when calling `allocMappedBufIfSupported` it was not used because the trait `hasMappedBufSupport` has never been specialized to be `true`.
This led to spotting a bug in `Buffer.hpp` used in `mathTest`, where the accelerator platform was used to allocate memory on the host (never seen before because CUDA/HIP and the CPU backend don't use the `Platform` to do the allocation).