### PR TITLE
fix cray clang compiler errors

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -194,13 +194,6 @@ else()
         endif()
     endif()
 
-    # C++17 relaxed template template argument matching is disabled by default until Clang 19
-    # https://github.com/llvm/llvm-project/commit/b86e0992bfa6
-    # https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#150
-    # for example, is required to create alpaka::EnabledAccTags
-    # the feature is implemented since Clang 4
-    alpaka_set_compiler_options(HOST_DEVICE target alpaka "$<$<AND:$<CXX_COMPILER_ID:Clang,AppleClang,IntelLLVM>>:SHELL:-frelaxed-template-template-args>")
-
     # Add debug optimization levels. CMake doesn't do this by default.
     # Note that -Og is the recommended gcc optimization level for debug mode but is equivalent to -O1 for clang (and its derivates).
     alpaka_set_compiler_options(HOST_DEVICE target alpaka "$<$<AND:$<CONFIG:Debug>,$<CXX_COMPILER_ID:GNU>,$<COMPILE_LANGUAGE:CXX>>:SHELL:-Og>"
@@ -610,13 +603,6 @@ if(alpaka_ACC_GPU_HIP_ENABLE)
             alpaka_set_compiler_options(HOST_DEVICE target alpaka "$<$<COMPILE_LANGUAGE:CXX>:-D__HIP_PLATFORM_HCC__>")
         endif()
 
-        # C++17 relaxed template template argument matching is disabled by default until Clang 19
-        # https://github.com/llvm/llvm-project/commit/b86e0992bfa6
-        # https://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#150
-        # for example, is required to create alpaka::EnabledAccTags
-        # TODO(SimeonEhrig): restict HIP version, if first HIP version is release using Clang 19
-        alpaka_set_compiler_options(HOST_DEVICE target alpaka "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-frelaxed-template-template-args>")
-
         alpaka_compiler_option(HIP_KEEP_FILES "Keep all intermediate files that are generated during internal compilation steps 'CMakeFiles/<targetname>.dir'" OFF)
         if(alpaka_HIP_KEEP_FILES)
             alpaka_set_compiler_options(HOST_DEVICE target alpaka "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-save-temps>")
@@ -677,7 +663,6 @@ if(alpaka_ACC_SYCL_ENABLE)
         alpaka_set_compiler_options(HOST_DEVICE target alpaka "-fsycl")
         target_link_options(alpaka INTERFACE "-fsycl")
         alpaka_set_compiler_options(HOST_DEVICE target alpaka "-sycl-std=2020")
-        alpaka_set_compiler_options(HOST_DEVICE target alpaka "-frelaxed-template-template-args")
 
         #-----------------------------------------------------------------------------------------------------------------
         # Determine SYCL targets

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -357,6 +357,11 @@ if(alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE OR alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE)
     else()
         find_package(OpenMP REQUIRED COMPONENTS CXX)
         target_link_libraries(alpaka INTERFACE OpenMP::OpenMP_CXX)
+        # shown with CMake 3.29 and cray clang 17
+        # workaround: cmake is missing to add '-fopenmp' to the linker flags
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "CrayClang")
+            target_link_libraries(alpaka INTERFACE -fopenmp)
+        endif()
     endif()
 endif()
 

--- a/include/alpaka/meta/Filter.hpp
+++ b/include/alpaka/meta/Filter.hpp
@@ -12,16 +12,16 @@ namespace alpaka::meta
 {
     namespace detail
     {
-        template<template<typename...> class TList, template<typename> class TPred, typename... Ts>
+        template<template<typename...> class TList, template<typename...> class TPred, typename... Ts>
         struct FilterImplHelper;
 
-        template<template<typename...> class TList, template<typename> class TPred>
+        template<template<typename...> class TList, template<typename...> class TPred>
         struct FilterImplHelper<TList, TPred>
         {
             using type = TList<>;
         };
 
-        template<template<typename...> class TList, template<typename> class TPred, typename T, typename... Ts>
+        template<template<typename...> class TList, template<typename...> class TPred, typename T, typename... Ts>
         struct FilterImplHelper<TList, TPred, T, Ts...>
         {
             using type = std::conditional_t<
@@ -30,15 +30,18 @@ namespace alpaka::meta
                 typename FilterImplHelper<TList, TPred, Ts...>::type>;
         };
 
-        template<typename TList, template<typename> class TPred>
+        template<typename TList, template<typename...> class TPred>
         struct FilterImpl;
 
-        template<template<typename...> class TList, template<typename> class TPred, typename... Ts>
+        template<template<typename...> class TList, template<typename...> class TPred, typename... Ts>
         struct FilterImpl<TList<Ts...>, TPred>
         {
             using type = typename detail::FilterImplHelper<TList, TPred, Ts...>::type;
         };
     } // namespace detail
-    template<typename TList, template<typename> class TPred>
+
+    /// \tparam TPred Only the first parameter is used, all other must be set by TPred to some default.
+    ///               Using '...' instead of a single type is a workaround for CrayClang.
+    template<typename TList, template<typename...> class TPred>
     using Filter = typename detail::FilterImpl<TList, TPred>::type;
 } // namespace alpaka::meta


### PR DESCRIPTION
- fix cray clang compile issue
  ```
  include/alpaka/acc/TagAccIsEnabled.hpp:34:66: error: template template argument has different template parameters than its corresponding template template parameter
   34 |     using EnabledAccTags = alpaka::meta::Filter<AccTags, alpaka::AccIsEnabled>;
      |    
  ```
- fix cray clang OpenMP linker issues, missing flag `-fopenmp`
- remove clang workaround we applied in https://github.com/alpaka-group/alpaka/pull/2267