### PR TITLE
Use `__builtin_assume_aligned()` to promise the correct alignment

### DIFF
--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynMember.hpp
@@ -92,22 +92,15 @@ namespace alpaka
         template<typename T, std::size_t TStaticAllocKiB>
         struct GetDynSharedMem<T, BlockSharedMemDynMember<TStaticAllocKiB>>
         {
-#if ALPAKA_COMP_GNUC
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored                                                                                    \
-        "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
-#endif
             static auto getMem(BlockSharedMemDynMember<TStaticAllocKiB> const& mem) -> T*
             {
+                constexpr auto alignment = core::vectorization::defaultAlignment;
                 static_assert(
-                    core::vectorization::defaultAlignment >= alignof(T),
+                    alignment >= alignof(T),
                     "Unable to get block shared dynamic memory for types with alignment higher than "
                     "defaultAlignment!");
-                return reinterpret_cast<T*>(mem.dynMemBegin());
+                return reinterpret_cast<T*>(__builtin_assume_aligned(mem.dynMemBegin(), alignment));
             }
-#if ALPAKA_COMP_GNUC
-#    pragma GCC diagnostic pop
-#endif
         };
     } // namespace trait
 } // namespace alpaka

--- a/include/alpaka/block/shared/st/BlockSharedMemStMemberMasterSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMemberMasterSync.hpp
@@ -40,11 +40,6 @@ namespace alpaka
 
     namespace trait
     {
-#if ALPAKA_COMP_GNUC
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored                                                                                    \
-        "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
-#endif
         template<typename T, std::size_t TDataAlignBytes, std::size_t TuniqueId>
         struct DeclareSharedVar<T, TuniqueId, BlockSharedMemStMemberMasterSync<TDataAlignBytes>>
         {
@@ -71,9 +66,7 @@ namespace alpaka
                 return *data;
             }
         };
-#if ALPAKA_COMP_GNUC
-#    pragma GCC diagnostic pop
-#endif
+
         template<std::size_t TDataAlignBytes>
         struct FreeSharedVars<BlockSharedMemStMemberMasterSync<TDataAlignBytes>>
         {

--- a/include/alpaka/block/shared/st/detail/BlockSharedMemStMemberImpl.hpp
+++ b/include/alpaka/block/shared/st/detail/BlockSharedMemStMemberImpl.hpp
@@ -64,12 +64,6 @@ namespace alpaka::detail
             meta->offset = m_allocdBytes;
         }
 
-#if ALPAKA_COMP_GNUC
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored                                                                                    \
-        "-Wcast-align" // "cast from 'unsigned char*' to 'unsigned int*' increases required alignment of target type"
-#endif
-
         //! Give the pointer to an exiting variable
         //!
         //! @tparam T type of the variable
@@ -89,11 +83,12 @@ namespace alpaka::detail
                     = varChunkEnd<MetaData>(off) - static_cast<std::uint32_t>(sizeof(MetaData));
                 ALPAKA_ASSERT_ACC(
                     (alignedMetaDataOffset + static_cast<std::uint32_t>(sizeof(MetaData))) <= m_allocdBytes);
-                auto* metaDataPtr = reinterpret_cast<MetaData*>(m_mem + alignedMetaDataOffset);
+                auto* metaDataPtr = reinterpret_cast<MetaData*>(
+                    __builtin_assume_aligned(m_mem + alignedMetaDataOffset, alignof(MetaData)));
                 off = metaDataPtr->offset;
 
                 if(metaDataPtr->id == id)
-                    return reinterpret_cast<T*>(&m_mem[off - sizeof(T)]);
+                    return reinterpret_cast<T*>(__builtin_assume_aligned(&m_mem[off - sizeof(T)], alignof(T)));
             }
 
             // Variable not found.
@@ -104,14 +99,10 @@ namespace alpaka::detail
         template<typename T>
         auto getLatestVarPtr() const -> T*
         {
-            return reinterpret_cast<T*>(&m_mem[m_allocdBytes - sizeof(T)]);
+            return reinterpret_cast<T*>(__builtin_assume_aligned(&m_mem[m_allocdBytes - sizeof(T)], alignof(T)));
         }
 
     private:
