### PR TITLE
Implement cache of device properties

### DIFF
--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -6,7 +6,7 @@
 #pragma once
 
 #include "alpaka/dev/Traits.hpp"
-#include "alpaka/dev/common/QueueRegistry.hpp"
+#include "alpaka/dev/common/DevGenericImpl.hpp"
 #include "alpaka/dev/cpu/SysInfo.hpp"
 #include "alpaka/mem/buf/Traits.hpp"
 #include "alpaka/platform/Traits.hpp"
@@ -55,7 +55,7 @@ namespace alpaka
     namespace cpu::detail
     {
         //! The CPU device implementation.
-        using DevCpuImpl = alpaka::detail::QueueRegistry<cpu::ICpuQueue>;
+        using DevCpuImpl = alpaka::detail::DevGenericImpl<cpu::ICpuQueue>;
     } // namespace cpu::detail
 
     //! The CPU device handle.

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "alpaka/dev/Traits.hpp"
+#include "alpaka/dev/common/DeviceProperties.hpp"
 #include "alpaka/dev/common/QueueRegistry.hpp"
 #include "alpaka/dev/cpu/SysInfo.hpp"
 #include "alpaka/mem/buf/Traits.hpp"
@@ -57,7 +58,9 @@ namespace alpaka
         friend struct trait::GetDevByIdx<PlatformCpu>;
 
     protected:
-        DevCpu() : m_spDevCpuImpl(std::make_shared<cpu::detail::DevCpuImpl>())
+        DevCpu()
+            : m_spDevCpuImpl(std::make_shared<cpu::detail::DevCpuImpl>())
+            , m_deviceProperties(std::make_shared<alpaka::DeviceProperties>())
         {
         }
 
@@ -89,8 +92,15 @@ namespace alpaka
             return 0;
         }
 
+        friend struct trait::GetName<DevCpu>;
+        friend struct trait::GetMemBytes<DevCpu>;
+        friend struct trait::GetFreeMemBytes<DevCpu>;
+        friend struct trait::GetWarpSizes<DevCpu>;
+        friend struct trait::GetPreferredWarpSize<DevCpu>;
+
     private:
         std::shared_ptr<cpu::detail::DevCpuImpl> m_spDevCpuImpl;
+        std::shared_ptr<alpaka::DeviceProperties> m_deviceProperties;
     };
 
     namespace trait
@@ -99,9 +109,13 @@ namespace alpaka
         template<>
         struct GetName<DevCpu>
         {
-            ALPAKA_FN_HOST static auto getName(DevCpu const& /* dev */) -> std::string
+            ALPAKA_FN_HOST static auto getName(DevCpu const& dev) -> std::string
             {
-                return cpu::detail::getCpuName();
+                if(!dev.m_deviceProperties->name.has_value())
+                {
+                    dev.m_deviceProperties->name = cpu::detail::getCpuName();
+                }
+                return dev.m_deviceProperties->name.value();
             }
         };
 
@@ -109,9 +123,13 @@ namespace alpaka
         template<>
         struct GetMemBytes<DevCpu>
         {
-            ALPAKA_FN_HOST static auto getMemBytes(DevCpu const& /* dev */) -> std::size_t
+            ALPAKA_FN_HOST static auto getMemBytes(DevCpu const& dev) -> std::size_t
             {
-                return cpu::detail::getTotalGlobalMemSizeBytes();
+                if(!dev.m_deviceProperties->totalGlobalMem.has_value())
+                {
+                    dev.m_deviceProperties->totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
+                }
+                return dev.m_deviceProperties->totalGlobalMem.value();
             }
         };
 
@@ -119,9 +137,13 @@ namespace alpaka
         template<>
         struct GetFreeMemBytes<DevCpu>
         {
-            ALPAKA_FN_HOST static auto getFreeMemBytes(DevCpu const& /* dev */) -> std::size_t
+            ALPAKA_FN_HOST static auto getFreeMemBytes(DevCpu const& dev) -> std::size_t
             {
-                return cpu::detail::getFreeGlobalMemSizeBytes();
+                if(!dev.m_deviceProperties->freeGlobalMem.has_value())
+                {
+                    dev.m_deviceProperties->freeGlobalMem = cpu::detail::getFreeGlobalMemSizeBytes();
+                }
+                return dev.m_deviceProperties->freeGlobalMem.value();
             }
         };
 

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -105,10 +105,11 @@ namespace alpaka
         template<>
         struct GetName<DevCpu>
         {
-            ALPAKA_FN_HOST static auto getName(DevCpu const& /* dev */) -> std::string
+            ALPAKA_FN_HOST static auto getName(DevCpu const& dev) -> std::string
             {
-                static auto name = cpu::detail::getCpuName();
-                return name;
+                auto& name = dev.m_spDevCpuImpl->deviceProperties().name;
+                std::call_once(dev.m_spDevCpuImpl->onceFlag(), [&]() noexcept { name = cpu::detail::getCpuName(); });
+                return name.value();
             }
         };
 
@@ -116,10 +117,13 @@ namespace alpaka
         template<>
         struct GetMemBytes<DevCpu>
         {
-            ALPAKA_FN_HOST static auto getMemBytes(DevCpu const& /* dev */) -> std::size_t
+            ALPAKA_FN_HOST static auto getMemBytes(DevCpu const& dev) -> std::size_t
             {
-                static auto totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
-                return totalGlobalMem;
+                auto& totalGlobalMem = dev.m_spDevCpuImpl->deviceProperties().totalGlobalMem;
+                std::call_once(
+                    dev.m_spDevCpuImpl->onceFlag(),
+                    [&]() noexcept { totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes(); });
+                return totalGlobalMem.value();
             }
         };
 

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -42,15 +42,6 @@ namespace alpaka
     } // namespace trait
     struct PlatformCpu;
 
-    namespace detail
-    {
-        inline void setDeviceProperties(alpaka::DevCpu const&, alpaka::DeviceProperties& devProperties)
-        {
-            devProperties.name = cpu::detail::getCpuName();
-            devProperties.totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
-        }
-    } // namespace detail
-
     //! The CPU device.
     namespace cpu::detail
     {
@@ -96,6 +87,12 @@ namespace alpaka
         [[nodiscard]] auto getNativeHandle() const noexcept
         {
             return 0;
+        }
+
+        static void setDeviceProperties(alpaka::DevCpu const&, alpaka::DeviceProperties& devProperties)
+        {
+            devProperties.name = cpu::detail::getCpuName();
+            devProperties.totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
         }
 
         friend struct trait::GetName<DevCpu>;

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -44,7 +44,11 @@ namespace alpaka
 
     namespace detail
     {
-        inline void setDeviceProperties(int, alpaka::DeviceProperties& devProperties)
+        template<typename TApi>
+        inline void setDeviceProperties(int, alpaka::DeviceProperties& devProperties);
+
+        template<>
+        inline void setDeviceProperties<void>(int, alpaka::DeviceProperties& devProperties)
         {
             devProperties.name = cpu::detail::getCpuName();
             devProperties.totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -114,7 +114,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getName(DevCpu const& dev) -> std::string
             {
                 {
-                    std::lock_guard lock(*dev.m_mutex);
+                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
                     if(!dev.m_deviceProperties->name.has_value())
                     {
                         dev.m_deviceProperties->name = cpu::detail::getCpuName();
@@ -131,7 +131,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getMemBytes(DevCpu const& dev) -> std::size_t
             {
                 {
-                    std::lock_guard lock(*dev.m_mutex);
+                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
                     if(!dev.m_deviceProperties->totalGlobalMem.has_value())
                     {
                         dev.m_deviceProperties->totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
@@ -148,7 +148,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevCpu const& dev) -> std::size_t
             {
                 {
-                    std::lock_guard lock(*dev.m_mutex);
+                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
                     if(!dev.m_deviceProperties->freeGlobalMem.has_value())
                     {
                         dev.m_deviceProperties->freeGlobalMem = cpu::detail::getFreeGlobalMemSizeBytes();

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -61,6 +61,7 @@ namespace alpaka
         DevCpu()
             : m_spDevCpuImpl(std::make_shared<cpu::detail::DevCpuImpl>())
             , m_deviceProperties(std::make_shared<alpaka::DeviceProperties>())
+            , m_mutex(std::make_shared<std::mutex>())
         {
         }
 
@@ -101,6 +102,7 @@ namespace alpaka
     private:
         std::shared_ptr<cpu::detail::DevCpuImpl> m_spDevCpuImpl;
         std::shared_ptr<alpaka::DeviceProperties> m_deviceProperties;
+        std::shared_ptr<std::mutex> m_mutex;
     };
 
     namespace trait
@@ -111,9 +113,12 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getName(DevCpu const& dev) -> std::string
             {
-                if(!dev.m_deviceProperties->name.has_value())
                 {
-                    dev.m_deviceProperties->name = cpu::detail::getCpuName();
+                    std::lock_guard lock(*dev.m_mutex);
+                    if(!dev.m_deviceProperties->name.has_value())
+                    {
+                        dev.m_deviceProperties->name = cpu::detail::getCpuName();
+                    }
                 }
                 return dev.m_deviceProperties->name.value();
             }
@@ -125,9 +130,12 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevCpu const& dev) -> std::size_t
             {
-                if(!dev.m_deviceProperties->totalGlobalMem.has_value())
                 {
-                    dev.m_deviceProperties->totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
+                    std::lock_guard lock(*dev.m_mutex);
+                    if(!dev.m_deviceProperties->totalGlobalMem.has_value())
+                    {
+                        dev.m_deviceProperties->totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
+                    }
                 }
                 return dev.m_deviceProperties->totalGlobalMem.value();
             }
@@ -139,9 +147,12 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevCpu const& dev) -> std::size_t
             {
-                if(!dev.m_deviceProperties->freeGlobalMem.has_value())
                 {
-                    dev.m_deviceProperties->freeGlobalMem = cpu::detail::getFreeGlobalMemSizeBytes();
+                    std::lock_guard lock(*dev.m_mutex);
+                    if(!dev.m_deviceProperties->freeGlobalMem.has_value())
+                    {
+                        dev.m_deviceProperties->freeGlobalMem = cpu::detail::getFreeGlobalMemSizeBytes();
+                    }
                 }
                 return dev.m_deviceProperties->freeGlobalMem.value();
             }

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -105,17 +105,10 @@ namespace alpaka
         template<>
         struct GetName<DevCpu>
         {
-            ALPAKA_FN_HOST static auto getName(DevCpu const& dev) -> std::string
+            ALPAKA_FN_HOST static auto getName(DevCpu const& /* dev */) -> std::string
             {
-                auto& name = dev.m_spDevCpuImpl->deviceProperties().name;
-                {
-                    std::lock_guard<std::mutex> lock(dev.m_spDevCpuImpl->mutex());
-                    if(!name.has_value())
-                    {
-                        name = cpu::detail::getCpuName();
-                    }
-                }
-                return name.value();
+                static auto name = cpu::detail::getCpuName();
+                return name;
             }
         };
 
@@ -123,17 +116,10 @@ namespace alpaka
         template<>
         struct GetMemBytes<DevCpu>
         {
-            ALPAKA_FN_HOST static auto getMemBytes(DevCpu const& dev) -> std::size_t
+            ALPAKA_FN_HOST static auto getMemBytes(DevCpu const& /* dev */) -> std::size_t
             {
-                auto& totalGlobalMem = dev.m_spDevCpuImpl->deviceProperties().totalGlobalMem;
-                {
-                    std::lock_guard<std::mutex> lock(dev.m_spDevCpuImpl->mutex());
-                    if(!totalGlobalMem.has_value())
-                    {
-                        totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
-                    }
-                }
-                return totalGlobalMem.value();
+                static auto totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
+                return totalGlobalMem;
             }
         };
 

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -101,6 +101,13 @@ namespace alpaka
 
     namespace trait
     {
+
+        static void setDeviceProperties(std::string& name, std::size_t& totalGlobalMem)
+        {
+            name = cpu::detail::getCpuName();
+            totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
+        }
+
         //! The CPU device name get trait specialization.
         template<>
         struct GetName<DevCpu>
@@ -113,8 +120,7 @@ namespace alpaka
                     [&]() noexcept
                     {
                         devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        devProperties->name = cpu::detail::getCpuName();
-                        devProperties->totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
+                        setDeviceProperties(devProperties->name, devProperties->totalGlobalMem);
                     });
                 return devProperties->name;
             }
@@ -132,8 +138,7 @@ namespace alpaka
                     [&]() noexcept
                     {
                         devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        devProperties->name = cpu::detail::getCpuName();
-                        devProperties->totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
+                        setDeviceProperties(devProperties->name, devProperties->totalGlobalMem);
                     });
 
                 return devProperties->totalGlobalMem;

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -107,14 +107,15 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getName(DevCpu const& dev) -> std::string
             {
+                auto& name = dev.m_spDevCpuImpl->deviceProperties().name;
                 {
                     std::lock_guard<std::mutex> lock(dev.m_spDevCpuImpl->mutex());
-                    if(!dev.m_spDevCpuImpl->deviceProperties().name.has_value())
+                    if(!name.has_value())
                     {
-                        dev.m_spDevCpuImpl->deviceProperties().name = cpu::detail::getCpuName();
+                        name = cpu::detail::getCpuName();
                     }
                 }
-                return dev.m_spDevCpuImpl->deviceProperties().name.value();
+                return name.value();
             }
         };
 
@@ -124,15 +125,15 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevCpu const& dev) -> std::size_t
             {
+                auto& totalGlobalMem = dev.m_spDevCpuImpl->deviceProperties().totalGlobalMem;
                 {
                     std::lock_guard<std::mutex> lock(dev.m_spDevCpuImpl->mutex());
-                    if(!dev.m_spDevCpuImpl->deviceProperties().totalGlobalMem.has_value())
+                    if(!totalGlobalMem.has_value())
                     {
-                        dev.m_spDevCpuImpl->deviceProperties().totalGlobalMem
-                            = cpu::detail::getTotalGlobalMemSizeBytes();
+                        totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
                     }
                 }
-                return dev.m_spDevCpuImpl->deviceProperties().totalGlobalMem.value();
+                return totalGlobalMem.value();
             }
         };
 

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -44,11 +44,7 @@ namespace alpaka
 
     namespace detail
     {
-        template<typename TApi>
-        inline void setDeviceProperties(int, alpaka::DeviceProperties& devProperties);
-
-        template<>
-        inline void setDeviceProperties<void>(int, alpaka::DeviceProperties& devProperties)
+        inline void setDeviceProperties(alpaka::DevCpu const&, alpaka::DeviceProperties& devProperties)
         {
             devProperties.name = cpu::detail::getCpuName();
             devProperties.totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
@@ -121,7 +117,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getName(DevCpu const& dev) -> std::string
             {
-                return dev.m_spDevCpuImpl->deviceProperties()->name;
+                return dev.m_spDevCpuImpl->deviceProperties(dev)->name;
             }
         };
 
@@ -131,7 +127,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevCpu const& dev) -> std::size_t
             {
-                return dev.m_spDevCpuImpl->deviceProperties()->totalGlobalMem;
+                return dev.m_spDevCpuImpl->deviceProperties(dev)->totalGlobalMem;
             }
         };
 

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -42,6 +42,15 @@ namespace alpaka
     } // namespace trait
     struct PlatformCpu;
 
+    namespace detail
+    {
+        inline void setDeviceProperties(int, alpaka::DeviceProperties& devProperties)
+        {
+            devProperties.name = cpu::detail::getCpuName();
+            devProperties.totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
+        }
+    } // namespace detail
+
     //! The CPU device.
     namespace cpu::detail
     {
@@ -102,27 +111,13 @@ namespace alpaka
     namespace trait
     {
 
-        static void setDeviceProperties(std::string& name, std::size_t& totalGlobalMem)
-        {
-            name = cpu::detail::getCpuName();
-            totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
-        }
-
         //! The CPU device name get trait specialization.
         template<>
         struct GetName<DevCpu>
         {
             ALPAKA_FN_HOST static auto getName(DevCpu const& dev) -> std::string
             {
-                auto& devProperties = dev.m_spDevCpuImpl->deviceProperties();
-                std::call_once(
-                    dev.m_spDevCpuImpl->onceFlag(),
-                    [&]() noexcept
-                    {
-                        devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        setDeviceProperties(devProperties->name, devProperties->totalGlobalMem);
-                    });
-                return devProperties->name;
+                return dev.m_spDevCpuImpl->deviceProperties()->name;
             }
         };
 
@@ -132,16 +127,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevCpu const& dev) -> std::size_t
             {
-                auto& devProperties = dev.m_spDevCpuImpl->deviceProperties();
-                std::call_once(
-                    dev.m_spDevCpuImpl->onceFlag(),
-                    [&]() noexcept
-                    {
-                        devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        setDeviceProperties(devProperties->name, devProperties->totalGlobalMem);
-                    });
-
-                return devProperties->totalGlobalMem;
+                return dev.m_spDevCpuImpl->deviceProperties()->totalGlobalMem;
             }
         };
 

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include "alpaka/dev/Traits.hpp"
-#include "alpaka/dev/common/DeviceProperties.hpp"
 #include "alpaka/dev/common/QueueRegistry.hpp"
 #include "alpaka/dev/cpu/SysInfo.hpp"
 #include "alpaka/mem/buf/Traits.hpp"
@@ -58,10 +57,7 @@ namespace alpaka
         friend struct trait::GetDevByIdx<PlatformCpu>;
 
     protected:
-        DevCpu()
-            : m_spDevCpuImpl(std::make_shared<cpu::detail::DevCpuImpl>())
-            , m_deviceProperties(std::make_shared<alpaka::DeviceProperties>())
-            , m_mutex(std::make_shared<std::mutex>())
+        DevCpu() : m_spDevCpuImpl(std::make_shared<cpu::detail::DevCpuImpl>())
         {
         }
 
@@ -101,8 +97,6 @@ namespace alpaka
 
     private:
         std::shared_ptr<cpu::detail::DevCpuImpl> m_spDevCpuImpl;
-        std::shared_ptr<alpaka::DeviceProperties> m_deviceProperties;
-        std::shared_ptr<std::mutex> m_mutex;
     };
 
     namespace trait
