### PR TITLE
[1.3] Disable test not supported by SYCL

### DIFF
--- a/test/unit/warp/src/Activemask.cpp
+++ b/test/unit/warp/src/Activemask.cpp
@@ -65,6 +65,9 @@ struct alpaka::trait::WarpSize<ActivemaskMultipleThreadWarpTestKernel<TWarpSize>
 TEMPLATE_LIST_TEST_CASE("activemask", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
+    using Dim = alpaka::Dim<Acc>;
+    using Idx = alpaka::Idx<Acc>;
+
     if constexpr(alpaka::accMatchesTags<
                      Acc,
                      alpaka::TagCpuSycl,
@@ -72,14 +75,10 @@ TEMPLATE_LIST_TEST_CASE("activemask", "[warp]", alpaka::test::TestAccs)
                      alpaka::TagFpgaSyclIntel,
                      alpaka::TagGenericSycl>)
     {
-        std::cout << "Test disabled for SYCL\n";
-        return;
+        WARN("Test disabled for SYCL");
     }
     else
     {
-        using Dim = alpaka::Dim<Acc>;
-        using Idx = alpaka::Idx<Acc>;
-
         auto const platform = alpaka::Platform<Acc>{};
         auto const dev = alpaka::getDevByIdx(platform, 0);
         auto const warpExtents = alpaka::getWarpSizes(dev);

--- a/test/unit/warp/src/All.cpp
+++ b/test/unit/warp/src/All.cpp
@@ -70,46 +70,59 @@ TEMPLATE_LIST_TEST_CASE("all", "[warp]", alpaka::test::TestAccs)
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    auto const platform = alpaka::Platform<Acc>{};
-    auto const dev = alpaka::getDevByIdx(platform, 0);
-    auto const warpExtents = alpaka::getWarpSizes(dev);
-    for(auto const warpExtent : warpExtents)
+    if constexpr(alpaka::accMatchesTags<
+                     Acc,
+                     alpaka::TagCpuSycl,
+                     alpaka::TagGpuSyclIntel,
+                     alpaka::TagFpgaSyclIntel,
+                     alpaka::TagGenericSycl>)
     {
-        auto const scalar = Dim::value == 0 || warpExtent == 1;
-        if(scalar)
+        WARN("Test disabled for SYCL");
+    }
+    else
+    {
+        auto const platform = alpaka::Platform<Acc>{};
+        auto const dev = alpaka::getDevByIdx(platform, 0);
+        auto const warpExtents = alpaka::getWarpSizes(dev);
+        for(auto const warpExtent : warpExtents)
         {
-            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
-            REQUIRE(fixture(AllSingleThreadWarpTestKernel{}));
-        }
-        else
-        {
-            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-            // Enforce one warp per thread block
-            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-            auto fixture = ExecutionFixture{workDiv};
-            if(warpExtent == 4)
+            auto const scalar = Dim::value == 0 || warpExtent == 1;
+            if(scalar)
             {
-                REQUIRE(fixture(AllMultipleThreadWarpTestKernel<4>{}));
+                alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+                REQUIRE(fixture(AllSingleThreadWarpTestKernel{}));
             }
-            else if(warpExtent == 8)
+            else
             {
-                REQUIRE(fixture(AllMultipleThreadWarpTestKernel<8>{}));
-            }
-            else if(warpExtent == 16)
-            {
-                REQUIRE(fixture(AllMultipleThreadWarpTestKernel<16>{}));
-            }
-            else if(warpExtent == 32)
-            {
-                REQUIRE(fixture(AllMultipleThreadWarpTestKernel<32>{}));
-            }
-            else if(warpExtent == 64)
-            {
-                REQUIRE(fixture(AllMultipleThreadWarpTestKernel<64>{}));
+                using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+                auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+                // Enforce one warp per thread block
+                auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+                blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+                auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+                auto workDiv =
+                    typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+                auto fixture = ExecutionFixture{workDiv};
+                if(warpExtent == 4)
+                {
+                    REQUIRE(fixture(AllMultipleThreadWarpTestKernel<4>{}));
+                }
+                else if(warpExtent == 8)
+                {
+                    REQUIRE(fixture(AllMultipleThreadWarpTestKernel<8>{}));
+                }
+                else if(warpExtent == 16)
+                {
+                    REQUIRE(fixture(AllMultipleThreadWarpTestKernel<16>{}));
+                }
+                else if(warpExtent == 32)
+                {
+                    REQUIRE(fixture(AllMultipleThreadWarpTestKernel<32>{}));
+                }
+                else if(warpExtent == 64)
+                {
+                    REQUIRE(fixture(AllMultipleThreadWarpTestKernel<64>{}));
+                }
             }
         }
     }


### PR DESCRIPTION
Backport #2468.

According to the documentation of the **SYCL Group functions** [1](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:group-functions) and **SYCL Group algorithms library** [2](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:algorithms), calling `sycl::all_of_group` with some threads having exited the kernel is _undefined behaviour_. This was confirmed during a support meeting with Intel.

oneAPI has an extension to support non-uniform (sub)groups: [sycl_ext_oneapi_non_uniform_groups](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_non_uniform_groups.asciidoc).
The implementation of the SYCL warp functions should be extended using it; until then, we disable the failing test when using a SYCL back-end and instead print an informational message.