-#if ALPAKA_COMP_GNUC
-#    pragma GCC diagnostic pop
-#endif
-
         //! Byte offset to the end of the memory chunk
         //!
         //! Calculate bytes required to store a type with a aligned starting address in m_mem.

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -568,14 +568,7 @@ namespace alpaka
                     ALPAKA_FN_HOST_ACC constexpr reference access(data_handle_type p, size_t i) const noexcept
                     {
                         assert(i % alignof(ElementType) == 0);
-#    if ALPAKA_COMP_GNUC
-#        pragma GCC diagnostic push
-#        pragma GCC diagnostic ignored "-Wcast-align"
-#    endif
-                        return *reinterpret_cast<ElementType*>(p + i);
-#    if ALPAKA_COMP_GNUC
-#        pragma GCC diagnostic pop
-#    endif
+                        return *reinterpret_cast<ElementType*>(__builtin_assume_aligned(p + i, alignof(ElementType)));
                     }
                 };
 

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -92,17 +92,10 @@ namespace alpaka
     public:
         ALPAKA_FN_HOST auto computeNativePtr()
         {
-#if ALPAKA_COMP_GNUC
-#    pragma GCC diagnostic push
-            // "cast from 'std::uint8_t*' to 'TElem*' increases required alignment of target type"
-#    pragma GCC diagnostic ignored "-Wcast-align"
-#endif
-            return reinterpret_cast<TElem*>(
-                reinterpret_cast<std::uint8_t*>(alpaka::getPtrNative(m_viewParentView))
-                + (m_offsetsElements * getPitchesInBytes(m_viewParentView)).sum());
-#if ALPAKA_COMP_GNUC
-#    pragma GCC diagnostic pop
-#endif
+            TElem* base = alpaka::getPtrNative(m_viewParentView);
+            auto offset = (m_offsetsElements * getPitchesInBytes(m_viewParentView)).sum();
+            std::byte* ptr = reinterpret_cast<std::byte*>(base) + offset;
+            return reinterpret_cast<TElem*>(__builtin_assume_aligned(ptr, alignof(TElem)));
         }
 
         ViewPlainPtr<Dev, TElem, TDim, TIdx> m_viewParentView; // This wraps the parent view.

--- a/include/alpaka/test/mem/view/Iterator.hpp
+++ b/include/alpaka/test/mem/view/Iterator.hpp
@@ -86,15 +86,9 @@ namespace alpaka::test
                         = mapIdx<Dim::value>(Vec<DimInt<1>, Idx>{m_currentIdx}, m_extents);
                     auto const offsetInBytes = (currentIdxDimx * m_pitchBytes).sum();
                     using QualifiedByte = MimicConst<std::byte, Elem>;
-#if ALPAKA_COMP_GNUC
-#    pragma GCC diagnostic push
-                    // "cast from 'Byte*' to 'Elem*' increases required alignment of target type"
-#    pragma GCC diagnostic ignored "-Wcast-align"
-#endif
-                    return *reinterpret_cast<Elem*>(reinterpret_cast<QualifiedByte*>(m_nativePtr) + offsetInBytes);
-#if ALPAKA_COMP_GNUC
-#    pragma GCC diagnostic pop
-#endif
+                    return *reinterpret_cast<Elem*>(__builtin_assume_aligned(
+                        reinterpret_cast<QualifiedByte*>(m_nativePtr) + offsetInBytes,
+                        alignof(Elem)));
                 }
                 ALPAKA_UNREACHABLE(*m_nativePtr);
             }

--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -16,12 +16,6 @@
 #include <tuple>
 #include <type_traits>
 
-#if ALPAKA_COMP_GNUC
-#    pragma GCC diagnostic push
-// "cast from 'std::uint8_t*' to 'Elem*' increases required alignment of target type"
-#    pragma GCC diagnostic ignored "-Wcast-align"
-#endif
-
 namespace alpaka::test
 {
     template<typename TAcc, typename TElem, bool Const>
@@ -91,9 +85,6 @@ namespace alpaka::test
         CHECK(alpaka::getPtrNative(viewMove) == nativePtr2);
     }
 } // namespace alpaka::test
-#if ALPAKA_COMP_GNUC
-#    pragma GCC diagnostic pop
-#endif
 
 TEMPLATE_LIST_TEST_CASE("viewPlainPtrTest", "[memView]", alpaka::test::TestAccs)
 {

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -16,12 +16,6 @@
 #include <numeric>
 #include <type_traits>
 
-#if ALPAKA_COMP_GNUC
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored                                                                                    \
-        "-Wcast-align" // "cast from 'std::uint8_t*' to 'Elem*' increases required alignment of target type"
-#endif
-
 namespace alpaka::test
 {
     template<typename TAcc, typename TDev, typename TElem, typename TDim, typename TIdx, typename TBuf>
@@ -48,7 +42,7 @@ namespace alpaka::test
             auto viewPtrNative = reinterpret_cast<std::uint8_t*>(alpaka::getPtrNative(buf));
             if constexpr(TDim::value > 0)
                 viewPtrNative += (offsetView * pitchBuf).sum();
-            REQUIRE(reinterpret_cast<TElem*>(viewPtrNative) == alpaka::getPtrNative(view));
+            REQUIRE(viewPtrNative == reinterpret_cast<std::uint8_t const*>(alpaka::getPtrNative(view)));
         }
     }
 
@@ -130,9 +124,6 @@ namespace alpaka::test
         alpaka::test::testViewSubViewImmutable<TAcc>(view, buf, dev, viewExtent, viewOffset);
     }
 } // namespace alpaka::test
-#if ALPAKA_COMP_GNUC
-#    pragma GCC diagnostic pop
-#endif
 
 TEMPLATE_LIST_TEST_CASE("viewSubViewNoOffsetTest", "[memView]", alpaka::test::TestAccs)
 {


### PR DESCRIPTION
Use `__builtin_assume_aligned()` where needed to guarantee the correct alignment to the compiler, instead of disabling the `-Wcast-align` warning.

Note: the same effect could be achieved with an intermediate cast to `uintptr_t`. In principle `__builtin_assume_aligned()` should be preferred because the compiler might actually make use of the information.