@@ -114,13 +108,13 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getName(DevCpu const& dev) -> std::string
             {
                 {
-                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
-                    if(!dev.m_deviceProperties->name.has_value())
+                    std::lock_guard<std::mutex> lock(dev.m_spDevCpuImpl->mutex());
+                    if(!dev.m_spDevCpuImpl->deviceProperties().name.has_value())
                     {
-                        dev.m_deviceProperties->name = cpu::detail::getCpuName();
+                        dev.m_spDevCpuImpl->deviceProperties().name = cpu::detail::getCpuName();
                     }
                 }
-                return dev.m_deviceProperties->name.value();
+                return dev.m_spDevCpuImpl->deviceProperties().name.value();
             }
         };
 
@@ -131,13 +125,14 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getMemBytes(DevCpu const& dev) -> std::size_t
             {
                 {
-                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
-                    if(!dev.m_deviceProperties->totalGlobalMem.has_value())
+                    std::lock_guard<std::mutex> lock(dev.m_spDevCpuImpl->mutex());
+                    if(!dev.m_spDevCpuImpl->deviceProperties().totalGlobalMem.has_value())
                     {
-                        dev.m_deviceProperties->totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
+                        dev.m_spDevCpuImpl->deviceProperties().totalGlobalMem
+                            = cpu::detail::getTotalGlobalMemSizeBytes();
                     }
                 }
-                return dev.m_deviceProperties->totalGlobalMem.value();
+                return dev.m_spDevCpuImpl->deviceProperties().totalGlobalMem.value();
             }
         };
 
@@ -145,16 +140,9 @@ namespace alpaka
         template<>
         struct GetFreeMemBytes<DevCpu>
         {
-            ALPAKA_FN_HOST static auto getFreeMemBytes(DevCpu const& dev) -> std::size_t
+            ALPAKA_FN_HOST static auto getFreeMemBytes(DevCpu const& /* dev */) -> std::size_t
             {
-                {
-                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
-                    if(!dev.m_deviceProperties->freeGlobalMem.has_value())
-                    {
-                        dev.m_deviceProperties->freeGlobalMem = cpu::detail::getFreeGlobalMemSizeBytes();
-                    }
-                }
-                return dev.m_deviceProperties->freeGlobalMem.value();
+                return cpu::detail::getFreeGlobalMemSizeBytes();
             }
         };
 

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -112,6 +112,7 @@ namespace alpaka
                     dev.m_spDevCpuImpl->onceFlag(),
                     [&]() noexcept
                     {
+                        devProperties = std::make_optional<alpaka::DeviceProperties>();
                         devProperties->name = cpu::detail::getCpuName();
                         devProperties->totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
                     });
@@ -130,6 +131,7 @@ namespace alpaka
                     dev.m_spDevCpuImpl->onceFlag(),
                     [&]() noexcept
                     {
+                        devProperties = std::make_optional<alpaka::DeviceProperties>();
                         devProperties->name = cpu::detail::getCpuName();
                         devProperties->totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
                     });

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -107,9 +107,15 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getName(DevCpu const& dev) -> std::string
             {
-                auto& name = dev.m_spDevCpuImpl->deviceProperties().name;
-                std::call_once(dev.m_spDevCpuImpl->onceFlag(), [&]() noexcept { name = cpu::detail::getCpuName(); });
-                return name.value();
+                auto& devProperties = dev.m_spDevCpuImpl->deviceProperties();
+                std::call_once(
+                    dev.m_spDevCpuImpl->onceFlag(),
+                    [&]() noexcept
+                    {
+                        devProperties->name = cpu::detail::getCpuName();
+                        devProperties->totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
+                    });
+                return devProperties->name;
             }
         };
 
@@ -119,11 +125,16 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevCpu const& dev) -> std::size_t
             {
-                auto& totalGlobalMem = dev.m_spDevCpuImpl->deviceProperties().totalGlobalMem;
+                auto& devProperties = dev.m_spDevCpuImpl->deviceProperties();
                 std::call_once(
                     dev.m_spDevCpuImpl->onceFlag(),
-                    [&]() noexcept { totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes(); });
-                return totalGlobalMem.value();
+                    [&]() noexcept
+                    {
+                        devProperties->name = cpu::detail::getCpuName();
+                        devProperties->totalGlobalMem = cpu::detail::getTotalGlobalMemSizeBytes();
+                    });
+
+                return devProperties->totalGlobalMem;
             }
         };
 

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -113,10 +113,21 @@ namespace alpaka
                 return m_context;
             }
 
+            std::shared_mutex& mutex()
+            {
+                return m_mutex;
+            }
+
+            alpaka::DeviceProperties& deviceProperties()
+            {
+                return m_deviceProperties;
+            }
+
         private:
             sycl::device m_device;
             sycl::context m_context;
             std::vector<std::weak_ptr<QueueGenericSyclImpl>> m_queues;
+            alpaka::DeviceProperties m_deviceProperties;
             std::shared_mutex mutable m_mutex;
         };
     } // namespace detail
@@ -132,8 +143,6 @@ namespace alpaka
     public:
         DevGenericSycl(sycl::device device, sycl::context context)
             : m_impl{std::make_shared<detail::DevGenericSyclImpl>(std::move(device), std::move(context))}
-            , m_deviceProperties{std::make_shared<alpaka::DeviceProperties>()}
-            , m_mutex{std::make_shared<std::mutex>()}
         {
         }
 
@@ -153,8 +162,6 @@ namespace alpaka
         }
 
         std::shared_ptr<detail::DevGenericSyclImpl> m_impl;
-        std::shared_ptr<alpaka::DeviceProperties> m_deviceProperties;
-        std::shared_ptr<std::mutex> m_mutex;
     };
 
     namespace trait
@@ -166,14 +173,14 @@ namespace alpaka
             static auto getName(DevGenericSycl<TTag> const& dev) -> std::string
             {
                 {
-                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
-                    if(!dev.m_deviceProperties->name.has_value())
+                    std::lock_guard<std::shared_mutex> lock(dev.m_impl->mutex());
+                    if(!dev.m_impl->deviceProperties().name.has_value())
                     {
                         auto const device = dev.getNativeHandle().first;
-                        dev.m_deviceProperties->name = device.template get_info<sycl::info::device::name>();
+                        dev.m_impl->deviceProperties().name = device.template get_info<sycl::info::device::name>();
                     }
                 }
-                return dev.m_deviceProperties->name.value();
+                return dev.m_impl->deviceProperties().name.value();
             }
         };
 
@@ -184,15 +191,15 @@ namespace alpaka
             static auto getMemBytes(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
                 {
-                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
-                    if(!dev.m_deviceProperties->totalGlobalMem.has_value())
+                    std::lock_guard<std::shared_mutex> lock(dev.m_impl->mutex());
+                    if(!dev.m_impl->deviceProperties().totalGlobalMem.has_value())
                     {
                         auto const device = dev.getNativeHandle().first;
-                        dev.m_deviceProperties->totalGlobalMem
+                        dev.m_impl->deviceProperties().totalGlobalMem
                             = device.template get_info<sycl::info::device::global_mem_size>();
                     }
                 }
-                return dev.m_deviceProperties->totalGlobalMem.value();
+                return dev.m_impl->deviceProperties().totalGlobalMem.value();
             }
         };
 
@@ -216,8 +223,8 @@ namespace alpaka
             static auto getWarpSizes(DevGenericSycl<TTag> const& dev) -> std::vector<std::size_t>
             {
                 {
-                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
-                    if(!dev.m_deviceProperties->warpSizes.has_value())
+                    std::lock_guard<std::shared_mutex> lock(dev.m_impl->mutex());
+                    if(!dev.m_impl->deviceProperties().warpSizes.has_value())
                     {
                         auto const device = dev.getNativeHandle().first;
                         std::vector<std::size_t> warp_sizes
@@ -229,10 +236,10 @@ namespace alpaka
                             warp_sizes.erase(find64);
                         // Sort the warp sizes in decreasing order
                         std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
-                        dev.m_deviceProperties->warpSizes = std::move(warp_sizes);
+                        dev.m_impl->deviceProperties().warpSizes = std::move(warp_sizes);
                     }
                 }
-                return dev.m_deviceProperties->warpSizes.value();
+                return dev.m_impl->deviceProperties().warpSizes.value();
             }
         };
 
@@ -243,10 +250,10 @@ namespace alpaka
             static auto getPreferredWarpSize(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
                 {
-                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
-                    if(dev.m_deviceProperties->warpSizes.has_value())
+                    std::lock_guard<std::shared_mutex> lock(dev.m_impl->mutex());
+                    if(dev.m_impl->deviceProperties().warpSizes.has_value())
                     {
-                        return dev.m_deviceProperties->warpSizes.value().front();
+                        return dev.m_impl->deviceProperties().warpSizes.value().front();
                     }
                 }
                 return GetWarpSizes<DevGenericSycl<TTag>>::getWarpSizes(dev).front();

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -132,6 +132,8 @@ namespace alpaka
     public:
         DevGenericSycl(sycl::device device, sycl::context context)
             : m_impl{std::make_shared<detail::DevGenericSyclImpl>(std::move(device), std::move(context))}
+            , m_deviceProperties{std::make_shared<alpaka::DeviceProperties>()}
+            , m_mutex{std::make_shared<std::mutex>()}
         {
         }
 
@@ -152,6 +154,7 @@ namespace alpaka
 
         std::shared_ptr<detail::DevGenericSyclImpl> m_impl;
         std::shared_ptr<alpaka::DeviceProperties> m_deviceProperties;
+        std::shared_ptr<std::mutex> m_mutex;
     };
 
     namespace trait
