### PR TITLE
support CI Container image 4.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ variables:
   # container version of the generated jobs
   # should be merged with ALPAKA_GITLAB_CI_CONTAINER_VERSION
   # see: script/job_generator/generate_job_yaml.py
-  ALPAKA_GITLAB_CI_GENERATOR_CONTAINER_VERSION: "3.2"
+  ALPAKA_GITLAB_CI_GENERATOR_CONTAINER_VERSION: "4.0"
 
 generate:
   stage: generator

--- a/script/gitlabci/job_base.yml
+++ b/script/gitlabci/job_base.yml
@@ -18,7 +18,7 @@
 .basecfg_cuda_gcc:
   image: ubuntu:${ALPAKA_CI_UBUNTU_VER}
   variables:
-    ALPAKA_CI_UBUNTU_VER: "20.04"
+    ALPAKA_CI_UBUNTU_VER: "24.04"
     ALPAKA_CI_CXX: g++
     alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE: "ON"
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "ON"
@@ -50,7 +50,7 @@
 .basecfg_cuda_clang:
   image: ubuntu:${ALPAKA_CI_UBUNTU_VER}
   variables:
-    ALPAKA_CI_UBUNTU_VER: "20.04"
+    ALPAKA_CI_UBUNTU_VER: "24.04"
     ALPAKA_CI_CXX: clang++
     alpaka_ACC_CPU_B_SEQ_T_THREADS_ENABLE: "ON"
     alpaka_ACC_CPU_B_OMP2_T_SEQ_ENABLE: "ON"

--- a/script/gitlabci/job_cuda.yml
+++ b/script/gitlabci/job_cuda.yml
@@ -3,9 +3,9 @@
 # nvcc + g++
 linux_nvcc12.0_gcc11_debug_relocatable_device_code_compile_only:
   extends: .base_cuda_gcc_compile_only
-  image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu20.04-cuda110-gcc:3.2
+  image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu24.04-cuda120-gcc:4.0
   variables:
-    ALPAKA_CI_UBUNTU_VER: "20.04"
+    ALPAKA_CI_UBUNTU_VER: "24.04"
     ALPAKA_CI_CUDA_VERSION: "12.0"
     ALPAKA_CI_GCC_VER: 11
     CMAKE_BUILD_TYPE: Debug
@@ -19,9 +19,9 @@ linux_nvcc12.0_gcc11_debug_relocatable_device_code_compile_only:
 
 linux_nvcc12.0_gcc11_release_extended_lambda_off_compile_only:
   extends: .base_cuda_gcc_compile_only
-  image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu20.04-cuda110-gcc:3.2
+  image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu24.04-cuda120-gcc:4.0
   variables:
-    ALPAKA_CI_UBUNTU_VER: "20.04"
+    ALPAKA_CI_UBUNTU_VER: "24.04"
     ALPAKA_CI_CUDA_VERSION: "12.0"
     ALPAKA_CI_GCC_VER: 11
     CMAKE_BUILD_TYPE: Release
@@ -36,9 +36,9 @@ linux_nvcc12.0_gcc11_release_extended_lambda_off_compile_only:
 
 linux_nvcc12.5_gcc13_release_cuda_only_mode:
   extends: .base_cuda_gcc
-  image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu20.04-gcc:3.2
+  image: registry.hzdr.de/crp/alpaka-group-container/alpaka-ci-ubuntu24.04-cuda125-gcc:4.0
   variables:
-    ALPAKA_CI_UBUNTU_VER: "20.04"
+    ALPAKA_CI_UBUNTU_VER: "24.04"
     ALPAKA_CI_CUDA_VERSION: "12.5"
     ALPAKA_CI_GCC_VER: 13
     CMAKE_BUILD_TYPE: Release

--- a/script/job_generator/alpaka_filter.py
+++ b/script/job_generator/alpaka_filter.py
@@ -142,11 +142,35 @@ def alpaka_post_filter(row: List) -> bool:
         ):
             return False
 
-    # except for the ROCm images, we use only the Ubuntu 24.04 image
+    # we use the Ubuntu 22.04 for
+    # - HIP 6.0 until 6.2
+    # - If Clang 14 and older is used
+    # - If CUDA 12.3 and older is used, because the CUDA versions does not support the libstdc++ 13
+    #   which is provided by the Ubuntu host compiler GCC 13
     # the ROCm Ubuntu support is handled by the alpaka-job-matrix-library
     if row_check_version(row, UBUNTU, "==", "22.04"):
         for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
-            if row_check_name(row, compiler_type, "!=", HIPCC):
-                return False
+            for compiler in (GCC, ICPX):
+                if row_check_name(row, compiler_type, "==", compiler):
+                    return False
 
+            for compiler in (CLANG, CLANG_CUDA):
+                if row_check_name(
+                    row, compiler_type, "==", compiler
+                ) and row_check_version(row, compiler_type, ">", "14"):
+                    return False
+
+    if row_check_version(row, UBUNTU, "==", "24.04"):
+        for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+            for compiler in (CLANG, CLANG_CUDA):
+                if row_check_name(
+                    row, compiler_type, "==", compiler
+                ) and row_check_version(row, compiler_type, "<", "15"):
+                    return False
+            if (
+                row_check_name(row, DEVICE_COMPILER, "==", NVCC)
+                and row_check_name(row, HOST_COMPILER, "==", CLANG)
+                and row_check_version(row, DEVICE_COMPILER, "<=", "12.3")
+            ):
+                return False
     return True

--- a/script/job_generator/alpaka_filter.py
+++ b/script/job_generator/alpaka_filter.py
@@ -142,4 +142,11 @@ def alpaka_post_filter(row: List) -> bool:
         ):
             return False
 
+    # except for the ROCm images, we use only the Ubuntu 24.04 image
+    # the ROCm Ubuntu support is handled by the alpaka-job-matrix-library
+    if row_check_version(row, UBUNTU, "==", "22.04"):
+        for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
+            if row_check_name(row, compiler_type, "!=", HIPCC):
+                return False
+
     return True

--- a/script/job_generator/requirements.txt
+++ b/script/job_generator/requirements.txt
@@ -1,4 +1,4 @@
-alpaka-job-coverage == 1.5.8
+alpaka-job-coverage == 1.6.0
 allpairspy == 2.5.0
 typeguard < 3.0.0
 pyaml

--- a/script/job_generator/versions.py
+++ b/script/job_generator/versions.py
@@ -67,7 +67,7 @@ sw_versions: Dict[str, List[str]] = {
             ALPAKA_ACC_SYCL_ENABLE,
         ],
     ],
-    UBUNTU: ["20.04"],
+    UBUNTU: ["22.04", "24.04"],
     CMAKE: ["3.25.3", "3.26.4", "3.27.9", "3.28.6", "3.29.8", "3.30.3"],
     BOOST: [
         "1.74.0",


### PR DESCRIPTION
- container 4.0 uses Ubuntu 22.04 and 24.04 as base images