### PR TITLE
reduce Uniform/Independent-Elements iterator register footprint

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -95,7 +95,7 @@ auto example(TAccTag const&) -> int
 
     // Define the work division for kernels to be run on devAcc and devHost
     using Vec = alpaka::Vec<Dim, Idx>;
-    Vec const elementsPerThread(Vec::all(static_cast<Idx>(1)));
+    Vec const elementsPerThread(Vec::all(static_cast<Idx>(3)));
     Vec const elementsPerGrid(Vec::all(static_cast<Idx>(10)));
 
     // Create host and device buffers

--- a/include/alpaka/exec/IndependentElements.hpp
+++ b/include/alpaka/exec/IndependentElements.hpp
@@ -146,9 +146,9 @@ namespace alpaka
             };
 
         private:
-            const Idx first_;
-            const Idx stride_;
-            const Idx extent_;
+            Idx const first_;
+            Idx const stride_;
+            Idx const extent_;
         };
 
     } // namespace detail
@@ -311,11 +311,12 @@ namespace alpaka
 
                 ALPAKA_FN_ACC inline const_iterator(Idx elements, Idx stride, Idx extent, Idx first)
                     : elements_{elements}
-                    , stride_{stride}
+                    ,
+                    // we need to reduce the stride by on element range because index_ is later increased with each
+                    // increment
+                    stride_{stride - elements}
                     , extent_{extent}
-                    , first_{std::min(first, extent)}
-                    , index_{first_}
-                    , range_{std::min(first + elements, extent)}
+                    , index_{std::min(first, extent)}
                 {
                 }
 
@@ -328,22 +329,16 @@ namespace alpaka
                 // pre-increment the iterator
                 ALPAKA_FN_ACC inline const_iterator& operator++()
                 {
-                    // increment the index along the elements processed by the current thread
+                    ++indexElem_;
                     ++index_;
-                    if(index_ < range_)
-                        return *this;
+                    if(indexElem_ >= elements_)
+                    {
+                        indexElem_ = 0;
+                        index_ += stride_;
+                    }
+                    if(index_ >= extent_)
+                        index_ = extent_;
 
-                    // increment the thread index with the block stride
-                    first_ += stride_;
-                    index_ = first_;
-                    range_ = std::min(first_ + elements_, extent_);
-                    if(index_ < extent_)
-                        return *this;
-
-                    // the iterator has reached or passed the end of the extent, clamp it to the extent
-                    first_ = extent_;
-                    index_ = extent_;
-                    range_ = extent_;
                     return *this;
                 }
 
@@ -357,7 +352,7 @@ namespace alpaka
 
                 ALPAKA_FN_ACC inline bool operator==(const_iterator const& other) const
                 {
-                    return (index_ == other.index_) and (first_ == other.first_);
+                    return (*(*this) == *other);
                 }
 
                 ALPAKA_FN_ACC inline bool operator!=(const_iterator const& other) const
@@ -371,16 +366,15 @@ namespace alpaka
                 Idx stride_;
                 Idx extent_;
                 // modified by the pre/post-increment operator
-                Idx first_;
                 Idx index_;
-                Idx range_;
+                Idx indexElem_ = 0;
             };
 
         private:
-            const Idx elements_;
-            const Idx thread_;
-            const Idx stride_;
-            const Idx extent_;
+            Idx const elements_;
+            Idx const thread_;
+            Idx const stride_;
+            Idx const extent_;
         };
 
     } // namespace detail

--- a/include/alpaka/exec/UniformElements.hpp
+++ b/include/alpaka/exec/UniformElements.hpp
@@ -153,7 +153,7 @@ namespace alpaka
                     ++index_;
                     if(indexElem_ >= elements_)
                     {
-                        indexElem_ = Idx{0};
+                        indexElem_ = 0;
                         index_ += stride_;
                     }
                     if(index_ >= extent_)
@@ -187,7 +187,7 @@ namespace alpaka
                 Idx extent_;
                 // modified by the pre/post-increment operator
                 Idx index_;
-                Idx indexElem_ = {0};
+                Idx indexElem_ = 0;
             };
 
         private:


### PR DESCRIPTION
reduce register footprint

fix #2382

Rewrite Uniform/Independent-Elements iterator to reduce the register footprint.

- avoid multiple returns within a function
- reduce the iterator state size by one element

Change bufferCopy example, use the element layer for CPU accelerators.

The original code before using the UniformElements in the bufferCopy example required 38 and 56 registers.
With this PR we requires 64 and 71 registers but this can not be compared to the old develop branch because the old implementation ignores the element layer.
Compared to the current development branch where [80 and 85 registers](https://github.com/alpaka-group/alpaka/pull/2377#issuecomment-2348309816) are required this refactoring is a huge improvement and will increase the occupancy in real word usage.

The increment of the iterator have now always the cost of two integral value increments and two comparisons where the comparisons will be transformed into [comparison and selection instruction](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#comparison-and-selection-instructions) on GPU devices therefore there is no branching overhead.

```
ptxas info    : 219055 bytes gmem, 72 bytes cmem[3]
ptxas info    : Compiling entry function '_ZN6alpaka6detail9gpuKernelI17PrintBufferKernelNS_9ApiCudaRtENS_22AccGpuUniformCudaHipRtIS3_St17integral_constantImLm3EEmEES6_mJNSt12experimental6mdspanIjNS8_7extentsImJLm18446744073709551615ELm18446744073709551615ELm18446744073709551615EEEENS8_13layout_strideENS_12experimental6traits6detail19ByteIndexedAccessorIjEEEEEEEvNS_3VecIT2_T3_EET_DpT4_' for 'sm_52'
ptxas info    : Function properties for _ZN6alpaka6detail9gpuKernelI17PrintBufferKernelNS_9ApiCudaRtENS_22AccGpuUniformCudaHipRtIS3_St17integral_constantImLm3EEmEES6_mJNSt12experimental6mdspanIjNS8_7extentsImJLm18446744073709551615ELm18446744073709551615ELm18446744073709551615EEEENS8_13layout_strideENS_12experimental6traits6detail19ByteIndexedAccessorIjEEEEEEEvNS_3VecIT2_T3_EET_DpT4_
    32 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 64 registers, 408 bytes cmem[0]
ptxas info    : Compiling entry function '_ZN6alpaka6detail9gpuKernelI16TestBufferKernelNS_9ApiCudaRtENS_22AccGpuUniformCudaHipRtIS3_St17integral_constantImLm3EEmEES6_mJNSt12experimental6mdspanIjNS8_7extentsImJLm18446744073709551615ELm18446744073709551615ELm18446744073709551615EEEENS8_13layout_strideENS_12experimental6traits6detail19ByteIndexedAccessorIjEEEEEEEvNS_3VecIT2_T3_EET_DpT4_' for 'sm_52'
ptxas info    : Function properties for _ZN6alpaka6detail9gpuKernelI16TestBufferKernelNS_9ApiCudaRtENS_22AccGpuUniformCudaHipRtIS3_St17integral_constantImLm3EEmEES6_mJNSt12experimental6mdspanIjNS8_7extentsImJLm18446744073709551615ELm18446744073709551615ELm18446744073709551615EEEENS8_13layout_strideENS_12experimental6traits6detail19ByteIndexedAccessorIjEEEEEEEvNS_3VecIT2_T3_EET_DpT4_
    0 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 71 registers, 408 bytes cmem[0]
```