### PR TITLE
Mark the deduction guide for vector as ALPAKA_FN_HOST_ACC

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -31,8 +31,6 @@ struct TestBufferKernel
     template<typename TAcc, typename MdSpan>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, MdSpan data) const -> void
     {
-        using Vec = alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>>;
-
         auto const idx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
         auto const gridSize = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
@@ -41,7 +39,9 @@ struct TestBufferKernel
                 for(size_t x = idx[2]; x < data.extent(2); x += gridSize[2])
                     ALPAKA_ASSERT_ACC(
                         data(z, y, x)
-                        == alpaka::mapIdx<1u>(Vec{z, y, x}, Vec{data.extent(0), data.extent(1), data.extent(2)})[0]);
+                        == alpaka::mapIdx<1u>(
+                            alpaka::Vec{z, y, x},
+                            alpaka::Vec{data.extent(0), data.extent(1), data.extent(2)})[0]);
     }
 };
 

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -592,7 +592,8 @@ namespace alpaka
     };
 
     template<typename TFirstIndex, typename... TRestIndices>
-    Vec(TFirstIndex&&, TRestIndices&&...) -> Vec<DimInt<1 + sizeof...(TRestIndices)>, std::decay_t<TFirstIndex>>;
+    ALPAKA_FN_HOST_ACC Vec(TFirstIndex&&, TRestIndices&&...)
+        -> Vec<DimInt<1 + sizeof...(TRestIndices)>, std::decay_t<TFirstIndex>>;
 
     template<typename T>
     inline constexpr bool isVec = false;


### PR DESCRIPTION
This is a fix for some compilers which cant otherwise deduce the type on device
PR also changes an example to show usage of this deduction on device code