### PR TITLE
Implement support for explicit GPU kernel names

### DIFF
--- a/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/kernel/TaskKernelGpuUniformCudaHipRt.hpp
@@ -78,6 +78,14 @@ namespace alpaka
 #        if BOOST_COMP_CLANG
 #            pragma clang diagnostic pop
 #        endif
+
+        template<typename TKernelFnObj, typename TAcc, typename... TArgs>
+        inline void (*kernelName)(
+            Vec<Dim<TAcc>, Idx<TAcc>> const,
+            TKernelFnObj const,
+            remove_restrict_t<std::decay_t<TArgs>>...)
+            = gpuKernel<TKernelFnObj, TAcc, TArgs...>;
+
     } // namespace detail
 
     namespace uniform_cuda_hip
@@ -248,7 +256,7 @@ namespace alpaka
 #        endif
 
                 auto kernelName
-                    = alpaka::detail::gpuKernel<TKernelFnObj, TAcc, remove_restrict_t<std::decay_t<TArgs>>...>;
+                    = alpaka::detail::kernelName<TKernelFnObj, TAcc, remove_restrict_t<std::decay_t<TArgs>>...>;
 
 #        if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 // Log the function attributes.
@@ -317,7 +325,7 @@ namespace alpaka
                 [[maybe_unused]] TKernelFn const& kernelFn,
                 [[maybe_unused]] TArgs&&... args) -> alpaka::KernelFunctionAttributes
             {
-                auto kernelName = alpaka::detail::gpuKernel<
+                auto kernelName = alpaka::detail::kernelName<
                     TKernelFn,
                     AccGpuUniformCudaHipRt<TApi, TDim, TIdx>,
                     remove_restrict_t<std::decay_t<TArgs>>...>;
@@ -363,9 +371,96 @@ namespace alpaka
                 return kernelFunctionAttributes;
             }
         };
+
     } // namespace trait
+
 } // namespace alpaka
 
+// These macros can be used to give a more readable name to a GPU kernel.
+// KERNEL must be the class or struct whose operator()(acc, ...) implements the kernel.
+// ::NAME (or ::NAMESPACE::NAME) must be a unique name across the whole program.
+
+struct The_ALPAKA_KERNEL_NAME_macro_must_be_called_in_the_global_namespace;
+
+#        define ALPAKA_KERNEL_NAME(KERNEL, NAME)                                                                      \
+                                                                                                                      \
+            struct The_ALPAKA_KERNEL_NAME_macro_must_be_called_in_the_global_namespace;                               \
+                                                                                                                      \
+            static_assert(                                                                                            \
+                std::is_same_v<                                                                                       \
+                    The_ALPAKA_KERNEL_NAME_macro_must_be_called_in_the_global_namespace,                              \
+                    ::The_ALPAKA_KERNEL_NAME_macro_must_be_called_in_the_global_namespace>,                           \
+                "The ALPAKA_KERNEL_NAME macro must be called in the global namespace");                               \
+                                                                                                                      \
+            template<typename TAcc, typename... TArgs>                                                                \
+            __global__ void NAME(                                                                                     \
+                alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const extent,                                       \
+                KERNEL const kernelFnObj,                                                                             \
+                TArgs... args)                                                                                        \
+            {                                                                                                         \
+                TAcc const acc(extent);                                                                               \
+                kernelFnObj(const_cast<TAcc const&>(acc), args...);                                                   \
+            }                                                                                                         \
+                                                                                                                      \
+            namespace alpaka::detail                                                                                  \
+            {                                                                                                         \
+                template<typename TAcc, typename... TArgs>                                                            \
+                inline void (*kernelName<KERNEL, TAcc, TArgs...>)(                                                    \
+                    alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const,                                          \
+                    KERNEL const,                                                                                     \
+                    TArgs...)                                                                                         \
+                    = ::NAME<TAcc, TArgs...>;                                                                         \
+            }
+
+struct The_ALPAKA_KERNEL_SCOPED_NAME_macro_must_be_called_in_the_global_namespace;
+
+#        define ALPAKA_KERNEL_SCOPED_NAME(KERNEL, NAMESPACE, NAME)                                                    \
+            struct The_ALPAKA_KERNEL_SCOPED_NAME_macro_must_be_called_in_the_global_namespace;                        \
+                                                                                                                      \
+            static_assert(                                                                                            \
+                std::is_same_v<                                                                                       \
+                    The_ALPAKA_KERNEL_SCOPED_NAME_macro_must_be_called_in_the_global_namespace,                       \
+                    ::The_ALPAKA_KERNEL_SCOPED_NAME_macro_must_be_called_in_the_global_namespace>,                    \
+                "The ALPAKA_KERNEL_SCOPED_NAME macro must be called in the global namespace");                        \
+                                                                                                                      \
+            namespace NAMESPACE                                                                                       \
+            {                                                                                                         \
+                template<typename TAcc, typename... TArgs>                                                            \
+                __global__ void NAME(                                                                                 \
+                    alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const extent,                                   \
+                    KERNEL const kernelFnObj,                                                                         \
+                    TArgs... args)                                                                                    \
+                {                                                                                                     \
+                    TAcc const acc(extent);                                                                           \
+                    kernelFnObj(const_cast<TAcc const&>(acc), args...);                                               \
+                }                                                                                                     \
+            }                                                                                                         \
+                                                                                                                      \
+            namespace alpaka::detail                                                                                  \
+            {                                                                                                         \
+                template<typename TAcc, typename... TArgs>                                                            \
+                inline void (*kernelName<KERNEL, TAcc, TArgs...>)(                                                    \
+                    alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> const,                                          \
+                    KERNEL const,                                                                                     \
+                    TArgs...)                                                                                         \
+                    = ::NAMESPACE::NAME<TAcc, TArgs...>;                                                              \
+            }
+
+
+#    else
+
+// In host-only mode, expand to empty macros
+
+#        define ALPAKA_KERNEL_NAME(KERNEL, NAME)
+#        define ALPAKA_KERNEL_SCOPED_NAME(KERNEL, NAMESPACE, NAME)
+
 #    endif
