### PR TITLE
Fix template arguments of SYCL buffer specializations

### DIFF
--- a/include/alpaka/mem/buf/BufCpuSycl.hpp
+++ b/include/alpaka/mem/buf/BufCpuSycl.hpp
@@ -4,16 +4,14 @@
 
 #pragma once
 
-#include "alpaka/dev/DevCpuSycl.hpp"
 #include "alpaka/mem/buf/BufGenericSycl.hpp"
-#include "alpaka/platform/PlatformCpuSycl.hpp"
 
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_ONEAPI_CPU)
 
 namespace alpaka
 {
     template<typename TElem, typename TDim, typename TIdx>
-    using BufCpuSycl = BufGenericSycl<TElem, TDim, TIdx, PlatformCpuSycl>;
+    using BufCpuSycl = BufGenericSycl<TElem, TDim, TIdx, TagCpuSycl>;
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/mem/buf/BufFpgaSyclIntel.hpp
+++ b/include/alpaka/mem/buf/BufFpgaSyclIntel.hpp
@@ -4,16 +4,14 @@
 
 #pragma once
 
-#include "alpaka/dev/DevFpgaSyclIntel.hpp"
 #include "alpaka/mem/buf/BufGenericSycl.hpp"
-#include "alpaka/platform/PlatformFpgaSyclIntel.hpp"
 
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_ONEAPI_FPGA)
 
 namespace alpaka
 {
     template<typename TElem, typename TDim, typename TIdx>
-    using BufFpgaSyclIntel = BufGenericSycl<TElem, TDim, TIdx, PlatformFpgaSyclIntel>;
+    using BufFpgaSyclIntel = BufGenericSycl<TElem, TDim, TIdx, TagFpgaSyclIntel>;
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/mem/buf/BufGpuSyclIntel.hpp
+++ b/include/alpaka/mem/buf/BufGpuSyclIntel.hpp
@@ -4,16 +4,14 @@
 
 #pragma once
 
-#include "alpaka/dev/DevGpuSyclIntel.hpp"
 #include "alpaka/mem/buf/BufGenericSycl.hpp"
-#include "alpaka/platform/PlatformGpuSyclIntel.hpp"
 
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_ONEAPI_GPU)
 
 namespace alpaka
 {
     template<typename TElem, typename TDim, typename TIdx>
-    using BufGpuSyclIntel = BufGenericSycl<TElem, TDim, TIdx, PlatformGpuSyclIntel>;
+    using BufGpuSyclIntel = BufGenericSycl<TElem, TDim, TIdx, TagGpuSyclIntel>;
 } // namespace alpaka
 
 #endif


### PR DESCRIPTION
`BufCpuSycl`, `BufFpgaSyclIntel`, and `BufGpuSyclIntel` were still templated on the platform instead of being templated on the Tag.
We are not using them anywhere in the alpaka tests, that's why this issue has not been spotted before. 
I changed `memBufTest` to use them explicitly to avoid similar issues in the future, let me know if it's ok.