### PR TITLE
Implement creation of CUDA/HIP Queue with external Stream

### DIFF
--- a/docs/source/dev/backends.rst
+++ b/docs/source/dev/backends.rst
@@ -240,9 +240,9 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +---------------------------------+-----------------------------------------------------------------------+
     | cudaDeviceSynchronize           | void alpaka::wait(device)                                             |
     +---------------------------------+-----------------------------------------------------------------------+
-    | cudaGetDevice                   | n/a (no current device)                                               |
+    | cudaGetDevice                   | alpaka::ApiCudaRt::getDevice()                                        |
     +---------------------------------+-----------------------------------------------------------------------+
-    | cudaGetDeviceCount              | std::size_t alpaka::getDevCount< TPlatform >()                         |
+    | cudaGetDeviceCount              | std::size_t alpaka::getDevCount< TPlatform >()                        |
     +---------------------------------+-----------------------------------------------------------------------+
     | cudaGetDeviceFlags              | --                                                                    |
     +---------------------------------+-----------------------------------------------------------------------+

--- a/docs/source/dev/backends.rst
+++ b/docs/source/dev/backends.rst
@@ -240,7 +240,7 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +---------------------------------+-----------------------------------------------------------------------+
     | cudaDeviceSynchronize           | void alpaka::wait(device)                                             |
     +---------------------------------+-----------------------------------------------------------------------+
-    | cudaGetDevice                   | alpaka::ApiCudaRt::getDevice()                                        |
+    | cudaGetDevice                   | n/a (no current device)                                               |
     +---------------------------------+-----------------------------------------------------------------------+
     | cudaGetDeviceCount              | std::size_t alpaka::getDevCount< TPlatform >()                        |
     +---------------------------------+-----------------------------------------------------------------------+

--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -194,12 +194,7 @@ namespace alpaka
 #    endif
         }
 
-        static inline Error_t getDevice(int* device)
-        {
-            return ::cudaGetDevice(device);
-        }
-
-        static inline int getDevice()
+        static inline int getCurrentDevice()
         {
             int device;
             auto error = ::cudaGetDevice(&device);

--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -7,8 +7,6 @@
 #include "alpaka/core/Config.hpp"
 #include "alpaka/core/UniformCudaHip.hpp"
 
-#include <stdexcept>
-
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 #    include <cuda_runtime_api.h>
 

--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/core/Config.hpp"
+#include "alpaka/core/UniformCudaHip.hpp"
 
 #include <stdexcept>
 
@@ -197,9 +198,8 @@ namespace alpaka
         static inline int getCurrentDevice()
         {
             int device;
-            auto error = ::cudaGetDevice(&device);
-            if(error != cudaSuccess)
-                throw std::runtime_error(cudaGetErrorString(error));
+            using TApi = alpaka::ApiCudaRt;
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(::cudaGetDevice(&device));
 
             return device;
         }

--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -192,6 +192,11 @@ namespace alpaka
 #    endif
         }
 
+        static inline Error_t getDevice(int* device)
+        {
+            return ::cudaGetDevice(device);
+        }
+
         static inline Error_t getDeviceCount(int* count)
         {
             return ::cudaGetDeviceCount(count);

--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -6,6 +6,8 @@
 
 #include "alpaka/core/Config.hpp"
 
+#include <stdexcept>
+
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 #    include <cuda_runtime_api.h>
 
@@ -200,7 +202,9 @@ namespace alpaka
         static inline int getDevice()
         {
             int device;
-            ::cudaGetDevice(&device);
+            auto error = ::cudaGetDevice(&device);
+            if(error != cudaSuccess)
+                throw std::runtime_error(cudaGetErrorString(error));
 
             return device;
         }

--- a/include/alpaka/core/ApiCudaRt.hpp
+++ b/include/alpaka/core/ApiCudaRt.hpp
@@ -197,6 +197,14 @@ namespace alpaka
             return ::cudaGetDevice(device);
         }
 
+        static inline int getDevice()
+        {
+            int device;
+            ::cudaGetDevice(&device);
+
+            return device;
+        }
+
         static inline Error_t getDeviceCount(int* count)
         {
             return ::cudaGetDeviceCount(count);

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/core/Config.hpp"
+#include "alpaka/core/UniformCudaHip.hpp"
 
 #include <stdexcept>
 
@@ -222,9 +223,7 @@ namespace alpaka
         static inline int getCurrentDevice()
         {
             int device;
-            auto error = ::hipGetDevice(&device);
-            if(error != hipSuccess)
-                throw std::runtime_error(hipGetErrorString(error));
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(::hipGetDevice(&device));
 
             return device;
         }

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -6,6 +6,8 @@
 
 #include "alpaka/core/Config.hpp"
 
+#include <stdexcept>
+
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
 
 #    include <hip/hip_runtime_api.h>
@@ -225,7 +227,9 @@ namespace alpaka
         static inline int getDevice()
         {
             int device;
-            ::hipGetDevice(&device);
+            auto error = ::hipGetDevice(&device);
+            if(error != hipSuccess)
+                throw std::runtime_error(hipGetErrorString(error));
 
             return device;
         }

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -217,6 +217,11 @@ namespace alpaka
 #    endif
         }
 
+        static inline Error_t getDevice(int* device)
+        {
+            return ::hipGetDevice(device);
+        }
+
         static inline Error_t getDeviceCount(int* count)
         {
             return ::hipGetDeviceCount(count);

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -222,6 +222,14 @@ namespace alpaka
             return ::hipGetDevice(device);
         }
 
+        static inline int getDevice()
+        {
+            int device;
+            ::hipGetDevice(*&evice);
+
+            return device;
+        }
+
         static inline Error_t getDeviceCount(int* count)
         {
             return ::hipGetDeviceCount(count);

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -223,6 +223,7 @@ namespace alpaka
         static inline int getCurrentDevice()
         {
             int device;
+            using TApi = alpaka::ApiHipRt;
             ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(::hipGetDevice(&device));
 
             return device;

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -225,7 +225,7 @@ namespace alpaka
         static inline int getDevice()
         {
             int device;
-            ::hipGetDevice(*&evice);
+            ::hipGetDevice(&device);
 
             return device;
         }

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -7,8 +7,6 @@
 #include "alpaka/core/Config.hpp"
 #include "alpaka/core/UniformCudaHip.hpp"
 
-#include <stdexcept>
-
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
 
 #    include <hip/hip_runtime_api.h>

--- a/include/alpaka/core/ApiHipRt.hpp
+++ b/include/alpaka/core/ApiHipRt.hpp
@@ -219,12 +219,7 @@ namespace alpaka
 #    endif
         }
 
-        static inline Error_t getDevice(int* device)
-        {
-            return ::hipGetDevice(device);
-        }
-
-        static inline int getDevice()
+        static inline int getCurrentDevice()
         {
             int device;
             auto error = ::hipGetDevice(&device);

--- a/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
@@ -58,7 +58,7 @@ public:
 
   ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(TApi::Stream_t stream)
       : m_dev(alpaka::getDevByIdx(alpaka::PlatformUniformCudaHipRt<TApi>{},
-                                  static_cast<std::size_t>(TApi::getDevice()))),
+                                  static_cast<std::size_t>(TApi::getCurrentDevice()))),
         m_UniformCudaHipQueue(stream), m_isOwning(false) {}
 
   QueueUniformCudaHipRtImpl(QueueUniformCudaHipRtImpl &&) = default;

--- a/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
@@ -34,7 +34,7 @@ namespace alpaka
     class DevUniformCudaHipRt;
 
     template<typename TApi>
