### PR TITLE
add math functions for complex type for the oneAPI backend

### DIFF
--- a/include/alpaka/kernel/TaskKernelCpuSycl.hpp
+++ b/include/alpaka/kernel/TaskKernelCpuSycl.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/acc/AccCpuSycl.hpp"
 #include "alpaka/acc/Tag.hpp"
 #include "alpaka/kernel/TaskKernelGenericSycl.hpp"
 

--- a/include/alpaka/kernel/TaskKernelFpgaSyclIntel.hpp
+++ b/include/alpaka/kernel/TaskKernelFpgaSyclIntel.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/acc/AccFpgaSyclIntel.hpp"
 #include "alpaka/acc/Tag.hpp"
 #include "alpaka/kernel/TaskKernelGenericSycl.hpp"
 

--- a/include/alpaka/kernel/TaskKernelGpuSyclIntel.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuSyclIntel.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/acc/AccGpuSyclIntel.hpp"
 #include "alpaka/acc/Tag.hpp"
 #include "alpaka/kernel/TaskKernelGenericSycl.hpp"
 

--- a/include/alpaka/math/Complex.hpp
+++ b/include/alpaka/math/Complex.hpp
@@ -1,11 +1,13 @@
-/* Copyright 2022 Sergei Bastrakov
+/* Copyright 2024 Sergei Bastrakov, Aurora Perego
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
 #include "alpaka/core/Common.hpp"
+#include "alpaka/core/Decay.hpp"
 #include "alpaka/math/FloatEqualExact.hpp"
+#include "alpaka/math/Traits.hpp"
 
 #include <cmath>
 #include <complex>
@@ -579,4 +581,366 @@ namespace alpaka
     } // namespace internal
 
     using internal::Complex;
+
+#if defined(ALPAKA_ACC_SYCL_ENABLED) || defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+
+    namespace math::trait
+    {
+
+        //! The abs trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Abs<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                return sqrt(ctx, arg.real() * arg.real() + arg.imag() * arg.imag());
+            }
+        };
+
+        //! The acos trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Acos<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                // This holds everywhere, including the branch cuts: acos(z) = -i * ln(z + i * sqrt(1 - z^2))
+                return Complex<T>{static_cast<T>(0.0), static_cast<T>(-1.0)}
+                       * log(
+                           ctx,
+                           arg
+                               + Complex<T>{static_cast<T>(0.0), static_cast<T>(1.0)}
+                                     * sqrt(ctx, static_cast<T>(1.0) - arg * arg));
+            }
+        };
+
+        //! The acosh trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Acosh<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                // acos(z) = ln(z + sqrt(z-1) * sqrt(z+1))
+                return log(ctx, arg + sqrt(ctx, arg - static_cast<T>(1.0)) * sqrt(ctx, arg + static_cast<T>(1.0)));
+            }
+        };
+
+        //! The arg Complex<T> specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Arg<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
+            {
+                return atan2(ctx, argument.imag(), argument.real());
+            }
+        };
+
+        //! The asin trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Asin<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                // This holds everywhere, including the branch cuts: asin(z) = i * ln(sqrt(1 - z^2) - i * z)
+                return Complex<T>{static_cast<T>(0.0), static_cast<T>(1.0)}
+                       * log(
+                           ctx,
+                           sqrt(ctx, static_cast<T>(1.0) - arg * arg)
+                               - Complex<T>{static_cast<T>(0.0), static_cast<T>(1.0)} * arg);
+            }
+        };
+
+        //! The asinh trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Asinh<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                // asinh(z) = ln(z + sqrt(z^2 + 1))
+                return log(ctx, arg + sqrt(ctx, arg * arg + static_cast<T>(1.0)));
+            }
+        };
+
+        //! The atan trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Atan<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                // This holds everywhere, including the branch cuts: atan(z) = -i/2 * ln((i - z) / (i + z))
+                return Complex<T>{static_cast<T>(0.0), static_cast<T>(-0.5)}
+                       * log(
+                           ctx,
+                           (Complex<T>{static_cast<T>(0.0), static_cast<T>(1.0)} - arg)
+                               / (Complex<T>{static_cast<T>(0.0), static_cast<T>(1.0)} + arg));
+            }
+        };
+
+        //! The atanh trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Atanh<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                //  atanh(z) = 0.5 * (ln(1 + z) - ln(1 - z))
+                return static_cast<T>(0.5)
+                       * (log(ctx, static_cast<T>(1.0) + arg) - log(ctx, static_cast<T>(1.0) - arg));
+            }
+        };
+
+        //! The conj specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Conj<TAcc, Complex<T>>
+        {
+            ALPAKA_FN_ACC auto operator()(TAcc const& /* conj_ctx */, Complex<T> const& arg)
+            {
+                return Complex<T>{arg.real(), -arg.imag()};
+            }
+        };
+
+        //! The cos trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Cos<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                // cos(z) = 0.5 * (exp(i * z) + exp(-i * z))
+                return T(0.5)
+                       * (exp(ctx, Complex<T>{static_cast<T>(0.0), static_cast<T>(1.0)} * arg)
+                          + exp(ctx, Complex<T>{static_cast<T>(0.0), static_cast<T>(-1.0)} * arg));
+            }
+        };
+
+        //! The cosh trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Cosh<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                // cosh(z) = 0.5 * (exp(z) + exp(-z))
+                return T(0.5) * (exp(ctx, arg) + exp(ctx, static_cast<T>(-1.0) * arg));
+            }
+        };
+
+        //! The exp trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Exp<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                // exp(z) = exp(x + iy) = exp(x) * (cos(y) + i * sin(y))
+                auto re = T{}, im = T{};
+                sincos(ctx, arg.imag(), im, re);
+                return exp(ctx, arg.real()) * Complex<T>{re, im};
+            }
+        };
+
+        //! The log trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Log<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
+            {
+                // Branch cut along the negative real axis (same as for std::complex),
+                // principal value of ln(z) = ln(|z|) + i * arg(z)
+                return log(ctx, abs(ctx, argument))
+                       + Complex<T>{static_cast<T>(0.0), static_cast<T>(1.0)} * arg(ctx, argument);
+            }
+        };
+
+        //! The log2 trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Log2<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
+            {
+                return log(ctx, argument) / log(ctx, static_cast<T>(2));
+            }
+        };
+
+        //! The log10 trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Log10<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
+            {
+                return log(ctx, argument) / log(ctx, static_cast<T>(10));
+            }
+        };
+
+        //! The pow trait specialization for complex types.
+        template<typename TAcc, typename T, typename U>
+        struct Pow<TAcc, Complex<T>, Complex<U>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& base, Complex<U> const& exponent)
+            {
+                // Type promotion matching rules of complex std::pow but simplified given our math only supports float
+                // and double, no long double.
+                using Promoted
+                    = Complex<std::conditional_t<is_decayed_v<T, float> && is_decayed_v<U, float>, float, double>>;
+                // pow(z1, z2) = e^(z2 * log(z1))
+                return exp(ctx, Promoted{exponent} * log(ctx, Promoted{base}));
+            }
+        };
+
+        //! The pow trait specialization for complex and real types.
+        template<typename TAcc, typename T, typename U>
+        struct Pow<TAcc, Complex<T>, U>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& base, U const& exponent)
+            {
+                return pow(ctx, base, Complex<U>{exponent});
+            }
+        };
+
+        //! The pow trait specialization for real and complex types.
+        template<typename TAcc, typename T, typename U>
+        struct Pow<TAcc, T, Complex<U>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, T const& base, Complex<U> const& exponent)
+            {
+                return pow(ctx, Complex<T>{base}, exponent);
+            }
+        };
+
+        //! The rsqrt trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Rsqrt<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                return static_cast<T>(1.0) / sqrt(ctx, arg);
+            }
+        };
+
+        //! The sin trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Sin<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                // sin(z) = (exp(i * z) - exp(-i * z)) / 2i
+                return (exp(ctx, Complex<T>{static_cast<T>(0.0), static_cast<T>(1.0)} * arg)
+                        - exp(ctx, Complex<T>{static_cast<T>(0.0), static_cast<T>(-1.0)} * arg))
+                       / Complex<T>{static_cast<T>(0.0), static_cast<T>(2.0)};
+            }
+        };
+
+        //! The sinh trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Sinh<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                // sinh(z) = (exp(z) - exp(-i * z)) / 2
+                return (exp(ctx, arg) - exp(ctx, static_cast<T>(-1.0) * arg)) / static_cast<T>(2.0);
+            }
+        };
+
+        //! The sincos trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct SinCos<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(
+                TCtx const& ctx,
+                Complex<T> const& arg,
+                Complex<T>& result_sin,
+                Complex<T>& result_cos) -> void
+            {
+                result_sin = sin(ctx, arg);
+                result_cos = cos(ctx, arg);
+            }
+        };
+
+        //! The sqrt trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Sqrt<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
+            {
+                // Branch cut along the negative real axis (same as for std::complex),
+                // principal value of sqrt(z) = sqrt(|z|) * e^(i * arg(z) / 2)
+                auto const halfArg = T(0.5) * arg(ctx, argument);
+                auto re = T{}, im = T{};
+                sincos(ctx, halfArg, im, re);
+                return sqrt(ctx, abs(ctx, argument)) * Complex<T>(re, im);
+            }
+        };
+
+        //! The tan trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Tan<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                // tan(z) = i * (e^-iz - e^iz) / (e^-iz + e^iz) = i * (1 - e^2iz) / (1 + e^2iz)
+                // Warning: this straightforward implementation can easily result in NaN as 0/0 or inf/inf.
+                auto const expValue = exp(ctx, Complex<T>{static_cast<T>(0.0), static_cast<T>(2.0)} * arg);
+                return Complex<T>{static_cast<T>(0.0), static_cast<T>(1.0)} * (static_cast<T>(1.0) - expValue)
+                       / (static_cast<T>(1.0) + expValue);
+            }
+        };
+
+        //! The tanh trait specialization for complex types.
+        template<typename TAcc, typename T>
+        struct Tanh<TAcc, Complex<T>>
+        {
+            //! Take context as original (accelerator) type, since we call other math functions
+            template<typename TCtx>
+            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            {
+                // tanh(z) = (e^z - e^-z)/(e^z+e^-z)
+                return (exp(ctx, arg) - exp(ctx, static_cast<T>(-1.0) * arg))
+                       / (exp(ctx, arg) + exp(ctx, static_cast<T>(-1.0) * arg));
+            }
+        };
+    } // namespace math::trait
+
+#endif
+
 } // namespace alpaka

