### PR TITLE
[1.3] Add missing #includes for SYCL tags

### DIFF
--- a/include/alpaka/mem/buf/BufCpuSycl.hpp
+++ b/include/alpaka/mem/buf/BufCpuSycl.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/acc/Tag.hpp"
 #include "alpaka/mem/buf/BufGenericSycl.hpp"
 
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_ONEAPI_CPU)

--- a/include/alpaka/mem/buf/BufFpgaSyclIntel.hpp
+++ b/include/alpaka/mem/buf/BufFpgaSyclIntel.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/acc/Tag.hpp"
 #include "alpaka/mem/buf/BufGenericSycl.hpp"
 
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_ONEAPI_FPGA)

--- a/include/alpaka/mem/buf/BufGpuSyclIntel.hpp
+++ b/include/alpaka/mem/buf/BufGpuSyclIntel.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/acc/Tag.hpp"
 #include "alpaka/mem/buf/BufGenericSycl.hpp"
 
 #if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(ALPAKA_SYCL_ONEAPI_GPU)

--- a/include/alpaka/mem/global/DeviceGlobalGenericSycl.hpp
+++ b/include/alpaka/mem/global/DeviceGlobalGenericSycl.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/acc/Tag.hpp"
 #include "alpaka/elem/Traits.hpp"
 #include "alpaka/mem/global/Traits.hpp"
 #include "alpaka/queue/sycl/QueueGenericSyclBase.hpp"

--- a/include/alpaka/platform/PlatformCpuSycl.hpp
+++ b/include/alpaka/platform/PlatformCpuSycl.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/acc/Tag.hpp"
 #include "alpaka/dev/DevGenericSycl.hpp"
 #include "alpaka/dev/Traits.hpp"
 #include "alpaka/platform/PlatformGenericSycl.hpp"

--- a/include/alpaka/platform/PlatformFpgaSyclIntel.hpp
+++ b/include/alpaka/platform/PlatformFpgaSyclIntel.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/acc/Tag.hpp"
 #include "alpaka/dev/DevGenericSycl.hpp"
 #include "alpaka/dev/Traits.hpp"
 #include "alpaka/platform/PlatformGenericSycl.hpp"

--- a/include/alpaka/platform/PlatformGpuSyclIntel.hpp
+++ b/include/alpaka/platform/PlatformGpuSyclIntel.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "alpaka/acc/Tag.hpp"
 #include "alpaka/dev/DevGenericSycl.hpp"
 #include "alpaka/dev/Traits.hpp"
 #include "alpaka/platform/PlatformGenericSycl.hpp"


### PR DESCRIPTION
Backport #2534 to the develop-1.3 branch.