@@ -162,10 +165,13 @@ namespace alpaka
         {
             static auto getName(DevGenericSycl<TTag> const& dev) -> std::string
             {
-                if(!dev.m_deviceProperties->name.has_value())
                 {
-                    auto const device = dev.getNativeHandle().first;
-                    dev.m_deviceProperties->name = device.template get_info<sycl::info::device::name>();
+                    std::lock_guard lock(*dev.m_mutex);
+                    if(!dev.m_deviceProperties->name.has_value())
+                    {
+                        auto const device = dev.getNativeHandle().first;
+                        dev.m_deviceProperties->name = device.template get_info<sycl::info::device::name>();
+                    }
                 }
                 return dev.m_deviceProperties->name.value();
             }
@@ -177,11 +183,14 @@ namespace alpaka
         {
             static auto getMemBytes(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
-                if(!dev.m_deviceProperties->totalGlobalMem.has_value())
                 {
-                    auto const device = dev.getNativeHandle().first;
-                    dev.m_deviceProperties->totalGlobalMem
-                        = device.template get_info<sycl::info::device::global_mem_size>();
+                    std::lock_guard lock(*dev.m_mutex);
+                    if(!dev.m_deviceProperties->totalGlobalMem.has_value())
+                    {
+                        auto const device = dev.getNativeHandle().first;
+                        dev.m_deviceProperties->totalGlobalMem
+                            = device.template get_info<sycl::info::device::global_mem_size>();
+                    }
                 }
                 return dev.m_deviceProperties->totalGlobalMem.value();
             }
@@ -206,18 +215,22 @@ namespace alpaka
         {
             static auto getWarpSizes(DevGenericSycl<TTag> const& dev) -> std::vector<std::size_t>
             {
-                if(!dev.m_deviceProperties->warpSizes.has_value())
                 {
-                    auto const device = dev.getNativeHandle().first;
-                    std::vector<std::size_t> warp_sizes
-                        = device.template get_info<sycl::info::device::sub_group_sizes>();
-                    // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently does not
-                    auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
-                    if(find64 != warp_sizes.end())
-                        warp_sizes.erase(find64);
-                    // Sort the warp sizes in decreasing order
-                    std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
-                    dev.m_deviceProperties->warpSizes = std::move(warp_sizes);
+                    std::lock_guard lock(*dev.m_mutex);
+                    if(!dev.m_deviceProperties->warpSizes.has_value())
+                    {
+                        auto const device = dev.getNativeHandle().first;
+                        std::vector<std::size_t> warp_sizes
+                            = device.template get_info<sycl::info::device::sub_group_sizes>();
+                        // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently does
+                        // not
+                        auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
+                        if(find64 != warp_sizes.end())
+                            warp_sizes.erase(find64);
+                        // Sort the warp sizes in decreasing order
+                        std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
+                        dev.m_deviceProperties->warpSizes = std::move(warp_sizes);
+                    }
                 }
                 return dev.m_deviceProperties->warpSizes.value();
             }
@@ -229,9 +242,12 @@ namespace alpaka
         {
             static auto getPreferredWarpSize(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
-                if(dev.m_deviceProperties->preferredWarpSize.has_value())
                 {
-                    return dev.m_deviceProperties->preferredWarpSize.value().front();
+                    std::lock_guard lock(*dev.m_mutex);
+                    if(dev.m_deviceProperties->preferredWarpSize.has_value())
+                    {
+                        return dev.m_deviceProperties->preferredWarpSize.value().front();
+                    }
                 }
                 return GetWarpSizes<DevGenericSycl<TTag>>::getWarpSizes(dev).front();
             }

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -120,7 +120,7 @@ namespace alpaka
                     [&]()
                     {
                         m_deviceProperties = std::make_optional<alpaka::DeviceProperties>();
-                        auto const device = this->get_device();
+                        auto const& device = this->get_device();
                         m_deviceProperties->name = device.template get_info<sycl::info::device::name>();
                         m_deviceProperties->totalGlobalMem
                             = device.template get_info<sycl::info::device::global_mem_size>();

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -9,6 +9,7 @@
 #include "alpaka/core/Common.hpp"
 #include "alpaka/core/Sycl.hpp"
 #include "alpaka/dev/Traits.hpp"
+#include "alpaka/dev/common/DeviceProperties.hpp"
 #include "alpaka/mem/buf/Traits.hpp"
 #include "alpaka/platform/Traits.hpp"
 #include "alpaka/queue/Properties.hpp"
@@ -150,6 +151,7 @@ namespace alpaka
         }
 
         std::shared_ptr<detail::DevGenericSyclImpl> m_impl;
+        std::shared_ptr<alpaka::DeviceProperties> m_deviceProperties;
     };
 
     namespace trait
@@ -160,8 +162,12 @@ namespace alpaka
         {
             static auto getName(DevGenericSycl<TTag> const& dev) -> std::string
             {
-                auto const device = dev.getNativeHandle().first;
-                return device.template get_info<sycl::info::device::name>();
+                if(!dev.m_deviceProperties->name.has_value())
+                {
+                    auto const device = dev.getNativeHandle().first;
+                    dev.m_deviceProperties->name = device.template get_info<sycl::info::device::name>();
+                }
+                return dev.m_deviceProperties->name.value();
             }
         };
 
@@ -171,8 +177,13 @@ namespace alpaka
         {
             static auto getMemBytes(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
-                auto const device = dev.getNativeHandle().first;
-                return device.template get_info<sycl::info::device::global_mem_size>();
+                if(!dev.m_deviceProperties->totalGlobalMem.has_value())
+                {
+                    auto const device = dev.getNativeHandle().first;
+                    dev.m_deviceProperties->totalGlobalMem
+                        = device.template get_info<sycl::info::device::global_mem_size>();
+                }
+                return dev.m_deviceProperties->totalGlobalMem.value();
             }
         };
 
@@ -195,15 +206,20 @@ namespace alpaka
         {
             static auto getWarpSizes(DevGenericSycl<TTag> const& dev) -> std::vector<std::size_t>
             {
-                auto const device = dev.getNativeHandle().first;
-                std::vector<std::size_t> warp_sizes = device.template get_info<sycl::info::device::sub_group_sizes>();
-                // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently does not
-                auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
-                if(find64 != warp_sizes.end())
-                    warp_sizes.erase(find64);
-                // Sort the warp sizes in decreasing order
-                std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
-                return warp_sizes;
+                if(!dev.m_deviceProperties->warpSizes.has_value())
+                {
+                    auto const device = dev.getNativeHandle().first;
+                    std::vector<std::size_t> warp_sizes
+                        = device.template get_info<sycl::info::device::sub_group_sizes>();
+                    // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently does not
+                    auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
+                    if(find64 != warp_sizes.end())
+                        warp_sizes.erase(find64);
+                    // Sort the warp sizes in decreasing order
+                    std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
+                    dev.m_deviceProperties->warpSizes = std::move(warp_sizes);
+                }
+                return dev.m_deviceProperties->warpSizes.value();
             }
         };
 
@@ -213,6 +229,10 @@ namespace alpaka
         {
             static auto getPreferredWarpSize(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
+                if(dev.m_deviceProperties->preferredWarpSize.has_value())
+                {
+                    return dev.m_deviceProperties->preferredWarpSize.value().front();
+                }
                 return GetWarpSizes<DevGenericSycl<TTag>>::getWarpSizes(dev).front();
             }
         };

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -172,15 +172,16 @@ namespace alpaka
         {
             static auto getName(DevGenericSycl<TTag> const& dev) -> std::string
             {
+                auto& name = dev.m_impl->deviceProperties().name;
                 {
                     std::lock_guard<std::shared_mutex> lock(dev.m_impl->mutex());
-                    if(!dev.m_impl->deviceProperties().name.has_value())
+                    if(!name.has_value())
                     {
                         auto const device = dev.getNativeHandle().first;
-                        dev.m_impl->deviceProperties().name = device.template get_info<sycl::info::device::name>();
+                        name = device.template get_info<sycl::info::device::name>();
                     }
                 }
-                return dev.m_impl->deviceProperties().name.value();
+                return name.value();
             }
         };
 
@@ -190,16 +191,16 @@ namespace alpaka
         {
             static auto getMemBytes(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
+                auto& totalGlobalMem = dev.m_impl->deviceProperties().totalGlobalMem;
                 {
                     std::lock_guard<std::shared_mutex> lock(dev.m_impl->mutex());
-                    if(!dev.m_impl->deviceProperties().totalGlobalMem.has_value())
+                    if(!totalGlobalMem.has_value())
                     {
                         auto const device = dev.getNativeHandle().first;
-                        dev.m_impl->deviceProperties().totalGlobalMem
-                            = device.template get_info<sycl::info::device::global_mem_size>();
+                        totalGlobalMem = device.template get_info<sycl::info::device::global_mem_size>();
                     }
                 }
-                return dev.m_impl->deviceProperties().totalGlobalMem.value();
+                return totalGlobalMem.value();
             }
         };
 
@@ -222,9 +223,10 @@ namespace alpaka
         {
             static auto getWarpSizes(DevGenericSycl<TTag> const& dev) -> std::vector<std::size_t>
             {
+                auto& warpSizes = dev.m_impl->deviceProperties().warpSizes
                 {
                     std::lock_guard<std::shared_mutex> lock(dev.m_impl->mutex());
-                    if(!dev.m_impl->deviceProperties().warpSizes.has_value())
+                    if(!warpSizes.has_value())
                     {
                         auto const device = dev.getNativeHandle().first;
                         std::vector<std::size_t> warp_sizes
@@ -236,10 +238,10 @@ namespace alpaka
                             warp_sizes.erase(find64);
                         // Sort the warp sizes in decreasing order
                         std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
-                        dev.m_impl->deviceProperties().warpSizes = std::move(warp_sizes);
+                        warpSizes = std::move(warp_sizes);
                     }
                 }
-                return dev.m_impl->deviceProperties().warpSizes.value();
+                return warpSizes.value();
             }
         };
 
@@ -249,11 +251,12 @@ namespace alpaka
         {
             static auto getPreferredWarpSize(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
+                auto& warpSizes = dev.m_impl->deviceProperties().warpSizes;
                 {
                     std::lock_guard<std::shared_mutex> lock(dev.m_impl->mutex());
-                    if(dev.m_impl->deviceProperties().warpSizes.has_value())
+                    if(warpSizes.has_value())
                     {
-                        return dev.m_impl->deviceProperties().warpSizes.value().front();
+                        return warpSizes.value().front();
                     }
                 }
                 return GetWarpSizes<DevGenericSycl<TTag>>::getWarpSizes(dev).front();

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -223,7 +223,7 @@ namespace alpaka
         {
             static auto getWarpSizes(DevGenericSycl<TTag> const& dev) -> std::vector<std::size_t>
             {
-                auto& warpSizes = dev.m_impl->deviceProperties().warpSizes
+                auto& warpSizes = dev.m_impl->deviceProperties().warpSizes;
                 {
                     std::lock_guard<std::shared_mutex> lock(dev.m_impl->mutex());
                     if(!warpSizes.has_value())

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -118,7 +118,7 @@ namespace alpaka
                 return m_onceFlag;
             }
 
-            alpaka::DeviceProperties& deviceProperties()
+            std::optional<alpaka::DeviceProperties>& deviceProperties()
             {
                 return m_deviceProperties;
             }
@@ -127,7 +127,7 @@ namespace alpaka
             sycl::device m_device;
             sycl::context m_context;
             std::vector<std::weak_ptr<QueueGenericSyclImpl>> m_queues;
-            alpaka::DeviceProperties m_deviceProperties;
+            std::optional<alpaka::DeviceProperties> m_deviceProperties;
             std::shared_mutex mutable m_mutex;
             std::once_flag m_onceFlag;
         };
@@ -173,15 +173,30 @@ namespace alpaka
         {
             static auto getName(DevGenericSycl<TTag> const& dev) -> std::string
             {
-                auto& name = dev.m_impl->deviceProperties().name;
+                auto& devProperties = dev.m_impl->deviceProperties();
                 std::call_once(
                     dev.m_impl->onceFlag(),
                     [&]()
                     {
+                        devProperties = std::make_optional<alpaka::DeviceProperties>();
                         auto const device = dev.getNativeHandle().first;
-                        name = device.template get_info<sycl::info::device::name>();
+                        devProperties->name = device.template get_info<sycl::info::device::name>();
+                        devProperties->totalGlobalMem
+                            = device.template get_info<sycl::info::device::global_mem_size>();
+
+                        std::vector<std::size_t> warp_sizes
+                            = device.template get_info<sycl::info::device::sub_group_sizes>();
+                        // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently
+                        // does not
+                        auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
+                        if(find64 != warp_sizes.end())
+                            warp_sizes.erase(find64);
+                        // Sort the warp sizes in decreasing order
+                        std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
+                        devProperties->warpSizes = std::move(warp_sizes);
+                        devProperties->preferredWarpSize = devProperties->warpSizes.front();
                     });
-                return name.value();
+                return devProperties->name;
             }
         };
 
@@ -191,15 +206,31 @@ namespace alpaka
         {
             static auto getMemBytes(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
-                auto& totalGlobalMem = dev.m_impl->deviceProperties().totalGlobalMem;
+                auto& devProperties = dev.m_impl->deviceProperties();
                 std::call_once(
                     dev.m_impl->onceFlag(),
                     [&]()
                     {
+                        devProperties = std::make_optional<alpaka::DeviceProperties>();
                         auto const device = dev.getNativeHandle().first;
-                        totalGlobalMem = device.template get_info<sycl::info::device::global_mem_size>();
+                        devProperties->name = device.template get_info<sycl::info::device::name>();
+                        devProperties->totalGlobalMem
+                            = device.template get_info<sycl::info::device::global_mem_size>();
+
+                        std::vector<std::size_t> warp_sizes
+                            = device.template get_info<sycl::info::device::sub_group_sizes>();
+                        // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently
+                        // does not
+                        auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
+                        if(find64 != warp_sizes.end())
+                            warp_sizes.erase(find64);
+                        // Sort the warp sizes in decreasing order
+                        std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
+                        devProperties->warpSizes = std::move(warp_sizes);
+                        devProperties->preferredWarpSize = devProperties->warpSizes.front();
                     });
-                return totalGlobalMem.value();
+
+                return devProperties->totalGlobalMem;
             }
         };
 
@@ -222,12 +253,17 @@ namespace alpaka
         {
             static auto getWarpSizes(DevGenericSycl<TTag> const& dev) -> std::vector<std::size_t>
             {
-                auto& warpSizes = dev.m_impl->deviceProperties().warpSizes;
+                auto& devProperties = dev.m_impl->deviceProperties();
                 std::call_once(
                     dev.m_impl->onceFlag(),
                     [&]()
                     {
+                        devProperties = std::make_optional<alpaka::DeviceProperties>();
                         auto const device = dev.getNativeHandle().first;
+                        devProperties->name = device.template get_info<sycl::info::device::name>();
+                        devProperties->totalGlobalMem
+                            = device.template get_info<sycl::info::device::global_mem_size>();
+
                         std::vector<std::size_t> warp_sizes
                             = device.template get_info<sycl::info::device::sub_group_sizes>();
                         // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently
@@ -237,9 +273,11 @@ namespace alpaka
                             warp_sizes.erase(find64);
                         // Sort the warp sizes in decreasing order
                         std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
-                        warpSizes = std::move(warp_sizes);
+                        devProperties->warpSizes = std::move(warp_sizes);
+                        devProperties->preferredWarpSize = devProperties->warpSizes.front();
                     });
-                return warpSizes.value();
+
+                return devProperties->warpSizes;
             }
         };
 
@@ -249,9 +287,31 @@ namespace alpaka
         {
             static auto getPreferredWarpSize(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
-                auto& warpSizes = dev.m_impl->deviceProperties().warpSizes;
-                std::call_once(dev.m_impl->onceFlag(), [&]() { return warpSizes.value().front(); });
-                return GetWarpSizes<DevGenericSycl<TTag>>::getWarpSizes(dev).front();
+                auto& devProperties = dev.m_impl->deviceProperties();
+                std::call_once(
+                    dev.m_impl->onceFlag(),
+                    [&]()
+                    {
+                        devProperties = std::make_optional<alpaka::DeviceProperties>();
+                        auto const device = dev.getNativeHandle().first;
+                        devProperties->name = device.template get_info<sycl::info::device::name>();
+                        devProperties->totalGlobalMem
+                            = device.template get_info<sycl::info::device::global_mem_size>();
+
+                        std::vector<std::size_t> warp_sizes
+                            = device.template get_info<sycl::info::device::sub_group_sizes>();
+                        // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently
+                        // does not
+                        auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
+                        if(find64 != warp_sizes.end())
+                            warp_sizes.erase(find64);
+                        // Sort the warp sizes in decreasing order
+                        std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
+                        devProperties->warpSizes = std::move(warp_sizes);
+                        devProperties->preferredWarpSize = devProperties->warpSizes.front();
+                    });
+
+                return devProperties->preferredWarpSize;
             }
         };
 

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -113,9 +113,9 @@ namespace alpaka
                 return m_context;
             }
 
-            std::shared_mutex& mutex()
+            std::once_flag& onceFlag()
             {
-                return m_mutex;
+                return m_onceFlag;
             }
 
             alpaka::DeviceProperties& deviceProperties()
@@ -129,6 +129,7 @@ namespace alpaka
             std::vector<std::weak_ptr<QueueGenericSyclImpl>> m_queues;
             alpaka::DeviceProperties m_deviceProperties;
             std::shared_mutex mutable m_mutex;
+            std::once_flag m_onceFlag;
         };
     } // namespace detail
 
@@ -173,14 +174,13 @@ namespace alpaka
             static auto getName(DevGenericSycl<TTag> const& dev) -> std::string
             {
                 auto& name = dev.m_impl->deviceProperties().name;
-                {
-                    std::lock_guard<std::shared_mutex> lock(dev.m_impl->mutex());
-                    if(!name.has_value())
+                std::call_once(
+                    dev.m_impl->onceFlag(),
+                    [&]()
                     {
                         auto const device = dev.getNativeHandle().first;
                         name = device.template get_info<sycl::info::device::name>();
-                    }
-                }
+                    });
                 return name.value();
             }
         };
@@ -192,14 +192,13 @@ namespace alpaka
             static auto getMemBytes(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
                 auto& totalGlobalMem = dev.m_impl->deviceProperties().totalGlobalMem;
-                {
-                    std::lock_guard<std::shared_mutex> lock(dev.m_impl->mutex());
-                    if(!totalGlobalMem.has_value())
+                std::call_once(
+                    dev.m_impl->onceFlag(),
+                    [&]()
                     {
                         auto const device = dev.getNativeHandle().first;
                         totalGlobalMem = device.template get_info<sycl::info::device::global_mem_size>();
-                    }
-                }
+                    });
                 return totalGlobalMem.value();
             }
         };
@@ -224,23 +223,22 @@ namespace alpaka
             static auto getWarpSizes(DevGenericSycl<TTag> const& dev) -> std::vector<std::size_t>
             {
                 auto& warpSizes = dev.m_impl->deviceProperties().warpSizes;
-                {
-                    std::lock_guard<std::shared_mutex> lock(dev.m_impl->mutex());
-                    if(!warpSizes.has_value())
+                std::call_once(
+                    dev.m_impl->onceFlag(),
+                    [&]()
                     {
                         auto const device = dev.getNativeHandle().first;
                         std::vector<std::size_t> warp_sizes
                             = device.template get_info<sycl::info::device::sub_group_sizes>();
-                        // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently does
-                        // not
+                        // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently
+                        // does not
                         auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
                         if(find64 != warp_sizes.end())
                             warp_sizes.erase(find64);
                         // Sort the warp sizes in decreasing order
                         std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
                         warpSizes = std::move(warp_sizes);
-                    }
-                }
+                    });
                 return warpSizes.value();
             }
         };
