### PR TITLE
update oneAPI to 2025.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,16 @@ The [source code documentation](https://alpaka-group.github.io/alpaka/) is gener
 Accelerator Back-ends
 ---------------------
 
-| Accelerator Back-end   | Lib/API                                                 | Devices               | Execution strategy grid-blocks     | Execution strategy block-threads     |
-|------------------------|---------------------------------------------------------|-----------------------|------------------------------------|--------------------------------------|
-| Serial                 | n/a                                                     | Host CPU (single core) | sequential                         | sequential (only 1 thread per block) |
-| OpenMP 2.0+ blocks     | OpenMP 2.0+                                             | Host CPU (multi core) | parallel (preemptive multitasking) | sequential (only 1 thread per block) |
-| OpenMP 2.0+ threads    | OpenMP 2.0+                                             | Host CPU (multi core) | sequential                         | parallel (preemptive multitasking)   |
-| std::thread            | std::thread                                             | Host CPU (multi core) | sequential                         | parallel (preemptive multitasking)   |
-| TBB                    | TBB 2.2+                                                | Host CPU (multi core) | parallel (preemptive multitasking) | sequential (only 1 thread per block) |
-| CUDA                   | CUDA 12.0+                                              | NVIDIA GPUs           | parallel (undefined)               | parallel (lock-step within warps)    |
-| HIP(clang)             | [HIP 6.0+](https://github.com/ROCm-Developer-Tools/HIP) | AMD GPUs              | parallel (undefined)               | parallel (lock-step within warps)    |
+| Accelerator Back-end   | Lib/API                                                 | Devices                    | Execution strategy grid-blocks     | Execution strategy block-threads     |
+|------------------------|---------------------------------------------------------|----------------------------|------------------------------------|--------------------------------------|
+| Serial                 | n/a                                                     | Host CPU (single core)     | sequential                         | sequential (only 1 thread per block) |
+| OpenMP 2.0+ blocks     | OpenMP 2.0+                                             | Host CPU (multi core)      | parallel (preemptive multitasking) | sequential (only 1 thread per block) |
+| OpenMP 2.0+ threads    | OpenMP 2.0+                                             | Host CPU (multi core)      | sequential                         | parallel (preemptive multitasking)   |
+| std::thread            | std::thread                                             | Host CPU (multi core)      | sequential                         | parallel (preemptive multitasking)   |
+| TBB                    | TBB 2.2+                                                | Host CPU (multi core)      | parallel (preemptive multitasking) | sequential (only 1 thread per block) |
+| CUDA                   | CUDA 12.0+                                              | NVIDIA GPUs                | parallel (undefined)               | parallel (lock-step within warps)    |
+| HIP(clang)             | [HIP 6.0+](https://github.com/ROCm-Developer-Tools/HIP) | AMD GPUs                   | parallel (undefined)               | parallel (lock-step within warps)    |
+| SYCL(oneAPI)           | oneAPI 2024.2+                                          | CPUs, Intel GPUs and FPGAs | parallel (undefined)               | parallel (lock-step within warps)    |
 
 
 Supported Compilers
@@ -65,7 +66,7 @@ Supported Compilers
 
 This library uses C++20 (or newer when available).
 
-| Accelerator Back-end | gcc 10.4 / 11.1 (Linux)        | gcc 12.3 (Linux)                      | gcc 13.1 (Linux)                      | clang 10/11 (Linux)            | clang 12 (Linux)               | clang 13 (Linux)               | clang 14 (Linux)               | clang 15 (Linux)               | clang 16 (Linux)               | clang 17 (Linux)                      | clang 18 (Linux)                      | clang 19 (Linux)   | icpx 2024.2 (Linux)     | Xcode 15.4 / 16.1 (macOS) | Visual Studio 2022 (Windows) |
+| Accelerator Back-end | gcc 10.4 / 11.1 (Linux)        | gcc 12.3 (Linux)                      | gcc 13.1 (Linux)                      | clang 10/11 (Linux)            | clang 12 (Linux)               | clang 13 (Linux)               | clang 14 (Linux)               | clang 15 (Linux)               | clang 16 (Linux)               | clang 17 (Linux)                      | clang 18 (Linux)                      | clang 19 (Linux)   | icpx 2025.0 (Linux)     | Xcode 15.4 / 16.1 (macOS) | Visual Studio 2022 (Windows) |
 |----------------------|--------------------------------|---------------------------------------|---------------------------------------|--------------------------------|--------------------------------|--------------------------------|--------------------------------|--------------------------------|--------------------------------|---------------------------------------|---------------------------------------|--------------------|-------------------------|---------------------------|------------------------------|
 | Serial               | :white_check_mark:             | :white_check_mark:                    | :white_check_mark:                    | :white_check_mark:             | :white_check_mark:             | :white_check_mark:             | :white_check_mark:             | :white_check_mark:             | :white_check_mark:             | :white_check_mark:                    | :white_check_mark:                    | :white_check_mark: | :white_check_mark:      | :white_check_mark:        | :white_check_mark:           |
 | OpenMP 2.0+ blocks   | :white_check_mark:             | :white_check_mark:                    | :white_check_mark:                    | :white_check_mark:             | :white_check_mark:             | :white_check_mark:             | :white_check_mark:             | :white_check_mark:             | :white_check_mark:             | :white_check_mark:                    | :white_check_mark:                    | :white_check_mark: | :white_check_mark: [^1] | :white_check_mark:        | :white_check_mark:           |

--- a/script/job_generator/generate_job_yaml.py
+++ b/script/job_generator/generate_job_yaml.py
@@ -377,6 +377,8 @@ def job_variables(job: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
             variables["ALPAKA_CI_CLANG_VER"] = "18"
         elif job[DEVICE_COMPILER][VERSION] == "2024.2":
             variables["ALPAKA_CI_CLANG_VER"] = "19"
+        elif job[DEVICE_COMPILER][VERSION] == "2025.0":
+            variables["ALPAKA_CI_CLANG_VER"] = "19"
         variables["ALPAKA_CI_STDLIB"] = "libstdc++"
         variables["ALPAKA_CI_ONEAPI_VERSION"] = job[DEVICE_COMPILER][VERSION]
         variables["alpaka_SYCL_ONEAPI_CPU"] = "ON"

--- a/script/job_generator/versions.py
+++ b/script/job_generator/versions.py
@@ -23,7 +23,7 @@ sw_versions: Dict[str, List[str]] = {
         "12.6",
     ],
     HIPCC: ["6.0", "6.1", "6.2"],
-    ICPX: ["2024.2"],
+    ICPX: ["2025.0"],
     # Contains all enabled back-ends.
     # There are special cases for ALPAKA_ACC_GPU_CUDA_ENABLE and ALPAKA_ACC_GPU_HIP_ENABLE
     # which have to be combined with nvcc and hipcc versions.


### PR DESCRIPTION
With the new release all the tests of the SYCL CPU backend are passing, some of them were failing before with `PI_ERROR_OUT_OF_RESOURCES`.