### PR TITLE
Remove workarounds for CUDA 11.x and ROCm 5.x

### DIFF
--- a/include/alpaka/atomic/AtomicCpu.hpp
+++ b/include/alpaka/atomic/AtomicCpu.hpp
@@ -1,20 +1,8 @@
-/* Copyright 2024 Andrea Bocci, Felice Pantaleo
+/* Copyright 2025 Andrea Bocci, Felice Pantaleo
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
-
-#include "alpaka/core/BoostPredef.hpp"
-
-// clang 9/10/11 together with nvcc<11.6.0 as host compiler fails at compile time when using boost::atomic_ref
-#ifdef BOOST_COMP_CLANG_AVAILABLE
-#    if(BOOST_COMP_CLANG < BOOST_VERSION_NUMBER(12, 0, 0) && BOOST_COMP_NVCC                                          \
-        && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 6, 0))
-#        if !defined(ALPAKA_DISABLE_ATOMIC_ATOMICREF)
-#            define ALPAKA_DISABLE_ATOMIC_ATOMICREF
-#        endif
-#    endif
-#endif // BOOST_COMP_CLANG_AVAILABLE
 
 #include "alpaka/atomic/AtomicAtomicRef.hpp"
 #include "alpaka/atomic/AtomicStdLibLock.hpp"

--- a/include/alpaka/core/Unreachable.hpp
+++ b/include/alpaka/core/Unreachable.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Jan Stephan, Jeffrey Kelling
+/* Copyright 2025 Jan Stephan, Jeffrey Kelling, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -11,11 +11,7 @@
 //!
 //! \param x A dummy value for the expected return type of the calling function.
 #if(BOOST_COMP_NVCC && BOOST_ARCH_PTX)
-#    if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(11, 3, 0)
-#        define ALPAKA_UNREACHABLE(...) __builtin_unreachable()
-#    else
-#        define ALPAKA_UNREACHABLE(...) return __VA_ARGS__
-#    endif
+#    define ALPAKA_UNREACHABLE(...) __builtin_unreachable()
 #elif BOOST_COMP_MSVC
 #    define ALPAKA_UNREACHABLE(...) __assume(false)
 #elif BOOST_COMP_GNUC || BOOST_COMP_CLANG

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci, Jan Stephan,
+/* Copyright 2025 Alexander Matthes, Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci, Jan Stephan,
  *                Bernhard Manfred Gruber, Antonio Di Pilato
  * SPDX-License-Identifier: MPL-2.0
  */
