### PR TITLE
call job_generator.py only one time to generate all job yaml files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,10 +28,8 @@ generate:
     - pip3 install -r script/job_generator/requirements.txt
     # it is sufficient to verify once, as the same job matrix is generated, verified and then filtered each time
     # disable verify because we know that the generator is broken: https://github.com/thombashi/allpairspy/pull/10
-    #- python3 script/job_generator/job_generator.py ${ALPAKA_GITLAB_CI_GENERATOR_CONTAINER_VERSION} --verify --wave compile_only_job -o compile_only.yml
-    - python3 script/job_generator/job_generator.py ${ALPAKA_GITLAB_CI_GENERATOR_CONTAINER_VERSION} --wave compile_only_job -o compile_only.yml
-    - python3 script/job_generator/job_generator.py ${ALPAKA_GITLAB_CI_GENERATOR_CONTAINER_VERSION} --wave runtime_job_cpu -o runtime_cpu.yml
-    - python3 script/job_generator/job_generator.py ${ALPAKA_GITLAB_CI_GENERATOR_CONTAINER_VERSION} --wave runtime_job_gpu -o runtime_gpu.yml
+    # - python3 script/job_generator/job_generator.py ${ALPAKA_GITLAB_CI_GENERATOR_CONTAINER_VERSION} --verify --split-waves --wave-out-compile_only_job=compile_only.yml --wave-out-runtime_job_gpu=runtime_cpu.yml --wave-out-runtime_job_cpu=runtime_gpu.yml
+    - python3 script/job_generator/job_generator.py ${ALPAKA_GITLAB_CI_GENERATOR_CONTAINER_VERSION} --split-waves --wave-out-compile_only_job=compile_only.yml --wave-out-runtime_job_gpu=runtime_cpu.yml --wave-out-runtime_job_cpu=runtime_gpu.yml
     - cat compile_only.yml
     - cat runtime_cpu.yml
     - cat runtime_gpu.yml

--- a/script/job_generator/generate_job_yaml.py
+++ b/script/job_generator/generate_job_yaml.py
@@ -600,7 +600,7 @@ def write_job_yaml(
         # If there is no CI job, create a dummy job.
         # This can happen if the filter filters out all jobs.
         number_of_jobs = 0
-        for wave_name in WAVE_GROUP_NAMES:
+        for wave_name in job_matrix.keys():
             number_of_jobs += len(job_matrix[wave_name])
 
         if number_of_jobs == 0:
@@ -618,7 +618,7 @@ def write_job_yaml(
 
         stages: Dict[str, List[str]] = {"stages": []}
 
-        for wave_name in WAVE_GROUP_NAMES:
+        for wave_name in job_matrix.keys():
             # setup all stages
             for stage_number in range(len(job_matrix[wave_name])):
                 stages["stages"].append(f"{wave_name}-stage{stage_number}")
@@ -640,7 +640,7 @@ def write_job_yaml(
             job_base_yaml = yaml.load(file, yaml.loader.SafeLoader)
         yaml.dump(job_base_yaml, output_file)
 
-        for wave_name in WAVE_GROUP_NAMES:
+        for wave_name in job_matrix.keys():
             # Writes each job separately to the file.
             # If all jobs would be collected first in dict, the order would be not guarantied.
             for stage_number, wave in enumerate(job_matrix[wave_name]):


### PR DESCRIPTION
Before we called the job generator 3 times to generate the jobs for each pipeline. So it generates the same matrix 3 times an throw away the unused jobs. Now, we call it only one time and write all jobs to different output files. Therefore we generate only one time the combination matrix. 