### PR TITLE
Fix `ALPAKA_THROW_ACC` for CUDA/HIP-only mode

### DIFF
--- a/include/alpaka/core/RuntimeMacros.hpp
+++ b/include/alpaka/core/RuntimeMacros.hpp
@@ -7,18 +7,20 @@
 // Implementation details
 #include "alpaka/core/Sycl.hpp"
 
+#include <stdexcept>
+
 //! ALPAKA_THROW_ACC either aborts(terminating the program and creating a core dump) or throws std::runtime_error
-//! depending on the Acc. The std::runtime_error exception can be catched in the catch block.
+//! depending on the Acc. The std::runtime_error exception can be caught in the catch block.
 //!
-//! For CUDA __trap function is used which triggers std::runtime_error but can be catched during wait not exec.
+//! For CUDA __trap function is used which triggers std::runtime_error but can be caught during wait not exec.
 //! For HIP abort() function is used and calls __builtin_trap()
-//! For Sycl assert(false) is not used since it can be disabled -DNDEBUG compile option. abort() is used although it
-//! generates a runtime error instead of aborting in GPUs: "Caught synchronous SYCL exception: Unresolved Symbol
-//! <abort> -999 (Unknown PI error)."
+//! For SYCL assert(false) is not used since it can be disabled with the -DNDEBUG compile option. abort() is used
+//! although it generates a runtime error instead of aborting in GPUs:
+//! "Caught synchronous SYCL exception: Unresolved Symbol <abort> -999 (Unknown PI error)."
 //!
 //! The OpenMP specification mandates that exceptions thrown by some thread must be handled by the same thread.
 //! Therefore std::runtime_error thrown by ALPAKA_THROW_ACC aborts the the program for OpenMP backends. If needed
-//! the SIGABRT signal can be catched by signal handler.
+//! the SIGABRT signal can be caught by signal handler.
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && defined(__CUDA_ARCH__)
 #    define ALPAKA_THROW_ACC(MSG)                                                                                     \
         {                                                                                                             \
@@ -42,6 +44,12 @@
                 "alpaka encountered a user-defined error condition while running on the SYCL back-end:\n%s",          \
                 (MSG));                                                                                               \
             abort();                                                                                                  \
+        }
+#elif defined(ALPAKA_ACC_GPU_CUDA_ONLY_MODE) || defined(ALPAKA_ACC_GPU_HIP_ONLY_MODE)
+// In CUDA-only or HIP-only mode, ALPAKA_FN_ACC functions are __device__ functions, and do not support having a throw
+// visible even during host compilation
+#    define ALPAKA_THROW_ACC(MSG)                                                                                     \
+        {                                                                                                             \
         }
 #else
 #    define ALPAKA_THROW_ACC(MSG)                                                                                     \


### PR DESCRIPTION
In CUDA-only or HIP-only mode, `ALPAKA_FN_ACC` functions are `__device__` functions, and do not support having a throw visible even during host compilation.