### PR TITLE
CI: disable SYCL warp tests

### DIFF
--- a/test/unit/warp/src/Any.cpp
+++ b/test/unit/warp/src/Any.cpp
@@ -70,46 +70,59 @@ TEMPLATE_LIST_TEST_CASE("any", "[warp]", alpaka::test::TestAccs)
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    auto const platform = alpaka::Platform<Acc>{};
-    auto const dev = alpaka::getDevByIdx(platform, 0);
-    auto const warpExtents = alpaka::getWarpSizes(dev);
-    for(auto const warpExtent : warpExtents)
+    if constexpr(alpaka::accMatchesTags<
+                     Acc,
+                     alpaka::TagCpuSycl,
+                     alpaka::TagGpuSyclIntel,
+                     alpaka::TagFpgaSyclIntel,
+                     alpaka::TagGenericSycl>)
     {
-        auto const scalar = Dim::value == 0 || warpExtent == 1;
-        if(scalar)
+        WARN("Test disabled for SYCL");
+    }
+    else
+    {
+        auto const platform = alpaka::Platform<Acc>{};
+        auto const dev = alpaka::getDevByIdx(platform, 0);
+        auto const warpExtents = alpaka::getWarpSizes(dev);
+        for(auto const warpExtent : warpExtents)
         {
-            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
-            REQUIRE(fixture(AnySingleThreadWarpTestKernel{}));
-        }
-        else
-        {
-            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-            // Enforce one warp per thread block
-            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-            auto fixture = ExecutionFixture{workDiv};
-            if(warpExtent == 4)
+            auto const scalar = Dim::value == 0 || warpExtent == 1;
+            if(scalar)
             {
-                REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<4>{}));
+                alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+                REQUIRE(fixture(AnySingleThreadWarpTestKernel{}));
             }
-            else if(warpExtent == 8)
+            else
             {
-                REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<8>{}));
-            }
-            else if(warpExtent == 16)
-            {
-                REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<16>{}));
-            }
-            else if(warpExtent == 32)
-            {
-                REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<32>{}));
-            }
-            else if(warpExtent == 64)
-            {
-                REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<64>{}));
+                using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+                auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+                // Enforce one warp per thread block
+                auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+                blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+                auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+                auto workDiv =
+                    typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+                auto fixture = ExecutionFixture{workDiv};
+                if(warpExtent == 4)
+                {
+                    REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<4>{}));
+                }
+                else if(warpExtent == 8)
+                {
+                    REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<8>{}));
+                }
+                else if(warpExtent == 16)
+                {
+                    REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<16>{}));
+                }
+                else if(warpExtent == 32)
+                {
+                    REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<32>{}));
+                }
+                else if(warpExtent == 64)
+                {
+                    REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<64>{}));
+                }
             }
         }
     }

--- a/test/unit/warp/src/Ballot.cpp
+++ b/test/unit/warp/src/Ballot.cpp
@@ -78,46 +78,59 @@ TEMPLATE_LIST_TEST_CASE("ballot", "[warp]", alpaka::test::TestAccs)
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    auto const platform = alpaka::Platform<Acc>{};
-    auto const dev = alpaka::getDevByIdx(platform, 0);
-    auto const warpExtents = alpaka::getWarpSizes(dev);
-    for(auto const warpExtent : warpExtents)
+    if constexpr(alpaka::accMatchesTags<
+                     Acc,
+                     alpaka::TagCpuSycl,
+                     alpaka::TagGpuSyclIntel,
+                     alpaka::TagFpgaSyclIntel,
+                     alpaka::TagGenericSycl>)
     {
-        auto const scalar = Dim::value == 0 || warpExtent == 1;
-        if(scalar)
+        WARN("Test disabled for SYCL");
+    }
+    else
+    {
+        auto const platform = alpaka::Platform<Acc>{};
+        auto const dev = alpaka::getDevByIdx(platform, 0);
+        auto const warpExtents = alpaka::getWarpSizes(dev);
+        for(auto const warpExtent : warpExtents)
         {
-            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
-            REQUIRE(fixture(BallotSingleThreadWarpTestKernel{}));
-        }
-        else
-        {
-            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-            // Enforce one warp per thread block
-            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-            auto fixture = ExecutionFixture{workDiv};
-            if(warpExtent == 4)
+            auto const scalar = Dim::value == 0 || warpExtent == 1;
+            if(scalar)
             {
-                REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<4>{}));
+                alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+                REQUIRE(fixture(BallotSingleThreadWarpTestKernel{}));
             }