@@ -273,11 +273,6 @@ namespace alpaka
         template<typename TApi, typename TElem, typename TDim, typename TIdx>
         struct AsyncBufAlloc<TElem, TDim, TIdx, DevUniformCudaHipRt<TApi>>
         {
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-            static_assert(
-                std::is_same_v<TApi, ApiCudaRt> && TApi::version >= BOOST_VERSION_NUMBER(11, 2, 0),
-                "Support for stream-ordered memory buffers requires CUDA 11.2 or higher.");
-#    endif
 #    if defined(ALPAKA_ACC_GPU_HIP_ENABLED)
             static_assert(
                 std::is_same_v<TApi, ApiHipRt> && TApi::version >= BOOST_VERSION_NUMBER(5, 3, 0),
@@ -324,13 +319,13 @@ namespace alpaka
                   TDim::value <= 1
                   && (
 #    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                      std::is_same_v<TApi, ApiCudaRt> && TApi::version >= BOOST_VERSION_NUMBER(11, 2, 0)
+                      std::is_same_v<TApi, ApiCudaRt>
 #    elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
                       std::is_same_v<TApi, ApiHipRt> && TApi::version >= BOOST_VERSION_NUMBER(5, 3, 0)
 #    else
                       false
 #    endif
-                          )>
+                      )>
         {
         };
 

--- a/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/BufUniformCudaHipRt.hpp
@@ -273,11 +273,6 @@ namespace alpaka
         template<typename TApi, typename TElem, typename TDim, typename TIdx>
         struct AsyncBufAlloc<TElem, TDim, TIdx, DevUniformCudaHipRt<TApi>>
         {
-#    if defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-            static_assert(
-                std::is_same_v<TApi, ApiHipRt> && TApi::version >= BOOST_VERSION_NUMBER(5, 3, 0),
-                "Support for stream-ordered memory buffers requires HIP/ROCm 5.3 or higher.");
-#    endif
             static_assert(
                 TDim::value <= 1,
                 "CUDA/HIP devices support only one-dimensional stream-ordered memory buffers.");
@@ -314,18 +309,7 @@ namespace alpaka
 
         //! The CUDA/HIP stream-ordered memory allocation capability trait specialization.
         template<typename TApi, typename TDim>
-        struct HasAsyncBufSupport<TDim, DevUniformCudaHipRt<TApi>>
-            : std::bool_constant<
-                  TDim::value <= 1
-                  && (
-#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                      std::is_same_v<TApi, ApiCudaRt>
-#    elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-                      std::is_same_v<TApi, ApiHipRt> && TApi::version >= BOOST_VERSION_NUMBER(5, 3, 0)
-#    else
-                      false
-#    endif
-                      )>
+        struct HasAsyncBufSupport<TDim, DevUniformCudaHipRt<TApi>> : std::bool_constant<TDim::value <= 1>
         {
         };
 

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Axel Huebl, Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Andrea Bocci, Jan Stephan,
+/* Copyright 2025 Axel Huebl, Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Andrea Bocci, Jan Stephan,
  *                Bernhard Manfred Gruber
  * SPDX-License-Identifier: MPL-2.0
  */
@@ -56,20 +56,6 @@ namespace alpaka
         //! Value constructor.
         //! This constructor is only available if the number of parameters matches the vector idx.
         ALPAKA_NO_HOST_ACC_WARNING
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(11, 3, 0)                                              \
-    && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 4, 0)
-        // This constructor tries to avoid SFINAE, which crashes nvcc 11.3. We also need to have a first
-        // argument, so an unconstrained ctor with forwarding references does not hijack the compiler provided
-        // copy-ctor.
-        template<typename... TArgs>
-        ALPAKA_FN_HOST_ACC constexpr Vec(TVal arg0, TArgs&&... args)
-            : m_data{std::move(arg0), static_cast<TVal>(std::forward<TArgs>(args))...}
-        {
-            static_assert(
-                1 + sizeof...(TArgs) == TDim::value && (std::is_convertible_v<std::decay_t<TArgs>, TVal> && ...),
-                "Wrong number of arguments to Vec constructor or types are not convertible to TVal.");
-        }
-#else
         template<
             typename... TArgs,
             typename = std::enable_if_t<
@@ -77,28 +63,15 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC constexpr Vec(TArgs&&... args) : m_data{static_cast<TVal>(std::forward<TArgs>(args))...}
         {
         }
-#endif
 
         //! Generator constructor.
         //! Initializes the vector with the values returned from generator(IC) in order, where IC::value runs from 0 to
         //! TDim - 1 (inclusive).
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(11, 3, 0)                                              \
-    && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 4, 0)
-        template<typename F>
-        ALPAKA_FN_HOST_ACC constexpr explicit Vec(
-            F&& generator,
-            std::void_t<decltype(generator(std::integral_constant<std::size_t, 0>{}))>* ignore = nullptr)
-            : Vec(std::forward<F>(generator), std::make_index_sequence<TDim::value>{})
-        {
-            static_cast<void>(ignore);
-        }
-#else
         template<typename F, std::enable_if_t<std::is_invocable_v<F, std::integral_constant<std::size_t, 0>>, int> = 0>
         ALPAKA_FN_HOST_ACC constexpr explicit Vec(F&& generator)
             : Vec(std::forward<F>(generator), std::make_index_sequence<TDim::value>{})
         {
         }
-#endif
 
     private:
         template<typename F, std::size_t... Is>