--- a/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/math/MathUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Axel Huebl, Benjamin Worpitz, Matthias Werner, Bert Wesarg, Valentin Gehrke, René Widera,
+/* Copyright 2024 Axel Huebl, Benjamin Worpitz, Matthias Werner, Bert Wesarg, Valentin Gehrke, René Widera,
  * Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber, Jeffrey Kelling, Sergei Bastrakov
  * SPDX-License-Identifier: MPL-2.0
  */
@@ -305,18 +305,6 @@ namespace alpaka::math
             }
         };
 
-        //! The CUDA abs trait specialization for complex types.
-        template<typename T>
-        struct Abs<AbsUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                return sqrt(ctx, arg.real() * arg.real() + arg.imag() * arg.imag());
-            }
-        };
-
         //! The CUDA acos trait specialization for real types.
         template<typename TArg>
         struct Acos<AcosUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
@@ -331,19 +319,6 @@ namespace alpaka::math
                     static_assert(!sizeof(TArg), "Unsupported data type");
 
                 ALPAKA_UNREACHABLE(TArg{});
-            }
-        };
-
-        //! The CUDA acos trait specialization for complex types.
-        template<typename T>
-        struct Acos<AcosUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                // This holds everywhere, including the branch cuts: acos(z) = -i * ln(z + i * sqrt(1 - z^2))
-                return Complex<T>{0.0, -1.0} * log(ctx, arg + Complex<T>{0.0, 1.0} * sqrt(ctx, T(1.0) - arg * arg));
             }
         };
 