-            else if(warpExtent == 8)
+            else
             {
-                REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<8>{}));
-            }
-            else if(warpExtent == 16)
-            {
-                REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<16>{}));
-            }
-            else if(warpExtent == 32)
-            {
-                REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<32>{}));
-            }
-            else if(warpExtent == 64)
-            {
-                REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<64>{}));
+                using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+                auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+                // Enforce one warp per thread block
+                auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+                blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+                auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+                auto workDiv =
+                    typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+                auto fixture = ExecutionFixture{workDiv};
+                if(warpExtent == 4)
+                {
+                    REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<4>{}));
+                }
+                else if(warpExtent == 8)
+                {
+                    REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<8>{}));
+                }
+                else if(warpExtent == 16)
+                {
+                    REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<16>{}));
+                }
+                else if(warpExtent == 32)
+                {
+                    REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<32>{}));
+                }
+                else if(warpExtent == 64)
+                {
+                    REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<64>{}));
+                }
             }
         }
     }

--- a/test/unit/warp/src/ShflDown.cpp
+++ b/test/unit/warp/src/ShflDown.cpp
@@ -125,46 +125,59 @@ TEMPLATE_LIST_TEST_CASE("shfl_down", "[warp]", alpaka::test::TestAccs)
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    auto const platform = alpaka::Platform<Acc>{};
-    Dev const dev(alpaka::getDevByIdx(platform, 0u));
-    auto const warpExtents = alpaka::getWarpSizes(dev);
-    for(auto const warpExtent : warpExtents)
+    if constexpr(alpaka::accMatchesTags<
+                     Acc,
+                     alpaka::TagCpuSycl,
+                     alpaka::TagGpuSyclIntel,
+                     alpaka::TagFpgaSyclIntel,
+                     alpaka::TagGenericSycl>)
     {
-        auto const scalar = Dim::value == 0 || warpExtent == 1;
-        if(scalar)
+        WARN("Test disabled for SYCL");
+    }
+    else
+    {
+        auto const platform = alpaka::Platform<Acc>{};
+        Dev const dev(alpaka::getDevByIdx(platform, 0u));
+        auto const warpExtents = alpaka::getWarpSizes(dev);
+        for(auto const warpExtent : warpExtents)
         {
-            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
-            REQUIRE(fixture(ShflDownSingleThreadWarpTestKernel{}));
-        }
-        else
-        {
-            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-            // Enforce one warp per thread block
-            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-            auto fixture = ExecutionFixture{workDiv};
-            if(warpExtent == 4)
+            auto const scalar = Dim::value == 0 || warpExtent == 1;
+            if(scalar)
             {
-                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<4>{}));
+                alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+                REQUIRE(fixture(ShflDownSingleThreadWarpTestKernel{}));
             }
-            else if(warpExtent == 8)
+            else
             {
-                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<8>{}));
-            }
-            else if(warpExtent == 16)
-            {
-                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<16>{}));
-            }
-            else if(warpExtent == 32)
-            {
-                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<32>{}));
-            }
-            else if(warpExtent == 64)
-            {
-                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<64>{}));
+                using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+                auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+                // Enforce one warp per thread block
+                auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+                blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+                auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+                auto workDiv =
+                    typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+                auto fixture = ExecutionFixture{workDiv};
+                if(warpExtent == 4)
+                {
+                    REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<4>{}));
+                }
+                else if(warpExtent == 8)
+                {
+                    REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<8>{}));
+                }
+                else if(warpExtent == 16)
+                {
+                    REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<16>{}));
+                }
+                else if(warpExtent == 32)
+                {
+                    REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<32>{}));
+                }
+                else if(warpExtent == 64)
+                {
+                    REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<64>{}));
+                }
             }
         }
     }

--- a/test/unit/warp/src/ShflUp.cpp
+++ b/test/unit/warp/src/ShflUp.cpp
@@ -121,46 +121,59 @@ TEMPLATE_LIST_TEST_CASE("shfl_up", "[warp]", alpaka::test::TestAccs)
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    auto const platform = alpaka::Platform<Acc>{};
-    Dev const dev(alpaka::getDevByIdx(platform, 0u));
-    auto const warpExtents = alpaka::getWarpSizes(dev);
-    for(auto const warpExtent : warpExtents)
+    if constexpr(alpaka::accMatchesTags<
+                     Acc,
+                     alpaka::TagCpuSycl,
+                     alpaka::TagGpuSyclIntel,
+                     alpaka::TagFpgaSyclIntel,
+                     alpaka::TagGenericSycl>)
     {
-        auto const scalar = Dim::value == 0 || warpExtent == 1;
-        if(scalar)
+        WARN("Test disabled for SYCL");
+    }
+    else
+    {
+        auto const platform = alpaka::Platform<Acc>{};
+        Dev const dev(alpaka::getDevByIdx(platform, 0u));
+        auto const warpExtents = alpaka::getWarpSizes(dev);
+        for(auto const warpExtent : warpExtents)
         {
-            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
-            REQUIRE(fixture(ShflUpSingleThreadWarpTestKernel{}));
-        }
-        else
-        {
-            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-            // Enforce one warp per thread block
-            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-            auto fixture = ExecutionFixture{workDiv};
-            if(warpExtent == 4)
+            auto const scalar = Dim::value == 0 || warpExtent == 1;
+            if(scalar)
             {
-                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<4>{}));
+                alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+                REQUIRE(fixture(ShflUpSingleThreadWarpTestKernel{}));
             }
