### PR TITLE
[1.3] Add missing wait to get correct timer information

### DIFF
--- a/example/vectorAdd/src/vectorAdd.cpp
+++ b/example/vectorAdd/src/vectorAdd.cpp
@@ -142,9 +142,12 @@ auto example(TAccTag const&) -> int
 
     // Enqueue the kernel execution task
     {
+        // wait in case we are using an asynchronous queue to time actual kernel runtime
+        alpaka::wait(queue);
         auto const beginT = std::chrono::high_resolution_clock::now();
         alpaka::enqueue(queue, taskKernel);
-        alpaka::wait(queue); // wait in case we are using an asynchronous queue to time actual kernel runtime
+        // wait in case we are using an asynchronous queue to time actual kernel runtime
+        alpaka::wait(queue);
         auto const endT = std::chrono::high_resolution_clock::now();
         std::cout << "Time for kernel execution: " << std::chrono::duration<double>(endT - beginT).count() << 's'
                   << std::endl;


### PR DESCRIPTION
The wait was missing which results into wrong timings in cases where the example was changed to use a asynchronous queue.
The time for the memcopies before the operations was part of the kernel execution time.

Bakport #2432 to the develop-1.3 branch.