@@ -364,19 +339,6 @@ namespace alpaka::math
             }
         };
 
-        //! The CUDA acosh trait specialization for complex types.
-        template<typename T>
-        struct Acosh<AcoshUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                // acos(z) = ln(z + sqrt(z-1) * sqrt(z+1))
-                return log(ctx, arg + sqrt(ctx, arg - static_cast<T>(1.0)) * sqrt(ctx, arg + static_cast<T>(1.0)));
-            }
-        };
-
         //! The CUDA arg trait specialization for real types.
         template<typename TArgument>
         struct Arg<ArgUniformCudaHipBuiltIn, TArgument, std::enable_if_t<std::is_floating_point_v<TArgument>>>
@@ -387,18 +349,6 @@ namespace alpaka::math
             {
                 // Fall back to atan2 so that boundary cases are resolved consistently
                 return atan2(ctx, TArgument{0.0}, argument);
-            }
-        };
-
-        //! The CUDA arg Complex<T> specialization for complex types.
-        template<typename T>
-        struct Arg<ArgUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& argument)
-            {
-                return atan2(ctx, argument.imag(), argument.real());
             }
         };
 
@@ -419,19 +369,6 @@ namespace alpaka::math
             }
         };
 
-        //! The CUDA asin trait specialization for complex types.
-        template<typename T>
-        struct Asin<AsinUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                // This holds everywhere, including the branch cuts: asin(z) = i * ln(sqrt(1 - z^2) - i * z)
-                return Complex<T>{0.0, 1.0} * log(ctx, sqrt(ctx, T(1.0) - arg * arg) - Complex<T>{0.0, 1.0} * arg);
-            }
-        };
-
         //! The CUDA asinh trait specialization for real types.
         template<typename TArg>
         struct Asinh<AsinhUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
