### PR TITLE
CI: remove CUDA 11.2 from gihub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ concurrency:
 # alpaka_ACC_ANY_BT_OMP5_ENABLE                 : {ON, OFF}
 #   [ON] OMP_NUM_THREADS                        : {1, 2, 3, 4}
 # alpaka_ACC_GPU_CUDA_ENABLE                    : {ON, OFF}
-#   [ON] ALPAKA_CI_CUDA_VERSION                 : {11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6}
+#   [ON] ALPAKA_CI_CUDA_VERSION                 : {12.1}
 #   [ON] ALPAKA_CI_CUDA_COMPILER                : {nvcc, [ALPAKA_CI_CXX==clang++]:clang++}
 # alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE             : {ON, OFF}
 # alpaka_ACC_GPU_HIP_ENABLE                     : {ON, OFF}
@@ -108,9 +108,9 @@ jobs:
       matrix:
         include:
         ### Analysis builds
-        - name: linux_clang-14_cuda-11.2_debug_analysis
-          os: ubuntu-22.04
-          env: {ALPAKA_CI_CXX: clang++, ALPAKA_CI_CLANG_VER: 14,     ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_CMAKE_VER: 3.25.3, OMP_NUM_THREADS: 4, ALPAKA_CI_ANALYSIS: ON, ALPAKA_CI_RUN_TESTS: OFF, alpaka_DEBUG: 1, alpaka_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "11.2", ALPAKA_CI_CUDA_COMPILER : clang++,   alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF, CMAKE_CUDA_ARCHITECTURES: 61, alpaka_RELOCATABLE_DEVICE_CODE: OFF, alpaka_CUDA_SHOW_REGISTER: OFF, alpaka_CUDA_KEEP_FILES: OFF, alpaka_CUDA_EXPT_EXTENDED_LAMBDA: OFF}
+        - name: linux_clang-18_cuda-12.1_debug_analysis
+          os: ubuntu-24.04
+          env: {ALPAKA_CI_CXX: clang++, ALPAKA_CI_CLANG_VER: 18,     ALPAKA_CI_STDLIB: libstdc++, CMAKE_BUILD_TYPE: Debug,   ALPAKA_BOOST_VERSION: 1.79.0, ALPAKA_CI_CMAKE_VER: 3.25.3, OMP_NUM_THREADS: 4, ALPAKA_CI_ANALYSIS: ON, ALPAKA_CI_RUN_TESTS: OFF, alpaka_DEBUG: 1, alpaka_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "12.1", ALPAKA_CI_CUDA_COMPILER : clang++,   alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF, CMAKE_CUDA_ARCHITECTURES: 80, alpaka_RELOCATABLE_DEVICE_CODE: OFF, alpaka_CUDA_SHOW_REGISTER: OFF, alpaka_CUDA_KEEP_FILES: OFF, alpaka_CUDA_EXPT_EXTENDED_LAMBDA: OFF}
           container: ubuntu:20.04
         - name: windows_cl-2022_debug_analysis
           os: windows-2022
@@ -138,15 +138,6 @@ jobs:
         - name: windows_cl-2022_debug
           os: windows-2022
           env: {ALPAKA_CI_CXX: cl.exe,  ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_CMAKE_VER: 3.25.3   , OMP_NUM_THREADS: 4,                                                                                                                                                                                           alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
-
-        ## CUDA 12.1
-        # nvcc + MSVC
-        # - name: windows_nvcc-12.1_cl-2022_release_cuda-only
-        #  os: windows-2022
-        #  env: {ALPAKA_CI_CXX: cl.exe,  ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Release, ALPAKA_CI_CMAKE_VER: 3.25.3, ALPAKA_CI_RUN_TESTS: OFF,                     alpaka_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "12.1", CMAKE_CUDA_ARCHITECTURES: "50;90", alpaka_ACC_GPU_CUDA_ONLY_MODE: ON,                                                     alpaka_ACC_CPU_B_SEQ_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE: OFF, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: OFF, alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE: OFF}
-        # - name: windows_nvcc-12.1_cl-2022_debug
-        #  os: windows-2022
-        #  env: {ALPAKA_CI_CXX: cl.exe,  ALPAKA_CI_CL_VER: 2022,                                   CMAKE_BUILD_TYPE: Debug,   ALPAKA_CI_CMAKE_VER: 3.25.1, ALPAKA_CI_RUN_TESTS: OFF,                     alpaka_ACC_GPU_CUDA_ENABLE: ON, ALPAKA_CI_CUDA_VERSION: "12.1",                                                                                                                           alpaka_ACC_CPU_BT_OMP5_ENABLE: OFF, alpaka_ACC_CPU_B_TBB_T_SEQ_ENABLE: OFF}
 
         ### Ubuntu
         ## native

--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -403,6 +403,12 @@ if(alpaka_ACC_GPU_CUDA_ENABLE)
                 message(WARNING "If you are using CUDA 11.3 please note of the following issue: https://github.com/alpaka-group/alpaka/issues/1857")
             endif()
 
+            # workaround: ISA code parsing when compiling as debug with clang as CUDA compiler
+            # https://github.com/llvm/llvm-project/issues/58491
+            if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+                alpaka_set_compiler_options(DEVICE target alpaka "$<$<COMPILE_LANGUAGE:CUDA>:SHELL:-g -Xarch_device -g0>")
+            endif()
+
             if(alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE OR alpaka_ACC_CPU_B_SEQ_T_OMP2_ENABLE)
                 message(FATAL_ERROR "Clang as a CUDA compiler does not support OpenMP 2!")
             endif()


### PR DESCRIPTION
Use CUDA 12.1 with clang 18 instead of CUDA 11.2.
CUDA 12.1 is the latest version supported by clang 18. Clang 18 is the first compiler supports CUDA 12+.