### PR TITLE
Make complex math functions host-device

### DIFF
--- a/include/alpaka/math/Complex.hpp
+++ b/include/alpaka/math/Complex.hpp
@@ -593,7 +593,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 return sqrt(ctx, arg.real() * arg.real() + arg.imag() * arg.imag());
             }
@@ -605,7 +605,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 // This holds everywhere, including the branch cuts: acos(z) = -i * ln(z + i * sqrt(1 - z^2))
                 return Complex<T>{static_cast<T>(0.0), static_cast<T>(-1.0)}
@@ -623,7 +623,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 // acos(z) = ln(z + sqrt(z-1) * sqrt(z+1))
                 return log(ctx, arg + sqrt(ctx, arg - static_cast<T>(1.0)) * sqrt(ctx, arg + static_cast<T>(1.0)));
@@ -636,7 +636,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
             {
                 return atan2(ctx, argument.imag(), argument.real());
             }
@@ -648,7 +648,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 // This holds everywhere, including the branch cuts: asin(z) = i * ln(sqrt(1 - z^2) - i * z)
                 return Complex<T>{static_cast<T>(0.0), static_cast<T>(1.0)}
@@ -665,7 +665,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 // asinh(z) = ln(z + sqrt(z^2 + 1))
                 return log(ctx, arg + sqrt(ctx, arg * arg + static_cast<T>(1.0)));
@@ -678,7 +678,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 // This holds everywhere, including the branch cuts: atan(z) = -i/2 * ln((i - z) / (i + z))
                 return Complex<T>{static_cast<T>(0.0), static_cast<T>(-0.5)}
@@ -695,7 +695,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 //  atanh(z) = 0.5 * (ln(1 + z) - ln(1 - z))
                 return static_cast<T>(0.5)
@@ -707,7 +707,7 @@ namespace alpaka
         template<typename TAcc, typename T>
         struct Conj<TAcc, Complex<T>>
         {
-            ALPAKA_FN_ACC auto operator()(TAcc const& /* conj_ctx */, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TAcc const& /* conj_ctx */, Complex<T> const& arg)
             {
                 return Complex<T>{arg.real(), -arg.imag()};
             }
@@ -719,7 +719,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 // cos(z) = 0.5 * (exp(i * z) + exp(-i * z))
                 return T(0.5)
@@ -734,7 +734,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 // cosh(z) = 0.5 * (exp(z) + exp(-z))
                 return T(0.5) * (exp(ctx, arg) + exp(ctx, static_cast<T>(-1.0) * arg));
@@ -747,7 +747,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 // exp(z) = exp(x + iy) = exp(x) * (cos(y) + i * sin(y))
                 auto re = T{}, im = T{};
@@ -762,7 +762,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
             {
                 // Branch cut along the negative real axis (same as for std::complex),
                 // principal value of ln(z) = ln(|z|) + i * arg(z)
@@ -777,7 +777,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
             {
                 return log(ctx, argument) / log(ctx, static_cast<T>(2));
             }
@@ -789,7 +789,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
             {
                 return log(ctx, argument) / log(ctx, static_cast<T>(10));
             }
@@ -801,7 +801,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& base, Complex<U> const& exponent)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& base, Complex<U> const& exponent)
             {
                 // Type promotion matching rules of complex std::pow but simplified given our math only supports float
                 // and double, no long double.
@@ -818,7 +818,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& base, U const& exponent)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& base, U const& exponent)
             {
                 return pow(ctx, base, Complex<U>{exponent});
             }
@@ -830,7 +830,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, T const& base, Complex<U> const& exponent)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, T const& base, Complex<U> const& exponent)
             {
                 return pow(ctx, Complex<T>{base}, exponent);
             }
@@ -842,7 +842,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 return static_cast<T>(1.0) / sqrt(ctx, arg);
             }