-            else if(warpExtent == 8)
+            else
             {
-                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<8>{}));
-            }
-            else if(warpExtent == 16)
-            {
-                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<16>{}));
-            }
-            else if(warpExtent == 32)
-            {
-                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<32>{}));
-            }
-            else if(warpExtent == 64)
-            {
-                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<64>{}));
+                using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+                auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+                // Enforce one warp per thread block
+                auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+                blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+                auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+                auto workDiv =
+                    typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+                auto fixture = ExecutionFixture{workDiv};
+                if(warpExtent == 4)
+                {
+                    REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<4>{}));
+                }
+                else if(warpExtent == 8)
+                {
+                    REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<8>{}));
+                }
+                else if(warpExtent == 16)
+                {
+                    REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<16>{}));
+                }
+                else if(warpExtent == 32)
+                {
+                    REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<32>{}));
+                }
+                else if(warpExtent == 64)
+                {
+                    REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<64>{}));
+                }
             }
         }
     }

--- a/test/unit/warp/src/ShflXor.cpp
+++ b/test/unit/warp/src/ShflXor.cpp
@@ -106,46 +106,59 @@ TEMPLATE_LIST_TEST_CASE("shfl_xor", "[warp]", alpaka::test::TestAccs)
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    auto const platform = alpaka::Platform<Acc>{};
-    Dev const dev(alpaka::getDevByIdx(platform, 0u));
-    auto const warpExtents = alpaka::getWarpSizes(dev);
-    for(auto const warpExtent : warpExtents)
+    if constexpr(alpaka::accMatchesTags<
+                     Acc,
+                     alpaka::TagCpuSycl,
+                     alpaka::TagGpuSyclIntel,
+                     alpaka::TagFpgaSyclIntel,
+                     alpaka::TagGenericSycl>)
     {
-        auto const scalar = Dim::value == 0 || warpExtent == 1;
-        if(scalar)
+        WARN("Test disabled for SYCL");
+    }
+    else
+    {
+        auto const platform = alpaka::Platform<Acc>{};
+        Dev const dev(alpaka::getDevByIdx(platform, 0u));
+        auto const warpExtents = alpaka::getWarpSizes(dev);
+        for(auto const warpExtent : warpExtents)
         {
-            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
-            REQUIRE(fixture(ShflXorSingleThreadWarpTestKernel{}));
-        }
-        else
-        {
-            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-            // Enforce one warp per thread block
-            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-            auto fixture = ExecutionFixture{workDiv};
-            if(warpExtent == 4)
+            auto const scalar = Dim::value == 0 || warpExtent == 1;
+            if(scalar)
             {
-                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<4>{}));
+                alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+                REQUIRE(fixture(ShflXorSingleThreadWarpTestKernel{}));
             }
-            else if(warpExtent == 8)
+            else
             {
-                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<8>{}));
-            }
-            else if(warpExtent == 16)
-            {
-                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<16>{}));
-            }
-            else if(warpExtent == 32)
-            {
-                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<32>{}));
-            }
-            else if(warpExtent == 64)
-            {
-                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<64>{}));
+                using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+                auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+                // Enforce one warp per thread block
+                auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+                blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+                auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+                auto workDiv =
+                    typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+                auto fixture = ExecutionFixture{workDiv};
+                if(warpExtent == 4)
+                {
+                    REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<4>{}));
+                }
+                else if(warpExtent == 8)
+                {
+                    REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<8>{}));
+                }
+                else if(warpExtent == 16)
+                {
+                    REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<16>{}));
+                }
+                else if(warpExtent == 32)
+                {
+                    REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<32>{}));
+                }
+                else if(warpExtent == 64)
+                {
+                    REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<64>{}));
+                }
             }
         }
     }


### PR DESCRIPTION
The warp tests in alpaka assume that warp functions are not collective.
In #2470 we missed to deactivate the tests disabled in this PR.

This PR is required for the fix of the SYCL index order #2488 