+
+#else
+
+// If CUDA or HIP are not available, expand to empty macros
+
+#    define ALPAKA_KERNEL_NAME(KERNEL, NAME)
+#    define ALPAKA_KERNEL_SCOPED_NAME(KERNEL, NAMESPACE, NAME)
 
 #endif

--- a/test/unit/kernel/src/KernelWithName.cpp
+++ b/test/unit/kernel/src/KernelWithName.cpp
@@ -1,0 +1,63 @@
+/* Copyright 2025 Andrea Bocci
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/kernel/Traits.hpp>
+#include <alpaka/meta/ForEachType.hpp>
+#include <alpaka/test/KernelExecutionFixture.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+class KernelWithName
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAcc>
+    ALPAKA_FN_ACC auto operator()(TAcc const& /* acc */, bool* success, std::int32_t val) const -> void
+    {
+        ALPAKA_CHECK(*success, 42 == val);
+    }
+};
+
+ALPAKA_KERNEL_NAME(KernelWithName, kernelWithName)
+
+TEMPLATE_LIST_TEST_CASE("KernelWithName", "[kernel]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+    using Dim = alpaka::Dim<Acc>;
+    using Idx = alpaka::Idx<Acc>;
+
+    alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::ones());
+
+    KernelWithName kernel;
+
+    REQUIRE(fixture(kernel, 42));
+}
+
+class KernelWithScopedName
+{
+public:
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAcc>
+    ALPAKA_FN_ACC auto operator()(TAcc const& /* acc */, bool* success, std::int32_t val) const -> void
+    {
+        ALPAKA_CHECK(*success, 42 == val);
+    }
+};
+
+ALPAKA_KERNEL_SCOPED_NAME(KernelWithScopedName, scope, kernelWithName)
+
+TEMPLATE_LIST_TEST_CASE("KernelWithScopedName", "[kernel]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+    using Dim = alpaka::Dim<Acc>;
+    using Idx = alpaka::Idx<Acc>;
+
+    alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::ones());
+
+    KernelWithScopedName kernel;
+
+    REQUIRE(fixture(kernel, 42));
+}


### PR DESCRIPTION
Introduce two macros `ALPAKA_KERNEL_SCOPED_NAME(KERNEL, NAMESPACE, NAME)` and `ALPAKA_KERNEL_NAME(KERNEL, NAME)` to define explicit names for GPU kernels.

A GPU kernel normally looks like `alpaka::detail::gpuKernel<Kernel, Acc, ...>`.
Using the macro
```c++
ALPAKA_KERNEL_NAME(Kernel, kernel)
```
makes it appear as `kernel<Acc, ...>`.

The macros can only be used in the global namespace. Using them in another namespaces causes a static assertion.

Add a test for the new functionality.