@@ -252,13 +250,7 @@ namespace alpaka
             static auto getPreferredWarpSize(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
                 auto& warpSizes = dev.m_impl->deviceProperties().warpSizes;
-                {
-                    std::lock_guard<std::shared_mutex> lock(dev.m_impl->mutex());
-                    if(warpSizes.has_value())
-                    {
-                        return warpSizes.value().front();
-                    }
-                }
+                std::call_once(dev.m_impl->onceFlag(), [&]() { return warpSizes.value().front(); });
                 return GetWarpSizes<DevGenericSycl<TTag>>::getWarpSizes(dev).front();
             }
         };

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -113,13 +113,31 @@ namespace alpaka
                 return m_context;
             }
 
-            auto onceFlag() -> std::once_flag&
-            {
-                return m_onceFlag;
-            }
-
             auto deviceProperties() -> std::optional<alpaka::DeviceProperties>&
             {
+                std::call_once(
+                    m_onceFlag,
+                    [&]()
+                    {
+                        m_deviceProperties = std::make_optional<alpaka::DeviceProperties>();
+                        auto const device = this->get_device();
+                        m_deviceProperties->name = device.template get_info<sycl::info::device::name>();
+                        m_deviceProperties->totalGlobalMem
+                            = device.template get_info<sycl::info::device::global_mem_size>();
+
+                        std::vector<std::size_t> warp_sizes
+                            = device.template get_info<sycl::info::device::sub_group_sizes>();
+                        // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently
+                        // does not
+                        auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
+                        if(find64 != warp_sizes.end())
+                            warp_sizes.erase(find64);
+                        // Sort the warp sizes in decreasing order
+                        std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
+                        m_deviceProperties->warpSizes = std::move(warp_sizes);
+                        m_deviceProperties->preferredWarpSize = m_deviceProperties->warpSizes.front();
+                    });
+
                 return m_deviceProperties;
             }
 
@@ -168,50 +186,13 @@ namespace alpaka
     namespace trait
     {
 
-        template<concepts::Tag TTag>
-        static inline void setDeviceProperties(
-            DevGenericSycl<TTag> const& dev,
-            std::string& name,
-            std::size_t& totalGlobalMem,
-            std::vector<std::size_t>& warpSizes,
-            std::size_t& preferredWarpSize)
-        {
-            auto const device = dev.getNativeHandle().first;
-            name = device.template get_info<sycl::info::device::name>();
-            totalGlobalMem = device.template get_info<sycl::info::device::global_mem_size>();
-
-            std::vector<std::size_t> warp_sizes = device.template get_info<sycl::info::device::sub_group_sizes>();
-            // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently
-            // does not
-            auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
-            if(find64 != warp_sizes.end())
-                warp_sizes.erase(find64);
-            // Sort the warp sizes in decreasing order
-            std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
-            warpSizes = std::move(warp_sizes);
-            preferredWarpSize = warpSizes.front();
-        }
-
         //! The SYCL device name get trait specialization.
         template<concepts::Tag TTag>
         struct GetName<DevGenericSycl<TTag>>
         {
             static auto getName(DevGenericSycl<TTag> const& dev) -> std::string
             {
-                auto& devProperties = dev.m_impl->deviceProperties();
-                std::call_once(
-                    dev.m_impl->onceFlag(),
-                    [&]()
-                    {
-                        devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        setDeviceProperties(
-                            dev,
-                            devProperties->name,
-                            devProperties->totalGlobalMem,
-                            devProperties->warpSizes,
-                            devProperties->preferredWarpSize);
-                    });
-                return devProperties->name;
+                return dev.m_impl->deviceProperties()->name;
             }
         };
 
@@ -221,21 +202,7 @@ namespace alpaka
         {
             static auto getMemBytes(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
-                auto& devProperties = dev.m_impl->deviceProperties();
-                std::call_once(
-                    dev.m_impl->onceFlag(),
-                    [&]()
-                    {
-                        devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        setDeviceProperties(
-                            dev,
-                            devProperties->name,
-                            devProperties->totalGlobalMem,
-                            devProperties->warpSizes,
-                            devProperties->preferredWarpSize);
-                    });
-
-                return devProperties->totalGlobalMem;
+                return dev.m_impl->deviceProperties()->totalGlobalMem;
             }
         };
 
@@ -258,21 +225,7 @@ namespace alpaka
         {
             static auto getWarpSizes(DevGenericSycl<TTag> const& dev) -> std::vector<std::size_t>
             {
-                auto& devProperties = dev.m_impl->deviceProperties();
-                std::call_once(
-                    dev.m_impl->onceFlag(),
-                    [&]()
-                    {
-                        devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        setDeviceProperties(
-                            dev,
-                            devProperties->name,
-                            devProperties->totalGlobalMem,
-                            devProperties->warpSizes,
-                            devProperties->preferredWarpSize);
-                    });
-
-                return devProperties->warpSizes;
+                return dev.m_impl->deviceProperties()->warpSizes;
             }
         };
 
@@ -282,21 +235,7 @@ namespace alpaka
         {
             static auto getPreferredWarpSize(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
-                auto& devProperties = dev.m_impl->deviceProperties();
-                std::call_once(
-                    dev.m_impl->onceFlag(),
-                    [&]()
-                    {
-                        devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        setDeviceProperties(
-                            dev,
-                            devProperties->name,
-                            devProperties->totalGlobalMem,
-                            devProperties->warpSizes,
-                            devProperties->preferredWarpSize);
-                    });
-
-                return devProperties->preferredWarpSize;
+                return dev.m_impl->deviceProperties()->preferredWarpSize;
             }
         };
 

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -167,6 +167,31 @@ namespace alpaka
 
     namespace trait
     {
+
+        template<concepts::Tag TTag>
+        static inline void setDeviceProperties(
+            DevGenericSycl<TTag> const& dev,
+            std::string& name,
+            std::size_t& totalGlobalMem,
+            std::vector<std::size_t>& warpSizes,
+            std::size_t& preferredWarpSize)
+        {
+            auto const device = dev.getNativeHandle().first;
+            name = device.template get_info<sycl::info::device::name>();
+            totalGlobalMem = device.template get_info<sycl::info::device::global_mem_size>();
+
+            std::vector<std::size_t> warp_sizes = device.template get_info<sycl::info::device::sub_group_sizes>();
+            // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently
+            // does not
+            auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
+            if(find64 != warp_sizes.end())
+                warp_sizes.erase(find64);
+            // Sort the warp sizes in decreasing order
+            std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
+            warpSizes = std::move(warp_sizes);
+            preferredWarpSize = warpSizes.front();
+        }
+
         //! The SYCL device name get trait specialization.
         template<concepts::Tag TTag>
         struct GetName<DevGenericSycl<TTag>>
@@ -179,22 +204,12 @@ namespace alpaka
                     [&]()
                     {
                         devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        auto const device = dev.getNativeHandle().first;
-                        devProperties->name = device.template get_info<sycl::info::device::name>();
-                        devProperties->totalGlobalMem
-                            = device.template get_info<sycl::info::device::global_mem_size>();
-
-                        std::vector<std::size_t> warp_sizes
-                            = device.template get_info<sycl::info::device::sub_group_sizes>();
-                        // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently
-                        // does not
-                        auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
-                        if(find64 != warp_sizes.end())
-                            warp_sizes.erase(find64);
-                        // Sort the warp sizes in decreasing order
-                        std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
-                        devProperties->warpSizes = std::move(warp_sizes);
-                        devProperties->preferredWarpSize = devProperties->warpSizes.front();
+                        setDeviceProperties(
+                            dev,
+                            devProperties->name,
+                            devProperties->totalGlobalMem,
+                            devProperties->warpSizes,
+                            devProperties->preferredWarpSize);
                     });
                 return devProperties->name;
             }
@@ -212,22 +227,12 @@ namespace alpaka
                     [&]()
                     {
                         devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        auto const device = dev.getNativeHandle().first;
-                        devProperties->name = device.template get_info<sycl::info::device::name>();
-                        devProperties->totalGlobalMem
-                            = device.template get_info<sycl::info::device::global_mem_size>();
-
-                        std::vector<std::size_t> warp_sizes
-                            = device.template get_info<sycl::info::device::sub_group_sizes>();
-                        // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently
-                        // does not
-                        auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
-                        if(find64 != warp_sizes.end())
-                            warp_sizes.erase(find64);
-                        // Sort the warp sizes in decreasing order
-                        std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
-                        devProperties->warpSizes = std::move(warp_sizes);
-                        devProperties->preferredWarpSize = devProperties->warpSizes.front();
+                        setDeviceProperties(
+                            dev,
+                            devProperties->name,
+                            devProperties->totalGlobalMem,
+                            devProperties->warpSizes,
+                            devProperties->preferredWarpSize);
                     });
 
                 return devProperties->totalGlobalMem;
@@ -259,22 +264,12 @@ namespace alpaka
                     [&]()
                     {
                         devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        auto const device = dev.getNativeHandle().first;
-                        devProperties->name = device.template get_info<sycl::info::device::name>();
-                        devProperties->totalGlobalMem
-                            = device.template get_info<sycl::info::device::global_mem_size>();
-
-                        std::vector<std::size_t> warp_sizes
-                            = device.template get_info<sycl::info::device::sub_group_sizes>();
-                        // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently
-                        // does not
-                        auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
-                        if(find64 != warp_sizes.end())
-                            warp_sizes.erase(find64);
-                        // Sort the warp sizes in decreasing order
-                        std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
-                        devProperties->warpSizes = std::move(warp_sizes);
-                        devProperties->preferredWarpSize = devProperties->warpSizes.front();
+                        setDeviceProperties(
+                            dev,
+                            devProperties->name,
+                            devProperties->totalGlobalMem,
+                            devProperties->warpSizes,
+                            devProperties->preferredWarpSize);
                     });
 
                 return devProperties->warpSizes;
@@ -293,22 +288,12 @@ namespace alpaka
                     [&]()
                     {
                         devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        auto const device = dev.getNativeHandle().first;
-                        devProperties->name = device.template get_info<sycl::info::device::name>();
-                        devProperties->totalGlobalMem
-                            = device.template get_info<sycl::info::device::global_mem_size>();
-
-                        std::vector<std::size_t> warp_sizes
-                            = device.template get_info<sycl::info::device::sub_group_sizes>();
-                        // The CPU runtime supports a sub-group size of 64, but the SYCL implementation currently
-                        // does not
-                        auto find64 = std::find(warp_sizes.begin(), warp_sizes.end(), 64);
-                        if(find64 != warp_sizes.end())
-                            warp_sizes.erase(find64);
-                        // Sort the warp sizes in decreasing order
-                        std::sort(warp_sizes.begin(), warp_sizes.end(), std::greater<>{});
-                        devProperties->warpSizes = std::move(warp_sizes);
-                        devProperties->preferredWarpSize = devProperties->warpSizes.front();
+                        setDeviceProperties(
+                            dev,
+                            devProperties->name,
+                            devProperties->totalGlobalMem,
+                            devProperties->warpSizes,
+                            devProperties->preferredWarpSize);
                     });
 
                 return devProperties->preferredWarpSize;

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -166,7 +166,7 @@ namespace alpaka
             static auto getName(DevGenericSycl<TTag> const& dev) -> std::string
             {
                 {
-                    std::lock_guard lock(*dev.m_mutex);
+                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
                     if(!dev.m_deviceProperties->name.has_value())
                     {
                         auto const device = dev.getNativeHandle().first;
@@ -184,7 +184,7 @@ namespace alpaka
             static auto getMemBytes(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
                 {
-                    std::lock_guard lock(*dev.m_mutex);
+                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
                     if(!dev.m_deviceProperties->totalGlobalMem.has_value())
                     {
                         auto const device = dev.getNativeHandle().first;
@@ -216,7 +216,7 @@ namespace alpaka
             static auto getWarpSizes(DevGenericSycl<TTag> const& dev) -> std::vector<std::size_t>
             {
                 {
-                    std::lock_guard lock(*dev.m_mutex);
+                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
                     if(!dev.m_deviceProperties->warpSizes.has_value())
                     {
                         auto const device = dev.getNativeHandle().first;
@@ -243,7 +243,7 @@ namespace alpaka
             static auto getPreferredWarpSize(DevGenericSycl<TTag> const& dev) -> std::size_t
             {
                 {
-                    std::lock_guard lock(*dev.m_mutex);
+                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
                     if(dev.m_deviceProperties->preferredWarpSize.has_value())
                     {
                         return dev.m_deviceProperties->preferredWarpSize.value().front();

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -113,12 +113,12 @@ namespace alpaka
                 return m_context;
             }
 
-            std::once_flag& onceFlag()
+            auto onceFlag() -> std::once_flag&
             {
                 return m_onceFlag;
             }
 
-            std::optional<alpaka::DeviceProperties>& deviceProperties()
+            auto deviceProperties() -> std::optional<alpaka::DeviceProperties>&
             {
                 return m_deviceProperties;
             }

--- a/include/alpaka/dev/DevGenericSycl.hpp
+++ b/include/alpaka/dev/DevGenericSycl.hpp
@@ -244,9 +244,9 @@ namespace alpaka
             {
                 {
                     std::lock_guard<std::mutex> lock(*dev.m_mutex);
-                    if(dev.m_deviceProperties->preferredWarpSize.has_value())
+                    if(dev.m_deviceProperties->warpSizes.has_value())
                     {
-                        return dev.m_deviceProperties->preferredWarpSize.value().front();
+                        return dev.m_deviceProperties->warpSizes.value().front();
                     }
                 }
                 return GetWarpSizes<DevGenericSycl<TTag>>::getWarpSizes(dev).front();

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -67,6 +67,7 @@ namespace alpaka
         DevUniformCudaHipRt()
             : m_QueueRegistry{std::make_shared<alpaka::detail::QueueRegistry<IDeviceQueue>>()}
             , m_deviceProperties{std::make_shared<alpaka::DeviceProperties>()}
+            , m_mutex(std::make_shared<std::mutex>())
         {
         }
 

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -122,19 +122,20 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getName(DevUniformCudaHipRt<TApi> const& dev) -> std::string
             {
+                auto& name = dev.m_QueueRegistry->deviceProperties().name;
                 {
                     std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
-                    if(!dev.m_QueueRegistry->deviceProperties().name.has_value())
+                    if(!name.has_value())
                     {
                         // There is cuda/hip-DeviceGetAttribute as faster alternative to cuda/hip-GetDeviceProperties
                         // to get a single device property but it has no option to get the name
                         typename TApi::DeviceProp_t devProp;
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, dev.getNativeHandle()));
-                        dev.m_QueueRegistry->deviceProperties().name = std::string(devProp.name);
+                        name = std::string(devProp.name);
                     }
                 }
 
-                return dev.m_QueueRegistry->deviceProperties().name.value();
+                return name.value();
             }
         };
 
@@ -144,9 +145,10 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
+                auto& totalGlobalMem = dev.m_QueueRegistry->deviceProperties().totalGlobalMem;
                 {
                     std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
-                    if(!dev.m_QueueRegistry->deviceProperties().totalGlobalMem.has_value())
+                    if(!totalGlobalMem.has_value())
                     {
                         // Set the current device to wait for.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
@@ -156,11 +158,11 @@ namespace alpaka
 
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
 
-                        dev.m_QueueRegistry->deviceProperties().totalGlobalMem = totalInternal;
+                        totalGlobalMem = totalInternal;
                     }
                 }
 
-                return dev.m_QueueRegistry->deviceProperties().totalGlobalMem.value();
+                return totalGlobalMem.value();
             }
         };
 
@@ -170,10 +172,11 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
+                auto& freeInternal = dev.m_QueueRegistry->deviceProperties().freeInternal;
                 std::size_t freeInternal(0u);
                 {
                     std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
-                    if(!dev.m_QueueRegistry->deviceProperties().totalGlobalMem.has_value())
+                    if(!totalGlobalMem.has_value())
                     {
                         // Set the current device to wait for.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
@@ -182,7 +185,7 @@ namespace alpaka
 
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
 
-                        dev.m_QueueRegistry->deviceProperties().totalGlobalMem = totalInternal;
+                        totalGlobalMem = totalInternal;
                     }
                 }
 
@@ -196,15 +199,28 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getWarpSizes(DevUniformCudaHipRt<TApi> const& dev) -> std::vector<std::size_t>
             {
+                auto& warpSizes = dev.m_QueueRegistry->deviceProperties().warpSizes;
                 {
                     std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
-                    if(!dev.m_QueueRegistry->deviceProperties().warpSizes.has_value())
+                    if(!warpSizes.has_value())
                     {
-                        dev.m_QueueRegistry->deviceProperties().warpSizes = std::vector<std::size_t>{
-                            GetPreferredWarpSize<DevUniformCudaHipRt<TApi>>::getPreferredWarpSize(dev)};
+                        if(dev.m_QueueRegistry->deviceProperties().preferredWarpSize.has_value())
+                        {
+                            warpSizes = std::vector<std::size_t>{
+                                dev.m_QueueRegistry->deviceProperties().preferredWarpSize.value()};
+                        }
+                        else
+                        {
+                            int warpSize = 0;
+                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::deviceGetAttribute(
+                                &warpSize,
+                                TApi::deviceAttributeWarpSize,
+                                dev.getNativeHandle()));
+                            warpSizes = std::vector<std::size_t>{warpSize};
+                        }
                     }
                 }
-                return dev.m_QueueRegistry->deviceProperties().warpSizes.value();
+                return warpSizes.value();
             }
         };
 
@@ -214,19 +230,20 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getPreferredWarpSize(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
+                auto& preferredWarpSize = dev.m_QueueRegistry->deviceProperties().preferredWarpSize;
                 {
                     std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
-                    if(!dev.m_QueueRegistry->deviceProperties().preferredWarpSize.has_value())
+                    if(!preferredWarpSize.has_value())
                     {
                         int warpSize = 0;
 
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, dev.getNativeHandle()));
-                        dev.m_QueueRegistry->deviceProperties().preferredWarpSize = static_cast<std::size_t>(warpSize);
+                        preferredWarpSize = static_cast<std::size_t>(warpSize);
                     }
                 }
 
-                return dev.m_QueueRegistry->deviceProperties().preferredWarpSize.value();
+                return preferredWarpSize.value();
             }
         };
 

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -21,6 +21,7 @@
 #include "alpaka/wait/Traits.hpp"
 
 #include <cstddef>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -108,6 +109,7 @@ namespace alpaka
             : m_iDevice(iDevice)
             , m_QueueRegistry(std::make_shared<alpaka::detail::QueueRegistry<IDeviceQueue>>())
             , m_deviceProperties(std::make_shared<alpaka::DeviceProperties>())
+            , m_mutex(std::make_shared<std::mutex>())
         {
         }
 
@@ -115,6 +117,7 @@ namespace alpaka
 
         std::shared_ptr<alpaka::detail::QueueRegistry<IDeviceQueue>> m_QueueRegistry;
         std::shared_ptr<alpaka::DeviceProperties> m_deviceProperties;
+        std::shared_ptr<std::mutex> m_mutex;
     };
 
     namespace trait
@@ -125,14 +128,16 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getName(DevUniformCudaHipRt<TApi> const& dev) -> std::string
             {
-                if(!dev.m_deviceProperties->name.has_value())
                 {
-                    // There is cuda/hip-DeviceGetAttribute as faster alternative to cuda/hip-GetDeviceProperties to
-                    // get a
-                    // single device property but it has no option to get the name
-                    typename TApi::DeviceProp_t devProp;
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, dev.getNativeHandle()));
-                    dev.m_deviceProperties->name = std::string(devProp.name);
+                    std::lock_guard lock(*dev.m_mutex);
+                    if(!dev.m_deviceProperties->name.has_value())
+                    {
+                        // There is cuda/hip-DeviceGetAttribute as faster alternative to cuda/hip-GetDeviceProperties
+                        // to get a single device property but it has no option to get the name
+                        typename TApi::DeviceProp_t devProp;
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, dev.getNativeHandle()));
+                        dev.m_deviceProperties->name = std::string(devProp.name);
+                    }
                 }
 
                 return dev.m_deviceProperties->name.value();
