### PR TITLE
CMake: overwork `std::mdspan` support for nvcc

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -954,12 +954,6 @@ if (NOT alpaka_USE_MDSPAN STREQUAL "OFF")
         message(FATAL_ERROR "std::mdspan on MSVC requires C++20. Please enable C++20 via alpaka_CXX_STANDARD. Use of std::mdspan has been disabled.")
     endif ()
 
-    if (alpaka_ACC_GPU_CUDA_ENABLE AND (CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA") AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
-        # this issue actually only occurs when the host compiler (not the CXX compiler) is clang, but cmake does not let us query the host compiler id
-        # see: https://gitlab.kitware.com/cmake/cmake/-/issues/20901
-        message(FATAL_ERROR "std::mdspan does not work with nvcc and clang as host compiler. Use of std::mdspan has been disabled.")
-    endif ()
-
     if (alpaka_ACC_GPU_CUDA_ENABLE AND CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND (NOT alpaka_CUDA_EXPT_EXTENDED_LAMBDA STREQUAL ON))
         message(FATAL_ERROR "std::mdspan requires nvcc's extended lambdas.")
     endif()

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -951,19 +951,16 @@ endif()
 
 if (NOT alpaka_USE_MDSPAN STREQUAL "OFF")
     if (MSVC AND (alpaka_CXX_STANDARD LESS 20))
-        message(WARNING "std::mdspan on MSVC requires C++20. Please enable C++20 via alpaka_CXX_STANDARD. Use of std::mdspan has been disabled.")
-        set(alpaka_USE_MDSPAN "OFF" CACHE STRING "Use std::mdspan with alpaka" FORCE)
+        message(FATAL_ERROR "std::mdspan on MSVC requires C++20. Please enable C++20 via alpaka_CXX_STANDARD. Use of std::mdspan has been disabled.")
     endif ()
 
     if (alpaka_ACC_GPU_CUDA_ENABLE AND (CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA") AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
         # this issue actually only occurs when the host compiler (not the CXX compiler) is clang, but cmake does not let us query the host compiler id
         # see: https://gitlab.kitware.com/cmake/cmake/-/issues/20901
-        message(WARNING "std::mdspan does not work with nvcc and clang as host compiler. Use of std::mdspan has been disabled.")
-        set(alpaka_USE_MDSPAN "OFF" CACHE STRING "Use std::mdspan with alpaka" FORCE)
+        message(FATAL_ERROR "std::mdspan does not work with nvcc and clang as host compiler. Use of std::mdspan has been disabled.")
     endif ()
 
-    if (alpaka_ACC_GPU_CUDA_ENABLE AND (NOT alpaka_CUDA_EXPT_EXTENDED_LAMBDA STREQUAL ON))
-        message(WARNING "std::mdspan requires nvcc's extended lambdas. Use of std::mdspan has been disabled.")
-        set(alpaka_USE_MDSPAN "OFF" CACHE STRING "Use std::mdspan with alpaka" FORCE)
+    if (alpaka_ACC_GPU_CUDA_ENABLE AND CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND (NOT alpaka_CUDA_EXPT_EXTENDED_LAMBDA STREQUAL ON))
+        message(FATAL_ERROR "std::mdspan requires nvcc's extended lambdas.")
     endif()
 endif()

--- a/script/job_generator/generate_job_yaml.py
+++ b/script/job_generator/generate_job_yaml.py
@@ -345,10 +345,15 @@ def job_variables(job: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
         variables["ALPAKA_CI_STDLIB"] = "libstdc++"
         variables["CMAKE_CUDA_ARCHITECTURES"] = job[SM_LEVEL][VERSION]
         variables["ALPAKA_CI_CUDA_VERSION"] = job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION]
+        variables["alpaka_CUDA_EXPT_EXTENDED_LAMBDA"] = "OFF"
 
     if job[DEVICE_COMPILER][NAME] == NVCC:
         # general configuration, if nvcc is the CUDA compiler
         variables["ALPAKA_CI_CUDA_COMPILER"] = "nvcc"
+
+        # MdSpan requires alpaka_CUDA_EXPT_EXTENDED_LAMBDA
+        if job[MDSPAN][VERSION] == ON_VER:
+            variables["alpaka_CUDA_EXPT_EXTENDED_LAMBDA"] = "ON"
 
         # configuration, if GCC is the CUDA host compiler
         if job[HOST_COMPILER][NAME] == GCC:


### PR DESCRIPTION
TLTR;
- abort CMake configuration with error if nvcc experimental lamda support is disabled than mdspan is throwing a compiler error for the missing feature
- allow to use nvcc and mspan with clang as host compiler 

MdSpan throws a readable compiler error if the nvcc experimental extension is disabled. Actual the CMake should avoid it, because it should automatically disable mdspan but it does not work. Also the behavior feels wrong. An explicit enabled feature is automatically disabled. I think it is better, if the user knows, that is not working and ether disable mdspan or find another solution.

Also the PR enables using nvcc with host compiler clang and mdspan. This was disabled with initial support of mdspan. There is no documentation about what was the actual compiler problem. For me, it was less work to remove the restriction in CMake than writing a job generator filter rule. So tried it and the test pass. So I will keep it, because it is the better solution.

Compile time error message: https://gitlab.com/hzdr/crp/alpaka/-/jobs/8788083447

separated from PR: #2315