### PR TITLE
set default environment variables in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     env: ${{ matrix.env }}
     container: ${{ matrix.container }}
+    defaults:
+      run:
+        shell: bash
 
     strategy:
       fail-fast: false
@@ -200,14 +203,13 @@ jobs:
       if: (contains(github.event.head_commit.message, 'ci_filter') && !contains(github.event.head_commit.message, matrix.name ))
       run: exit 1
     - uses: actions/checkout@v3
-    - name: build + test
-      if: (runner.os == 'Windows')
+    # Print the environment variables in an additional step so that the environment variables can be displayed if the job is still running.
+    # Call ./script/set_default_env_vars.sh in each step, as the environment variables are not shared between the steps by default.
+    - name: print environment variables
       env:
         ALPAKA_CI_OS_NAME: ${{runner.os}}
-      shell: bash
-      run: cd ${GITHUB_WORKSPACE} && ./script/ci.sh
+      run: cd ${GITHUB_WORKSPACE} && source ./script/set_default_env_vars.sh && source ./script/gitlabci/print_env.sh
     - name: build + test
-      if: (runner.os == 'Linux' || runner.os == 'macOS')
       env:
         ALPAKA_CI_OS_NAME: ${{runner.os}}
-      run: cd ${GITHUB_WORKSPACE} && ./script/ci.sh
+      run: cd ${GITHUB_WORKSPACE} && source ./script/set_default_env_vars.sh && ./script/ci.sh

--- a/script/gitlabci/print_env.sh
+++ b/script/gitlabci/print_env.sh
@@ -11,52 +11,71 @@ if [ -z ${alpaka_DISABLE_EXIT_FAILURE+x} ]; then
     set -e
 fi
 