-    class PlatformUniformCudaHipRt;
+    struct PlatformUniformCudaHipRt;
 
     namespace uniform_cuda_hip::detail
     {

--- a/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
@@ -66,13 +66,13 @@ namespace alpaka
             }
 
             ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(TApi::Stream_t stream)
-                : m_UniformCudaHipQueue(stream)
+                : m_dev(
+                      alpaka::getDevByIdx(
+                          alpaka::PlatformUniformCudaHipRt<TApi>{},
+                          static_cast<std::size_t>(TApi::getDevice())))
+                , m_UniformCudaHipQueue(stream)
                 , m_isOwning(false)
             {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-                int deviceId;
-                TApi::getDevice(&deviceId);
-                m_dev = alpaka::getDevByIdx(alpaka::PlatformUniformCudaHipRt<TApi>{}, deviceId);
             }
 
             QueueUniformCudaHipRtImpl(QueueUniformCudaHipRtImpl&&) = default;
@@ -98,6 +98,7 @@ namespace alpaka
             }
 
         public:
+            int m_deviceId;
             DevUniformCudaHipRt<TApi> const m_dev; //!< The device this queue is bound to.
             core::CallbackThread m_callbackThread;
 
@@ -118,6 +119,12 @@ namespace alpaka
                 : m_spQueueImpl(std::make_shared<QueueUniformCudaHipRtImpl<TApi>>(dev))
             {
                 dev.registerQueue(m_spQueueImpl);
+            }
+
+            ALPAKA_FN_HOST QueueUniformCudaHipRt(typename TApi::Stream_t stream)
+                : m_spQueueImpl(std::make_shared<QueueUniformCudaHipRtImpl<TApi>>(stream))
+            {
+                m_spQueueImpl->m_dev.registerQueue(m_spQueueImpl);
             }
 
             ALPAKA_FN_HOST auto operator==(QueueUniformCudaHipRt const& rhs) const -> bool

--- a/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
@@ -43,6 +43,7 @@ namespace alpaka
             ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(DevUniformCudaHipRt<TApi> const& dev)
                 : m_dev(dev)
                 , m_UniformCudaHipQueue()
+                , m_isOwning(true)
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
@@ -61,6 +62,16 @@ namespace alpaka
                     TApi::streamCreateWithFlags(&m_UniformCudaHipQueue, TApi::streamNonBlocking));
             }
 
+            ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(TApi::Stream_t stream)
+                : m_UniformCudaHipQueue(stream)
+                , m_isOwning(false)
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+                auto deviceId;
+                TApi::getDevice(&deviceId);
+                m_dev = alpaka::getDevByIdx(alpaka::PlatformUniformCudaHipRt<TApi>{}, deviceId);
+            }
+
             QueueUniformCudaHipRtImpl(QueueUniformCudaHipRtImpl&&) = default;
             auto operator=(QueueUniformCudaHipRtImpl&&) -> QueueUniformCudaHipRtImpl& = delete;
 
@@ -71,8 +82,11 @@ namespace alpaka
                 // Make sure all pending async work is finished before destroying the stream to guarantee determinism.
                 // This would not be necessary for plain CUDA/HIP operations, but we can have host functions in the
                 // stream, which reference this queue instance and its CallbackThread. Make sure they are done.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::streamSynchronize(m_UniformCudaHipQueue));
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::streamDestroy(m_UniformCudaHipQueue));
+                if(m_isOwning)
+                {
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::streamSynchronize(m_UniformCudaHipQueue));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::streamDestroy(m_UniformCudaHipQueue));
+                }
             }
 
             [[nodiscard]] auto getNativeHandle() const noexcept
@@ -86,6 +100,7 @@ namespace alpaka
 
         private:
             typename TApi::Stream_t m_UniformCudaHipQueue;
+            bool m_isOwning;
         };
 
         //! The CUDA/HIP RT queue.
@@ -220,10 +235,11 @@ namespace alpaka
                 uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>& queue,
                 TTask const& task) -> void
             {
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::launchHostFunc(
-                    queue.getNativeHandle(),
-                    uniformCudaHipRtHostFunc,
-                    new HostFuncData{*queue.m_spQueueImpl, task}));
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    TApi::launchHostFunc(
+                        queue.getNativeHandle(),
+                        uniformCudaHipRtHostFunc,
+                        new HostFuncData{*queue.m_spQueueImpl, task}));
                 if constexpr(TBlocking)
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::streamSynchronize(queue.getNativeHandle()));
             }