@@ -145,18 +150,21 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                if(!dev.m_deviceProperties->freeGlobalMem.has_value())
                 {
-                    // Set the current device to wait for.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
+                    std::lock_guard lock(*dev.m_mutex);
+                    if(!dev.m_deviceProperties->freeGlobalMem.has_value())
+                    {
+                        // Set the current device to wait for.
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
 
-                    std::size_t freeInternal(0u);
-                    std::size_t totalInternal(0u);
+                        std::size_t freeInternal(0u);
+                        std::size_t totalInternal(0u);
 
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
 
-                    dev.m_deviceProperties->totalGlobalMem = totalInternal;
-                    dev.m_deviceProperties->freeGlobalMem = freeInternal;
+                        dev.m_deviceProperties->totalGlobalMem = totalInternal;
+                        dev.m_deviceProperties->freeGlobalMem = freeInternal;
+                    }
                 }
 
                 return dev.m_deviceProperties->totalGlobalMem.value();
@@ -169,18 +177,21 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                if(!dev.m_deviceProperties->totalGlobalMem.has_value())
                 {
-                    // Set the current device to wait for.
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
+                    std::lock_guard lock(*dev.m_mutex);
+                    if(!dev.m_deviceProperties->totalGlobalMem.has_value())
+                    {
+                        // Set the current device to wait for.
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
 
-                    std::size_t freeInternal(0u);
-                    std::size_t totalInternal(0u);
+                        std::size_t freeInternal(0u);
+                        std::size_t totalInternal(0u);
 
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
 
-                    dev.m_deviceProperties->totalGlobalMem = totalInternal;
-                    dev.m_deviceProperties->freeGlobalMem = freeInternal;
+                        dev.m_deviceProperties->totalGlobalMem = totalInternal;
+                        dev.m_deviceProperties->freeGlobalMem = freeInternal;
+                    }
                 }
 
                 return dev.m_deviceProperties->freeGlobalMem.value();
@@ -193,10 +204,13 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getWarpSizes(DevUniformCudaHipRt<TApi> const& dev) -> std::vector<std::size_t>
             {
-                if(!dev.m_deviceProperties->warpSizes.has_value())
                 {
-                    dev.m_deviceProperties->warpSizes = std::vector<std::size_t>{
-                        GetPreferredWarpSize<DevUniformCudaHipRt<TApi>>::getPreferredWarpSize(dev)};
+                    std::lock_guard lock(*dev.m_mutex);
+                    if(!dev.m_deviceProperties->warpSizes.has_value())
+                    {
+                        dev.m_deviceProperties->warpSizes = std::vector<std::size_t>{
+                            GetPreferredWarpSize<DevUniformCudaHipRt<TApi>>::getPreferredWarpSize(dev)};
+                    }
                 }
                 return dev.m_deviceProperties->warpSizes.value();
             }
@@ -208,13 +222,16 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getPreferredWarpSize(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                if(!dev.m_deviceProperties->preferredWarpSize.has_value())
                 {
-                    int warpSize = 0;
+                    std::lock_guard lock(*dev.m_mutex);
+                    if(!dev.m_deviceProperties->preferredWarpSize.has_value())
+                    {
+                        int warpSize = 0;
 
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                        TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, dev.getNativeHandle()));
-                    dev.m_deviceProperties->preferredWarpSize = static_cast<std::size_t>(warpSize);
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                            TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, dev.getNativeHandle()));
+                        dev.m_deviceProperties->preferredWarpSize = static_cast<std::size_t>(warpSize);
+                    }
                 }
 
                 return dev.m_deviceProperties->preferredWarpSize.value();

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -122,20 +122,33 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getName(DevUniformCudaHipRt<TApi> const& dev) -> std::string
             {
-                auto& name = dev.m_QueueRegistry->deviceProperties().name;
+                auto& devProperties = dev.m_QueueRegistry->deviceProperties();
                 std::call_once(
                     dev.m_QueueRegistry->onceFlag(),
                     [&]()
                     {
+                        devProperties = std::make_optional<alpaka::DeviceProperties>();
+                        auto devHandle = dev.getNativeHandle();
                         // There is cuda/hip-DeviceGetAttribute as faster alternative to
                         // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
                         // the name
                         typename TApi::DeviceProp_t devProp;
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, dev.getNativeHandle()));
-                        name = std::string(devProp.name);
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
+                        devProperties->name = std::string(devProp.name);
+
+                        std::size_t freeInternal(0u);
+                        std::size_t totalInternal(0u);
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
+                        devProperties->totalGlobalMem = totalInternal;
+
+                        int warpSize = 0;
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                            TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
+                        devProperties->warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
+                        devProperties->preferredWarpSize = static_cast<std::size_t>(warpSize);
                     });
 
-                return name.value();
+                return devProperties->name;
             }
         };
 
@@ -145,23 +158,33 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                auto& totalGlobalMem = dev.m_QueueRegistry->deviceProperties().totalGlobalMem;
+                auto& devProperties = dev.m_QueueRegistry->deviceProperties();
                 std::call_once(
                     dev.m_QueueRegistry->onceFlag(),
                     [&]()
                     {
-                        // Set the current device to wait for.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
+                        devProperties = std::make_optional<alpaka::DeviceProperties>();
+                        auto devHandle = dev.getNativeHandle();
+                        // There is cuda/hip-DeviceGetAttribute as faster alternative to
+                        // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
+                        // the name
+                        typename TApi::DeviceProp_t devProp;
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
+                        devProperties->name = std::string(devProp.name);
 
                         std::size_t freeInternal(0u);
                         std::size_t totalInternal(0u);
-
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
+                        devProperties->totalGlobalMem = totalInternal;
 
-                        totalGlobalMem = totalInternal;
+                        int warpSize = 0;
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                            TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
+                        devProperties->warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
+                        devProperties->preferredWarpSize = static_cast<std::size_t>(warpSize);
                     });
 
-                return totalGlobalMem.value();
+                return devProperties->totalGlobalMem;
             }
         };
 
@@ -171,20 +194,30 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                auto& totalGlobalMem = dev.m_QueueRegistry->deviceProperties().totalGlobalMem;
+                auto& devProperties = dev.m_QueueRegistry->deviceProperties();
                 std::size_t freeInternal(0u);
                 std::call_once(
-                    dev.m_QueueRegistry->m_onceFlag(),
+                    dev.m_QueueRegistry->onceFlag(),
                     [&]()
                     {
-                        // Set the current device to wait for.
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
+                        devProperties = std::make_optional<alpaka::DeviceProperties>();
+                        auto devHandle = dev.getNativeHandle();
+                        // There is cuda/hip-DeviceGetAttribute as faster alternative to
+                        // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
+                        // the name
+                        typename TApi::DeviceProp_t devProp;
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
+                        devProperties->name = std::string(devProp.name);
 
                         std::size_t totalInternal(0u);
-
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
+                        devProperties->totalGlobalMem = totalInternal;
 
-                        totalGlobalMem = totalInternal;
+                        int warpSize = 0;
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                            TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
+                        devProperties->warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
+                        devProperties->preferredWarpSize = static_cast<std::size_t>(warpSize);
                     });
 
                 return freeInternal;
@@ -197,27 +230,33 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getWarpSizes(DevUniformCudaHipRt<TApi> const& dev) -> std::vector<std::size_t>
             {
-                auto& warpSizes = dev.m_QueueRegistry->deviceProperties().warpSizes;
+                auto& devProperties = dev.m_QueueRegistry->deviceProperties();
                 std::call_once(
                     dev.m_QueueRegistry->onceFlag(),
                     [&]()
                     {
-                        if(dev.m_QueueRegistry->deviceProperties().preferredWarpSize.has_value())
-                        {
-                            warpSizes = std::vector<std::size_t>{
-                                dev.m_QueueRegistry->deviceProperties().preferredWarpSize.value()};
-                        }
-                        else
-                        {
-                            int warpSize = 0;
-                            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::deviceGetAttribute(
-                                &warpSize,
-                                TApi::deviceAttributeWarpSize,
-                                dev.getNativeHandle()));
-                            warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
-                        }
+                        devProperties = std::make_optional<alpaka::DeviceProperties>();
+                        auto devHandle = dev.getNativeHandle();
+                        // There is cuda/hip-DeviceGetAttribute as faster alternative to
+                        // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
+                        // the name
+                        typename TApi::DeviceProp_t devProp;
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
+                        devProperties->name = std::string(devProp.name);
+
+                        std::size_t freeInternal(0u);
+                        std::size_t totalInternal(0u);
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
+                        devProperties->totalGlobalMem = totalInternal;
+
+                        int warpSize = 0;
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                            TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
+                        devProperties->warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
+                        devProperties->preferredWarpSize = static_cast<std::size_t>(warpSize);
                     });
-                return warpSizes.value();
+
+                return devProperties->warpSizes;
             }
         };
 
@@ -227,19 +266,33 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getPreferredWarpSize(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                auto& preferredWarpSize = dev.m_QueueRegistry->deviceProperties().preferredWarpSize;
+                auto& devProperties = dev.m_QueueRegistry->deviceProperties();
                 std::call_once(
                     dev.m_QueueRegistry->onceFlag(),
                     [&]()
                     {
-                        int warpSize = 0;
+                        devProperties = std::make_optional<alpaka::DeviceProperties>();
+                        auto devHandle = dev.getNativeHandle();
+                        // There is cuda/hip-DeviceGetAttribute as faster alternative to
+                        // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
+                        // the name
+                        typename TApi::DeviceProp_t devProp;
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
+                        devProperties->name = std::string(devProp.name);
 
+                        std::size_t freeInternal(0u);
+                        std::size_t totalInternal(0u);
+                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
+                        devProperties->totalGlobalMem = totalInternal;
+
+                        int warpSize = 0;
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, dev.getNativeHandle()));
-                        preferredWarpSize = static_cast<std::size_t>(warpSize);
+                            TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
+                        devProperties->warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
+                        devProperties->preferredWarpSize = static_cast<std::size_t>(warpSize);
                     });
 
-                return preferredWarpSize.value();
+                return devProperties->preferredWarpSize;
             }
         };
 

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -35,6 +35,30 @@ namespace alpaka
         struct GetDevByIdx;
     } // namespace trait
 
+    namespace detail
+    {
+        template<typename TApi>
+        inline void setDeviceProperties(int iDevice, alpaka::DeviceProperties& devProperties)
+        {
+            // There is cuda/hip-DeviceGetAttribute as faster alternative to
+            // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
+            // the name
+            typename TApi::DeviceProp_t devProp;
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, iDevice));
+            devProperties.name = std::string(devProp.name);
+
+            std::size_t totalInternal(0u);
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
+            devProperties.totalGlobalMem = totalInternal;
+
+            int warpSize = 0;
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, iDevice));
+            devProperties.warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
+            devProperties.preferredWarpSize = static_cast<std::size_t>(warpSize);
+        }
+    } // namespace detail
+
     namespace uniform_cuda_hip::detail
     {
         template<typename TApi, bool TBlocking>
@@ -117,57 +141,13 @@ namespace alpaka
     namespace trait
     {
 
-        template<typename TApi>
-        static inline void setDeviceProperties(
-            DevUniformCudaHipRt<TApi> const& dev,
-            std::string& name,
-            std::size_t& freeInternal,
-            std::size_t& totalGlobalMem,
-            std::vector<std::size_t>& warpSizes,
-            std::size_t& preferredWarpSize)
-        {
-            // There is cuda/hip-DeviceGetAttribute as faster alternative to
-            // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
-            // the name
-            auto devHandle = dev.getNativeHandle();
-            typename TApi::DeviceProp_t devProp;
-            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
-            name = std::string(devProp.name);
-
-            std::size_t totalInternal(0u);
-            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
-            totalGlobalMem = totalInternal;
-
-            int warpSize = 0;
-            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
-            warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
-            preferredWarpSize = static_cast<std::size_t>(warpSize);
-        }
-
         //! The CUDA/HIP RT device name get trait specialization.
         template<typename TApi>
         struct GetName<DevUniformCudaHipRt<TApi>>
         {
             ALPAKA_FN_HOST static auto getName(DevUniformCudaHipRt<TApi> const& dev) -> std::string
             {
-                auto& devProperties = dev.m_QueueRegistry->deviceProperties();
-                std::call_once(
-                    dev.m_QueueRegistry->onceFlag(),
-                    [&]()
-                    {
-                        devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        std::size_t freeInternal(0u);
-                        setDeviceProperties(
-                            dev,
-                            devProperties->name,
-                            freeInternal,
-                            devProperties->totalGlobalMem,
-                            devProperties->warpSizes,
-                            devProperties->preferredWarpSize);
-                    });
-
-                return devProperties->name;
+                return m_QueueRegistry->deviceProperties(dev.getNativeHandle())->name;
             }
         };
 
@@ -177,23 +157,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                auto& devProperties = dev.m_QueueRegistry->deviceProperties();
-                std::call_once(
-                    dev.m_QueueRegistry->onceFlag(),
-                    [&]()
-                    {
-                        devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        std::size_t freeInternal(0u);
-                        setDeviceProperties(
-                            dev,
-                            devProperties->name,
-                            freeInternal,
-                            devProperties->totalGlobalMem,
-                            devProperties->warpSizes,
-                            devProperties->preferredWarpSize);
-                    });
-
-                return devProperties->totalGlobalMem;
+                return m_QueueRegistry->deviceProperties(dev.getNativeHandle())->totalGlobalMem;
             }
         };
 