@@ -446,19 +383,6 @@ namespace alpaka::math
                     static_assert(!sizeof(TArg), "Unsupported data type");
 
                 ALPAKA_UNREACHABLE(TArg{});
-            }
-        };
-
-        //! The CUDA asinh trait specialization for complex types.
-        template<typename T>
-        struct Asinh<AsinhUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                // asinh(z) = ln(z + sqrt(z^2 + 1))
-                return log(ctx, arg + sqrt(ctx, arg * arg + static_cast<T>(1.0)));
             }
         };
 
@@ -479,19 +403,6 @@ namespace alpaka::math
             }
         };
 
-        //! The CUDA atan trait specialization for complex types.
-        template<typename T>
-        struct Atan<AtanUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                // This holds everywhere, including the branch cuts: atan(z) = -i/2 * ln((i - z) / (i + z))
-                return Complex<T>{0.0, -0.5} * log(ctx, (Complex<T>{0.0, 1.0} - arg) / (Complex<T>{0.0, 1.0} + arg));
-            }
-        };
-
         //! The CUDA atanh trait specialization for real types.
         template<typename TArg>
         struct Atanh<AtanhUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
@@ -506,20 +417,6 @@ namespace alpaka::math
                     static_assert(!sizeof(TArg), "Unsupported data type");
 
                 ALPAKA_UNREACHABLE(TArg{});
-            }
-        };
-
-        //! The CUDA atanh trait specialization for complex types.
-        template<typename T>
-        struct Atanh<AtanhUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                //  atanh(z) = 0.5 * (ln(1 + z) - ln(1 - z))
-                return static_cast<T>(0.5)
-                       * (log(ctx, static_cast<T>(1.0) + arg) - log(ctx, static_cast<T>(1.0) - arg));
             }
         };
 
@@ -591,16 +488,6 @@ namespace alpaka::math
             }
         };
 
-        //! The CUDA conj specialization for complex types.
-        template<typename T>
-        struct Conj<ConjUniformCudaHipBuiltIn, Complex<T>>
-        {
-            __host__ __device__ auto operator()(ConjUniformCudaHipBuiltIn const& /* conj_ctx */, Complex<T> const& arg)
-            {
-                return Complex<T>{arg.real(), -arg.imag()};
-            }
-        };
-
         //! The CUDA copysign trait specialization for real types.
         template<typename TMag, typename TSgn>
         struct Copysign<
@@ -642,19 +529,6 @@ namespace alpaka::math
             }
         };
 
-        //! The CUDA cos trait specialization for complex types.
-        template<typename T>
-        struct Cos<CosUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                // cos(z) = 0.5 * (exp(i * z) + exp(-i * z))
-                return T(0.5) * (exp(ctx, Complex<T>{0.0, 1.0} * arg) + exp(ctx, Complex<T>{0.0, -1.0} * arg));
-            }
-        };
-
         //! The CUDA cosh trait specialization for real types.
         template<typename TArg>
         struct Cosh<CoshUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
@@ -669,19 +543,6 @@ namespace alpaka::math
                     static_assert(!sizeof(TArg), "Unsupported data type");
 
                 ALPAKA_UNREACHABLE(TArg{});
