### PR TITLE
install specific CMake version in Windows CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           container: ubuntu:20.04
         - name: windows_cl-2022_debug_analysis
           os: windows-2022
-          env: {ALPAKA_CI_CXX: cl.exe,  ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.78.0, ALPAKA_CI_CMAKE_VER: 3,                          ALPAKA_CI_ANALYSIS: ON, alpaka_DEBUG: 2}
+          env: {ALPAKA_CI_CXX: cl.exe,  ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.78.0, ALPAKA_CI_CMAKE_VER: 3.25.3,                          ALPAKA_CI_ANALYSIS: ON, alpaka_DEBUG: 2}
         - name: macos_xcode-15.4_debug_analysis
           os: macos-14
           env: {ALPAKA_CI_CXX: clang++, ALPAKA_CI_XCODE_VER: 15.4,                                CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.81.0,                                                  ALPAKA_CI_ANALYSIS: ON, alpaka_DEBUG: 2,                                                                                                                                                                             alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: ON, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: ON, ALPAKA_CI_BUILD_JOBS: 3}
@@ -135,10 +135,10 @@ jobs:
         ### Windows
         - name: windows_cl-2022_release
           os: windows-2022
-          env: {ALPAKA_CI_CXX: cl.exe,  ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.79.0, ALPAKA_CI_CMAKE_VER: 3     , OMP_NUM_THREADS: 1}
+          env: {ALPAKA_CI_CXX: cl.exe,  ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Release, ALPAKA_BOOST_VERSION: 1.79.0, ALPAKA_CI_CMAKE_VER: 3.25.3   , OMP_NUM_THREADS: 1}
         - name: windows_cl-2022_debug
           os: windows-2022
-          env: {ALPAKA_CI_CXX: cl.exe,  ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.80.0, ALPAKA_CI_CMAKE_VER: 3     , OMP_NUM_THREADS: 4,                                                                                                                                                                                           alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
+          env: {ALPAKA_CI_CXX: cl.exe,  ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.80.0, ALPAKA_CI_CMAKE_VER: 3.25.3   , OMP_NUM_THREADS: 4,                                                                                                                                                                                           alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
 
         ## CUDA 12.1
         # nvcc + MSVC

--- a/script/install_boost.sh
+++ b/script/install_boost.sh
@@ -50,7 +50,7 @@ then
     BOOST_BASE_NAME=$(echo -n ${ALPAKA_CI_BOOST_BRANCH} | tr "." "_" | tr "-" "_")
     BOOST_BASE_VERSION=$(echo -n ${ALPAKA_CI_BOOST_BRANCH} | sed 's/boost-//')
     BOOST_TAR_FILE_NAME="${BOOST_BASE_NAME}.tar.gz"
-    BOOST_DOWNLOAD_LINK="https://boostorg.jfrog.io/artifactory/main/release/${BOOST_BASE_VERSION}/source/${BOOST_TAR_FILE_NAME}"
+    BOOST_DOWNLOAD_LINK="https://archives.boost.io/release/${BOOST_BASE_VERSION}/source/${BOOST_TAR_FILE_NAME}"
     rm -rf ${BOOST_ROOT}
     travis_retry wget -q ${BOOST_DOWNLOAD_LINK}
     tar -xf "$BOOST_TAR_FILE_NAME"

--- a/script/install_cmake.sh
+++ b/script/install_cmake.sh
@@ -45,10 +45,8 @@ then
             fi
         elif [ "$ALPAKA_CI_OS_NAME" = "Windows" ]
         then
-            # uninstalling CMake is broken in the GitHub Actions Windows Image
-            # therefore we need to use what is installed
-            #choco uninstall cmake.install
-            #choco install cmake.install --no-progress --version ${ALPAKA_CI_CMAKE_VER}
+            choco uninstall cmake.install
+            choco install cmake.install --no-progress --version ${ALPAKA_CI_CMAKE_VER}
             cmake --version
         fi
     fi


### PR DESCRIPTION
The bug, which avoids uninstalling CMake should be solved.
Updates also boost archive URL to fix install boost problem.