### PR TITLE
add static function dim() to alpaka::Vec

### DIFF
--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -368,6 +368,12 @@ namespace alpaka
             return (*this)[I];
         }
 
+        //! \return The number of dimensions of the vector.
+        [[nodiscard]] ALPAKA_FN_HOST_ACC static consteval auto dim() noexcept -> TVal
+        {
+            return TDim::value;
+        }
+
         //! \return The element-wise sum of two vectors.
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC friend constexpr auto operator+(Vec const& p, Vec const& q) -> Vec

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -177,7 +177,14 @@ TEST_CASE("basicVecTraits", "[vec]")
     }
 
     {
-        constexpr alpaka::Vec<Dim, Idx> vec3(static_cast<Idx>(47u), static_cast<Idx>(8u), static_cast<Idx>(3u));
+        using Vec3 = alpaka::Vec<Dim, Idx>;
+        constexpr Vec3 vec3(static_cast<Idx>(47u), static_cast<Idx>(8u), static_cast<Idx>(3u));
+
+        // alpaka::Vec::dim
+        {
+            STATIC_REQUIRE(vec3.dim() == 3);
+            STATIC_REQUIRE(Vec3::dim() == 3);
+        }
 
         // alpaka::Vec operator +
         {


### PR DESCRIPTION
Easy way to get the dim of a alpaka::Vec.