-            }
-        };
-
-        //! The CUDA cosh trait specialization for complex types.
-        template<typename T>
-        struct Cosh<CoshUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                // cosh(z) = 0.5 * (exp(z) + exp(-z))
-                return T(0.5) * (exp(ctx, arg) + exp(ctx, static_cast<T>(-1.0) * arg));
             }
         };
 
@@ -716,21 +577,6 @@ namespace alpaka::math
                     static_assert(!sizeof(TArg), "Unsupported data type");
 
                 ALPAKA_UNREACHABLE(TArg{});
-            }
-        };
-
-        //! The CUDA exp trait specialization for complex types.
-        template<typename T>
-        struct Exp<ExpUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                // exp(z) = exp(x + iy) = exp(x) * (cos(y) + i * sin(y))
-                auto re = T{}, im = T{};
-                sincos(ctx, arg.imag(), im, re);
-                return exp(ctx, arg.real()) * Complex<T>{re, im};
             }
         };
 
@@ -855,20 +701,6 @@ namespace alpaka::math
             }
         };
 
-        //! The CUDA log trait specialization for complex types.
-        template<typename T>
-        struct Log<LogUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& argument)
-            {
-                // Branch cut along the negative real axis (same as for std::complex),
-                // principal value of ln(z) = ln(|z|) + i * arg(z)
-                return log(ctx, abs(ctx, argument)) + Complex<T>{0.0, 1.0} * arg(ctx, argument);
-            }
-        };
-
         //! The CUDA log2 trait specialization for real types.
         template<typename TArg>
         struct Log2<Log2UniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
@@ -900,18 +732,6 @@ namespace alpaka::math
                     static_assert(!sizeof(TArg), "Unsupported data type");
 
                 ALPAKA_UNREACHABLE(TArg{});
-            }
-        };
-
-        //! The CUDA log10 trait specialization for complex types.
-        template<typename T>
-        struct Log10<Log10UniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& argument)
-            {
-                return log(ctx, argument) / log(ctx, static_cast<T>(10));
             }
         };
 
@@ -1004,47 +824,6 @@ namespace alpaka::math
                 using Ret [[maybe_unused]]
                 = std::conditional_t<is_decayed_v<TBase, float> && is_decayed_v<TExp, float>, float, double>;
                 ALPAKA_UNREACHABLE(Ret{});
-            }
-        };
-
-        //! The CUDA pow trait specialization for complex types.
-        template<typename T, typename U>
-        struct Pow<PowUniformCudaHipBuiltIn, Complex<T>, Complex<U>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& base, Complex<U> const& exponent)
-            {
-                // Type promotion matching rules of complex std::pow but simplified given our math only supports float
-                // and double, no long double.
-                using Promoted
-                    = Complex<std::conditional_t<is_decayed_v<T, float> && is_decayed_v<U, float>, float, double>>;
-                // pow(z1, z2) = e^(z2 * log(z1))
-                return exp(ctx, Promoted{exponent} * log(ctx, Promoted{base}));
-            }
-        };
-
-        //! The CUDA pow trait specialization for complex and real types.
-        template<typename T, typename U>
-        struct Pow<PowUniformCudaHipBuiltIn, Complex<T>, U>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& base, U const& exponent)
-            {
-                return pow(ctx, base, Complex<U>{exponent});
-            }
-        };
-
-        //! The CUDA pow trait specialization for real and complex types.
-        template<typename T, typename U>
-        struct Pow<PowUniformCudaHipBuiltIn, T, Complex<U>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, T const& base, Complex<U> const& exponent)
-            {
-                return pow(ctx, Complex<T>{base}, exponent);
             }
         };
 
@@ -1144,18 +923,6 @@ namespace alpaka::math
             }
         };
 
-        //! The CUDA rsqrt trait specialization for complex types.
-        template<typename T>
-        struct Rsqrt<RsqrtUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                return T{1.0} / sqrt(ctx, arg);
-            }
-        };
-
         //! The CUDA sin trait specialization for real types.
         template<typename TArg>
         struct Sin<SinUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
@@ -1173,20 +940,6 @@ namespace alpaka::math
             }
         };
 
-        //! The CUDA sin trait specialization for complex types.
-        template<typename T>
-        struct Sin<SinUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                // sin(z) = (exp(i * z) - exp(-i * z)) / 2i
-                return (exp(ctx, Complex<T>{0.0, 1.0} * arg) - exp(ctx, Complex<T>{0.0, -1.0} * arg))
-                       / Complex<T>{0.0, 2.0};
-            }
-        };
-
         //! The CUDA sinh trait specialization for real types.
         template<typename TArg>
         struct Sinh<SinhUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
