### PR TITLE
release 1.3.0 changelog, version and zenodo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -8,27 +8,14 @@
       "orcid": "0000-0002-6515-5666"
     },
     {
+      "name": "Widera, René",
+      "affiliation": "Helmholtz-Zentrum Dresden-Rossendorf",
+      "orcid": "0000-0003-1642-0459"
+    },
+    {
       "name": "Ehrig, Simeon",
       "affiliation": "Helmholtz-Zentrum Dresden-Rossendorf",
       "orcid": "0000-0002-8218-3116"
-    },
-    {
-      "name": "Erdem, Sven",
-      "affiliation": "Helmholtz-Zentrum Berlin"
-    },
-    {
-      "name": "Fila, Mateusz Jakub",
-      "affiliation": "CERN"
-    },
-    {
-      "name": "Gruber, Bernhard Manfred",
-      "affiliation": "CASUS, Helmholtz-Zentrum Dresden-Rossendorf, CERN",
-      "orcid": "0000-0001-7848-1690"
-    },
-    {
-      "name": "Lenz, Julian",
-      "affiliation": "CASUS, Helmholtz-Zentrum Dresden-Rossendorf",
-      "orcid": "0000-0001-5250-0005"
     },
     {
       "name": "Perego, Aurora",
@@ -36,25 +23,44 @@
       "orcid": "0009-0002-5210-6213"
     },
     {
-      "name": "Varvarin, Michael",
-      "affiliation": "CASUS, Helmholtz-Zentrum Dresden-Rossendorf"
-    },
-    {
-      "name": "Vyskočil, Jiří",
-      "affiliation": "CASUS, Helmholtz-Zentrum Dresden-Rossendorf",
-      "orcid": "0000-0001-8822-0929"
-    },
-    {
-      "name": "Widera, René",
-      "affiliation": "Helmholtz-Zentrum Dresden-Rossendorf",
-      "orcid": "0000-0003-1642-0459"
-    },
-    {
       "name": "Yusufoglu, Mehmet",
       "affiliation": "CASUS, Helmholtz-Zentrum Dresden-Rossendorf"
     }
   ],
   "contributors": [
+    {
+      "name": "Erdem, Sven",
+      "affiliation": "Helmholtz-Zentrum Berlin",
+      "type": "Other"
+    },
+    {
+      "name": "Fila, Mateusz Jakub",
+      "affiliation": "CERN",
+      "type": "Other"
+    },
+    {
+      "name": "Gruber, Bernhard Manfred",
+      "affiliation": "CASUS, Helmholtz-Zentrum Dresden-Rossendorf, CERN",
+      "orcid": "0000-0001-7848-1690",
+      "type": "Other"
+    },
+    {
+      "name": "Lenz, Julian",
+      "affiliation": "CASUS, Helmholtz-Zentrum Dresden-Rossendorf",
+      "orcid": "0000-0001-5250-0005",
+      "type": "Other"
+    },
+    {
+      "name": "Varvarin, Michael",
+      "affiliation": "CASUS, Helmholtz-Zentrum Dresden-Rossendorf",
+      "type": "Other"
+    },
+    {
+      "name": "Vyskočil, Jiří",
+      "affiliation": "CASUS, Helmholtz-Zentrum Dresden-Rossendorf",
+      "orcid": "0000-0001-8822-0929",
+      "type": "Other"
+    },
     {
       "name": "Bastrakov, Sergei",
       "affiliation": "Helmholtz-Zentrum Dresden-Rossendorf",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,39 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.3.0] - 2025-07-04
+
+### Added
+
+- add static function `dim()` to alpaka::Vec #2428
+- add math functions for complex type for the oneAPI backend #2447
+- Gitlab CI: enable test for the SYCL CPU backend #2462
+
+### Changed
+
+- Intel FPGA SYCL backend does not support 64-bit atomics #2453
+- update Ubuntu 20.04 images in GitHub Actions #2522
+- alpaka::math custom implementations for CPU backend #2525
+
+### Fixed
+
+- fix parallelLoopPatterns for the Intel FPGA SYCL back-end #2457
+- fix bablestream benchmark #2521
+- add missing wait to get correct timer information #2523
+- rename directory cuda_hip to cuda-hip to fix amalgamation #2524
+- fix `ALPAKA_THROW_ACC` for CUDA/HIP-only mode #2529
+- add `#include <chrono>` everywhere it is used #2530
+- SYCL:
+  - fix SYCL index order #2526
+  - change attribute intel::reqd_sub_group_size to sycl::reqd_sub_group_size #2528
+  - fix template arguments of SYCL buffer specializations #2429
+  - protect usage of `__SYCL_TARGET` macros #2532
+- CI:
+  - backport CI fixes from 2.0 dev branch #2449
+  - update GitHub Action checkout action and upload-artifact action to v4 #2455
+  - disable test not supported by SYCL #2469
+  - disable SYCL warp tests #2527
+
 ## [1.2.0] - 2024-10-02
 
 ### Added

--- a/include/alpaka/version.hpp
+++ b/include/alpaka/version.hpp
@@ -7,7 +7,7 @@
 #include <boost/predef/version_number.h>
 
 #define ALPAKA_VERSION_MAJOR 1
-#define ALPAKA_VERSION_MINOR 2
+#define ALPAKA_VERSION_MINOR 3
 #define ALPAKA_VERSION_PATCH 0
 
 //! The alpaka library version number


### PR DESCRIPTION
- update zenodo file
- write changelog for 1.3.0
- update version to 1.3.0

note: I have not ordered the contributor section (call it lazyness)  because in the dev branch we will take over the changes from release 2.0.0.