-# display output with yellow color
-echo -e "\033[0;33mSteps to setup containter locally"
+# print all environment variables, which are required to reproduce alpaka build
+#
+# @param $1 (optional): set `export_env` to print all environment variables in the shape of:
+#    export VAR_NAME=VAR_VALUE \
+function print_env() {
+    if [[ $# -ge 1 ]] && [[ "$1" == "export_env" ]]; then
+        export_cmd=true
+    else
+        export_cmd=false
+    fi
 
-# display the correct docker run command
-first_step_prefix="1. Run docker image via:"
-if [ "${CMAKE_CXX_COMPILER:-}" == "nvc++" ] || [ "${alpaka_ACC_GPU_CUDA_ENABLE}" == "ON" ];
-then
-    if [ "${ALPAKA_CI_RUN_TESTS}" == "ON" ];
-    then
-        echo "${first_step_prefix} docker run --gpus=all -it ${CI_JOB_IMAGE} bash"
+    # take all env variables, filter it and display it with a `export` prefix
+    env_name_prefixes=("^ALPAKA_*" "^alpaka_*" "^CMAKE_*" "^BOOST_*" "^CUDA_*")
+    for reg in ${env_name_prefixes[@]}; do
+        if printenv | grep -qE ${reg}; then
+            printenv | grep -E ${reg} | sort | while read -r line; do
+                if $export_cmd == true; then
+                    echo "export $line \\"
+                else
+                    echo "$line"
+                fi
+            done
+        fi
+    done
+}
+
+# on GitLab CI print all instructions to run test locally
+# on GitHub Actions, simply print environment variables
+if [ ! -z "${GITLAB_CI+x}" ]; then
+    # display output with yellow color
+    echo -e "\033[0;33mSteps to setup container locally"
+
+    # display the correct docker run command
+    first_step_prefix="1. Run docker image via:"
+    if [ "${CMAKE_CXX_COMPILER:-}" == "nvc++" ] || [ "${alpaka_ACC_GPU_CUDA_ENABLE}" == "ON" ]; then
+        if [ "${ALPAKA_CI_RUN_TESTS}" == "ON" ]; then
+            echo "${first_step_prefix} docker run --gpus=all -it ${CI_JOB_IMAGE} bash"
+        else
+            echo "${first_step_prefix} docker run -it ${CI_JOB_IMAGE} bash"
+        fi
+    elif [ "${alpaka_ACC_GPU_HIP_ENABLE}" == "ON" ]; then
+        if [ "${ALPAKA_CI_RUN_TESTS}" == "ON" ]; then
+            echo "${first_step_prefix} docker run -it --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video ${CI_JOB_IMAGE} bash"
+        else
+            echo "${first_step_prefix} docker run -it ${CI_JOB_IMAGE} bash"
+        fi
     else
         echo "${first_step_prefix} docker run -it ${CI_JOB_IMAGE} bash"
     fi
-elif [ "${alpaka_ACC_GPU_HIP_ENABLE}" == "ON" ];
-then
-    if [ "${ALPAKA_CI_RUN_TESTS}" == "ON" ];
-    then
-        echo "${first_step_prefix} docker run -it --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video ${CI_JOB_IMAGE} bash"
-    else
-        echo "${first_step_prefix} docker run -it ${CI_JOB_IMAGE} bash"
-    fi
+
+    echo -e "2. Run the following export commands in the container to setup environment\n"
+    print_env export_env
+
+    echo "export CI_RUNNER_TAGS='${CI_RUNNER_TAGS}' \\"
+
+    # the variable is not set, but should be set if a job is debugged locally in a container
+    echo 'export alpaka_DISABLE_EXIT_FAILURE=true \'
+    echo 'export GITLAB_CI=true'
+    echo ""
+
+    echo "3. install git: apt update && apt install -y git"
+    echo "4. clone alpaka repository: git clone https://gitlab.com/hzdr/crp/alpaka.git --depth 1 -b ${CI_COMMIT_BRANCH}"
+    echo "5. Run the following script: cd alpaka && ./script/gitlab_ci_run.sh"
+    # reset the color
+    echo -e "\033[0m"
 else
-    echo "${first_step_prefix} docker run -it ${CI_JOB_IMAGE} bash"
+    print_env
 fi
-
-echo -e "2. Run the following export commands in the container to setup enviroment\n"
-
-# take all env variables, filter it and display it with a `export` prefix
-env_name_prefixes=("^ALPAKA_*" "^alpaka_*" "^CMAKE_*" "^BOOST_*" "^CUDA_*")
-for reg in ${env_name_prefixes[@]}; do
-    if printenv | grep -qE ${reg}; then
-        printenv | grep -E ${reg} | sort | while read -r line ; do
-            echo "export $line \\"
-        done
-    fi
-done
-
-echo "export CI_RUNNER_TAGS='${CI_RUNNER_TAGS}' \\"
-
-# the variable is not set, but should be set if a job is debugged locally in a container
-echo 'export alpaka_DISABLE_EXIT_FAILURE=true \'
-echo 'export GITLAB_CI=true'
-echo ""
-
-echo "3. install git: apt update && apt install -y git"
-echo "4. clone alpaka repository: git clone https://gitlab.com/hzdr/crp/alpaka.git --depth 1 -b ${CI_COMMIT_BRANCH}"
-echo "5. Run the following script: cd alpaka && ./script/gitlab_ci_run.sh"
-# reset the color
-echo -e "\033[0m"

--- a/script/job_generator/generate_job_yaml.py
+++ b/script/job_generator/generate_job_yaml.py
@@ -481,6 +481,7 @@ def create_job(job: Dict[str, Tuple[str, str]], container_version: float, gitlab
     job_yaml["image"] = job_image(job, container_version, gitlab_images)
     job_yaml["variables"] = job_variables(job)
     job_yaml["script"] = [
+        "source ./script/set_default_env_vars.sh",
         "source ./script/gitlabci/print_env.sh",
         "source ./script/gitlab_ci_run.sh",
     ]

--- a/script/set_default_env_vars.sh
+++ b/script/set_default_env_vars.sh
@@ -1,0 +1,5 @@
+#/usr/bin/env bash
+
+# set default values for unset environment variables
+
+export CMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS:="ON"}


### PR DESCRIPTION
- If a required environment variable is not set via job description, set a default value to get a well defined state.
- Implement only basic mechanism to set default environment variables, because I expect problems for some variables, which requires extra bug fixes.
- Set CMAKE_CXX_EXTENSIONS=ON (default of CMake if not set)
- Print environment variables also in GitHub Actions jobs.