### PR TITLE
Prints Acc tags of tags-tuple at runtime

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -239,6 +239,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/complex/src/complex.cpp
+++ b/example/complex/src/complex.cpp
@@ -80,6 +80,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/conv2DWithMdspan/src/conv2DWithMdspan.cpp
+++ b/example/conv2DWithMdspan/src/conv2DWithMdspan.cpp
@@ -230,6 +230,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/convolution1D/src/convolution1D.cpp
+++ b/example/convolution1D/src/convolution1D.cpp
@@ -190,6 +190,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/convolution2D/src/convolution2D.cpp
+++ b/example/convolution2D/src/convolution2D.cpp
@@ -394,6 +394,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/counterBasedRng/src/counterBasedRng.cpp
+++ b/example/counterBasedRng/src/counterBasedRng.cpp
@@ -226,6 +226,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/heatEquation/src/heatEquation.cpp
+++ b/example/heatEquation/src/heatEquation.cpp
@@ -186,6 +186,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/heatEquation2D/src/heatEquation2D.cpp
+++ b/example/heatEquation2D/src/heatEquation2D.cpp
@@ -204,6 +204,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/helloWorld/src/helloWorld.cpp
+++ b/example/helloWorld/src/helloWorld.cpp
@@ -161,6 +161,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/helloWorldLambda/src/helloWorldLambda.cpp
+++ b/example/helloWorldLambda/src/helloWorldLambda.cpp
@@ -134,6 +134,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/kernelSpecialization/src/kernelSpecialization.cpp
+++ b/example/kernelSpecialization/src/kernelSpecialization.cpp
@@ -95,6 +95,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/matrixMulWithMdspan/src/matrixMulMdSpan.cpp
+++ b/example/matrixMulWithMdspan/src/matrixMulMdSpan.cpp
@@ -192,6 +192,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/monteCarloIntegration/src/monteCarloIntegration.cpp
+++ b/example/monteCarloIntegration/src/monteCarloIntegration.cpp
@@ -139,6 +139,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/parallelLoopPatterns/src/parallelLoopPatterns.cpp
+++ b/example/parallelLoopPatterns/src/parallelLoopPatterns.cpp
@@ -435,6 +435,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/randomCells2D/src/randomCells2D.cpp
+++ b/example/randomCells2D/src/randomCells2D.cpp
@@ -309,6 +309,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/randomStrategies/src/randomStrategies.cpp
+++ b/example/randomStrategies/src/randomStrategies.cpp
@@ -340,6 +340,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/tagSpecialization/src/tagSpecialization.cpp
+++ b/example/tagSpecialization/src/tagSpecialization.cpp
@@ -119,6 +119,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -190,6 +190,8 @@ auto example(TAccTag const&) -> int
 
 auto main() -> int
 {
+    std::cout << "Check enabled accelerator tags:" << std::endl;
+    alpaka::printTagNames<alpaka::EnabledAccTags>();
     // Execute the example once for each enabled accelerator.
     // If you would like to execute it for a single accelerator only you can use the following code.
     //  \code{.cpp}

--- a/include/alpaka/acc/Tag.hpp
+++ b/include/alpaka/acc/Tag.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/core/BoostPredef.hpp"
 
 #include <iostream>
+#include <tuple>
 #include <type_traits>
 
 #define CREATE_ACC_TAG(tag_name)                                                                                      \
@@ -69,4 +70,28 @@ namespace alpaka
         alpaka::TagFpgaSyclIntel,
         alpaka::TagGpuSyclIntel>;
 
+    //!  \brief Function to print the names of each tag in the given tuple of tags
+    //!  \tparam TTuple is the type of the tuple of tags
+    template<typename TTuple>
+    void printTagNames()
+    {
+        // Check if the tuple is empty using std::tuple_size_v
+        if(std::tuple_size_v<TTuple> == 0)
+        {
+            std::cout << "No Tags!";
+        }
+        else
+        {
+            std::cout << "Tags: ";
+            // Print tags with comma in between
+            std::apply(
+                [](auto... args)
+                {
+                    auto index = std::tuple_size_v<TTuple>;
+                    ((std::cout << args.get_name() << (--index > 0u ? "," : "")), ...);
+                },
+                TTuple{});
+        }
+        std::cout << std::endl;
+    }
 } // namespace alpaka


### PR DESCRIPTION
Examples was exiting silently if there are no enabled backends. This issue is reported by the assistants of the october2024 workshop.

 This PR creates a function that prints the Acc-tags of the enabled backends at runtime. If there is no backends, the user is informed.

```
./heatEquation2D
Check enabled accelerator tags:
No Tags!
```

```
./heatEquation2D 
Check enabled accelerator tags:
Tags: TagCpuSerial,TagCpuThreads
Using alpaka accelerator: AccCpuSerial<2,unsigned int>
Execution results correct!
Using alpaka accelerator: AccCpuThreads<2,unsigned int>
Execution results correct!
```