### PR TITLE
alpaka job generator: add rule which requires that the sycl backend is enabled if icpx is the compiler

### DIFF
--- a/script/before_install.sh
+++ b/script/before_install.sh
@@ -91,6 +91,15 @@ then
 fi
 
 #-------------------------------------------------------------------------------
+# ONEAPI
+if [[ "${ALPAKA_CI_CXX}" == "icpx" ]]; then
+    if [[ "${alpaka_ACC_SYCL_ENABLE}" != "ON" ]]; then
+        echo_red "alpaka_ACC_SYCL_ENABLE needs to be enabled, if the C++ compiler is icpx"
+        exit 1
+    fi
+fi
+
+#-------------------------------------------------------------------------------
 if [ "$ALPAKA_CI_OS_NAME" = "Linux" ]
 then
     if [ "${ALPAKA_CI_STDLIB}" == "libc++" ]

--- a/script/job_generator/alpaka_filter.py
+++ b/script/job_generator/alpaka_filter.py
@@ -135,4 +135,11 @@ def alpaka_post_filter(row: List) -> bool:
         ):
             return False
 
+    # the SYCL backends needs to be enabled if the icpx compiler is used
+    if row_check_name(row, DEVICE_COMPILER, "==", ICPX):
+        if is_in_row(row, BACKENDS) and (
+            (ALPAKA_ACC_SYCL_ENABLE, ON_VER) not in row[param_map[BACKENDS]]
+        ):
+            return False
+
     return True


### PR DESCRIPTION
separated from PR: https://github.com/alpaka-group/alpaka/pull/2315