@@ -1201,19 +954,6 @@ namespace alpaka::math
                     static_assert(!sizeof(TArg), "Unsupported data type");
 
                 ALPAKA_UNREACHABLE(TArg{});
-            }
-        };
-
-        //! The CUDA sinh trait specialization for complex types.
-        template<typename T>
-        struct Sinh<SinhUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                // sinh(z) = (exp(z) - exp(-i * z)) / 2
-                return (exp(ctx, arg) - exp(ctx, static_cast<T>(-1.0) * arg)) / static_cast<T>(2.0);
             }
         };
 
@@ -1236,23 +976,6 @@ namespace alpaka::math
             }
         };
 
-        //! The CUDA sincos trait specialization for complex types.
-        template<typename T>
-        struct SinCos<SinCosUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(
-                TCtx const& ctx,
-                Complex<T> const& arg,
-                Complex<T>& result_sin,
-                Complex<T>& result_cos) -> void
-            {
-                result_sin = sin(ctx, arg);
-                result_cos = cos(ctx, arg);
-            }
-        };
-
         //! The CUDA sqrt trait specialization for real types.
         template<typename TArg>
         struct Sqrt<SqrtUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_arithmetic_v<TArg>>>
@@ -1267,23 +990,6 @@ namespace alpaka::math
                     static_assert(!sizeof(TArg), "Unsupported data type");
 
                 ALPAKA_UNREACHABLE(TArg{});
-            }
-        };
-
-        //! The CUDA sqrt trait specialization for complex types.
-        template<typename T>
-        struct Sqrt<SqrtUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& argument)
-            {
-                // Branch cut along the negative real axis (same as for std::complex),
-                // principal value of sqrt(z) = sqrt(|z|) * e^(i * arg(z) / 2)
-                auto const halfArg = T(0.5) * arg(ctx, argument);
-                auto re = T{}, im = T{};
-                sincos(ctx, halfArg, im, re);
-                return sqrt(ctx, abs(ctx, argument)) * Complex<T>(re, im);
             }
         };
 
@@ -1304,21 +1010,6 @@ namespace alpaka::math
             }
         };
 
-        //! The CUDA tan trait specialization for complex types.
-        template<typename T>
-        struct Tan<TanUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                // tan(z) = i * (e^-iz - e^iz) / (e^-iz + e^iz) = i * (1 - e^2iz) / (1 + e^2iz)
-                // Warning: this straightforward implementation can easily result in NaN as 0/0 or inf/inf.
-                auto const expValue = exp(ctx, Complex<T>{0.0, 2.0} * arg);
-                return Complex<T>{0.0, 1.0} * (T{1.0} - expValue) / (T{1.0} + expValue);
-            }
-        };
-
         //! The CUDA tanh trait specialization for real types.
         template<typename TArg>
         struct Tanh<TanhUniformCudaHipBuiltIn, TArg, std::enable_if_t<std::is_floating_point_v<TArg>>>
@@ -1333,20 +1024,6 @@ namespace alpaka::math
                     static_assert(!sizeof(TArg), "Unsupported data type");
 
                 ALPAKA_UNREACHABLE(TArg{});
-            }
-        };
-
-        //! The CUDA tanh trait specialization for complex types.
-        template<typename T>
-        struct Tanh<TanhUniformCudaHipBuiltIn, Complex<T>>
-        {
-            //! Take context as original (accelerator) type, since we call other math functions
-            template<typename TCtx>
-            __host__ __device__ auto operator()(TCtx const& ctx, Complex<T> const& arg)
-            {
-                // tanh(z) = (e^z - e^-z)/(e^z+e^-z)
-                return (exp(ctx, arg) - exp(ctx, static_cast<T>(-1.0) * arg))
-                       / (exp(ctx, arg) + exp(ctx, static_cast<T>(-1.0) * arg));
             }
         };
 


### PR DESCRIPTION
The oneAPI backend did not have the specialization of math functions on the device for complex types.
I moved (to avoid code duplication) the specializations done for CUDA/HIP to `Complex.hpp` to allow the oneAPI backend to use them as well.