### PR TITLE
Implement a fill function for buffers of arbitrary types

### DIFF
--- a/include/alpaka/mem/buf/cpu/BufCpu.hpp
+++ b/include/alpaka/mem/buf/cpu/BufCpu.hpp
@@ -37,6 +37,7 @@ namespace alpaka
 } // namespace alpaka
 
 #include "alpaka/mem/buf/cpu/Copy.hpp"
+#include "alpaka/mem/buf/cpu/Fill.hpp"
 #include "alpaka/mem/buf/cpu/Set.hpp"
 #include "alpaka/mem/buf/cpu/traits/BufCpuTraits.hpp"
 #include "alpaka/mem/buf/cpu/traits/ConstBufCpuTraits.hpp"

--- a/include/alpaka/mem/buf/cpu/Fill.hpp
+++ b/include/alpaka/mem/buf/cpu/Fill.hpp
@@ -1,0 +1,138 @@
+/* Copyright 2025 Maria Michailidi, Anna Polova, Abdulrahman Al Marzouqi
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/Assert.hpp"
+#include "alpaka/dim/DimIntegralConst.hpp"
+#include "alpaka/extent/Traits.hpp"
+#include "alpaka/mem/view/Traits.hpp"
+#include "alpaka/meta/Integral.hpp"
+#include "alpaka/meta/NdLoop.hpp"
+
+namespace alpaka
+{
+    class DevCpu;
+
+    namespace detail
+    {
+        //! The CPU device ND memory fill task base.
+        template<typename TDim, typename TView, typename TExtent>
+        struct TaskFillCpuBase
+        {
+            static_assert(TDim::value > 0);
+
+            using ExtentSize = Idx<TExtent>;
+            using DstSize = Idx<TView>;
+            using Elem = alpaka::Elem<TView>;
+
+            static_assert(std::is_trivially_copyable_v<Elem>, "Only trivially copyable types supported for fill");
+
+            template<typename TViewFwd>
+            TaskFillCpuBase(TViewFwd&& view, Elem const& value, TExtent const& extent)
+                : m_value(value)
+                , m_extent(getExtents(extent))
+                , m_extentWidth(getExtents(extent).back())
+#if(!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
+                , m_dstExtent(getExtents(view))
+#endif
+                , m_dstPitchBytes(getPitchesInBytes(view))
+                , m_dstMemNative(reinterpret_cast<std::uint8_t*>(getPtrNative(view)))
+            {
+                ALPAKA_ASSERT((castVec<DstSize>(m_extent) <= m_dstExtent).all());
+                if constexpr(TDim::value > 1)
+                    ALPAKA_ASSERT(
+                        m_extentWidth * static_cast<ExtentSize>(sizeof(Elem)) <= m_dstPitchBytes[TDim::value - 2]);
+
+                ALPAKA_ASSERT(reinterpret_cast<std::uintptr_t>(m_dstMemNative) % alignof(Elem) == 0);
+            }
+
+            Elem const m_value;
+            Vec<TDim, ExtentSize> const m_extent;
+            ExtentSize const m_extentWidth;
+#if(!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
+            Vec<TDim, DstSize> const m_dstExtent;
+#endif
+            Vec<TDim, DstSize> const m_dstPitchBytes;
+            std::uint8_t* const m_dstMemNative;
+        };
+
+        //! Generic ND version memory fill task.
+        template<typename TDim, typename TView, typename TExtent>
+        struct TaskFillCpu : public TaskFillCpuBase<TDim, TView, TExtent>
+        {
+            using TaskFillCpuBase<TDim, TView, TExtent>::TaskFillCpuBase;
+            using typename TaskFillCpuBase<TDim, TView, TExtent>::Elem;
+            using typename TaskFillCpuBase<TDim, TView, TExtent>::ExtentSize;
+
+            ALPAKA_FN_HOST auto operator()() const -> void
+            {
+                if(static_cast<std::size_t>(this->m_extent.prod()) != 0u)
+                {
+                    meta::ndLoopIncIdx(
+                        this->m_extent,
+                        [&](Vec<TDim, ExtentSize> const& idx)
+                        {
+                            std::uintptr_t offsetBytes
+                                = static_cast<std::uintptr_t>((idx * this->m_dstPitchBytes).sum());
+                            assert(offsetBytes % alignof(Elem) == 0);
+                            Elem* elem = reinterpret_cast<Elem*>(
+                                __builtin_assume_aligned(this->m_dstMemNative + offsetBytes, alignof(Elem)));
+
+                            *elem = this->m_value;
+                        });
+                }
+            }
+        };
+
+        // 0D version (scalar fill)
+        template<typename TView, typename TExtent>
+        struct TaskFillCpu<DimInt<0u>, TView, TExtent>
+        {
+            using Elem = alpaka::Elem<TView>;
+
+            template<typename TViewFwd>
+            TaskFillCpu(TViewFwd&& view, Elem const& value, [[maybe_unused]] TExtent const& extent)
+                : m_value(value)
+                , m_dstMemNative(getPtrNative(view))
+            {
+                ALPAKA_ASSERT(getExtents(extent).prod() == 1u);
+                ALPAKA_ASSERT(getExtents(view).prod() == 1u);
+                ALPAKA_ASSERT(reinterpret_cast<std::uintptr_t>(m_dstMemNative) % alignof(Elem) == 0);
+            }
+
+            ALPAKA_FN_HOST auto operator()() const noexcept -> void
+            {
+                *m_dstMemNative = m_value;
+            }
+
+            Elem const m_value;
+            Elem* const m_dstMemNative;
+        };
+    } // namespace detail
+
+    namespace trait
+    {
+        //! The memory fill task trait specialization for CPU devices.
+        template<typename TDim>
+        struct CreateTaskFill<TDim, DevCpu>
+        {
+            template<typename TExtent, typename TViewFwd>
+            ALPAKA_FN_HOST static auto createTaskFill(
+                TViewFwd&& view,
+                alpaka::Elem<std::remove_reference_t<TViewFwd>> const& value,
+                TExtent const& extent)
+            {
+                using TView = std::remove_reference_t<TViewFwd>;
+                using Elem = alpaka::Elem<TView>;
+                static_assert(
+                    std::is_trivially_copyable_v<Elem>,
+                    "Only trivially copyable types are supported for fill");
+
+                return alpaka::detail::TaskFillCpu<TDim, TView, TExtent>{std::forward<TViewFwd>(view), value, extent};
+            }
+        };
+    } // namespace trait
+
+} // namespace alpaka

--- a/include/alpaka/mem/buf/cpu/Fill.hpp
+++ b/include/alpaka/mem/buf/cpu/Fill.hpp
@@ -17,9 +17,9 @@ namespace alpaka
 
     namespace detail
     {
-        //! The CPU device ND memory fill task base.
+        //! The CPU device N-dimensional memory fill task.
         template<typename TDim, typename TView, typename TExtent>
-        struct TaskFillCpuBase
+        struct TaskFillCpu
         {
             static_assert(TDim::value > 0);
 
@@ -30,63 +30,63 @@ namespace alpaka
             static_assert(std::is_trivially_copyable_v<Elem>, "Only trivially copyable types supported for fill");
 
             template<typename TViewFwd>
-            TaskFillCpuBase(TViewFwd&& view, Elem const& value, TExtent const& extent)
+            TaskFillCpu(TViewFwd&& view, Elem const& value, TExtent const& extent)
                 : m_value(value)
                 , m_extent(getExtents(extent))
-                , m_extentWidth(getExtents(extent).back())
-#if(!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
+#if(!defined(NDEBUG))
                 , m_dstExtent(getExtents(view))
 #endif
                 , m_dstPitchBytes(getPitchesInBytes(view))
-                , m_dstMemNative(reinterpret_cast<std::uint8_t*>(getPtrNative(view)))
+                , m_dstMemNative(getPtrNative(view))
             {
                 ALPAKA_ASSERT((castVec<DstSize>(m_extent) <= m_dstExtent).all());
+                if constexpr(TDim::value > 0)
+                {
+                    ALPAKA_ASSERT(static_cast<std::size_t>(m_dstPitchBytes[TDim::value - 1]) >= sizeof(Elem));
+                    ALPAKA_ASSERT(static_cast<std::size_t>(m_dstPitchBytes[TDim::value - 1]) % alignof(Elem) == 0);
+                }
                 if constexpr(TDim::value > 1)
-                    ALPAKA_ASSERT(
-                        m_extentWidth * static_cast<ExtentSize>(sizeof(Elem)) <= m_dstPitchBytes[TDim::value - 2]);
-
+                {
+                    for(int dim = TDim::value - 2; dim >= 0; --dim)
+                    {
+                        ALPAKA_ASSERT(
+                            static_cast<std::size_t>(m_dstPitchBytes[dim])
+                            >= static_cast<std::size_t>(m_dstPitchBytes[dim + 1] * m_dstExtent[dim + 1]));
+                        ALPAKA_ASSERT(static_cast<std::size_t>(m_dstPitchBytes[dim]) % alignof(Elem) == 0);
+                    }
+                }
                 ALPAKA_ASSERT(reinterpret_cast<std::uintptr_t>(m_dstMemNative) % alignof(Elem) == 0);
             }
 
+            ALPAKA_FN_HOST auto operator()() const -> void
+            {
+                if(static_cast<std::size_t>(m_extent.prod()) != 0u)
+                {
+                    meta::ndLoopIncIdx(
+                        m_extent,
+                        [&](Vec<TDim, ExtentSize> const& idx)
+                        {
+                            // All elements of m_dstPitchBytes are multiples of the alignment of Elem.
+                            std::uintptr_t offsetBytes = static_cast<std::uintptr_t>((idx * m_dstPitchBytes).sum());
+                            Elem* elem = reinterpret_cast<Elem*>(__builtin_assume_aligned(
+                                reinterpret_cast<std::uint8_t*>(m_dstMemNative) + offsetBytes,
+                                alignof(Elem)));
+                            *elem = m_value;
+                        });
+                }
+            }
+
+        private:
             Elem const m_value;
             Vec<TDim, ExtentSize> const m_extent;
-            ExtentSize const m_extentWidth;
 #if(!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
             Vec<TDim, DstSize> const m_dstExtent;
 #endif
             Vec<TDim, DstSize> const m_dstPitchBytes;
-            std::uint8_t* const m_dstMemNative;
+            Elem* const m_dstMemNative;
         };
 
-        //! Generic ND version memory fill task.
-        template<typename TDim, typename TView, typename TExtent>
-        struct TaskFillCpu : public TaskFillCpuBase<TDim, TView, TExtent>
-        {
-            using TaskFillCpuBase<TDim, TView, TExtent>::TaskFillCpuBase;
-            using typename TaskFillCpuBase<TDim, TView, TExtent>::Elem;
-            using typename TaskFillCpuBase<TDim, TView, TExtent>::ExtentSize;
-
-            ALPAKA_FN_HOST auto operator()() const -> void
-            {
-                if(static_cast<std::size_t>(this->m_extent.prod()) != 0u)
-                {
-                    meta::ndLoopIncIdx(
-                        this->m_extent,
-                        [&](Vec<TDim, ExtentSize> const& idx)
-                        {
-                            std::uintptr_t offsetBytes
-                                = static_cast<std::uintptr_t>((idx * this->m_dstPitchBytes).sum());
-                            assert(offsetBytes % alignof(Elem) == 0);
-                            Elem* elem = reinterpret_cast<Elem*>(
-                                __builtin_assume_aligned(this->m_dstMemNative + offsetBytes, alignof(Elem)));
-
-                            *elem = this->m_value;
-                        });
-                }
-            }
-        };
-
-        // 0D version (scalar fill)
+        //! The CPU device 0-dimensional memory fill task specialisation.
         template<typename TView, typename TExtent>
         struct TaskFillCpu<DimInt<0u>, TView, TExtent>
         {
@@ -107,6 +107,7 @@ namespace alpaka
                 *m_dstMemNative = m_value;
             }
 
+        private:
             Elem const m_value;
             Elem* const m_dstMemNative;
         };

--- a/include/alpaka/mem/buf/sycl/BufGenericSycl.hpp
+++ b/include/alpaka/mem/buf/sycl/BufGenericSycl.hpp
@@ -45,6 +45,7 @@ namespace alpaka
 } // namespace alpaka
 
 #    include "alpaka/mem/buf/sycl/Copy.hpp"
+#    include "alpaka/mem/buf/sycl/Fill.hpp"
 #    include "alpaka/mem/buf/sycl/Set.hpp"
 #    include "alpaka/mem/buf/sycl/traits/BufGenericSyclTraits.hpp"
 #    include "alpaka/mem/buf/sycl/traits/ConstBufGenericSyclTraits.hpp"

--- a/include/alpaka/mem/buf/sycl/Fill.hpp
+++ b/include/alpaka/mem/buf/sycl/Fill.hpp
@@ -1,0 +1,198 @@
+/* Copyright 2025 Maria Michailidi, Anna Polova, Abdulrahman Al Marzouqi
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/Debug.hpp"
+#include "alpaka/core/Sycl.hpp"
+#include "alpaka/dev/DevGenericSycl.hpp"
+#include "alpaka/dev/Traits.hpp"
+#include "alpaka/dim/DimIntegralConst.hpp"
+#include "alpaka/extent/Traits.hpp"
+#include "alpaka/mem/buf/sycl/Common.hpp"
+#include "alpaka/mem/view/Traits.hpp"
+#include "alpaka/meta/NdLoop.hpp"
+#include "alpaka/queue/QueueGenericSyclBlocking.hpp"
+#include "alpaka/queue/QueueGenericSyclNonBlocking.hpp"
+#include "alpaka/queue/Traits.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <type_traits>
+
+
+#ifdef ALPAKA_ACC_SYCL_ENABLED
+
+namespace alpaka
+{
+
+    namespace detail
+    {
+
+        template<typename TDim, typename TView, typename TExtent, typename TValue>
+        struct TaskFillSyclBase
+        {
+            using ExtentSize = Idx<TExtent>;
+            using DstSize = Idx<TView>;
+            using Elem = alpaka::Elem<TView>;
+
+            template<typename TViewFwd>
+            TaskFillSyclBase(TViewFwd&& view, TValue const& value, TExtent const& extent)
+                : m_value(value)
+                , m_extent(getExtents(extent))
+                , m_extentWidth(m_extent.back())
+#    if(!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
+                , m_dstExtent(getExtents(view))
+#    endif
+                , m_dstPitchBytes(getPitchesInBytes(view))
+                , m_dstMemNative(getPtrNative(view))
+            {
+                ALPAKA_ASSERT((castVec<DstSize>(m_extent) <= m_dstExtent).all());
+                if constexpr(TDim::value > 1)
+                    ALPAKA_ASSERT(
+                        m_extentWidth * static_cast<ExtentSize>(sizeof(Elem)) <= m_dstPitchBytes[TDim::value - 2]);
+            }
+
+#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+            auto printDebug() const -> void
+            {
+                std::cout << __func__ << " e: " << m_extent << " ew: " << m_extentWidth << " de: " << m_dstExtent
+                          << " dptr: " << reinterpret_cast<void*>(m_dstMemNative) << " dpitchb: " << m_dstPitchBytes
+                          << std::endl;
+            }
+#    endif
+
+            TValue const m_value;
+            Vec<TDim, ExtentSize> const m_extent;
+            ExtentSize const m_extentWidth;
+#    if(!defined(NDEBUG)) || (ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL)
+            Vec<TDim, DstSize> const m_dstExtent;
+#    endif
+            Vec<TDim, DstSize> const m_dstPitchBytes;
+            Elem* const m_dstMemNative;
+
+            static constexpr auto is_sycl_task = true;
+        };
+
+        template<typename TDim, typename TView, typename TExtent, typename TValue>
+        struct TaskFillSycl : public TaskFillSyclBase<TDim, TView, TExtent, TValue>
+        {
+            using Base = TaskFillSyclBase<TDim, TView, TExtent, TValue>;
+            using Base::Base;
+            using typename Base::DstSize;
+            using typename Base::ExtentSize;
+            using DimMin1 = DimInt<TDim::value - 1u>;
+
+            auto operator()(sycl::queue& queue, std::vector<sycl::event> const& requirements) const -> sycl::event
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                this->printDebug();
+#    endif
+                Vec<DimMin1, ExtentSize> const extentWithoutInnermost(subVecBegin<DimMin1>(this->m_extent));
+                Vec<DimMin1, DstSize> const dstPitchBytesWithoutInnermost(subVecBegin<DimMin1>(this->m_dstPitchBytes));
+
+                std::vector<sycl::event> events;
+                events.reserve(static_cast<std::size_t>(extentWithoutInnermost.prod()));
+
+                if(static_cast<std::size_t>(this->m_extent.prod()) != 0u)
+                {
+                    using Elem = std::remove_cvref_t<decltype(this->m_value)>;
+
+                    meta::ndLoopIncIdx(
+                        extentWithoutInnermost,
+                        [&](Vec<DimMin1, ExtentSize> const& idx)
+                        {
+                            auto offsetBytes = (castVec<DstSize>(idx) * dstPitchBytesWithoutInnermost).sum();
+                            Elem* ptr = reinterpret_cast<Elem*>(
+                                reinterpret_cast<std::uint8_t*>(this->m_dstMemNative) + offsetBytes);
+
+                            assert(this->m_extentWidth >= 0);
+
+                            events.push_back(queue.fill<TValue>(
+                                ptr,
+                                this->m_value,
+                                static_cast<std::size_t>(this->m_extentWidth),
+                                requirements));
+                        });
+                }
+
+
+                return queue.ext_oneapi_submit_barrier(events);
+            }
+        };
+
+        template<typename TView, typename TExtent, typename TValue>
+        struct TaskFillSycl<DimInt<1u>, TView, TExtent, TValue>
+            : public TaskFillSyclBase<DimInt<1u>, TView, TExtent, TValue>
+        {
+            using Base = TaskFillSyclBase<DimInt<1u>, TView, TExtent, TValue>;
+            using Base::Base;
+
+            auto operator()(sycl::queue& queue, std::vector<sycl::event> const& requirements) const -> sycl::event
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+                this->printDebug();
+#    endif
+                if(static_cast<std::size_t>(this->m_extent.prod()) != 0u)
+                {
+                    return queue.fill(
+                        this->m_dstMemNative,
+                        this->m_value,
+                        static_cast<std::size_t>(this->m_extentWidth),
+                        requirements);
+                }
+                else
+                {
+                    return queue.ext_oneapi_submit_barrier();
+                }
+            }
+        };
+
+        template<typename TView, typename TExtent, typename TValue>
+        struct TaskFillSycl<DimInt<0u>, TView, TExtent, TValue>
+        {
+            using Elem = alpaka::Elem<TView>;
+
+            template<typename TViewFwd>
+            TaskFillSycl(TViewFwd&& view, TValue const& value, [[maybe_unused]] TExtent const& extent)
+                : m_value(value)
+                , m_dstMemNative(getPtrNative(view))
+            {
+                ALPAKA_ASSERT(getExtents(extent).prod() == 1u);
+                ALPAKA_ASSERT(getExtents(view).prod() == 1u);
+            }
+
+            auto operator()(sycl::queue& queue, std::vector<sycl::event> const& requirements) const -> sycl::event
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+                return queue.fill(m_dstMemNative, m_value, 1, requirements);
+            }
+
+            TValue const m_value;
+            Elem* const m_dstMemNative;
+            static constexpr auto is_sycl_task = true;
+        };
+
+    } // namespace detail
+
+    namespace trait
+    {
+        template<typename TDim, typename TPlatform>
+        struct CreateTaskFill<TDim, DevGenericSycl<TPlatform>>
+        {
+            template<typename TExtent, typename TView, typename TValue>
+            static auto createTaskFill(TView& view, TValue const& value, TExtent const& extent)
+                -> alpaka::detail::TaskFillSycl<TDim, TView, TExtent, TValue>
+            {
+                return alpaka::detail::TaskFillSycl<TDim, TView, TExtent, TValue>(view, value, extent);
+            }
+        };
+    } // namespace trait
+
+} // namespace alpaka
+#endif

--- a/include/alpaka/mem/buf/uniformCudaHip/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/BufUniformCudaHipRt.hpp
@@ -47,6 +47,7 @@ namespace alpaka
 } // namespace alpaka
 
 #    include "alpaka/mem/buf/uniformCudaHip/Copy.hpp"
+#    include "alpaka/mem/buf/uniformCudaHip/Fill.hpp"
 #    include "alpaka/mem/buf/uniformCudaHip/Set.hpp"
 #    include "alpaka/mem/buf/uniformCudaHip/traits/BufUniformCudaHipRtTraits.hpp"
 #    include "alpaka/mem/buf/uniformCudaHip/traits/ConstBufUniformCudaHipRtTraits.hpp"

--- a/include/alpaka/mem/buf/uniformCudaHip/ConstBufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/ConstBufUniformCudaHipRt.hpp
@@ -79,6 +79,7 @@ namespace alpaka
 } // namespace alpaka
 
 #    include "alpaka/mem/buf/uniformCudaHip/Copy.hpp"
+#    include "alpaka/mem/buf/uniformCudaHip/Fill.hpp"
 #    include "alpaka/mem/buf/uniformCudaHip/Set.hpp"
 
 #endif

--- a/include/alpaka/mem/buf/uniformCudaHip/Fill.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Fill.hpp
@@ -43,44 +43,30 @@ namespace alpaka
                 TExtent extent,
                 TPitchBytes pitchBytes) const
             {
-                if(extent.prod() != 1u)
+                for(auto const& idx : alpaka::uniformElementsND(acc, extent))
                 {
-                    for(auto const& idx : alpaka::uniformElementsND(acc, extent))
-                    {
-                        std::uintptr_t offsetBytes = static_cast<std::uintptr_t>((pitchBytes * idx).sum());
+                    // The host code checks that the pitches are a multiple of TElem's alignment.
+                    std::uintptr_t offsetBytes = static_cast<std::uintptr_t>((pitchBytes * idx).sum());
+                    TElem* elem = reinterpret_cast<TElem*>(
+                        __builtin_assume_aligned(reinterpret_cast<std::uint8_t*>(ptr) + offsetBytes, alignof(TElem)));
 
-                        TElem* elem = reinterpret_cast<TElem*>(__builtin_assume_aligned(
-                            reinterpret_cast<std::uint8_t*>(ptr) + offsetBytes,
-                            alignof(TElem)));
-
-                        // Write value at element address
-                        *elem = value;
-                    }
-                }
-            }
-        };
-
-        template<typename TElem, typename TExtent>
-        struct FillKernel0D
-        {
-            template<typename TAcc>
-            ALPAKA_FN_ACC void operator()([[maybe_unused]] TAcc const& acc, TElem* ptr, TElem value, TExtent extent)
-                const
-            {
-                if(extent.prod() == 1u)
-                {
-                    TElem* elem = reinterpret_cast<TElem*>(__builtin_assume_aligned(ptr, alignof(TElem)));
-
+                    // Write value at element address
                     *elem = value;
                 }
             }
         };
 
-        template<typename TDim, typename TIdx>
-        TIdx getThreadNumForFill()
+        template<typename TElem>
+        struct FillKernel0D
         {
-            return 64; // tbd
-        }
+            template<typename TAcc>
+            ALPAKA_FN_ACC void operator()([[maybe_unused]] TAcc const& acc, TElem* ptr, TElem value) const
+            {
+                // A zero-dimensional buffer always has a single element.
+                *ptr = value;
+            }
+        };
+
 
     } // namespace detail
 
@@ -104,33 +90,36 @@ namespace alpaka
 
                 if constexpr(TDim::value == 0)
                 {
-                    Vec threads = Vec::ones();
-                    Vec const elements = Vec::ones();
-                    Vec blocks = Vec::ones();
-
-                    WorkDiv grid = WorkDiv(blocks, threads, elements);
+                    // A zero-dimensional buffer always has a single element.
+                    WorkDiv grid{Vec{}, Vec{}, Vec{}};
                     return alpaka::createTaskKernel<Acc>(
                         grid,
-                        alpaka::detail::FillKernel0D<Elem, TExtent>{},
+                        alpaka::detail::FillKernel0D<Elem>{},
                         std::data(view),
-                        value,
-                        extent);
+                        value);
                 }
                 else
                 {
-                    Vec threads = Vec::ones();
-                    threads.x() = alpaka::detail::getThreadNumForFill<TDim, Idx>();
+                    // TODO: compute an efficient work division.
                     Vec const elements = Vec::ones();
-                    Vec blocks = Vec::ones();
-
+                    Vec threads = Vec::ones();
+                    threads.x() = 64;
+                    Vec const blocks = Vec::ones();
                     WorkDiv grid = WorkDiv(blocks, threads, elements);
+
+                    // Check that the pitches are a multiple of Elem's alignment.
+                    auto pitches = getPitchesInBytes(view);
+                    for([[maybe_unused]] auto pitch : pitches)
+                    {
+                        ALPAKA_ASSERT(static_cast<std::size_t>(pitch) % alignof(Elem) == 0);
+                    }
                     return alpaka::createTaskKernel<Acc>(
                         grid,
                         alpaka::detail::FillKernelND<Elem, TExtent, Vec>{},
                         std::data(view),
                         value,
                         extent,
-                        getPitchesInBytes(view));
+                        pitches);
                 }
             }
         };

--- a/include/alpaka/mem/buf/uniformCudaHip/Fill.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/Fill.hpp
@@ -1,0 +1,140 @@
+/* Copyright 2025 Maria Michailidi, Anna Polova, Abdulrahman Al Marzouqi
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/acc/AccGpuUniformCudaHipRt.hpp"
+#include "alpaka/core/Assert.hpp"
+#include "alpaka/core/Cuda.hpp"
+#include "alpaka/core/Hip.hpp"
+#include "alpaka/dev/Traits.hpp"
+#include "alpaka/dim/DimIntegralConst.hpp"
+#include "alpaka/exec/UniformElements.hpp"
+#include "alpaka/extent/Traits.hpp"
+#include "alpaka/kernel/Traits.hpp"
+#include "alpaka/mem/view/Traits.hpp"
+#include "alpaka/queue/QueueUniformCudaHipRtBlocking.hpp"
+#include "alpaka/queue/QueueUniformCudaHipRtNonBlocking.hpp"
+#include "alpaka/queue/Traits.hpp"
+#include "alpaka/wait/Traits.hpp"
+#include "alpaka/workdiv/WorkDivMembers.hpp"
+
+#include <iostream>
+#include <type_traits>
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+
+namespace alpaka
+{
+    template<typename TApi>
+    class DevUniformCudaHipRt;
+
+    namespace detail
+    {
+        template<typename TElem, typename TExtent, typename TPitchBytes>
+        struct FillKernelND
+        {
+            template<typename TAcc>
+            ALPAKA_FN_ACC void operator()(
+                TAcc const& acc,
+                TElem* ptr,
+                TElem value,
+                TExtent extent,
+                TPitchBytes pitchBytes) const
+            {
+                if(extent.prod() != 1u)
+                {
+                    for(auto const& idx : alpaka::uniformElementsND(acc, extent))
+                    {
+                        std::uintptr_t offsetBytes = static_cast<std::uintptr_t>((pitchBytes * idx).sum());
+
+                        TElem* elem = reinterpret_cast<TElem*>(__builtin_assume_aligned(
+                            reinterpret_cast<std::uint8_t*>(ptr) + offsetBytes,
+                            alignof(TElem)));
+
+                        // Write value at element address
+                        *elem = value;
+                    }
+                }
+            }
+        };
+
+        template<typename TElem, typename TExtent>
+        struct FillKernel0D
+        {
+            template<typename TAcc>
+            ALPAKA_FN_ACC void operator()([[maybe_unused]] TAcc const& acc, TElem* ptr, TElem value, TExtent extent)
+                const
+            {
+                if(extent.prod() == 1u)
+                {
+                    TElem* elem = reinterpret_cast<TElem*>(__builtin_assume_aligned(ptr, alignof(TElem)));
+
+                    *elem = value;
+                }
+            }
+        };
+
+        template<typename TDim, typename TIdx>
+        TIdx getThreadNumForFill()
+        {
+            return 64; // tbd
+        }
+
+    } // namespace detail
+
+    namespace trait
+    {
+        template<typename TDim, typename TApi>
+        struct CreateTaskFill<TDim, DevUniformCudaHipRt<TApi>>
+        {
+            template<typename TExtent, typename TViewFwd, typename TValue>
+            ALPAKA_FN_HOST static auto createTaskFill(TViewFwd&& view, TValue const& value, TExtent const& extent)
+            {
+                using View = std::remove_reference_t<TViewFwd>;
+                using Idx = alpaka::Idx<View>;
+                using Acc = AccGpuUniformCudaHipRt<TApi, TDim, Idx>;
+                using WorkDiv = alpaka::WorkDivMembers<TDim, Idx>;
+                using Vec = alpaka::Vec<TDim, Idx>;
+                using Elem = alpaka::Elem<View>;
+                static_assert(
+                    std::is_trivially_copyable_v<Elem>,
+                    "Only trivially copyable types are supported for fill");
+
+                if constexpr(TDim::value == 0)
+                {
+                    Vec threads = Vec::ones();
+                    Vec const elements = Vec::ones();
+                    Vec blocks = Vec::ones();
+
+                    WorkDiv grid = WorkDiv(blocks, threads, elements);
+                    return alpaka::createTaskKernel<Acc>(
+                        grid,
+                        alpaka::detail::FillKernel0D<Elem, TExtent>{},
+                        std::data(view),
+                        value,
+                        extent);
+                }
+                else
+                {
+                    Vec threads = Vec::ones();
+                    threads.x() = alpaka::detail::getThreadNumForFill<TDim, Idx>();
+                    Vec const elements = Vec::ones();
+                    Vec blocks = Vec::ones();
+
+                    WorkDiv grid = WorkDiv(blocks, threads, elements);
+                    return alpaka::createTaskKernel<Acc>(
+                        grid,
+                        alpaka::detail::FillKernelND<Elem, TExtent, Vec>{},
+                        std::data(view),
+                        value,
+                        extent,
+                        getPitchesInBytes(view));
+                }
+            }
+        };
+    } // namespace trait
+} // namespace alpaka
+
+#endif

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -113,6 +113,9 @@ namespace alpaka
         template<typename TDim, typename TDev, typename TSfinae = void>
         struct CreateTaskMemset;
 
+        template<typename TDim, typename TDev, typename TSfinae = void>
+        struct CreateTaskFill;
+
         //! The memory copy task trait.
         //!
         //! Copies memory from one view into another view possibly on a different device.
@@ -221,6 +224,24 @@ namespace alpaka
             extent);
     }
 
+    template<typename TExtent, typename TViewFwd, typename TValue>
+    ALPAKA_FN_HOST auto createTaskFill(TViewFwd&& view, TValue const& value, TExtent const& extent)
+    {
+        using TView = std::remove_reference_t<TViewFwd>;
+        static_assert(!std::is_const_v<TView>, "The view must not be const!");
+        static_assert(
+            Dim<TView>::value == Dim<TExtent>::value,
+            "The view and the extent are required to have the same dimensionality!");
+        static_assert(
+            meta::IsIntegralSuperset<Idx<TView>, Idx<TExtent>>::value,
+            "The view and the extent must have compatible index types!");
+
+        return trait::CreateTaskFill<Dim<TView>, Dev<TView>>::createTaskFill(
+            std::forward<TViewFwd>(view),
+            value,
+            extent);
+    }
+
     //! Sets the bytes of the memory of view, described by extent, to the given value.
     //!
     //! \param queue The queue to enqueue the view fill task into.
@@ -242,6 +263,18 @@ namespace alpaka
     ALPAKA_FN_HOST auto memset(TQueue& queue, TViewFwd&& view, std::uint8_t const& byte) -> void
     {
         enqueue(queue, createTaskMemset(std::forward<TViewFwd>(view), byte, getExtents(view)));
+    }
+
+    template<typename TViewFwd, typename TValue, typename TQueue>
+    ALPAKA_FN_HOST auto fill(TQueue& queue, TViewFwd&& view, TValue const& value) -> void
+    {
+        enqueue(queue, createTaskFill(std::forward<TViewFwd>(view), value, getExtents(view)));
+    }
+
+    template<typename TExtent, typename TViewFwd, typename TValue, typename TQueue>
+    ALPAKA_FN_HOST auto fill(TQueue& queue, TViewFwd&& view, TValue const& value, TExtent const& extent) -> void
+    {
+        enqueue(queue, createTaskFill(std::forward<TViewFwd>(view), value, extent));
     }
 
     //! Creates a memory copy task.

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2025 Axel Huebl, Benjamin Worpitz, Erik Zenker, Matthias Werner, René Widera, Andrea Bocci, Jan Stephan,
- *                Bernhard Manfred Gruber
+ *                Bernhard Manfred Gruber, Andrea Bocci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -382,6 +382,19 @@ namespace alpaka
             {
                 for(typename TDim::value_type i = 0; i < TDim::value; ++i)
                     r[i] = p[i] * q[i];
+            }
+            return r;
+        }
+
+        //! \return The element-wise product of a vector times a scalar.
+        ALPAKA_NO_HOST_ACC_WARNING
+        ALPAKA_FN_HOST_ACC friend constexpr auto operator*(Vec const& p, TVal const& q) -> Vec
+        {
+            Vec r;
+            if constexpr(TDim::value > 0)
+            {
+                for(typename TDim::value_type i = 0; i < TDim::value; ++i)
+                    r[i] = p[i] * q;
             }
             return r;
         }

--- a/test/unit/mem/buf/src/FillBuffers.cpp
+++ b/test/unit/mem/buf/src/FillBuffers.cpp
@@ -31,7 +31,7 @@ TEMPLATE_LIST_TEST_CASE("memBufFillPrimitiveValuesTest", "[memBuf]", alpaka::tes
     auto const platformAcc = alpaka::Platform<Acc>{};
     auto const dev = alpaka::getDevByIdx(platformAcc, 0);
 
-    INFO("Test fill function");
+    INFO("Test fill function on device");
     INFO(alpaka::getName(dev));
 
     Queue queue(dev);
@@ -87,7 +87,7 @@ TEMPLATE_LIST_TEST_CASE("memBufFillNonPrimitiveValuesTest", "[memBuf]", alpaka::
     auto const platformAcc = alpaka::Platform<Acc>{};
     auto const dev = alpaka::getDevByIdx(platformAcc, 0);
 
-    INFO("Test fill function");
+    INFO("Test fill function on device");
     INFO(alpaka::getName(dev));
 
     Queue queue(dev);
@@ -133,7 +133,7 @@ TEMPLATE_LIST_TEST_CASE("memBufFillScalarFloatTest", "[memBuf]", alpaka::test::T
     auto const platformAcc = alpaka::Platform<Acc>{};
     auto const dev = alpaka::getDevByIdx(platformAcc, 0);
 
-    INFO("Test fill function");
+    INFO("Test fill function on device");
     INFO(alpaka::getName(dev));
 
     Queue queue(dev);

--- a/test/unit/mem/buf/src/FillBuffers.cpp
+++ b/test/unit/mem/buf/src/FillBuffers.cpp
@@ -1,0 +1,155 @@
+/* Copyright 2025 Maria Michailidi, Anna Polova, Abdulrahman Al Marzouqi
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/mem/buf/Traits.hpp>
+#include <alpaka/mem/view/Traits.hpp>
+#include <alpaka/test/Extent.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
+#include <alpaka/test/mem/view/ViewTest.hpp>
+#include <alpaka/test/queue/Queue.hpp>
+
+#include <catch2/catch_message.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <numeric>
+#include <type_traits>
+
+TEMPLATE_LIST_TEST_CASE("memBufFillPrimitiveValuesTest", "[memBuf]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+    using Dev = alpaka::Dev<Acc>;
+    using Queue = alpaka::test::DefaultQueue<Dev>;
+    using Elem = int;
+    using Dim = alpaka::Dim<Acc>;
+    using Idx = alpaka::Idx<Acc>;
+
+    auto const platformHost = alpaka::PlatformCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
+
+    auto const platformAcc = alpaka::Platform<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platformAcc, 0);
+
+    INFO("Test fill function");
+    INFO(alpaka::getName(dev));
+
+    Queue queue(dev);
+
+    auto const extent = alpaka::test::extentBuf<Dim, Idx>;
+
+    auto buf = alpaka::allocBuf<Elem, Idx>(dev, extent);
+
+    constexpr Elem fillVal = 42;
+    alpaka::fill(queue, buf, fillVal);
+
+    // Copy result to host and check
+    auto bufHost = alpaka::allocBuf<Elem, Idx>(devHost, extent);
+    alpaka::memcpy(queue, bufHost, buf);
+    alpaka::wait(queue);
+
+    Elem const* ptr = std::data(bufHost);
+    Idx const size = alpaka::getExtentProduct(bufHost);
+    bool passed = true;
+    for(Idx i = 0; i < size; ++i)
+    {
+        if(ptr[i] != fillVal)
+        {
+            passed = false;
+        }
+    }
+    CHECK(passed);
+}
+
+struct Elem
+{
+    int i;
+    float f;
+
+    bool operator==(Elem const& other) const
+    {
+        return i == other.i && std::fabs(f - other.f) < 1e-9f;
+    }
+};
+
+TEMPLATE_LIST_TEST_CASE("memBufFillNonPrimitiveValuesTest", "[memBuf]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+    using Dev = alpaka::Dev<Acc>;
+    using Queue = alpaka::test::DefaultQueue<Dev>;
+
+    using Dim = alpaka::Dim<Acc>;
+    using Idx = alpaka::Idx<Acc>;
+
+    auto const platformHost = alpaka::PlatformCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
+
+    auto const platformAcc = alpaka::Platform<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platformAcc, 0);
+
+    INFO("Test fill function");
+    INFO(alpaka::getName(dev));
+
+    Queue queue(dev);
+
+    auto const extent = alpaka::test::extentBuf<Dim, Idx>;
+
+    auto buf = alpaka::allocBuf<Elem, Idx>(dev, extent);
+
+    constexpr Elem fillVal = {42, 99.0f};
+    alpaka::fill(queue, buf, fillVal);
+
+    // Copy result to host and check
+    auto bufHost = alpaka::allocBuf<Elem, Idx>(devHost, extent);
+    alpaka::memcpy(queue, bufHost, buf);
+    alpaka::wait(queue);
+
+    Elem const* ptr = std::data(bufHost);
+    Idx const size = alpaka::getExtentProduct(bufHost);
+    bool passed = true;
+    for(Idx i = 0; i < size; ++i)
+    {
+        if(ptr[i] != fillVal)
+        {
+            passed = false;
+        }
+    }
+    CHECK(passed);
+}
+
+TEMPLATE_LIST_TEST_CASE("memBufFillScalarFloatTest", "[memBuf]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+    using Dev = alpaka::Dev<Acc>;
+    using Queue = alpaka::test::DefaultQueue<Dev>;
+    using ElemT = float;
+    using Idx = alpaka::Idx<Acc>;
+
+    float epsilon = 1e-9f;
+
+    auto const platformHost = alpaka::PlatformCpu{};
+    auto const devHost = alpaka::getDevByIdx(platformHost, 0);
+
+    auto const platformAcc = alpaka::Platform<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platformAcc, 0);
+
+    INFO("Test fill function");
+    INFO(alpaka::getName(dev));
+
+    Queue queue(dev);
+
+    auto const extent = alpaka::test::extentBuf<alpaka::DimInt<0u>, Idx>;
+
+    auto buf = alpaka::allocBuf<ElemT, Idx>(dev, extent);
+
+    constexpr ElemT fillVal = 42.0f;
+    alpaka::fill(queue, buf, fillVal);
+
+    // Copy result to host and check
+    auto bufHost = alpaka::allocBuf<ElemT, Idx>(devHost, extent);
+    alpaka::memcpy(queue, bufHost, buf);
+    alpaka::wait(queue);
+
+    ElemT const* ptr = std::data(bufHost);
+    CHECK(std::fabs(ptr[0] - fillVal) < epsilon);
+}


### PR DESCRIPTION
Implement `alpaka::fill(queue, view, value[, extent])` to fill an N-dimensional buffer with a constant value, including various unit tests for the new function.