### PR TITLE
[1.3] Include `<chrono>` everywhere it is used

### DIFF
--- a/example/counterBasedRng/src/counterBasedRng.cpp
+++ b/example/counterBasedRng/src/counterBasedRng.cpp
@@ -6,7 +6,6 @@
 #include <alpaka/example/ExecuteForEachAccTag.hpp>
 #include <alpaka/rand/RandPhiloxStateless.hpp>
 
-#include <chrono>
 #include <iostream>
 #include <random>
 #include <typeinfo>

--- a/example/randomStrategies/src/randomStrategies.cpp
+++ b/example/randomStrategies/src/randomStrategies.cpp
@@ -5,7 +5,6 @@
 #include <alpaka/alpaka.hpp>
 #include <alpaka/example/ExecuteForEachAccTag.hpp>
 
-#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>

--- a/include/alpaka/test/MeasureKernelRunTime.hpp
+++ b/include/alpaka/test/MeasureKernelRunTime.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/alpaka.hpp"
 #include "alpaka/core/DemangleTypeNames.hpp"
 
+#include <chrono>
 #include <type_traits>
 #include <utility>
 

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -7,6 +7,7 @@
 
 #include "alpaka/alpaka.hpp"
 
+#include <chrono>
 #include <condition_variable>
 #include <mutex>
 #include <utility>

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -12,6 +12,7 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 
+#include <chrono>
 #include <numeric>
 #include <type_traits>
 

--- a/test/unit/queue/src/CollectiveQueue.cpp
+++ b/test/unit/queue/src/CollectiveQueue.cpp
@@ -15,6 +15,7 @@
 
 #    include <catch2/catch_test_macros.hpp>
 
+#    include <chrono>
 #    include <vector>
 
 struct QueueCollectiveTestKernel

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -13,6 +13,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <future>
 #include <thread>
 #include <typeinfo>


### PR DESCRIPTION
Make sure to `#include <chrono>` in all files that use `std::chrono`.