### PR TITLE
Remove deprecated ciso646 includes

### DIFF
--- a/include/alpaka/exec/IndependentElements.hpp
+++ b/include/alpaka/exec/IndependentElements.hpp
@@ -4,7 +4,6 @@
 #include "alpaka/idx/Accessors.hpp"
 
 #include <algorithm>
-#include <ciso646> // workaround for MSVC in c++17 mode - TODO: remove once we move to c++20
 #include <cstddef>
 #include <type_traits>
 

--- a/include/alpaka/exec/UniformElements.hpp
+++ b/include/alpaka/exec/UniformElements.hpp
@@ -6,7 +6,6 @@
 #include "alpaka/idx/Accessors.hpp"
 
 #include <algorithm>
-#include <ciso646> // workaround for MSVC in c++17 mode - TODO: remove once we move to c++20
 #include <cstddef>
 #include <type_traits>
 


### PR DESCRIPTION
This removes includes of [ciso646](https://en.cppreference.com/w/cpp/header/ciso646.html), which was deprecated in C++17 and removed in C++20. This fixes warnings such as 
```
In file included from /home/antonr/repos/alpaka/include/alpaka/exec/UniformElements.hpp:9,
                 from /home/antonr/repos/alpaka/include/alpaka/alpaka.hpp:105,
                 from /home/antonr/repos/alpaka/example/convolution2D/src/convolution2D.cpp:5:
/usr/include/c++/15.1.1/ciso646:46:4: warning: #warning "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros" [-Wcpp]
   46 | #  warning "<ciso646> is deprecated in C++17, use <version> to detect implementation-specific macros"
      |    ^~~~~~~
```
thrown by gcc-15.