@@ -854,7 +854,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 // sin(z) = (exp(i * z) - exp(-i * z)) / 2i
                 return (exp(ctx, Complex<T>{static_cast<T>(0.0), static_cast<T>(1.0)} * arg)
@@ -869,7 +869,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 // sinh(z) = (exp(z) - exp(-i * z)) / 2
                 return (exp(ctx, arg) - exp(ctx, static_cast<T>(-1.0) * arg)) / static_cast<T>(2.0);
@@ -882,7 +882,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(
+            ALPAKA_FN_HOST_ACC auto operator()(
                 TCtx const& ctx,
                 Complex<T> const& arg,
                 Complex<T>& result_sin,
@@ -899,7 +899,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& argument)
             {
                 // Branch cut along the negative real axis (same as for std::complex),
                 // principal value of sqrt(z) = sqrt(|z|) * e^(i * arg(z) / 2)
@@ -916,7 +916,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 // tan(z) = i * (e^-iz - e^iz) / (e^-iz + e^iz) = i * (1 - e^2iz) / (1 + e^2iz)
                 // Warning: this straightforward implementation can easily result in NaN as 0/0 or inf/inf.
@@ -932,7 +932,7 @@ namespace alpaka
         {
             //! Take context as original (accelerator) type, since we call other math functions
             template<typename TCtx>
-            ALPAKA_FN_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
+            ALPAKA_FN_HOST_ACC auto operator()(TCtx const& ctx, Complex<T> const& arg)
             {
                 // tanh(z) = (e^z - e^-z)/(e^z+e^-z)
                 return (exp(ctx, arg) - exp(ctx, static_cast<T>(-1.0) * arg))


### PR DESCRIPTION
This is the immediate fix requested in [here](https://github.com/alpaka-group/alpaka/pull/2436/files/cbf73204f60d33e65f58a29f42b9138ed89387be#r1956328783) for the following problem: Compiling in `alpaka_ACC_GPU_CUDA_ONLY_MODE=ON` resolves `ALPAKA_FN_ACC` into `__device__` (and not `__host__ __device__`). However, in some situations the compiler has problems deducing the correct return type (for return type `auto`) if it only ever knows the device code and doesn't generate host code. This results in weird compilation errors along the lines of `error: invalid use of void expression` for functions that clearly return a non-`void` value. In our case, the complex math functions are the culprit.

CUDA-only mode is currently not run in CI (presumably because some examples explicitly need `AccCpuSerial`). @SimeonEhrig, could we run CUDA-only mode in CI?

CAUTION: Running `test/unit/math/mathTest` in CUDA-only mode still fails after this fix with the following error message:
```
include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp(334) 'TApi::funcGetAttributes(&funcAttrs, reinterpret_cast<void const*>(kernelName))' returned error  : 'cudaErrorInvalidDeviceFunction': 'invalid device function'!

[...]

/test/unit/math/src/mathLambda.cpp:60: FAILED:
due to a fatal error condition:
  testing acc:alpaka::AccGpuUniformCudaHipRt<alpaka::ApiCudaRt, std::
  integral_constant<unsigned long, 1ul>, unsigned long> data type:double
  functor:__nv_hdl_wrapper_t<false, true, false, __nv_dl_tag<void
  (LambdaMathTestTemplate<alpaka::AccGpuUniformCudaHipRt<alpaka::ApiCudaRt,
  std::integral_constant<unsigned long, 1ul>, unsigned long>, double>::*)()
  const, &(void LambdaMathTestTemplate<alpaka::AccGpuUniformCudaHipRt<alpaka::
  ApiCudaRt, std::integral_constant<unsigned long, 1ul>, unsigned long>,
  double>::operator()<std::tuple<mathtest::OpAbs, mathtest::OpAcos, mathtest::
  OpAcosh, mathtest::OpArg, mathtest::OpAsin, mathtest::OpAsinh, mathtest::
  OpAtan, mathtest::OpAtanh, mathtest::OpCbrt, mathtest::OpCeil, mathtest::
  OpCos, mathtest::OpCosh, mathtest::OpErf, mathtest::OpExp, mathtest::OpFloor,
  mathtest::OpLog, mathtest::OpLog2, mathtest::OpLog10, mathtest::OpRound,
  mathtest::OpRsqrt, mathtest::OpSin, mathtest::OpSinh, mathtest::OpSqrt,
  mathtest::OpTan, mathtest::OpTanh, mathtest::OpTrunc, mathtest::OpIsnan,
  mathtest::OpIsinf, mathtest::OpIsfinite> >() const), 1u>, void (mathtest::
  ArgsItem<double, (mathtest::Arity)1> const&, alpaka::AccGpuUniformCudaHipRt
  <alpaka::ApiCudaRt, std::integral_constant<unsigned long, 1ul>, unsigned
  long> const&)> seed:2721678720
  SIGILL - Illegal instruction signal
```
(running in debug mode generates the SIGILL which seems to be somehow hidden otherwise). This disappears by disabling CUDA-only mode (still activating only a single accelerator). So apparently there's something more going on here. `cuda-gdb` reveals that it's while `getValidWorkDiv` failing to get function properties. This is likely related, potentially because I haven't found all instances of this happening. We need to dig into this further but I would still welcome merging this partial fix already because it's needed for PIConGPU.

As @psychocoderHPC is on vacation, would you, @AuroraPerego or someone else, do the honours please?