@@ -218,23 +182,8 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getWarpSizes(DevUniformCudaHipRt<TApi> const& dev) -> std::vector<std::size_t>
             {
-                auto& devProperties = dev.m_QueueRegistry->deviceProperties();
-                std::call_once(
-                    dev.m_QueueRegistry->onceFlag(),
-                    [&]()
-                    {
-                        devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        std::size_t freeInternal(0u);
-                        setDeviceProperties(
-                            dev,
-                            devProperties->name,
-                            freeInternal,
-                            devProperties->totalGlobalMem,
-                            devProperties->warpSizes,
-                            devProperties->preferredWarpSize);
-                    });
-
                 return devProperties->warpSizes;
+                return m_QueueRegistry->deviceProperties(dev.getNativeHandle())->warpSizes;
             }
         };
 
@@ -244,23 +193,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getPreferredWarpSize(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                auto& devProperties = dev.m_QueueRegistry->deviceProperties();
-                std::call_once(
-                    dev.m_QueueRegistry->onceFlag(),
-                    [&]()
-                    {
-                        devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        std::size_t freeInternal(0u);
-                        setDeviceProperties(
-                            dev,
-                            devProperties->name,
-                            freeInternal,
-                            devProperties->totalGlobalMem,
-                            devProperties->warpSizes,
-                            devProperties->preferredWarpSize);
-                    });
-
-                return devProperties->preferredWarpSize;
+                return m_QueueRegistry->deviceProperties(dev.getNativeHandle())->preferredWarpSize;
             }
         };
 

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -64,10 +64,7 @@ namespace alpaka
         using IDeviceQueue = uniform_cuda_hip::detail::QueueUniformCudaHipRtImpl<TApi>;
 
     protected:
-        DevUniformCudaHipRt()
-            : m_QueueRegistry{std::make_shared<alpaka::detail::QueueRegistry<IDeviceQueue>>()}
-            , m_deviceProperties{std::make_shared<alpaka::DeviceProperties>()}
-            , m_mutex(std::make_shared<std::mutex>())
+        DevUniformCudaHipRt() : m_QueueRegistry{std::make_shared<alpaka::detail::QueueRegistry<IDeviceQueue>>()}
         {
         }
 
@@ -109,16 +106,12 @@ namespace alpaka
         DevUniformCudaHipRt(int iDevice)
             : m_iDevice(iDevice)
             , m_QueueRegistry(std::make_shared<alpaka::detail::QueueRegistry<IDeviceQueue>>())
-            , m_deviceProperties(std::make_shared<alpaka::DeviceProperties>())
-            , m_mutex(std::make_shared<std::mutex>())
         {
         }
 
         int m_iDevice;
 
         std::shared_ptr<alpaka::detail::QueueRegistry<IDeviceQueue>> m_QueueRegistry;
-        std::shared_ptr<alpaka::DeviceProperties> m_deviceProperties;
-        std::shared_ptr<std::mutex> m_mutex;
     };
 
     namespace trait
@@ -130,18 +123,18 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getName(DevUniformCudaHipRt<TApi> const& dev) -> std::string
             {
                 {
-                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
-                    if(!dev.m_deviceProperties->name.has_value())
+                    std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
+                    if(!dev.m_QueueRegistry->deviceProperties().name.has_value())
                     {
                         // There is cuda/hip-DeviceGetAttribute as faster alternative to cuda/hip-GetDeviceProperties
                         // to get a single device property but it has no option to get the name
                         typename TApi::DeviceProp_t devProp;
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, dev.getNativeHandle()));
-                        dev.m_deviceProperties->name = std::string(devProp.name);
+                        dev.m_QueueRegistry->deviceProperties().name = std::string(devProp.name);
                     }
                 }
 
-                return dev.m_deviceProperties->name.value();
+                return dev.m_QueueRegistry->deviceProperties().name.value();
             }
         };
 
@@ -152,8 +145,8 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
                 {
-                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
-                    if(!dev.m_deviceProperties->freeGlobalMem.has_value())
+                    std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
+                    if(!dev.m_QueueRegistry->deviceProperties().totalGlobalMem.has_value())
                     {
                         // Set the current device to wait for.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
@@ -163,12 +156,11 @@ namespace alpaka
 
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
 
-                        dev.m_deviceProperties->totalGlobalMem = totalInternal;
-                        dev.m_deviceProperties->freeGlobalMem = freeInternal;
+                        dev.m_QueueRegistry->deviceProperties().totalGlobalMem = totalInternal;
                     }
                 }
 
-                return dev.m_deviceProperties->totalGlobalMem.value();
+                return dev.m_QueueRegistry->deviceProperties().totalGlobalMem.value();
             }
         };
 
@@ -178,24 +170,23 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
+                std::size_t freeInternal(0u);
                 {
-                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
-                    if(!dev.m_deviceProperties->totalGlobalMem.has_value())
+                    std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
+                    if(!dev.m_QueueRegistry->deviceProperties().totalGlobalMem.has_value())
                     {
                         // Set the current device to wait for.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
 
-                        std::size_t freeInternal(0u);
                         std::size_t totalInternal(0u);
 
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
 
-                        dev.m_deviceProperties->totalGlobalMem = totalInternal;
-                        dev.m_deviceProperties->freeGlobalMem = freeInternal;
+                        dev.m_QueueRegistry->deviceProperties().totalGlobalMem = totalInternal;
                     }
                 }
 
-                return dev.m_deviceProperties->freeGlobalMem.value();
+                return freeInternal;
             }
         };
 
@@ -206,14 +197,14 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getWarpSizes(DevUniformCudaHipRt<TApi> const& dev) -> std::vector<std::size_t>
             {
                 {
-                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
-                    if(!dev.m_deviceProperties->warpSizes.has_value())
+                    std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
+                    if(!dev.m_QueueRegistry->deviceProperties().warpSizes.has_value())
                     {
-                        dev.m_deviceProperties->warpSizes = std::vector<std::size_t>{
+                        dev.m_QueueRegistry->deviceProperties().warpSizes = std::vector<std::size_t>{
                             GetPreferredWarpSize<DevUniformCudaHipRt<TApi>>::getPreferredWarpSize(dev)};
                     }
                 }
-                return dev.m_deviceProperties->warpSizes.value();
+                return dev.m_QueueRegistry->deviceProperties().warpSizes.value();
             }
         };
 
@@ -224,18 +215,18 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getPreferredWarpSize(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
                 {
-                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
-                    if(!dev.m_deviceProperties->preferredWarpSize.has_value())
+                    std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
+                    if(!dev.m_QueueRegistry->deviceProperties().preferredWarpSize.has_value())
                     {
                         int warpSize = 0;
 
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, dev.getNativeHandle()));
-                        dev.m_deviceProperties->preferredWarpSize = static_cast<std::size_t>(warpSize);
+                        dev.m_QueueRegistry->deviceProperties().preferredWarpSize = static_cast<std::size_t>(warpSize);
                     }
                 }
 
-                return dev.m_deviceProperties->preferredWarpSize.value();
+                return dev.m_QueueRegistry->deviceProperties().preferredWarpSize.value();
             }
         };
 

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -47,6 +47,7 @@ namespace alpaka
             ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, iDevice));
             devProperties.name = std::string(devProp.name);
 
+            std::size_t freeInternal(0u);
             std::size_t totalInternal(0u);
             ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
             devProperties.totalGlobalMem = totalInternal;
@@ -147,7 +148,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getName(DevUniformCudaHipRt<TApi> const& dev) -> std::string
             {
-                return m_QueueRegistry->deviceProperties(dev.getNativeHandle())->name;
+                return dev.m_QueueRegistry->template deviceProperties<TApi>(dev.getNativeHandle())->name;
             }
         };
 
@@ -157,7 +158,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                return m_QueueRegistry->deviceProperties(dev.getNativeHandle())->totalGlobalMem;
+                return dev.m_QueueRegistry->template deviceProperties<TApi>(dev.getNativeHandle())->totalGlobalMem;
             }
         };
 
@@ -182,8 +183,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getWarpSizes(DevUniformCudaHipRt<TApi> const& dev) -> std::vector<std::size_t>
             {
-                return devProperties->warpSizes;
-                return m_QueueRegistry->deviceProperties(dev.getNativeHandle())->warpSizes;
+                return dev.m_QueueRegistry->template deviceProperties<TApi>(dev.getNativeHandle())->warpSizes;
             }
         };
 
@@ -193,7 +193,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getPreferredWarpSize(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                return m_QueueRegistry->deviceProperties(dev.getNativeHandle())->preferredWarpSize;
+                return dev.m_QueueRegistry->template deviceProperties<TApi>(dev.getNativeHandle())->preferredWarpSize;
             }
         };
 

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -10,6 +10,7 @@
 #include "alpaka/core/Hip.hpp"
 #include "alpaka/core/Interface.hpp"
 #include "alpaka/dev/Traits.hpp"
+#include "alpaka/dev/common/DeviceProperties.hpp"
 #include "alpaka/dev/common/QueueRegistry.hpp"
 #include "alpaka/mem/buf/Traits.hpp"
 #include "alpaka/platform/Traits.hpp"
@@ -62,7 +63,9 @@ namespace alpaka
         using IDeviceQueue = uniform_cuda_hip::detail::QueueUniformCudaHipRtImpl<TApi>;
 
     protected:
-        DevUniformCudaHipRt() : m_QueueRegistry{std::make_shared<alpaka::detail::QueueRegistry<IDeviceQueue>>()}
+        DevUniformCudaHipRt()
+            : m_QueueRegistry{std::make_shared<alpaka::detail::QueueRegistry<IDeviceQueue>>()}
+            , m_deviceProperties{std::make_shared<alpaka::DeviceProperties>()}
         {
         }
 
@@ -94,16 +97,24 @@ namespace alpaka
             m_QueueRegistry->registerQueue(spQueue);
         }
 
+        friend struct trait::GetName<DevUniformCudaHipRt<TApi>>;
+        friend struct trait::GetMemBytes<DevUniformCudaHipRt<TApi>>;
+        friend struct trait::GetFreeMemBytes<DevUniformCudaHipRt<TApi>>;
+        friend struct trait::GetWarpSizes<DevUniformCudaHipRt<TApi>>;
+        friend struct trait::GetPreferredWarpSize<DevUniformCudaHipRt<TApi>>;
+
     private:
         DevUniformCudaHipRt(int iDevice)
             : m_iDevice(iDevice)
             , m_QueueRegistry(std::make_shared<alpaka::detail::QueueRegistry<IDeviceQueue>>())
+            , m_deviceProperties(std::make_shared<alpaka::DeviceProperties>())
         {
         }
 
         int m_iDevice;
 
         std::shared_ptr<alpaka::detail::QueueRegistry<IDeviceQueue>> m_QueueRegistry;
+        std::shared_ptr<alpaka::DeviceProperties> m_deviceProperties;
     };
 
     namespace trait
@@ -114,12 +125,17 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getName(DevUniformCudaHipRt<TApi> const& dev) -> std::string
             {
-                // There is cuda/hip-DeviceGetAttribute as faster alternative to cuda/hip-GetDeviceProperties to get a
-                // single device property but it has no option to get the name
-                typename TApi::DeviceProp_t devProp;
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, dev.getNativeHandle()));
+                if(!dev.m_deviceProperties->name.has_value())
+                {
+                    // There is cuda/hip-DeviceGetAttribute as faster alternative to cuda/hip-GetDeviceProperties to
+                    // get a
+                    // single device property but it has no option to get the name
+                    typename TApi::DeviceProp_t devProp;
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, dev.getNativeHandle()));
+                    dev.m_deviceProperties->name = std::string(devProp.name);
+                }
 
-                return std::string(devProp.name);
+                return dev.m_deviceProperties->name.value();
             }
         };
 
@@ -129,15 +145,21 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
+                if(!dev.m_deviceProperties->freeGlobalMem.has_value())
+                {
+                    // Set the current device to wait for.
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
 
-                std::size_t freeInternal(0u);
-                std::size_t totalInternal(0u);
+                    std::size_t freeInternal(0u);
+                    std::size_t totalInternal(0u);
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
 
-                return totalInternal;
+                    dev.m_deviceProperties->totalGlobalMem = totalInternal;
+                    dev.m_deviceProperties->freeGlobalMem = freeInternal;
+                }
+
+                return dev.m_deviceProperties->totalGlobalMem.value();
             }
         };
 
@@ -147,15 +169,21 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                // Set the current device to wait for.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
+                if(!dev.m_deviceProperties->totalGlobalMem.has_value())
+                {
+                    // Set the current device to wait for.
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
 
-                std::size_t freeInternal(0u);
-                std::size_t totalInternal(0u);
+                    std::size_t freeInternal(0u);
+                    std::size_t totalInternal(0u);
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
 
-                return freeInternal;
+                    dev.m_deviceProperties->totalGlobalMem = totalInternal;
+                    dev.m_deviceProperties->freeGlobalMem = freeInternal;
+                }
+
+                return dev.m_deviceProperties->freeGlobalMem.value();
             }
         };
 
@@ -165,7 +193,12 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getWarpSizes(DevUniformCudaHipRt<TApi> const& dev) -> std::vector<std::size_t>
             {
-                return {GetPreferredWarpSize<DevUniformCudaHipRt<TApi>>::getPreferredWarpSize(dev)};
+                if(!dev.m_deviceProperties->warpSizes.has_value())
+                {
+                    dev.m_deviceProperties->warpSizes = std::vector<std::size_t>{
+                        GetPreferredWarpSize<DevUniformCudaHipRt<TApi>>::getPreferredWarpSize(dev)};
+                }
+                return dev.m_deviceProperties->warpSizes.value();
             }
         };
 
@@ -175,11 +208,16 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getPreferredWarpSize(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                int warpSize = 0;
+                if(!dev.m_deviceProperties->preferredWarpSize.has_value())
+                {
+                    int warpSize = 0;
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, dev.getNativeHandle()));
-                return static_cast<std::size_t>(warpSize);
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                        TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, dev.getNativeHandle()));
+                    dev.m_deviceProperties->preferredWarpSize = static_cast<std::size_t>(warpSize);
+                }
+
+                return dev.m_deviceProperties->preferredWarpSize.value();
             }
         };
 

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -172,7 +172,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                auto& freeInternal = dev.m_QueueRegistry->deviceProperties().freeInternal;
+                auto& totalGlobalMem = dev.m_QueueRegistry->deviceProperties().totalGlobalMem;
                 std::size_t freeInternal(0u);
                 {
                     std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
@@ -216,7 +216,7 @@ namespace alpaka
                                 &warpSize,
                                 TApi::deviceAttributeWarpSize,
                                 dev.getNativeHandle()));
