### PR TITLE
add CI job, which verifies that the README.md contains the generated compiler support table

### DIFF
--- a/.github/workflows/verify-readme.yml
+++ b/.github/workflows/verify-readme.yml
@@ -1,0 +1,14 @@
+# Copyright 2023 Bernhard Manfred Gruber
+# SPDX-License-Identifier: MPL-2.0
+
+name: Check compiler support table in README.md
+on: [push, pull_request]
+
+jobs:
+  single-header:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: verify that the compiler support table is up to date
+      run: |
+        ./script/readme_generator/generate_supported_compilers.py --verify

--- a/.github/workflows/verify-readme.yml
+++ b/.github/workflows/verify-readme.yml
@@ -5,7 +5,7 @@ name: Check compiler support table in README.md
 on: [push, pull_request]
 
 jobs:
-  single-header:
+  check-readme:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/script/readme_generator/supported_compilers.json
+++ b/script/readme_generator/supported_compilers.json
@@ -360,7 +360,7 @@
             "state": "no"
         }
     },
-    "icpx 2024.2 (Linux)": {
+    "icpx 2025.0 (Linux)": {
         "serial": {
             "state": "yes"
         },


### PR DESCRIPTION
The script `generate_supported_compilers.py` generates the compiler support Markdown table for the README.md from a config file. The script was introduced because the markdown table is huge and hard to modify.

Therefore the CI job checks if the README.md contains the markdown table, which is generated from the script. This covers the case, if somebody is changing directly the `README.md` instead modifying the `supported_compilers.json`, rendering a new table and copy the output in the `README.md`.