### PR TITLE
[1.3] SYCL: fix index order

### DIFF
--- a/include/alpaka/idx/bt/IdxBtGenericSycl.hpp
+++ b/include/alpaka/idx/bt/IdxBtGenericSycl.hpp
@@ -53,15 +53,15 @@ namespace alpaka::trait
             else if constexpr(TDim::value == 2)
             {
                 return Vec<TDim, TIdx>{
-                    static_cast<TIdx>(idx.m_item_bt.get_local_id(1)),
-                    static_cast<TIdx>(idx.m_item_bt.get_local_id(0))};
+                    static_cast<TIdx>(idx.m_item_bt.get_local_id(0)),
+                    static_cast<TIdx>(idx.m_item_bt.get_local_id(1))};
             }
             else
             {
                 return Vec<TDim, TIdx>{
-                    static_cast<TIdx>(idx.m_item_bt.get_local_id(2)),
+                    static_cast<TIdx>(idx.m_item_bt.get_local_id(0)),
                     static_cast<TIdx>(idx.m_item_bt.get_local_id(1)),
-                    static_cast<TIdx>(idx.m_item_bt.get_local_id(0))};
+                    static_cast<TIdx>(idx.m_item_bt.get_local_id(2))};
             }
         }
     };

--- a/include/alpaka/idx/gb/IdxGbGenericSycl.hpp
+++ b/include/alpaka/idx/gb/IdxGbGenericSycl.hpp
@@ -53,15 +53,15 @@ namespace alpaka::trait
             else if constexpr(TDim::value == 2)
             {
                 return Vec<TDim, TIdx>(
-                    static_cast<TIdx>(idx.m_item_gb.get_group(1)),
-                    static_cast<TIdx>(idx.m_item_gb.get_group(0)));
+                    static_cast<TIdx>(idx.m_item_gb.get_group(0)),
+                    static_cast<TIdx>(idx.m_item_gb.get_group(1)));
             }
             else
             {
                 return Vec<TDim, TIdx>(
-                    static_cast<TIdx>(idx.m_item_gb.get_group(2)),
+                    static_cast<TIdx>(idx.m_item_gb.get_group(0)),
                     static_cast<TIdx>(idx.m_item_gb.get_group(1)),
-                    static_cast<TIdx>(idx.m_item_gb.get_group(0)));
+                    static_cast<TIdx>(idx.m_item_gb.get_group(2)));
             }
         }
     };

--- a/include/alpaka/kernel/TaskKernelGenericSycl.hpp
+++ b/include/alpaka/kernel/TaskKernelGenericSycl.hpp
@@ -207,13 +207,13 @@ namespace alpaka
                 return sycl::range<1>{static_cast<std::size_t>(work_groups[0] * group_items[0])};
             else if constexpr(TDim::value == 2)
                 return sycl::range<2>{
-                    static_cast<std::size_t>(work_groups[1] * group_items[1]),
-                    static_cast<std::size_t>(work_groups[0] * group_items[0])};
+                    static_cast<std::size_t>(work_groups[0] * group_items[0]),
+                    static_cast<std::size_t>(work_groups[1] * group_items[1])};
             else
                 return sycl::range<3>{
-                    static_cast<std::size_t>(work_groups[2] * group_items[2]),
+                    static_cast<std::size_t>(work_groups[0] * group_items[0]),
                     static_cast<std::size_t>(work_groups[1] * group_items[1]),
-                    static_cast<std::size_t>(work_groups[0] * group_items[0])};
+                    static_cast<std::size_t>(work_groups[2] * group_items[2])};
         }
 
         auto get_local_size(Vec<TDim, TIdx> const& group_items) const
@@ -222,13 +222,13 @@ namespace alpaka
                 return sycl::range<1>{static_cast<std::size_t>(group_items[0])};
             else if constexpr(TDim::value == 2)
                 return sycl::range<2>{
-                    static_cast<std::size_t>(group_items[1]),
-                    static_cast<std::size_t>(group_items[0])};
+                    static_cast<std::size_t>(group_items[0]),
+                    static_cast<std::size_t>(group_items[1])};
             else
                 return sycl::range<3>{
-                    static_cast<std::size_t>(group_items[2]),
+                    static_cast<std::size_t>(group_items[0]),
                     static_cast<std::size_t>(group_items[1]),
-                    static_cast<std::size_t>(group_items[0])};
+                    static_cast<std::size_t>(group_items[2])};
         }
 
     public:

--- a/include/alpaka/workdiv/WorkDivGenericSycl.hpp
+++ b/include/alpaka/workdiv/WorkDivGenericSycl.hpp
@@ -64,15 +64,15 @@ namespace alpaka::trait
             else if constexpr(TDim::value == 2)
             {
                 return Vec<TDim, TIdx>{
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(1)),
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(0))};
+                    static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(0)),
+                    static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(1))};
             }
             else
             {
                 return Vec<TDim, TIdx>{
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(2)),
+                    static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(0)),
                     static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(1)),
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(0))};
+                    static_cast<TIdx>(workDiv.m_item_workdiv.get_group_range(2))};
             }
         }
     };
@@ -91,15 +91,15 @@ namespace alpaka::trait
             else if constexpr(TDim::value == 2)
             {
                 return Vec<TDim, TIdx>{
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(1)),
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(0))};
+                    static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(0)),
+                    static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(1))};
             }
             else
             {
                 return Vec<TDim, TIdx>{
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(2)),
+                    static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(0)),
                     static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(1)),
-                    static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(0))};
+                    static_cast<TIdx>(workDiv.m_item_workdiv.get_local_range(2))};
             }
         }
     };


### PR DESCRIPTION
Backport #2488 to the develop-1.3 branch.

The fast moving index in SYCL's nd_item is the rightmost one, equal to alpaka's index order.
In our code base we implemented it equal to CUDA's index order where the left most index is the fast moving index.