### PR TITLE
Add option for installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ endif()
 ################################################################################
 # Installation.
 
-option(alpaka_INSTALL "" OFF)
+option(alpaka_INSTALL "install alpaka even if used as project dependency" OFF)
 # Do not install if alpaka is used as a CMake subdirectory
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR alpaka_INSTALL)
     include(CMakePackageConfigHelpers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,8 +162,9 @@ endif()
 ################################################################################
 # Installation.
 
+option(alpaka_INSTALL "" OFF)
 # Do not install if alpaka is used as a CMake subdirectory
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR alpaka_INSTALL)
     include(CMakePackageConfigHelpers)
     include(GNUInstallDirs)
 
@@ -204,4 +205,7 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
             DESTINATION "${_alpaka_INSTALL_CMAKEDIR}")
     install(DIRECTORY "${_alpaka_ROOT_DIR}/cmake/tests"
             DESTINATION "${_alpaka_INSTALL_CMAKEDIR}")
+
+    install(TARGETS alpaka EXPORT alpakaTargets)
+    install(EXPORT alpakaTargets DESTINATION "${_alpaka_INSTALL_CMAKEDIR}" NAMESPACE alpaka::)
 endif()

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -602,7 +602,7 @@ if(alpaka_ACC_GPU_HIP_ENABLE)
 
         set(_alpaka_HIP_MIN_VER 5.1)
         set(_alpaka_HIP_MAX_VER 6.2)
-        
+
         checkCompilerCXXSupport(HIP ${alpaka_MIN_CXX_STANDARD})
 
         # construct hip version only with major and minor level
@@ -873,9 +873,15 @@ if(TARGET alpaka)
     # the alpaka library itself
     # SYSTEM voids showing warnings produced by alpaka when used in user applications.
     if(BUILD_TESTING)
-        target_include_directories(alpaka INTERFACE ${_alpaka_INCLUDE_DIRECTORY})
+        target_include_directories(alpaka
+          INTERFACE
+            $<BUILD_INTERFACE:${_alpaka_INCLUDE_DIRECTORY}>
+            $<INSTALL_INTERFACE:include>)
     else()
-        target_include_directories(alpaka SYSTEM INTERFACE ${_alpaka_INCLUDE_DIRECTORY})
+        target_include_directories(alpaka
+          SYSTEM INTERFACE
+            $<BUILD_INTERFACE:${_alpaka_INCLUDE_DIRECTORY}>
+            $<INSTALL_INTERFACE:include>)
     endif()
 
     if(${alpaka_DEBUG} GREATER 1)

--- a/docs/source/advanced/cmake.rst
+++ b/docs/source/advanced/cmake.rst
@@ -178,6 +178,12 @@ alpaka_USE_MDSPAN
      "SYSTEM" - Enable mdspan and acquire it via `find_package` from your system
      "FETCH" - Enable mdspan and download it via CMake's `FetchContent` from GitHub. The dependency will not be installed when you install alpaka.
 
+alpaka_INSTALL
+  .. code-block::
+
+     Install alpaka even if it is a project dependency.
+     Defaults to off (i.e. alpaka is not installed separately if alpaka is a project dependency).
+
 .. _cpu-serial:
 
 CPU Serial


### PR DESCRIPTION
Allow to install alpaka as part of another project if configured and export its targets into that installation.

Also fixes a bug: `target_include_directories` was given an absolute path (`_alpaka_INCLUDE_DIRECTORY` is absolute) to the source directory which meant that dependents always used the headers directly from the source directory if they were using the `alpaka::alpaka` target directly. That was never a problem if dependents were applications that didn't expose alpaka headers themselves or the final application to be built used alpaka itself (leading to basically the same situation). But if you try to install a library L that depends on alpaka and a user of the library tries to use L from the installation without using alpaka directly, it needs to find alpaka's headers and they are located in the source directory (which might have been removed already), not in the installation directory.