### PR TITLE
Single thread acc throw for invalid workdiv fix

### DIFF
--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -189,6 +189,13 @@ namespace alpaka
                 TKernelFnObj const& kernelFnObj,
                 TArgs&&... args)
             {
+                if(workDiv.m_blockThreadExtent.prod() != static_cast<TIdx>(1u))
+                {
+                    throw std::runtime_error(
+                        "The given work division is not valid for a single thread Acc: "
+                        + getAccName<AccCpuOmp2Blocks<TDim, TIdx>>() + ". Threads per block should be 1!");
+                }
+
                 return TaskKernelCpuOmp2Blocks<TDim, TIdx, TKernelFnObj, TArgs...>(
                     workDiv,
                     kernelFnObj,

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -182,6 +182,13 @@ namespace alpaka
                 TKernelFnObj const& kernelFnObj,
                 TArgs&&... args)
             {
+                if(workDiv.m_blockThreadExtent.prod() != static_cast<TIdx>(1u))
+                {
+                    throw std::runtime_error(
+                        "The given work division is not valid for a single thread Acc: "
+                        + getAccName<AccCpuSerial<TDim, TIdx>>() + ". Threads per block should be 1!");
+                }
+
                 return TaskKernelCpuSerial<TDim, TIdx, TKernelFnObj, TArgs...>(
                     workDiv,
                     kernelFnObj,

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -183,6 +183,13 @@ namespace alpaka
                 TKernelFnObj const& kernelFnObj,
                 TArgs&&... args)
             {
+                if(workDiv.m_blockThreadExtent.prod() != static_cast<TIdx>(1u))
+                {
+                    throw std::runtime_error(
+                        "The given work division is not valid for a single thread Acc: "
+                        + getAccName<AccCpuTbbBlocks<TDim, TIdx>>() + ". Threads per block should be 1!");
+                }
+
                 return TaskKernelCpuTbbBlocks<TDim, TIdx, TKernelFnObj, TArgs...>(
                     workDiv,
                     kernelFnObj,

--- a/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuOmp2Blocks.hpp
@@ -826,10 +826,6 @@ namespace alpaka
 
             // The number of blocks in the grid.
             TIdx const numBlocksInGrid(gridBlockExtent.prod());
-            if(blockThreadExtent.prod() != static_cast<TIdx>(1u))
-            {
-                throw std::runtime_error("Only one thread per block allowed in the OpenMP 2.0 block accelerator!");
-            }
 
             // Get the OpenMP schedule information for the given kernel and parameter types
             auto const schedule = std::apply(

--- a/include/alpaka/kernel/TaskKernelCpuSerial.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSerial.hpp
@@ -79,11 +79,6 @@ namespace alpaka
                 *static_cast<WorkDivMembers<TDim, TIdx> const*>(this),
                 blockSharedMemDynSizeBytes);
 
-            if(blockThreadExtent.prod() != static_cast<TIdx>(1u))
-            {
-                throw std::runtime_error("A block for the serial accelerator can only ever have one single thread!");
-            }
-
             // Execute the blocks serially.
             meta::ndLoopIncIdx(
                 gridBlockExtent,

--- a/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuTbbBlocks.hpp
@@ -83,11 +83,6 @@ namespace alpaka
             // The number of blocks in the grid.
             TIdx const numBlocksInGrid = gridBlockExtent.prod();
 
-            if(blockThreadExtent.prod() != static_cast<TIdx>(1u))
-            {
-                throw std::runtime_error("A block for the TBB accelerator can only ever have one single thread!");
-            }
-
             tbb::this_task_arena::isolate(
                 [&]
                 {


### PR DESCRIPTION
For a single thread acc if the WorkDiv number of threads per block is more than one, throw a runtime error
We will now throw in create task kernel. The current approach of throwing when the task kernel is executed doesn't work. ``CallbackThread::startWorkerThread``, tries to handle the  exception, but it needs to be dealt with the thread that creates it. 