--- a/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
@@ -1,5 +1,6 @@
-/* Copyright 2022 Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci,
- * Bernhard Manfred Gruber, Antonio Di Pilato SPDX-License-Identifier: MPL-2.0
+/* Copyright 2025 Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci, Bernhard Manfred Gruber,
+ * Antonio Di Pilato
+ * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once

--- a/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
@@ -55,14 +55,12 @@ namespace alpaka
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(m_dev.getNativeHandle()));
 
                 // - [cuda/hip]StreamDefault: Default queue creation flag.
-                // - [cuda/hip]StreamNonBlocking: Specifies that work running in the created
-                // queue may run concurrently with work in queue 0 (the NULL queue),
-                //   and that the created queue should perform no implicit synchronization
-                //   with queue 0.
+                // - [cuda/hip]StreamNonBlocking: Specifies that work running in the created queue may run
+                // concurrently with work in queue 0 (the NULL queue),
+                // and that the created queue should perform no implicit synchronization with queue 0.
                 // Create the queue on the current device.
-                // NOTE: [cuda/hip]StreamNonBlocking is required to match the semantic
-                // implemented in the alpaka CPU queue. It would be too much work to
-                // implement implicit default queue synchronization on CPU.
+                // NOTE: [cuda/hip]StreamNonBlocking is required to match the semantic implemented in the alpaka
+                // CPU queue. It would be too much work to implement implicit default queue synchronization on CPU.
 
                 ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
                     TApi::streamCreateWithFlags(&m_UniformCudaHipQueue, TApi::streamNonBlocking));
@@ -84,10 +82,9 @@ namespace alpaka
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                // Make sure all pending async work is finished before destroying the stream
-                // to guarantee determinism. This would not be necessary for plain CUDA/HIP
-                // operations, but we can have host functions in the stream, which reference
-                // this queue instance and its CallbackThread. Make sure they are done.
+                // Make sure all pending async work is finished before destroying the stream to guarantee determinism.
+                // This would not be necessary for plain CUDA/HIP operations, but we can have host functions in the
+                // stream, which reference this queue instance and its CallbackThread. Make sure they are done.
                 if(m_isOwning)
                 {
                     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::streamSynchronize(m_UniformCudaHipQueue));

--- a/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
@@ -33,6 +33,9 @@ namespace alpaka
     template<typename TApi>
     class DevUniformCudaHipRt;
 
+    template<typename TApi>
+    class PlatformUniformCudaHipRt;
+
     namespace uniform_cuda_hip::detail
     {
         //! The CUDA/HIP RT queue implementation.
@@ -67,7 +70,7 @@ namespace alpaka
                 , m_isOwning(false)
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-                auto deviceId;
+                int deviceId;
                 TApi::getDevice(&deviceId);
                 m_dev = alpaka::getDevByIdx(alpaka::PlatformUniformCudaHipRt<TApi>{}, deviceId);
             }

--- a/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
@@ -12,6 +12,7 @@
 #include "alpaka/dev/Traits.hpp"
 #include "alpaka/event/Traits.hpp"
 #include "alpaka/meta/DependentFalseType.hpp"
+#include "alpaka/platform/Traits.hpp"
 #include "alpaka/queue/Traits.hpp"
 #include "alpaka/traits/Traits.hpp"
 #include "alpaka/wait/Traits.hpp"

--- a/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
@@ -25,229 +25,248 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-namespace alpaka {
-template <typename TApi> class EventUniformCudaHipRt;
+namespace alpaka
+{
+    template<typename TApi>
+    class EventUniformCudaHipRt;
 
-template <typename TApi> class DevUniformCudaHipRt;
+    template<typename TApi>
+    class DevUniformCudaHipRt;
 
-template <typename TApi> struct PlatformUniformCudaHipRt;
+    template<typename TApi>
+    struct PlatformUniformCudaHipRt;
 
-namespace uniform_cuda_hip::detail {
-//! The CUDA/HIP RT queue implementation.
-template <typename TApi> class QueueUniformCudaHipRtImpl final {
-public:
-  ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(DevUniformCudaHipRt<TApi> const &dev)
-      : m_dev(dev), m_UniformCudaHipQueue(), m_isOwning(true) {
-    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+    namespace uniform_cuda_hip::detail
+    {
+        //! The CUDA/HIP RT queue implementation.
+        template<typename TApi>
+        class QueueUniformCudaHipRtImpl final
+        {
+        public:
+            ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(DevUniformCudaHipRt<TApi> const& dev)
+                : m_dev(dev)
+                , m_UniformCudaHipQueue()
+                , m_isOwning(true)
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-    // Set the current device.
-    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(m_dev.getNativeHandle()));
+                // Set the current device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(m_dev.getNativeHandle()));
 
-    // - [cuda/hip]StreamDefault: Default queue creation flag.
-    // - [cuda/hip]StreamNonBlocking: Specifies that work running in the created
-    // queue may run concurrently with work in queue 0 (the NULL queue),
-    //   and that the created queue should perform no implicit synchronization
-    //   with queue 0.
-    // Create the queue on the current device.
-    // NOTE: [cuda/hip]StreamNonBlocking is required to match the semantic
-    // implemented in the alpaka CPU queue. It would be too much work to
-    // implement implicit default queue synchronization on CPU.
+                // - [cuda/hip]StreamDefault: Default queue creation flag.
+                // - [cuda/hip]StreamNonBlocking: Specifies that work running in the created
+                // queue may run concurrently with work in queue 0 (the NULL queue),
+                //   and that the created queue should perform no implicit synchronization
+                //   with queue 0.
+                // Create the queue on the current device.
+                // NOTE: [cuda/hip]StreamNonBlocking is required to match the semantic
+                // implemented in the alpaka CPU queue. It would be too much work to
+                // implement implicit default queue synchronization on CPU.
 
-    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::streamCreateWithFlags(
-        &m_UniformCudaHipQueue, TApi::streamNonBlocking));
-  }
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+                    TApi::streamCreateWithFlags(&m_UniformCudaHipQueue, TApi::streamNonBlocking));
+            }
 
-  ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(TApi::Stream_t stream)
-      : m_dev(alpaka::getDevByIdx(alpaka::PlatformUniformCudaHipRt<TApi>{},
-                                  static_cast<std::size_t>(TApi::getCurrentDevice()))),
-        m_UniformCudaHipQueue(stream), m_isOwning(false) {}
+            ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(TApi::Stream_t stream)
+                : m_dev(alpaka::getDevByIdx(
+                      alpaka::PlatformUniformCudaHipRt<TApi>{},
+                      static_cast<std::size_t>(TApi::getCurrentDevice())))
+                , m_UniformCudaHipQueue(stream)
+                , m_isOwning(false)
+            {
+            }
 
-  QueueUniformCudaHipRtImpl(QueueUniformCudaHipRtImpl &&) = default;
-  auto operator=(QueueUniformCudaHipRtImpl &&)
-      -> QueueUniformCudaHipRtImpl & = delete;
+            QueueUniformCudaHipRtImpl(QueueUniformCudaHipRtImpl&&) = default;
+            auto operator=(QueueUniformCudaHipRtImpl&&) -> QueueUniformCudaHipRtImpl& = delete;
 
-  ALPAKA_FN_HOST ~QueueUniformCudaHipRtImpl() {
-    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+            ALPAKA_FN_HOST ~QueueUniformCudaHipRtImpl()
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-    // Make sure all pending async work is finished before destroying the stream
-    // to guarantee determinism. This would not be necessary for plain CUDA/HIP
-    // operations, but we can have host functions in the stream, which reference
-    // this queue instance and its CallbackThread. Make sure they are done.
-    if (m_isOwning) {
-      ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
-          TApi::streamSynchronize(m_UniformCudaHipQueue));
-      ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
-          TApi::streamDestroy(m_UniformCudaHipQueue));
-    }
-  }
+                // Make sure all pending async work is finished before destroying the stream
+                // to guarantee determinism. This would not be necessary for plain CUDA/HIP
+                // operations, but we can have host functions in the stream, which reference
+                // this queue instance and its CallbackThread. Make sure they are done.
+                if(m_isOwning)
+                {
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::streamSynchronize(m_UniformCudaHipQueue));
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::streamDestroy(m_UniformCudaHipQueue));
+                }
+            }
 
-  [[nodiscard]] auto getNativeHandle() const noexcept {
-    return m_UniformCudaHipQueue;
-  }
+            [[nodiscard]] auto getNativeHandle() const noexcept
+            {
+                return m_UniformCudaHipQueue;
+            }
 
-public:
-  DevUniformCudaHipRt<TApi> const m_dev; //!< The device this queue is bound to.
-  core::CallbackThread m_callbackThread;
+        public:
+            DevUniformCudaHipRt<TApi> const m_dev; //!< The device this queue is bound to.
+            core::CallbackThread m_callbackThread;
 
-private:
-  typename TApi::Stream_t m_UniformCudaHipQueue;
-  bool m_isOwning;
-};
+        private:
+            typename TApi::Stream_t m_UniformCudaHipQueue;
+            bool m_isOwning;
+        };
 
-//! The CUDA/HIP RT queue.
-template <typename TApi, bool TBlocking>
-class QueueUniformCudaHipRt
-    : public interface::Implements<ConceptCurrentThreadWaitFor,
-                                   QueueUniformCudaHipRt<TApi, TBlocking>>,
-      public interface::Implements<ConceptQueue,
-                                   QueueUniformCudaHipRt<TApi, TBlocking>>,
-      public interface::Implements<ConceptGetDev,
-                                   QueueUniformCudaHipRt<TApi, TBlocking>> {
-public:
-  ALPAKA_FN_HOST QueueUniformCudaHipRt(DevUniformCudaHipRt<TApi> const &dev)
-      : m_spQueueImpl(std::make_shared<QueueUniformCudaHipRtImpl<TApi>>(dev)) {
-    dev.registerQueue(m_spQueueImpl);
-  }
+        //! The CUDA/HIP RT queue.
+        template<typename TApi, bool TBlocking>
+        class QueueUniformCudaHipRt
+            : public interface::Implements<ConceptCurrentThreadWaitFor, QueueUniformCudaHipRt<TApi, TBlocking>>
+            , public interface::Implements<ConceptQueue, QueueUniformCudaHipRt<TApi, TBlocking>>
+            , public interface::Implements<ConceptGetDev, QueueUniformCudaHipRt<TApi, TBlocking>>
+        {
+        public:
+            ALPAKA_FN_HOST QueueUniformCudaHipRt(DevUniformCudaHipRt<TApi> const& dev)
+                : m_spQueueImpl(std::make_shared<QueueUniformCudaHipRtImpl<TApi>>(dev))
+            {
+                dev.registerQueue(m_spQueueImpl);
+            }
 
-  ALPAKA_FN_HOST QueueUniformCudaHipRt(typename TApi::Stream_t stream)
-      : m_spQueueImpl(
-            std::make_shared<QueueUniformCudaHipRtImpl<TApi>>(stream)) {
-    m_spQueueImpl->m_dev.registerQueue(m_spQueueImpl);
-  }
+            ALPAKA_FN_HOST QueueUniformCudaHipRt(typename TApi::Stream_t stream)
+                : m_spQueueImpl(std::make_shared<QueueUniformCudaHipRtImpl<TApi>>(stream))
+            {
+                m_spQueueImpl->m_dev.registerQueue(m_spQueueImpl);
+            }
 
-  ALPAKA_FN_HOST auto operator==(QueueUniformCudaHipRt const &rhs) const
-      -> bool {
-    return (m_spQueueImpl == rhs.m_spQueueImpl);
-  }
+            ALPAKA_FN_HOST auto operator==(QueueUniformCudaHipRt const& rhs) const -> bool
+            {
+                return (m_spQueueImpl == rhs.m_spQueueImpl);
+            }
 
-  ALPAKA_FN_HOST auto operator!=(QueueUniformCudaHipRt const &rhs) const
-      -> bool {
-    return !((*this) == rhs);
-  }
+            ALPAKA_FN_HOST auto operator!=(QueueUniformCudaHipRt const& rhs) const -> bool
+            {
+                return !((*this) == rhs);
+            }
 
-  [[nodiscard]] auto getNativeHandle() const noexcept {
-    return m_spQueueImpl->getNativeHandle();
-  }
+            [[nodiscard]] auto getNativeHandle() const noexcept
+            {
+                return m_spQueueImpl->getNativeHandle();
+            }
 
-  auto getCallbackThread() -> core::CallbackThread & {
-    return m_spQueueImpl->m_callbackThread;
-  }
+            auto getCallbackThread() -> core::CallbackThread&
+            {
+                return m_spQueueImpl->m_callbackThread;
+            }
 
-public:
-  std::shared_ptr<QueueUniformCudaHipRtImpl<TApi>> m_spQueueImpl;
-};
-} // namespace uniform_cuda_hip::detail
+        public:
+            std::shared_ptr<QueueUniformCudaHipRtImpl<TApi>> m_spQueueImpl;
+        };
+    } // namespace uniform_cuda_hip::detail
 
-namespace trait {
-//! The CUDA/HIP RT queue device get trait specialization.
-template <typename TApi, bool TBlocking>
-struct GetDev<
-    uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>> {
-  ALPAKA_FN_HOST static auto
-  getDev(uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const
-             &queue) -> DevUniformCudaHipRt<TApi> {
-    return queue.m_spQueueImpl->m_dev;
-  }
-};
+    namespace trait
+    {
+        //! The CUDA/HIP RT queue device get trait specialization.
+        template<typename TApi, bool TBlocking>
+        struct GetDev<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>>
+        {
+            ALPAKA_FN_HOST static auto getDev(uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const&
+                                                  queue) -> DevUniformCudaHipRt<TApi>
+            {
+                return queue.m_spQueueImpl->m_dev;
+            }
+        };
 
-//! The CUDA/HIP RT queue test trait specialization.
-template <typename TApi, bool TBlocking>
-struct Empty<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>> {
-  ALPAKA_FN_HOST static auto
-  empty(uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const
-            &queue) -> bool {
-    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+        //! The CUDA/HIP RT queue test trait specialization.
+        template<typename TApi, bool TBlocking>
+        struct Empty<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>>
+        {
+            ALPAKA_FN_HOST static auto empty(
+                uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const& queue) -> bool
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-    // Query is allowed even for queues on non current device.
-    typename TApi::Error_t ret = TApi::success;
-    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
-        ret = TApi::streamQuery(queue.getNativeHandle()), TApi::errorNotReady);
-    return (ret == TApi::success);
-  }
-};
+                // Query is allowed even for queues on non current device.
+                typename TApi::Error_t ret = TApi::success;
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
+                    ret = TApi::streamQuery(queue.getNativeHandle()),
+                    TApi::errorNotReady);
+                return (ret == TApi::success);
+            }
+        };
 
-//! The CUDA/HIP RT queue thread wait trait specialization.
-//!
-//! Blocks execution of the calling thread until the queue has finished
-//! processing all previously requested tasks (kernels, data copies, ...)
-template <typename TApi, bool TBlocking>
-struct CurrentThreadWaitFor<
-    uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>> {
-  ALPAKA_FN_HOST static auto currentThreadWaitFor(
-      uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const
-          &queue) -> void {
-    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+        //! The CUDA/HIP RT queue thread wait trait specialization.
+        //!
+        //! Blocks execution of the calling thread until the queue has finished
+        //! processing all previously requested tasks (kernels, data copies, ...)
+        template<typename TApi, bool TBlocking>
+        struct CurrentThreadWaitFor<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>>
+        {
+            ALPAKA_FN_HOST static auto currentThreadWaitFor(
+                uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const& queue) -> void
+            {
+                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-    // Sync is allowed even for queues on non current device.
-    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-        TApi::streamSynchronize(queue.getNativeHandle()));
-  }
-};
+                // Sync is allowed even for queues on non current device.
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::streamSynchronize(queue.getNativeHandle()));
+            }
+        };
 
-//! The CUDA/HIP RT blocking queue device type trait specialization.
-template <typename TApi, bool TBlocking>
-struct DevType<
-    uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>> {
-  using type = DevUniformCudaHipRt<TApi>;
-};
+        //! The CUDA/HIP RT blocking queue device type trait specialization.
+        template<typename TApi, bool TBlocking>
+        struct DevType<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>>
+        {
+            using type = DevUniformCudaHipRt<TApi>;
+        };
 
-//! The CUDA/HIP RT blocking queue event type trait specialization.
-template <typename TApi, bool TBlocking>
-struct EventType<
-    uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>> {
-  using type = EventUniformCudaHipRt<TApi>;
-};
+        //! The CUDA/HIP RT blocking queue event type trait specialization.
+        template<typename TApi, bool TBlocking>
+        struct EventType<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>>
+        {
+            using type = EventUniformCudaHipRt<TApi>;
+        };
 
-//! The CUDA/HIP RT blocking queue enqueue trait specialization.
-template <typename TApi, bool TBlocking, typename TTask>
-struct Enqueue<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>,
-               TTask> {
-  using QueueImpl = uniform_cuda_hip::detail::QueueUniformCudaHipRtImpl<TApi>;
+        //! The CUDA/HIP RT blocking queue enqueue trait specialization.
+        template<typename TApi, bool TBlocking, typename TTask>
+        struct Enqueue<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>, TTask>
+        {
+            using QueueImpl = uniform_cuda_hip::detail::QueueUniformCudaHipRtImpl<TApi>;
 
-  struct HostFuncData {
-    // We don't need to keep the queue alive, because in it's dtor it will
-    // synchronize with the CUDA/HIP stream and wait until all host functions
-    // and the CallbackThread are done. It's actually an error to copy the queue
-    // into the host function. Destroying it here would call CUDA/HIP APIs from
-    // the host function. Passing it further to the Callback thread, would make
-    // the Callback thread hold a task containing the queue with the
-    // CallbackThread itself. Destroying the task if no other queue instance
-    // exists will make the CallbackThread join itself and crash.
-    QueueImpl &q;
-    TTask t;
-  };
+            struct HostFuncData
+            {
+                // We don't need to keep the queue alive, because in it's dtor it will
+                // synchronize with the CUDA/HIP stream and wait until all host functions
+                // and the CallbackThread are done. It's actually an error to copy the queue
+                // into the host function. Destroying it here would call CUDA/HIP APIs from
+                // the host function. Passing it further to the Callback thread, would make
+                // the Callback thread hold a task containing the queue with the
+                // CallbackThread itself. Destroying the task if no other queue instance
+                // exists will make the CallbackThread join itself and crash.
+                QueueImpl& q;
+                TTask t;
+            };
 
-  ALPAKA_FN_HOST static void uniformCudaHipRtHostFunc(void *arg) {
-    auto data =
-        std::unique_ptr<HostFuncData>(reinterpret_cast<HostFuncData *>(arg));
-    auto &queue = data->q;
-    auto f = queue.m_callbackThread.submit([d = std::move(data)] { d->t(); });
-    f.wait();
-  }
+            ALPAKA_FN_HOST static void uniformCudaHipRtHostFunc(void* arg)
+            {
+                auto data = std::unique_ptr<HostFuncData>(reinterpret_cast<HostFuncData*>(arg));
+                auto& queue = data->q;
+                auto f = queue.m_callbackThread.submit([d = std::move(data)] { d->t(); });
+                f.wait();
+            }
 
-  ALPAKA_FN_HOST static auto enqueue(
-      uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> &queue,
-      TTask const &task) -> void {
-    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-        TApi::launchHostFunc(queue.getNativeHandle(), uniformCudaHipRtHostFunc,
-                             new HostFuncData{*queue.m_spQueueImpl, task}));
-    if constexpr (TBlocking)
-      ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-          TApi::streamSynchronize(queue.getNativeHandle()));
-  }
-};
+            ALPAKA_FN_HOST static auto enqueue(
+                uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>& queue,
+                TTask const& task) -> void
+            {
+                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::launchHostFunc(
+                    queue.getNativeHandle(),
+                    uniformCudaHipRtHostFunc,
+                    new HostFuncData{*queue.m_spQueueImpl, task}));
+                if constexpr(TBlocking)
+                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::streamSynchronize(queue.getNativeHandle()));
+            }
+        };
 
-//! The CUDA/HIP RT blocking queue native handle trait specialization.
-template <typename TApi, bool TBlocking>
-struct NativeHandle<
-    uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>> {
-  [[nodiscard]] static auto getNativeHandle(
-      uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const
-          &queue) {
-    return queue.getNativeHandle();
-  }
-};
-} // namespace trait
+        //! The CUDA/HIP RT blocking queue native handle trait specialization.
+        template<typename TApi, bool TBlocking>
+        struct NativeHandle<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>>
+        {
+            [[nodiscard]] static auto getNativeHandle(
+                uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const& queue)
+            {
+                return queue.getNativeHandle();
+            }
+        };
+    } // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
@@ -69,8 +69,8 @@ namespace alpaka
 
             ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(TApi::Stream_t stream)
                 : m_dev(alpaka::getDevByIdx(
-                      alpaka::PlatformUniformCudaHipRt<TApi>{},
-                      static_cast<std::size_t>(TApi::getCurrentDevice())))
+                    alpaka::PlatformUniformCudaHipRt<TApi>{},
+                    static_cast<std::size_t>(TApi::getCurrentDevice())))
                 , m_UniformCudaHipQueue(stream)
                 , m_isOwning(false)
             {
@@ -159,8 +159,9 @@ namespace alpaka
         template<typename TApi, bool TBlocking>
         struct GetDev<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>>
         {
-            ALPAKA_FN_HOST static auto getDev(uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const&
-                                                  queue) -> DevUniformCudaHipRt<TApi>
+            ALPAKA_FN_HOST static auto getDev(
+                uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const& queue)
+                -> DevUniformCudaHipRt<TApi>
             {
                 return queue.m_spQueueImpl->m_dev;
             }

--- a/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
@@ -1,6 +1,5 @@
-/* Copyright 2022 Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci, Bernhard Manfred Gruber,
- * Antonio Di Pilato
- * SPDX-License-Identifier: MPL-2.0
+/* Copyright 2022 Benjamin Worpitz, Matthias Werner, René Widera, Andrea Bocci,
+ * Bernhard Manfred Gruber, Antonio Di Pilato SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
@@ -25,247 +24,230 @@
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
-namespace alpaka
-{
-    template<typename TApi>
-    class EventUniformCudaHipRt;
+namespace alpaka {
+template <typename TApi> class EventUniformCudaHipRt;
 
-    template<typename TApi>
-    class DevUniformCudaHipRt;
+template <typename TApi> class DevUniformCudaHipRt;
 
-    template<typename TApi>
-    struct PlatformUniformCudaHipRt;
+template <typename TApi> struct PlatformUniformCudaHipRt;
 
-    namespace uniform_cuda_hip::detail
-    {
-        //! The CUDA/HIP RT queue implementation.
-        template<typename TApi>
-        class QueueUniformCudaHipRtImpl final
-        {
-        public:
-            ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(DevUniformCudaHipRt<TApi> const& dev)
-                : m_dev(dev)
-                , m_UniformCudaHipQueue()
-                , m_isOwning(true)
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+namespace uniform_cuda_hip::detail {
+//! The CUDA/HIP RT queue implementation.
+template <typename TApi> class QueueUniformCudaHipRtImpl final {
+public:
+  ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(DevUniformCudaHipRt<TApi> const &dev)
+      : m_dev(dev), m_UniformCudaHipQueue(), m_isOwning(true) {
+    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                // Set the current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(m_dev.getNativeHandle()));
+    // Set the current device.
+    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(m_dev.getNativeHandle()));
 
-                // - [cuda/hip]StreamDefault: Default queue creation flag.
-                // - [cuda/hip]StreamNonBlocking: Specifies that work running in the created queue may run
-                // concurrently with work in queue 0 (the NULL queue),
-                //   and that the created queue should perform no implicit synchronization with queue 0.
-                // Create the queue on the current device.
-                // NOTE: [cuda/hip]StreamNonBlocking is required to match the semantic implemented in the alpaka
-                // CPU queue. It would be too much work to implement implicit default queue synchronization on CPU.
+    // - [cuda/hip]StreamDefault: Default queue creation flag.
+    // - [cuda/hip]StreamNonBlocking: Specifies that work running in the created
+    // queue may run concurrently with work in queue 0 (the NULL queue),
+    //   and that the created queue should perform no implicit synchronization
+    //   with queue 0.
+    // Create the queue on the current device.
+    // NOTE: [cuda/hip]StreamNonBlocking is required to match the semantic
+    // implemented in the alpaka CPU queue. It would be too much work to
+    // implement implicit default queue synchronization on CPU.
 
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    TApi::streamCreateWithFlags(&m_UniformCudaHipQueue, TApi::streamNonBlocking));
-            }
+    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::streamCreateWithFlags(
+        &m_UniformCudaHipQueue, TApi::streamNonBlocking));
+  }
 
-            ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(TApi::Stream_t stream)
-                : m_dev(
-                      alpaka::getDevByIdx(
-                          alpaka::PlatformUniformCudaHipRt<TApi>{},
-                          static_cast<std::size_t>(TApi::getDevice())))
-                , m_UniformCudaHipQueue(stream)
-                , m_isOwning(false)
-            {
-            }
+  ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(TApi::Stream_t stream)
+      : m_dev(alpaka::getDevByIdx(alpaka::PlatformUniformCudaHipRt<TApi>{},
+                                  static_cast<std::size_t>(TApi::getDevice()))),
+        m_UniformCudaHipQueue(stream), m_isOwning(false) {}
 
-            QueueUniformCudaHipRtImpl(QueueUniformCudaHipRtImpl&&) = default;
-            auto operator=(QueueUniformCudaHipRtImpl&&) -> QueueUniformCudaHipRtImpl& = delete;
+  QueueUniformCudaHipRtImpl(QueueUniformCudaHipRtImpl &&) = default;
+  auto operator=(QueueUniformCudaHipRtImpl &&)
+      -> QueueUniformCudaHipRtImpl & = delete;
 
-            ALPAKA_FN_HOST ~QueueUniformCudaHipRtImpl()
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+  ALPAKA_FN_HOST ~QueueUniformCudaHipRtImpl() {
+    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                // Make sure all pending async work is finished before destroying the stream to guarantee determinism.
-                // This would not be necessary for plain CUDA/HIP operations, but we can have host functions in the
-                // stream, which reference this queue instance and its CallbackThread. Make sure they are done.
-                if(m_isOwning)
-                {
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::streamSynchronize(m_UniformCudaHipQueue));
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::streamDestroy(m_UniformCudaHipQueue));
-                }
-            }
+    // Make sure all pending async work is finished before destroying the stream
+    // to guarantee determinism. This would not be necessary for plain CUDA/HIP
+    // operations, but we can have host functions in the stream, which reference
+    // this queue instance and its CallbackThread. Make sure they are done.
+    if (m_isOwning) {
+      ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
+          TApi::streamSynchronize(m_UniformCudaHipQueue));
+      ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(
+          TApi::streamDestroy(m_UniformCudaHipQueue));
+    }
+  }
 
-            [[nodiscard]] auto getNativeHandle() const noexcept
-            {
-                return m_UniformCudaHipQueue;
-            }
+  [[nodiscard]] auto getNativeHandle() const noexcept {
+    return m_UniformCudaHipQueue;
+  }
 
-        public:
-            int m_deviceId;
-            DevUniformCudaHipRt<TApi> const m_dev; //!< The device this queue is bound to.
-            core::CallbackThread m_callbackThread;
+public:
+  int m_deviceId;
+  DevUniformCudaHipRt<TApi> const m_dev; //!< The device this queue is bound to.
+  core::CallbackThread m_callbackThread;
 
-        private:
-            typename TApi::Stream_t m_UniformCudaHipQueue;
-            bool m_isOwning;
-        };
+private:
+  typename TApi::Stream_t m_UniformCudaHipQueue;
+  bool m_isOwning;
+};
 
-        //! The CUDA/HIP RT queue.
-        template<typename TApi, bool TBlocking>
-        class QueueUniformCudaHipRt
-            : public interface::Implements<ConceptCurrentThreadWaitFor, QueueUniformCudaHipRt<TApi, TBlocking>>
-            , public interface::Implements<ConceptQueue, QueueUniformCudaHipRt<TApi, TBlocking>>
-            , public interface::Implements<ConceptGetDev, QueueUniformCudaHipRt<TApi, TBlocking>>
-        {
-        public:
-            ALPAKA_FN_HOST QueueUniformCudaHipRt(DevUniformCudaHipRt<TApi> const& dev)
-                : m_spQueueImpl(std::make_shared<QueueUniformCudaHipRtImpl<TApi>>(dev))
-            {
-                dev.registerQueue(m_spQueueImpl);
-            }
+//! The CUDA/HIP RT queue.
+template <typename TApi, bool TBlocking>
+class QueueUniformCudaHipRt
+    : public interface::Implements<ConceptCurrentThreadWaitFor,
+                                   QueueUniformCudaHipRt<TApi, TBlocking>>,
+      public interface::Implements<ConceptQueue,
+                                   QueueUniformCudaHipRt<TApi, TBlocking>>,
+      public interface::Implements<ConceptGetDev,
+                                   QueueUniformCudaHipRt<TApi, TBlocking>> {
+public:
+  ALPAKA_FN_HOST QueueUniformCudaHipRt(DevUniformCudaHipRt<TApi> const &dev)
+      : m_spQueueImpl(std::make_shared<QueueUniformCudaHipRtImpl<TApi>>(dev)) {
+    dev.registerQueue(m_spQueueImpl);
+  }
 
-            ALPAKA_FN_HOST QueueUniformCudaHipRt(typename TApi::Stream_t stream)
-                : m_spQueueImpl(std::make_shared<QueueUniformCudaHipRtImpl<TApi>>(stream))
-            {
-                m_spQueueImpl->m_dev.registerQueue(m_spQueueImpl);
-            }
+  ALPAKA_FN_HOST QueueUniformCudaHipRt(typename TApi::Stream_t stream)
+      : m_spQueueImpl(
+            std::make_shared<QueueUniformCudaHipRtImpl<TApi>>(stream)) {
+    m_spQueueImpl->m_dev.registerQueue(m_spQueueImpl);
+  }
 
-            ALPAKA_FN_HOST auto operator==(QueueUniformCudaHipRt const& rhs) const -> bool
-            {
-                return (m_spQueueImpl == rhs.m_spQueueImpl);
-            }
+  ALPAKA_FN_HOST auto operator==(QueueUniformCudaHipRt const &rhs) const
+      -> bool {
+    return (m_spQueueImpl == rhs.m_spQueueImpl);
+  }
 
-            ALPAKA_FN_HOST auto operator!=(QueueUniformCudaHipRt const& rhs) const -> bool
-            {
-                return !((*this) == rhs);
-            }
+  ALPAKA_FN_HOST auto operator!=(QueueUniformCudaHipRt const &rhs) const
+      -> bool {
+    return !((*this) == rhs);
+  }
 
-            [[nodiscard]] auto getNativeHandle() const noexcept
-            {
-                return m_spQueueImpl->getNativeHandle();
-            }
+  [[nodiscard]] auto getNativeHandle() const noexcept {
+    return m_spQueueImpl->getNativeHandle();
+  }
 
-            auto getCallbackThread() -> core::CallbackThread&
-            {
-                return m_spQueueImpl->m_callbackThread;
-            }
+  auto getCallbackThread() -> core::CallbackThread & {
+    return m_spQueueImpl->m_callbackThread;
+  }
 
-        public:
-            std::shared_ptr<QueueUniformCudaHipRtImpl<TApi>> m_spQueueImpl;
-        };
-    } // namespace uniform_cuda_hip::detail
+public:
+  std::shared_ptr<QueueUniformCudaHipRtImpl<TApi>> m_spQueueImpl;
+};
+} // namespace uniform_cuda_hip::detail
 
-    namespace trait
-    {
-        //! The CUDA/HIP RT queue device get trait specialization.
-        template<typename TApi, bool TBlocking>
-        struct GetDev<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>>
-        {
-            ALPAKA_FN_HOST static auto getDev(
-                uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const& queue)
-                -> DevUniformCudaHipRt<TApi>
-            {
-                return queue.m_spQueueImpl->m_dev;
-            }
-        };
+namespace trait {
+//! The CUDA/HIP RT queue device get trait specialization.
+template <typename TApi, bool TBlocking>
+struct GetDev<
+    uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>> {
+  ALPAKA_FN_HOST static auto
+  getDev(uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const
+             &queue) -> DevUniformCudaHipRt<TApi> {
+    return queue.m_spQueueImpl->m_dev;
+  }
+};
 
-        //! The CUDA/HIP RT queue test trait specialization.
-        template<typename TApi, bool TBlocking>
-        struct Empty<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>>
-        {
-            ALPAKA_FN_HOST static auto empty(
-                uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const& queue) -> bool
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+//! The CUDA/HIP RT queue test trait specialization.
+template <typename TApi, bool TBlocking>
+struct Empty<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>> {
+  ALPAKA_FN_HOST static auto
+  empty(uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const
+            &queue) -> bool {
+    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                // Query is allowed even for queues on non current device.
-                typename TApi::Error_t ret = TApi::success;
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
-                    ret = TApi::streamQuery(queue.getNativeHandle()),
-                    TApi::errorNotReady);
-                return (ret == TApi::success);
-            }
-        };
+    // Query is allowed even for queues on non current device.
+    typename TApi::Error_t ret = TApi::success;
+    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_IGNORE(
+        ret = TApi::streamQuery(queue.getNativeHandle()), TApi::errorNotReady);
+    return (ret == TApi::success);
+  }
+};
 
-        //! The CUDA/HIP RT queue thread wait trait specialization.
-        //!
-        //! Blocks execution of the calling thread until the queue has finished processing all previously requested
-        //! tasks (kernels, data copies, ...)
-        template<typename TApi, bool TBlocking>
-        struct CurrentThreadWaitFor<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>>
-        {
-            ALPAKA_FN_HOST static auto currentThreadWaitFor(
-                uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const& queue) -> void
-            {
-                ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+//! The CUDA/HIP RT queue thread wait trait specialization.
+//!
+//! Blocks execution of the calling thread until the queue has finished
+//! processing all previously requested tasks (kernels, data copies, ...)
+template <typename TApi, bool TBlocking>
+struct CurrentThreadWaitFor<
+    uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>> {
+  ALPAKA_FN_HOST static auto currentThreadWaitFor(
+      uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const
+          &queue) -> void {
+    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                // Sync is allowed even for queues on non current device.
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::streamSynchronize(queue.getNativeHandle()));
-            }
-        };
+    // Sync is allowed even for queues on non current device.
+    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+        TApi::streamSynchronize(queue.getNativeHandle()));
+  }
+};
 
-        //! The CUDA/HIP RT blocking queue device type trait specialization.
-        template<typename TApi, bool TBlocking>
-        struct DevType<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>>
-        {
-            using type = DevUniformCudaHipRt<TApi>;
-        };
+//! The CUDA/HIP RT blocking queue device type trait specialization.
+template <typename TApi, bool TBlocking>
+struct DevType<
+    uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>> {
+  using type = DevUniformCudaHipRt<TApi>;
+};
 
-        //! The CUDA/HIP RT blocking queue event type trait specialization.
-        template<typename TApi, bool TBlocking>
-        struct EventType<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>>
-        {
-            using type = EventUniformCudaHipRt<TApi>;
-        };
+//! The CUDA/HIP RT blocking queue event type trait specialization.
+template <typename TApi, bool TBlocking>
+struct EventType<
+    uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>> {
+  using type = EventUniformCudaHipRt<TApi>;
+};
 
-        //! The CUDA/HIP RT blocking queue enqueue trait specialization.
-        template<typename TApi, bool TBlocking, typename TTask>
-        struct Enqueue<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>, TTask>
-        {
-            using QueueImpl = uniform_cuda_hip::detail::QueueUniformCudaHipRtImpl<TApi>;
+//! The CUDA/HIP RT blocking queue enqueue trait specialization.
+template <typename TApi, bool TBlocking, typename TTask>
+struct Enqueue<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>,
+               TTask> {
+  using QueueImpl = uniform_cuda_hip::detail::QueueUniformCudaHipRtImpl<TApi>;
 
-            struct HostFuncData
-            {
-                // We don't need to keep the queue alive, because in it's dtor it will synchronize with the CUDA/HIP
-                // stream and wait until all host functions and the CallbackThread are done. It's actually an error to
-                // copy the queue into the host function. Destroying it here would call CUDA/HIP APIs from the host
-                // function. Passing it further to the Callback thread, would make the Callback thread hold a task
-                // containing the queue with the CallbackThread itself. Destroying the task if no other queue instance
-                // exists will make the CallbackThread join itself and crash.
-                QueueImpl& q;
-                TTask t;
-            };
+  struct HostFuncData {
+    // We don't need to keep the queue alive, because in it's dtor it will
+    // synchronize with the CUDA/HIP stream and wait until all host functions
+    // and the CallbackThread are done. It's actually an error to copy the queue
+    // into the host function. Destroying it here would call CUDA/HIP APIs from
+    // the host function. Passing it further to the Callback thread, would make
+    // the Callback thread hold a task containing the queue with the
+    // CallbackThread itself. Destroying the task if no other queue instance
+    // exists will make the CallbackThread join itself and crash.
+    QueueImpl &q;
+    TTask t;
+  };
 
-            ALPAKA_FN_HOST static void uniformCudaHipRtHostFunc(void* arg)
-            {
-                auto data = std::unique_ptr<HostFuncData>(reinterpret_cast<HostFuncData*>(arg));
-                auto& queue = data->q;
-                auto f = queue.m_callbackThread.submit([d = std::move(data)] { d->t(); });
-                f.wait();
-            }
+  ALPAKA_FN_HOST static void uniformCudaHipRtHostFunc(void *arg) {
+    auto data =
+        std::unique_ptr<HostFuncData>(reinterpret_cast<HostFuncData *>(arg));
+    auto &queue = data->q;
+    auto f = queue.m_callbackThread.submit([d = std::move(data)] { d->t(); });
+    f.wait();
+  }
 
-            ALPAKA_FN_HOST static auto enqueue(
-                uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>& queue,
-                TTask const& task) -> void
-            {
-                ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                    TApi::launchHostFunc(
-                        queue.getNativeHandle(),
-                        uniformCudaHipRtHostFunc,
-                        new HostFuncData{*queue.m_spQueueImpl, task}));
-                if constexpr(TBlocking)
-                    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::streamSynchronize(queue.getNativeHandle()));
-            }
-        };
+  ALPAKA_FN_HOST static auto enqueue(
+      uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> &queue,
+      TTask const &task) -> void {
+    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+        TApi::launchHostFunc(queue.getNativeHandle(), uniformCudaHipRtHostFunc,
+                             new HostFuncData{*queue.m_spQueueImpl, task}));
+    if constexpr (TBlocking)
+      ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
+          TApi::streamSynchronize(queue.getNativeHandle()));
+  }
+};
 
-        //! The CUDA/HIP RT blocking queue native handle trait specialization.
-        template<typename TApi, bool TBlocking>
-        struct NativeHandle<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>>
-        {
-            [[nodiscard]] static auto getNativeHandle(
-                uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const& queue)
-            {
-                return queue.getNativeHandle();
-            }
-        };
-    } // namespace trait
+//! The CUDA/HIP RT blocking queue native handle trait specialization.
+template <typename TApi, bool TBlocking>
+struct NativeHandle<
+    uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>> {
+  [[nodiscard]] static auto getNativeHandle(
+      uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking> const
+          &queue) {
+    return queue.getNativeHandle();
+  }
+};
+} // namespace trait
 } // namespace alpaka
 
 #endif

--- a/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
@@ -85,7 +85,6 @@ public:
   }
 
 public:
-  int m_deviceId;
   DevUniformCudaHipRt<TApi> const m_dev; //!< The device this queue is bound to.
   core::CallbackThread m_callbackThread;
 

--- a/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
@@ -67,7 +67,7 @@ namespace alpaka
                     TApi::streamCreateWithFlags(&m_UniformCudaHipQueue, TApi::streamNonBlocking));
             }
 
-            ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(TApi::Stream_t stream)
+            ALPAKA_FN_HOST QueueUniformCudaHipRtImpl(typename TApi::Stream_t stream)
                 : m_dev(alpaka::getDevByIdx(
                     alpaka::PlatformUniformCudaHipRt<TApi>{},
                     static_cast<std::size_t>(TApi::getCurrentDevice())))

--- a/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
+++ b/include/alpaka/queue/cuda-hip/QueueUniformCudaHipRt.hpp
@@ -188,8 +188,8 @@ namespace alpaka
 
         //! The CUDA/HIP RT queue thread wait trait specialization.
         //!
-        //! Blocks execution of the calling thread until the queue has finished
-        //! processing all previously requested tasks (kernels, data copies, ...)
+        //! Blocks execution of the calling thread until the queue has finished processing all previously requested
+        //! tasks (kernels, data copies, ...)
         template<typename TApi, bool TBlocking>
         struct CurrentThreadWaitFor<uniform_cuda_hip::detail::QueueUniformCudaHipRt<TApi, TBlocking>>
         {
@@ -225,13 +225,11 @@ namespace alpaka
 
             struct HostFuncData
             {
-                // We don't need to keep the queue alive, because in it's dtor it will
-                // synchronize with the CUDA/HIP stream and wait until all host functions
-                // and the CallbackThread are done. It's actually an error to copy the queue
-                // into the host function. Destroying it here would call CUDA/HIP APIs from
-                // the host function. Passing it further to the Callback thread, would make
-                // the Callback thread hold a task containing the queue with the
-                // CallbackThread itself. Destroying the task if no other queue instance
+                // We don't need to keep the queue alive, because in it's dtor it will synchronize with the CUDA/HIP
+                // stream and wait until all host functions and the CallbackThread are done. It's actually an error to
+                // copy the queue into the host function. Destroying it here would call CUDA/HIP APIs from the host
+                // function. Passing it further to the Callback thread, would make the Callback thread hold a task
+                // containing the queue with the CallbackThread itself. Destroying the task if no other queue instance
                 // exists will make the CallbackThread join itself and crash.
                 QueueImpl& q;
                 TTask t;

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -294,7 +294,7 @@ TEMPLATE_LIST_TEST_CASE("constructQueueWithStream", "[queue]", alpaka::test::Tes
     Api::Stream_t stream;
     ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(Api::streamCreate(&stream));
     auto queue = alpaka::QueueUniformCudaHipRtBlocking<Api>(stream);
-    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(Api::streamDestroy(stream));
+    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(Api::streamDestroy(stream));
 }
 
 #endif

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -281,25 +281,23 @@ TEMPLATE_LIST_TEST_CASE("isQueue", "[queue]", alpaka::test::TestQueues)
     REQUIRE(alpaka::isQueue<decltype(f.m_queue)>);
 }
 
-#if defined(alpaka_ACC_GPU_CUDA_ENABLE)
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
+
+#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
 using Api = alpaka::ApiCudaRt;
-#elif defined(alpaka_ACC_GPU_HIP_ENABLE)
+#    elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 using Api = alpaka::ApiHipRt;
-#endif
+#    endif
 
 TEMPLATE_LIST_TEST_CASE("constructQueueWithStream", "[queue]", alpaka::test::TestQueues)
 {
-#if defined(alpaka_ACC_GPU_CUDA_ENABLE) || defined(alpaka_ACC_GPU_HIP_ENABLE)
     using DevQueue = TestType;
     Api::Stream_t stream;
     Api::streamCreate(&stream);
 
-    auto queue = DevQueue(stream);
-    // maybe check the public device member?
-    REQUIRE(alpaka::isQueue<decltype(queue)>);
+    auto queue = alpaka::QueueUniformCudaHipRtBlocking<Api>(stream);
 
     Api::streamDestroy(stream);
-#else
-    REQUIRE(true);
-#endif
 }
+
+#endif

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -284,17 +284,17 @@ TEMPLATE_LIST_TEST_CASE("isQueue", "[queue]", alpaka::test::TestQueues)
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
 #    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-using Api = alpaka::ApiCudaRt;
+using TApi = alpaka::ApiCudaRt;
 #    elif defined(ALPAKA_ACC_GPU_HIP_ENABLED)
-using Api = alpaka::ApiHipRt;
+using TApi = alpaka::ApiHipRt;
 #    endif
 
 TEMPLATE_LIST_TEST_CASE("constructQueueWithStream", "[queue]", alpaka::test::TestQueues)
 {
-    Api::Stream_t stream;
-    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(Api::streamCreate(&stream));
-    auto queue = alpaka::QueueUniformCudaHipRtBlocking<Api>(stream);
-    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(Api::streamDestroy(stream));
+    TApi::Stream_t stream;
+    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::streamCreate(&stream));
+    auto queue = alpaka::QueueUniformCudaHipRtBlocking<TApi>(stream);
+    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::streamDestroy(stream));
 }
 
 #endif

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -294,9 +294,7 @@ TEMPLATE_LIST_TEST_CASE("constructQueueWithStream", "[queue]", alpaka::test::Tes
     using DevQueue = TestType;
     Api::Stream_t stream;
     Api::streamCreate(&stream);
-
     auto queue = alpaka::QueueUniformCudaHipRtBlocking<Api>(stream);
-
     Api::streamDestroy(stream);
 }
 

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -2,6 +2,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <alpaka/core/ApiCudaRt.hpp>
+#include <alpaka/core/ApiHipRt.hpp>
 #include <alpaka/meta/Concatenate.hpp>
 #include <alpaka/queue/Traits.hpp>
 #include <alpaka/test/queue/Queue.hpp>
@@ -277,4 +279,27 @@ TEMPLATE_LIST_TEST_CASE("isQueue", "[queue]", alpaka::test::TestQueues)
     Fixture f;
 
     REQUIRE(alpaka::isQueue<decltype(f.m_queue)>);
+}
+
+#if defined(alpaka_ACC_GPU_CUDA_ENABLE)
+using Api = alpaka::ApiCudaRt;
+#elif defined(alpaka_ACC_GPU_HIP_ENABLE)
+using Api = alpaka::ApiHipRt;
+#endif
+
+TEMPLATE_LIST_TEST_CASE("constructQueueWithStream", "[queue]", alpaka::test::TestQueues)
+{
+#if defined(alpaka_ACC_GPU_CUDA_ENABLE) || defined(alpaka_ACC_GPU_HIP_ENABLE)
+    using DevQueue = TestType;
+    Api::Stream_t stream;
+    Api::streamCreate(&stream);
+
+    auto queue = DevQueue(stream);
+    // maybe check the public device member?
+    REQUIRE(alpaka::isQueue<decltype(queue)>);
+
+    Api::streamDestroy(stream);
+#else
+    REQUIRE(true);
+#endif
 }

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -292,9 +292,9 @@ using Api = alpaka::ApiHipRt;
 TEMPLATE_LIST_TEST_CASE("constructQueueWithStream", "[queue]", alpaka::test::TestQueues)
 {
     Api::Stream_t stream;
-    Api::streamCreate(&stream);
+    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(Api::streamCreate(&stream));
     auto queue = alpaka::QueueUniformCudaHipRtBlocking<Api>(stream);
-    Api::streamDestroy(stream);
+    ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(Api::streamDestroy(stream));
 }
 
 #endif

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -291,7 +291,6 @@ using Api = alpaka::ApiHipRt;
 
 TEMPLATE_LIST_TEST_CASE("constructQueueWithStream", "[queue]", alpaka::test::TestQueues)
 {
-    using DevQueue = TestType;
     Api::Stream_t stream;
     Api::streamCreate(&stream);
     auto queue = alpaka::QueueUniformCudaHipRtBlocking<Api>(stream);


### PR DESCRIPTION
This PR implements the possibility of creating a CUDA/HIP Queue from an externally defined Stream.
To do this, the boolean member `isOwning` was added to the Queue class, which turns off the Stream destruction if the Queue was "not owning".
It also adds two overloads for the `cuda/hipGetDevice`, which were missing from the runtime APIs.