@@ -379,11 +352,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC friend constexpr auto operator+(Vec const& p, Vec const& q) -> Vec
         {
             Vec r;
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-            if(TDim::value > 0)
-#else
             if constexpr(TDim::value > 0)
-#endif
             {
                 for(typename TDim::value_type i = 0; i < TDim::value; ++i)
                     r[i] = p[i] + q[i];
@@ -396,19 +365,9 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC friend constexpr auto operator-(Vec const& p, Vec const& q) -> Vec
         {
             Vec r;
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-            if(TDim::value > 0)
-#else
             if constexpr(TDim::value > 0)
-#endif
             {
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-#    pragma diag_suppress = unsigned_compare_with_zero
-#endif
                 for(typename TDim::value_type i = 0; i < TDim::value; ++i)
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-#    pragma diag_default = unsigned_compare_with_zero
-#endif
                     r[i] = p[i] - q[i];
             }
             return r;
@@ -419,11 +378,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC friend constexpr auto operator*(Vec const& p, Vec const& q) -> Vec
         {
             Vec r;
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-            if(TDim::value > 0)
-#else
             if constexpr(TDim::value > 0)
-#endif
             {
                 for(typename TDim::value_type i = 0; i < TDim::value; ++i)
                     r[i] = p[i] * q[i];
@@ -434,19 +389,9 @@ namespace alpaka
         ALPAKA_NO_HOST_ACC_WARNING
         ALPAKA_FN_HOST_ACC friend constexpr auto operator==(Vec const& a, Vec const& b) -> bool
         {
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-            if(TDim::value > 0)
-#else
             if constexpr(TDim::value > 0)
-#endif
             {
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-#    pragma diag_suppress = unsigned_compare_with_zero
-#endif
                 for(typename TDim::value_type i(0); i < TDim::value; ++i)
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-#    pragma diag_default = unsigned_compare_with_zero
-#endif
                 {
                     if(a[i] != b[i])
                         return false;
@@ -466,11 +411,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC friend constexpr auto operator<(Vec const& p, Vec const& q) -> Vec<TDim, bool>
         {
             Vec<TDim, bool> r;
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-            if(TDim::value > 0)
-#else
             if constexpr(TDim::value > 0)
-#endif
             {
                 for(typename TDim::value_type i = 0; i < TDim::value; ++i)
                     r[i] = p[i] < q[i];
@@ -483,11 +424,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC friend constexpr auto operator<=(Vec const& p, Vec const& q) -> Vec<TDim, bool>
         {
             Vec<TDim, bool> r;
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-            if(TDim::value > 0)
-#else
             if constexpr(TDim::value > 0)
-#endif
             {
                 for(typename TDim::value_type i = 0; i < TDim::value; ++i)
                     r[i] = p[i] <= q[i];
@@ -500,11 +437,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC friend constexpr auto operator>(Vec const& p, Vec const& q) -> Vec<TDim, bool>
         {
             Vec<TDim, bool> r;
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-            if(TDim::value > 0)
-#else
             if constexpr(TDim::value > 0)
-#endif
             {
                 for(typename TDim::value_type i = 0; i < TDim::value; ++i)
                     r[i] = p[i] > q[i];
@@ -517,11 +450,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC friend constexpr auto operator>=(Vec const& p, Vec const& q) -> Vec<TDim, bool>
         {
             Vec<TDim, bool> r;
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-            if(TDim::value > 0)
-#else
             if constexpr(TDim::value > 0)
-#endif
             {
                 for(typename TDim::value_type i = 0; i < TDim::value; ++i)
                     r[i] = p[i] >= q[i];
@@ -534,11 +463,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC friend constexpr auto operator&&(Vec const& p, Vec const& q) -> Vec<TDim, bool>
         {
             Vec<TDim, bool> r;
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-            if(TDim::value > 0)
-#else
             if constexpr(TDim::value > 0)
-#endif
             {
                 for(typename TDim::value_type i = 0; i < TDim::value; ++i)
                     r[i] = p[i] && q[i];
@@ -551,11 +476,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC friend constexpr auto operator||(Vec const& p, Vec const& q) -> Vec<TDim, bool>
         {
             Vec<TDim, bool> r;
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-            if(TDim::value > 0)
-#else
             if constexpr(TDim::value > 0)
-#endif
             {
                 for(typename TDim::value_type i = 0; i < TDim::value; ++i)
                     r[i] = p[i] || q[i];
@@ -566,19 +487,9 @@ namespace alpaka
         ALPAKA_FN_HOST friend constexpr auto operator<<(std::ostream& os, Vec const& v) -> std::ostream&
         {
             os << "(";
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-            if(TDim::value > 0)
-#else
             if constexpr(TDim::value > 0)
-#endif
             {
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-#    pragma diag_suppress = unsigned_compare_with_zero
-#endif
                 for(typename TDim::value_type i = 0; i < TDim::value; ++i)
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-#    pragma diag_default = unsigned_compare_with_zero
-#endif
                 {
                     os << v[i];
                     if(i != TDim::value - 1)
@@ -612,11 +523,7 @@ namespace alpaka
     ALPAKA_FN_HOST_ACC constexpr auto toArray(Vec<TDim, TVal> const& v) -> std::array<TVal, TDim::value>
     {
         std::array<TVal, TDim::value> a{};
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-        if(TDim::value > 0)
-#else
         if constexpr(TDim::value > 0)
-#endif
         {
             for(unsigned i = 0; i < TDim::value; i++)
                 a[i] = v[i];
@@ -634,11 +541,7 @@ namespace alpaka
     ALPAKA_FN_HOST_ACC constexpr auto elementwise_min(Vec<TDim, TVal> const& p, Vecs const&... qs) -> Vec<TDim, TVal>
     {
         Vec<TDim, TVal> r;
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-        if(TDim::value > 0)
-#else
         if constexpr(TDim::value > 0)
-#endif
         {
             for(typename TDim::value_type i = 0; i < TDim::value; ++i)
                 r[i] = std::min({p[i], qs[i]...});
@@ -656,11 +559,7 @@ namespace alpaka
     ALPAKA_FN_HOST_ACC constexpr auto elementwise_max(Vec<TDim, TVal> const& p, Vecs const&... qs) -> Vec<TDim, TVal>
     {
         Vec<TDim, TVal> r;
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-        if(TDim::value > 0)
-#else
         if constexpr(TDim::value > 0)
-#endif
         {
             for(typename TDim::value_type i = 0; i < TDim::value; ++i)
                 r[i] = std::max({p[i], qs[i]...});
@@ -720,11 +619,7 @@ namespace alpaka
                 else
                 {
                     Vec<TDim, TValNew> r;
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-                    if(TDim::value > 0)
-#else
                     if constexpr(TDim::value > 0)
-#endif
                     {
                         for(typename TDim::value_type i = 0; i < TDim::value; ++i)
                             r[i] = static_cast<TValNew>(vec[i]);

--- a/test/unit/rand/src/RandTest.cpp
+++ b/test/unit/rand/src/RandTest.cpp
@@ -109,15 +109,5 @@ TEMPLATE_LIST_TEST_CASE("defaultRandomGeneratorIsTriviallyCopyable", "[rand]", a
 {
     using Acc = TestType;
     using DefaultEngine = decltype(alpaka::rand::engine::createDefault(std::declval<Acc>(), 0u, 0u, 0u));
-    constexpr auto isEngineTriviallyCopyable = std::is_trivially_copyable_v<DefaultEngine>;
-    // For older HIP versions the internal HIPrand/ROCrand state was not trivially copyable.
-    // This causes alpaka rand state for the HIP accelerator and those versions to also not be trivially copyable.
-    // It was fixed on AMD side in https://github.com/ROCmSoftwarePlatform/rocRAND/pull/252.
-    // Thus we guard the test to skip HIP accelerator and older HIP versions.
-#if defined(ALPAKA_ACC_GPU_HIP_ENABLED) && (BOOST_LANG_HIP < BOOST_VERSION_NUMBER(5, 2, 0))
-    if constexpr(!IsAccHIP<Acc>::value)
-        STATIC_REQUIRE(isEngineTriviallyCopyable);
-#else
-    STATIC_REQUIRE(isEngineTriviallyCopyable);
-#endif
+    STATIC_REQUIRE(std::is_trivially_copyable_v<DefaultEngine>);
 }

--- a/test/unit/workDiv/src/FooVec.hpp
+++ b/test/unit/workDiv/src/FooVec.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Sergei Bastrakov, Jan Stephan, Mehmet Yusufoglu
+/* Copyright 2025 Sergei Bastrakov, Jan Stephan, Mehmet Yusufoglu, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -95,11 +95,7 @@ namespace alpaka::trait
             -> alpaka::Vec<DimInt<N>, TVal>
         {
             alpaka::Vec<DimInt<N>, TVal> v{};
-#if BOOST_COMP_NVCC && BOOST_COMP_NVCC < BOOST_VERSION_NUMBER(11, 3, 0)
-            if(DimInt<N>::value > 0)
-#else
             if constexpr(DimInt<N>::value > 0)
-#endif
             {
                 // Reverse the vector since the dimensions ordered as z-y-x in alpaka
                 for(unsigned i = 0; i < DimInt<N>::value; i++)


### PR DESCRIPTION
The `develop` branch now requires CUDA 12.x and ROCm 6.x, so we can drop the workarounds for the older versions.