### PR TITLE
[1.3] Change attribute `intel::reqd_sub_group_size` to `sycl::reqd_sub_group_size`

### DIFF
--- a/include/alpaka/kernel/TaskKernelGenericSycl.hpp
+++ b/include/alpaka/kernel/TaskKernelGenericSycl.hpp
@@ -41,7 +41,7 @@
         cgh.parallel_for(                                                                                             \
             sycl::nd_range<TDim::value>{global_size, local_size},                                                     \
             [item_elements, dyn_shared_accessor, st_shared_accessor, k_func, k_args](                                 \
-                sycl::nd_item<TDim::value> work_item) [[intel::reqd_sub_group_size(sub_group_size)]]                  \
+                sycl::nd_item<TDim::value> work_item) [[sycl::reqd_sub_group_size(sub_group_size)]]                   \
             {                                                                                                         \
                 auto acc = TAcc{item_elements, work_item, dyn_shared_accessor, st_shared_accessor};                   \
                 std::apply(                                                                                           \


### PR DESCRIPTION
Backport #2509 to the develop-1.3 branch.

There is the following change in oneAPI software: https://github.com/oneapi-src/oneAPI-samples/pull/2667.

**Fixes Issue**
`warning: attribute 'intel::reqd_sub_group_size' is deprecated [-Wdeprecated-attributes]
note: did you mean to use 'sycl::reqd_sub_group_size' instead?`