-                            warpSizes = std::vector<std::size_t>{warpSize};
+                            warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
                         }
                     }
                 }

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -116,6 +116,35 @@ namespace alpaka
 
     namespace trait
     {
+
+        template<typename TApi>
+        static inline void setDeviceProperties(
+            DevUniformCudaHipRt<TApi> const& dev,
+            std::string& name,
+            std::size_t& freeInternal,
+            std::size_t& totalGlobalMem,
+            std::vector<std::size_t>& warpSizes,
+            std::size_t& preferredWarpSize)
+        {
+            // There is cuda/hip-DeviceGetAttribute as faster alternative to
+            // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
+            // the name
+            auto devHandle = dev.getNativeHandle();
+            typename TApi::DeviceProp_t devProp;
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
+            name = std::string(devProp.name);
+
+            std::size_t totalInternal(0u);
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
+            totalGlobalMem = totalInternal;
+
+            int warpSize = 0;
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
+            warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
+            preferredWarpSize = static_cast<std::size_t>(warpSize);
+        }
+
         //! The CUDA/HIP RT device name get trait specialization.
         template<typename TApi>
         struct GetName<DevUniformCudaHipRt<TApi>>
@@ -128,24 +157,14 @@ namespace alpaka
                     [&]()
                     {
                         devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        auto devHandle = dev.getNativeHandle();
-                        // There is cuda/hip-DeviceGetAttribute as faster alternative to
-                        // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
-                        // the name
-                        typename TApi::DeviceProp_t devProp;
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
-                        devProperties->name = std::string(devProp.name);
-
                         std::size_t freeInternal(0u);
-                        std::size_t totalInternal(0u);
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
-                        devProperties->totalGlobalMem = totalInternal;
-
-                        int warpSize = 0;
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
-                        devProperties->warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
-                        devProperties->preferredWarpSize = static_cast<std::size_t>(warpSize);
+                        setDeviceProperties(
+                            dev,
+                            devProperties->name,
+                            freeInternal,
+                            devProperties->totalGlobalMem,
+                            devProperties->warpSizes,
+                            devProperties->preferredWarpSize);
                     });
 
                 return devProperties->name;
@@ -164,24 +183,14 @@ namespace alpaka
                     [&]()
                     {
                         devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        auto devHandle = dev.getNativeHandle();
-                        // There is cuda/hip-DeviceGetAttribute as faster alternative to
-                        // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
-                        // the name
-                        typename TApi::DeviceProp_t devProp;
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
-                        devProperties->name = std::string(devProp.name);
-
                         std::size_t freeInternal(0u);
-                        std::size_t totalInternal(0u);
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
-                        devProperties->totalGlobalMem = totalInternal;
-
-                        int warpSize = 0;
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
-                        devProperties->warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
-                        devProperties->preferredWarpSize = static_cast<std::size_t>(warpSize);
+                        setDeviceProperties(
+                            dev,
+                            devProperties->name,
+                            freeInternal,
+                            devProperties->totalGlobalMem,
+                            devProperties->warpSizes,
+                            devProperties->preferredWarpSize);
                     });
 
                 return devProperties->totalGlobalMem;
@@ -194,31 +203,10 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                auto& devProperties = dev.m_QueueRegistry->deviceProperties();
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
                 std::size_t freeInternal(0u);
-                std::call_once(
-                    dev.m_QueueRegistry->onceFlag(),
-                    [&]()
-                    {
-                        devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        auto devHandle = dev.getNativeHandle();
-                        // There is cuda/hip-DeviceGetAttribute as faster alternative to
-                        // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
-                        // the name
-                        typename TApi::DeviceProp_t devProp;
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
-                        devProperties->name = std::string(devProp.name);
-
-                        std::size_t totalInternal(0u);
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
-                        devProperties->totalGlobalMem = totalInternal;
-
-                        int warpSize = 0;
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
-                        devProperties->warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
-                        devProperties->preferredWarpSize = static_cast<std::size_t>(warpSize);
-                    });
+                std::size_t totalInternal(0u);
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
 
                 return freeInternal;
             }
@@ -236,24 +224,14 @@ namespace alpaka
                     [&]()
                     {
                         devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        auto devHandle = dev.getNativeHandle();
-                        // There is cuda/hip-DeviceGetAttribute as faster alternative to
-                        // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
-                        // the name
-                        typename TApi::DeviceProp_t devProp;
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
-                        devProperties->name = std::string(devProp.name);
-
                         std::size_t freeInternal(0u);
-                        std::size_t totalInternal(0u);
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
-                        devProperties->totalGlobalMem = totalInternal;
-
-                        int warpSize = 0;
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
-                        devProperties->warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
-                        devProperties->preferredWarpSize = static_cast<std::size_t>(warpSize);
+                        setDeviceProperties(
+                            dev,
+                            devProperties->name,
+                            freeInternal,
+                            devProperties->totalGlobalMem,
+                            devProperties->warpSizes,
+                            devProperties->preferredWarpSize);
                     });
 
                 return devProperties->warpSizes;
@@ -272,24 +250,14 @@ namespace alpaka
                     [&]()
                     {
                         devProperties = std::make_optional<alpaka::DeviceProperties>();
-                        auto devHandle = dev.getNativeHandle();
-                        // There is cuda/hip-DeviceGetAttribute as faster alternative to
-                        // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
-                        // the name
-                        typename TApi::DeviceProp_t devProp;
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
-                        devProperties->name = std::string(devProp.name);
-
                         std::size_t freeInternal(0u);
-                        std::size_t totalInternal(0u);
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
-                        devProperties->totalGlobalMem = totalInternal;
-
-                        int warpSize = 0;
-                        ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                            TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
-                        devProperties->warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
-                        devProperties->preferredWarpSize = static_cast<std::size_t>(warpSize);
+                        setDeviceProperties(
+                            dev,
+                            devProperties->name,
+                            freeInternal,
+                            devProperties->totalGlobalMem,
+                            devProperties->warpSizes,
+                            devProperties->preferredWarpSize);
                     });
 
                 return devProperties->preferredWarpSize;

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -29,6 +29,10 @@
 
 namespace alpaka
 {
+
+    template<typename TApi>
+    class DevUniformCudaHipRt;
+
     namespace trait
     {
         template<typename TPlatform, typename TSfinae>
@@ -38,13 +42,16 @@ namespace alpaka
     namespace detail
     {
         template<typename TApi>
-        inline void setDeviceProperties(int iDevice, alpaka::DeviceProperties& devProperties)
+        inline void setDeviceProperties(
+            DevUniformCudaHipRt<TApi> const& device,
+            alpaka::DeviceProperties& devProperties)
         {
             // There is cuda/hip-DeviceGetAttribute as faster alternative to
             // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
             // the name
+            auto devHandle = device.getNativeHandle();
             typename TApi::DeviceProp_t devProp;
-            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, iDevice));
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
             devProperties.name = std::string(devProp.name);
 
             std::size_t freeInternal(0u);
@@ -54,7 +61,7 @@ namespace alpaka
 
             int warpSize = 0;
             ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, iDevice));
+                TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
             devProperties.warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
             devProperties.preferredWarpSize = static_cast<std::size_t>(warpSize);
         }
@@ -148,7 +155,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getName(DevUniformCudaHipRt<TApi> const& dev) -> std::string
             {
-                return dev.m_QueueRegistry->template deviceProperties<TApi>(dev.getNativeHandle())->name;
+                return dev.m_QueueRegistry->deviceProperties(dev)->name;
             }
         };
 
@@ -158,7 +165,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                return dev.m_QueueRegistry->template deviceProperties<TApi>(dev.getNativeHandle())->totalGlobalMem;
+                return dev.m_QueueRegistry->deviceProperties(dev)->totalGlobalMem;
             }
         };
 
@@ -183,7 +190,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getWarpSizes(DevUniformCudaHipRt<TApi> const& dev) -> std::vector<std::size_t>
             {
-                return dev.m_QueueRegistry->template deviceProperties<TApi>(dev.getNativeHandle())->warpSizes;
+                return dev.m_QueueRegistry->deviceProperties(dev)->warpSizes;
             }
         };
 
@@ -193,7 +200,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getPreferredWarpSize(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                return dev.m_QueueRegistry->template deviceProperties<TApi>(dev.getNativeHandle())->preferredWarpSize;
+                return dev.m_QueueRegistry->deviceProperties(dev)->preferredWarpSize;
             }
         };
 

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -123,17 +123,17 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getName(DevUniformCudaHipRt<TApi> const& dev) -> std::string
             {
                 auto& name = dev.m_QueueRegistry->deviceProperties().name;
-                {
-                    std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
-                    if(!name.has_value())
+                std::call_once(
+                    dev.m_QueueRegistry->onceFlag(),
+                    [&]()
                     {
-                        // There is cuda/hip-DeviceGetAttribute as faster alternative to cuda/hip-GetDeviceProperties
-                        // to get a single device property but it has no option to get the name
+                        // There is cuda/hip-DeviceGetAttribute as faster alternative to
+                        // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
+                        // the name
                         typename TApi::DeviceProp_t devProp;
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, dev.getNativeHandle()));
                         name = std::string(devProp.name);
-                    }
-                }
+                    });
 
                 return name.value();
             }
@@ -146,9 +146,9 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
                 auto& totalGlobalMem = dev.m_QueueRegistry->deviceProperties().totalGlobalMem;
-                {
-                    std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
-                    if(!totalGlobalMem.has_value())
+                std::call_once(
+                    dev.m_QueueRegistry->onceFlag(),
+                    [&]()
                     {
                         // Set the current device to wait for.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
@@ -159,8 +159,7 @@ namespace alpaka
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
 
                         totalGlobalMem = totalInternal;
-                    }
-                }
+                    });
 
                 return totalGlobalMem.value();
             }
@@ -174,9 +173,9 @@ namespace alpaka
             {
                 auto& totalGlobalMem = dev.m_QueueRegistry->deviceProperties().totalGlobalMem;
                 std::size_t freeInternal(0u);
-                {
-                    std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
-                    if(!totalGlobalMem.has_value())
+                std::call_once(
+                    dev.m_QueueRegistry->m_onceFlag(),
+                    [&]()
                     {
                         // Set the current device to wait for.
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
@@ -186,8 +185,7 @@ namespace alpaka
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
 
                         totalGlobalMem = totalInternal;
-                    }
-                }
+                    });
 
                 return freeInternal;
             }
@@ -200,9 +198,9 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getWarpSizes(DevUniformCudaHipRt<TApi> const& dev) -> std::vector<std::size_t>
             {
                 auto& warpSizes = dev.m_QueueRegistry->deviceProperties().warpSizes;
-                {
-                    std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
-                    if(!warpSizes.has_value())
+                std::call_once(
+                    dev.m_QueueRegistry->onceFlag(),
+                    [&]()
                     {
                         if(dev.m_QueueRegistry->deviceProperties().preferredWarpSize.has_value())
                         {
@@ -218,8 +216,7 @@ namespace alpaka
                                 dev.getNativeHandle()));
                             warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
                         }
-                    }
-                }
+                    });
                 return warpSizes.value();
             }
         };
@@ -231,17 +228,16 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getPreferredWarpSize(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
                 auto& preferredWarpSize = dev.m_QueueRegistry->deviceProperties().preferredWarpSize;
-                {
-                    std::lock_guard<std::mutex> lock(dev.m_QueueRegistry->mutex());
-                    if(!preferredWarpSize.has_value())
+                std::call_once(
+                    dev.m_QueueRegistry->onceFlag(),
+                    [&]()
                     {
                         int warpSize = 0;
 
                         ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                             TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, dev.getNativeHandle()));
                         preferredWarpSize = static_cast<std::size_t>(warpSize);
-                    }
-                }
+                    });
 
                 return preferredWarpSize.value();
             }

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -129,7 +129,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getName(DevUniformCudaHipRt<TApi> const& dev) -> std::string
             {
                 {
-                    std::lock_guard lock(*dev.m_mutex);
+                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
                     if(!dev.m_deviceProperties->name.has_value())
                     {
                         // There is cuda/hip-DeviceGetAttribute as faster alternative to cuda/hip-GetDeviceProperties
@@ -151,7 +151,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
                 {
-                    std::lock_guard lock(*dev.m_mutex);
+                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
                     if(!dev.m_deviceProperties->freeGlobalMem.has_value())
                     {
                         // Set the current device to wait for.
@@ -178,7 +178,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getFreeMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
                 {
-                    std::lock_guard lock(*dev.m_mutex);
+                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
                     if(!dev.m_deviceProperties->totalGlobalMem.has_value())
                     {
                         // Set the current device to wait for.
@@ -205,7 +205,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getWarpSizes(DevUniformCudaHipRt<TApi> const& dev) -> std::vector<std::size_t>
             {
                 {
-                    std::lock_guard lock(*dev.m_mutex);
+                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
                     if(!dev.m_deviceProperties->warpSizes.has_value())
                     {
                         dev.m_deviceProperties->warpSizes = std::vector<std::size_t>{
@@ -223,7 +223,7 @@ namespace alpaka
             ALPAKA_FN_HOST static auto getPreferredWarpSize(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
                 {
-                    std::lock_guard lock(*dev.m_mutex);
+                    std::lock_guard<std::mutex> lock(*dev.m_mutex);
                     if(!dev.m_deviceProperties->preferredWarpSize.has_value())
                     {
                         int warpSize = 0;

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -10,8 +10,8 @@
 #include "alpaka/core/Hip.hpp"
 #include "alpaka/core/Interface.hpp"
 #include "alpaka/dev/Traits.hpp"
+#include "alpaka/dev/common/DevGenericImpl.hpp"
 #include "alpaka/dev/common/DeviceProperties.hpp"
-#include "alpaka/dev/common/QueueRegistry.hpp"
 #include "alpaka/mem/buf/Traits.hpp"
 #include "alpaka/platform/Traits.hpp"
 #include "alpaka/queue/Properties.hpp"
@@ -96,7 +96,7 @@ namespace alpaka
         using IDeviceQueue = uniform_cuda_hip::detail::QueueUniformCudaHipRtImpl<TApi>;
 
     protected:
-        DevUniformCudaHipRt() : m_QueueRegistry{std::make_shared<alpaka::detail::QueueRegistry<IDeviceQueue>>()}
+        DevUniformCudaHipRt() : m_DevGenericImpl{std::make_shared<alpaka::detail::DevGenericImpl<IDeviceQueue>>()}
         {
         }
 
@@ -118,14 +118,14 @@ namespace alpaka
 
         [[nodiscard]] ALPAKA_FN_HOST auto getAllQueues() const -> std::vector<std::shared_ptr<IDeviceQueue>>
         {
-            return m_QueueRegistry->getAllExistingQueues();
+            return m_DevGenericImpl->getAllExistingQueues();
         }
 
         //! Registers the given queue on this device.
         //! NOTE: Every queue has to be registered for correct functionality of device wait operations!
         ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<IDeviceQueue> spQueue) const -> void
         {
-            m_QueueRegistry->registerQueue(spQueue);
+            m_DevGenericImpl->registerQueue(spQueue);
         }
 
         friend struct trait::GetName<DevUniformCudaHipRt<TApi>>;
@@ -137,13 +137,13 @@ namespace alpaka
     private:
         DevUniformCudaHipRt(int iDevice)
             : m_iDevice(iDevice)
-            , m_QueueRegistry(std::make_shared<alpaka::detail::QueueRegistry<IDeviceQueue>>())
+            , m_DevGenericImpl(std::make_shared<alpaka::detail::DevGenericImpl<IDeviceQueue>>())
         {
         }
 
         int m_iDevice;
 
-        std::shared_ptr<alpaka::detail::QueueRegistry<IDeviceQueue>> m_QueueRegistry;
+        std::shared_ptr<alpaka::detail::DevGenericImpl<IDeviceQueue>> m_DevGenericImpl;
     };
 
     namespace trait
@@ -155,7 +155,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getName(DevUniformCudaHipRt<TApi> const& dev) -> std::string
             {
-                return dev.m_QueueRegistry->deviceProperties(dev)->name;
+                return dev.m_DevGenericImpl->deviceProperties(dev)->name;
             }
         };
 
@@ -165,7 +165,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getMemBytes(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                return dev.m_QueueRegistry->deviceProperties(dev)->totalGlobalMem;
+                return dev.m_DevGenericImpl->deviceProperties(dev)->totalGlobalMem;
             }
         };
 
@@ -190,7 +190,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getWarpSizes(DevUniformCudaHipRt<TApi> const& dev) -> std::vector<std::size_t>
             {
-                return dev.m_QueueRegistry->deviceProperties(dev)->warpSizes;
+                return dev.m_DevGenericImpl->deviceProperties(dev)->warpSizes;
             }
         };
 
@@ -200,7 +200,7 @@ namespace alpaka
         {
             ALPAKA_FN_HOST static auto getPreferredWarpSize(DevUniformCudaHipRt<TApi> const& dev) -> std::size_t
             {
-                return dev.m_QueueRegistry->deviceProperties(dev)->preferredWarpSize;
+                return dev.m_DevGenericImpl->deviceProperties(dev)->preferredWarpSize;
             }
         };
 

--- a/include/alpaka/dev/DevUniformCudaHipRt.hpp
+++ b/include/alpaka/dev/DevUniformCudaHipRt.hpp
@@ -39,34 +39,6 @@ namespace alpaka
         struct GetDevByIdx;
     } // namespace trait
 
-    namespace detail
-    {
-        template<typename TApi>
-        inline void setDeviceProperties(
-            DevUniformCudaHipRt<TApi> const& device,
-            alpaka::DeviceProperties& devProperties)
-        {
-            // There is cuda/hip-DeviceGetAttribute as faster alternative to
-            // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
-            // the name
-            auto devHandle = device.getNativeHandle();
-            typename TApi::DeviceProp_t devProp;
-            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
-            devProperties.name = std::string(devProp.name);
-
-            std::size_t freeInternal(0u);
-            std::size_t totalInternal(0u);
-            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
-            devProperties.totalGlobalMem = totalInternal;
-
-            int warpSize = 0;
-            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
-            devProperties.warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
-            devProperties.preferredWarpSize = static_cast<std::size_t>(warpSize);
-        }
-    } // namespace detail
-
     namespace uniform_cuda_hip::detail
     {
         template<typename TApi, bool TBlocking>
@@ -126,6 +98,30 @@ namespace alpaka
         ALPAKA_FN_HOST auto registerQueue(std::shared_ptr<IDeviceQueue> spQueue) const -> void
         {
             m_DevGenericImpl->registerQueue(spQueue);
+        }
+
+        static void setDeviceProperties(
+            DevUniformCudaHipRt<TApi> const& device,
+            alpaka::DeviceProperties& devProperties)
+        {
+            // There is cuda/hip-DeviceGetAttribute as faster alternative to
+            // cuda/hip-GetDeviceProperties to get a single device property but it has no option to get
+            // the name
+            auto devHandle = device.getNativeHandle();
+            typename TApi::DeviceProp_t devProp;
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::getDeviceProperties(&devProp, devHandle));
+            devProperties.name = std::string(devProp.name);
+
+            std::size_t freeInternal(0u);
+            std::size_t totalInternal(0u);
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::memGetInfo(&freeInternal, &totalInternal));
+            devProperties.totalGlobalMem = totalInternal;
+
+            int warpSize = 0;
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                TApi::deviceGetAttribute(&warpSize, TApi::deviceAttributeWarpSize, devHandle));
+            devProperties.warpSizes = std::vector<std::size_t>{static_cast<std::size_t>(warpSize)};
+            devProperties.preferredWarpSize = static_cast<std::size_t>(warpSize);
         }
 
         friend struct trait::GetName<DevUniformCudaHipRt<TApi>>;

--- a/include/alpaka/dev/common/DevGenericImpl.hpp
+++ b/include/alpaka/dev/common/DevGenericImpl.hpp
@@ -31,7 +31,7 @@ namespace alpaka::detail
     //!
     //! @tparam TQueue queue implementation
     template<typename TQueue>
-    struct QueueRegistry
+    struct DevGenericImpl
     {
         ALPAKA_FN_HOST auto getAllExistingQueues() const -> std::vector<std::shared_ptr<TQueue>>
         {

--- a/include/alpaka/dev/common/DevGenericImpl.hpp
+++ b/include/alpaka/dev/common/DevGenericImpl.hpp
@@ -13,19 +13,8 @@
 #include <mutex>
 #include <optional>
 
-namespace alpaka
-{
-    class DevCpu;
-
-    template<typename TApi>
-    class DevUniformCudaHipRt;
-} // namespace alpaka
-
 namespace alpaka::detail
 {
-    inline void setDeviceProperties(alpaka::DevCpu const&, alpaka::DeviceProperties&);
-    template<typename TApi>
-    inline void setDeviceProperties(alpaka::DevUniformCudaHipRt<TApi> const&, alpaka::DeviceProperties&);
 
     //! The CPU/GPU device queue registry implementation.
     //!
@@ -74,7 +63,7 @@ namespace alpaka::detail
                 [&]() noexcept
                 {
                     m_deviceProperties = std::make_optional<alpaka::DeviceProperties>();
-                    setDeviceProperties(device, *m_deviceProperties);
+                    TDev::setDeviceProperties(device, *m_deviceProperties);
                 });
 
             return m_deviceProperties;

--- a/include/alpaka/dev/common/DeviceProperties.hpp
+++ b/include/alpaka/dev/common/DeviceProperties.hpp
@@ -1,6 +1,8 @@
 
 #pragma once
 
+#include "alpaka/dev/Traits.hpp"
+
 #include <optional>
 #include <string>
 #include <vector>

--- a/include/alpaka/dev/common/DeviceProperties.hpp
+++ b/include/alpaka/dev/common/DeviceProperties.hpp
@@ -8,6 +8,7 @@
 
 namespace alpaka
 {
+
     class DeviceProperties
     {
         std::string name;

--- a/include/alpaka/dev/common/DeviceProperties.hpp
+++ b/include/alpaka/dev/common/DeviceProperties.hpp
@@ -9,29 +9,11 @@
 namespace alpaka
 {
 
-    class DeviceProperties
+    struct DeviceProperties
     {
         std::string name;
         std::size_t totalGlobalMem;
         std::vector<std::size_t> warpSizes;
         std::size_t preferredWarpSize;
-
-    public:
-        DeviceProperties() = default;
-
-        template<typename TDev, typename TSfinae>
-        friend struct trait::GetName;
-
-        template<typename TDev, typename TSfinae>
-        friend struct trait::GetMemBytes;
-
-        template<typename TDev, typename TSfinae>
-        friend struct trait::GetFreeMemBytes;
-
-        template<typename TDev, typename TSfinae>
-        friend struct trait::GetWarpSizes;
-
-        template<typename TDev, typename TSfinae>
-        friend struct trait::GetPreferredWarpSize;
     };
 } // namespace alpaka

--- a/include/alpaka/dev/common/DeviceProperties.hpp
+++ b/include/alpaka/dev/common/DeviceProperties.hpp
@@ -13,7 +13,6 @@ namespace alpaka
     {
         std::optional<std::string> name;
         std::optional<std::size_t> totalGlobalMem;
-        std::optional<std::size_t> freeGlobalMem;
         std::optional<std::vector<std::size_t>> warpSizes;
         std::optional<std::size_t> preferredWarpSize;
 

--- a/include/alpaka/dev/common/DeviceProperties.hpp
+++ b/include/alpaka/dev/common/DeviceProperties.hpp
@@ -1,0 +1,36 @@
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace alpaka
+{
+    class DeviceProperties
+    {
+        std::optional<std::string> name;
+        std::optional<std::size_t> totalGlobalMem;
+        std::optional<std::size_t> freeGlobalMem;
+        std::optional<std::vector<std::size_t>> warpSizes;
+        std::optional<std::size_t> preferredWarpSize;
+
+    public:
+        DeviceProperties() = default;
+
+        template<typename TDev, typename TSfinae>
+        friend struct trait::GetName;
+
+        template<typename TDev, typename TSfinae>
+        friend struct trait::GetMemBytes;
+
+        template<typename TDev, typename TSfinae>
+        friend struct trait::GetFreeMemBytes;
+
+        template<typename TDev, typename TSfinae>
+        friend struct trait::GetWarpSizes;
+
+        template<typename TDev, typename TSfinae>
+        friend struct trait::GetPreferredWarpSize;
+    };
+} // namespace alpaka

--- a/include/alpaka/dev/common/DeviceProperties.hpp
+++ b/include/alpaka/dev/common/DeviceProperties.hpp
@@ -3,7 +3,6 @@
 
 #include "alpaka/dev/Traits.hpp"
 
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -11,10 +10,10 @@ namespace alpaka
 {
     class DeviceProperties
     {
-        std::optional<std::string> name;
-        std::optional<std::size_t> totalGlobalMem;
-        std::optional<std::vector<std::size_t>> warpSizes;
-        std::optional<std::size_t> preferredWarpSize;
+        std::string name;
+        std::size_t totalGlobalMem;
+        std::vector<std::size_t> warpSizes;
+        std::size_t preferredWarpSize;
 
     public:
         DeviceProperties() = default;

--- a/include/alpaka/dev/common/QueueRegistry.hpp
+++ b/include/alpaka/dev/common/QueueRegistry.hpp
@@ -59,6 +59,7 @@ namespace alpaka::detail
             m_queues.push_back(spQueue);
         }
 
+        template<typename TApi = void>
         auto deviceProperties(int iDevice = 0u) -> std::optional<alpaka::DeviceProperties>&
         {
             std::call_once(
@@ -66,7 +67,7 @@ namespace alpaka::detail
                 [&]() noexcept
                 {
                     m_deviceProperties = std::make_optional<alpaka::DeviceProperties>();
-                    setDeviceProperties(iDevice, *m_deviceProperties);
+                    setDeviceProperties<TApi>(iDevice, *m_deviceProperties);
                 });
 
             return m_deviceProperties;

--- a/include/alpaka/dev/common/QueueRegistry.hpp
+++ b/include/alpaka/dev/common/QueueRegistry.hpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 
 namespace alpaka::detail
 {
@@ -58,7 +59,7 @@ namespace alpaka::detail
             return m_onceFlag;
         }
 
-        alpaka::DeviceProperties& deviceProperties()
+        std::optional<alpaka::DeviceProperties>& deviceProperties()
         {
             return m_deviceProperties;
         }
@@ -66,7 +67,7 @@ namespace alpaka::detail
     private:
         std::mutex mutable m_Mutex;
         std::once_flag m_onceFlag;
-        alpaka::DeviceProperties m_deviceProperties;
+        std::optional<alpaka::DeviceProperties> m_deviceProperties;
         std::deque<std::weak_ptr<TQueue>> mutable m_queues;
     };
 } // namespace alpaka::detail

--- a/include/alpaka/dev/common/QueueRegistry.hpp
+++ b/include/alpaka/dev/common/QueueRegistry.hpp
@@ -13,12 +13,19 @@
 #include <mutex>
 #include <optional>
 
+namespace alpaka
+{
+    class DevCpu;
+
+    template<typename TApi>
+    class DevUniformCudaHipRt;
+} // namespace alpaka
+
 namespace alpaka::detail
 {
-
-    inline void setDeviceProperties(int iDevice, alpaka::DeviceProperties& devProperties);
+    inline void setDeviceProperties(alpaka::DevCpu const&, alpaka::DeviceProperties&);
     template<typename TApi>
-    inline void setDeviceProperties(int iDevice, alpaka::DeviceProperties& devProperties);
+    inline void setDeviceProperties(alpaka::DevUniformCudaHipRt<TApi> const&, alpaka::DeviceProperties&);
 
     //! The CPU/GPU device queue registry implementation.
     //!
@@ -59,15 +66,15 @@ namespace alpaka::detail
             m_queues.push_back(spQueue);
         }
 
-        template<typename TApi = void>
-        auto deviceProperties(int iDevice = 0u) -> std::optional<alpaka::DeviceProperties>&
+        template<typename TDev>
+        auto deviceProperties(TDev const& device) -> std::optional<alpaka::DeviceProperties>&
         {
             std::call_once(
                 m_onceFlag,
                 [&]() noexcept
                 {
                     m_deviceProperties = std::make_optional<alpaka::DeviceProperties>();
-                    setDeviceProperties<TApi>(iDevice, *m_deviceProperties);
+                    setDeviceProperties(device, *m_deviceProperties);
                 });
 
             return m_deviceProperties;

--- a/include/alpaka/dev/common/QueueRegistry.hpp
+++ b/include/alpaka/dev/common/QueueRegistry.hpp
@@ -53,9 +53,9 @@ namespace alpaka::detail
             m_queues.push_back(spQueue);
         }
 
-        std::mutex& mutex()
+        std::once_flag& onceFlag()
         {
-            return m_Mutex;
+            return m_onceFlag;
         }
 
         alpaka::DeviceProperties& deviceProperties()
@@ -65,6 +65,7 @@ namespace alpaka::detail
 
     private:
         std::mutex mutable m_Mutex;
+        std::once_flag m_onceFlag;
         alpaka::DeviceProperties m_deviceProperties;
         std::deque<std::weak_ptr<TQueue>> mutable m_queues;
     };

--- a/include/alpaka/dev/common/QueueRegistry.hpp
+++ b/include/alpaka/dev/common/QueueRegistry.hpp
@@ -54,12 +54,12 @@ namespace alpaka::detail
             m_queues.push_back(spQueue);
         }
 
-        std::once_flag& onceFlag()
+        auto onceFlag() -> std::once_flag&
         {
             return m_onceFlag;
         }
 
-        std::optional<alpaka::DeviceProperties>& deviceProperties()
+        auto deviceProperties() -> std::optional<alpaka::DeviceProperties>&
         {
             return m_deviceProperties;
         }

--- a/include/alpaka/dev/common/QueueRegistry.hpp
+++ b/include/alpaka/dev/common/QueueRegistry.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/core/Common.hpp"
+#include "alpaka/dev/common/DeviceProperties.hpp"
 
 #include <deque>
 #include <functional>
@@ -52,8 +53,19 @@ namespace alpaka::detail
             m_queues.push_back(spQueue);
         }
 
+        std::mutex& mutex()
+        {
+            return m_Mutex;
+        }
+
+        alpaka::DeviceProperties& deviceProperties()
+        {
+            return m_deviceProperties;
+        }
+
     private:
         std::mutex mutable m_Mutex;
+        alpaka::DeviceProperties m_deviceProperties;
         std::deque<std::weak_ptr<TQueue>> mutable m_queues;
     };
 } // namespace alpaka::detail

--- a/include/alpaka/dev/common/QueueRegistry.hpp
+++ b/include/alpaka/dev/common/QueueRegistry.hpp
@@ -15,6 +15,11 @@
 
 namespace alpaka::detail
 {
+
+    inline void setDeviceProperties(int iDevice, alpaka::DeviceProperties& devProperties);
+    template<typename TApi>
+    inline void setDeviceProperties(int iDevice, alpaka::DeviceProperties& devProperties);
+
     //! The CPU/GPU device queue registry implementation.
     //!
     //! @tparam TQueue queue implementation
@@ -54,13 +59,16 @@ namespace alpaka::detail
             m_queues.push_back(spQueue);
         }
 
-        auto onceFlag() -> std::once_flag&
+        auto deviceProperties(int iDevice = 0u) -> std::optional<alpaka::DeviceProperties>&
         {
-            return m_onceFlag;
-        }
+            std::call_once(
+                m_onceFlag,
+                [&]() noexcept
+                {
+                    m_deviceProperties = std::make_optional<alpaka::DeviceProperties>();
+                    setDeviceProperties(iDevice, *m_deviceProperties);
+                });
 
-        auto deviceProperties() -> std::optional<alpaka::DeviceProperties>&
-        {
             return m_deviceProperties;
         }
 


### PR DESCRIPTION
This PR caches the device properties once they have been accessed so as to reduce overheads for multiple consecutive calls.