### PR TITLE
Implement `alpaka::transform`

### DIFF
--- a/docs/source/dev/backends.rst
+++ b/docs/source/dev/backends.rst
@@ -381,7 +381,7 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMallocArray            | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMallocAsync            | alpaka::allocAsyncBuf<TElement>(queue, extents1D)                                          |
+    | cudaMallocAsync            | alpaka::allocAsyncBuf<TElement>(queue, extents) 1D, 2D, 3D supported!                      |
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMallocHost             | alpaka::allocMappedBuf<TElement, TIdx>(host, platform, extents) 1D, 2D, 3D supported! [1]  |
     +----------------------------+--------------------------------------------------------------------------------------------+
@@ -454,7 +454,7 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMemset2D               | alpaka::memset(queue, memBufDst, byte, extents2D)                                          |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemset2DAsync          | alpaka::memset(queue, memBufDst, byte, extents2D, queue)                                   |
+    | cudaMemset2DAsync          | alpaka::memset(queue, memBufDst, byte, extents2D)                                          |
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMemset3D               | alpaka::memset(queue, memBufDst, byte, extents3D)                                          |
     +----------------------------+--------------------------------------------------------------------------------------------+

--- a/include/alpaka/algo/Transform.hpp
+++ b/include/alpaka/algo/Transform.hpp
@@ -1,0 +1,193 @@
+/* Copyright 2025 Andrea Bocci, Simeon Ehrig
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/acc/Tag.hpp"
+#include "alpaka/dev/Traits.hpp"
+#include "alpaka/dim/DimIntegralConst.hpp"
+#include "alpaka/dim/Traits.hpp"
+#include "alpaka/elem/Traits.hpp"
+#include "alpaka/exec/UniformElements.hpp"
+#include "alpaka/extent/Traits.hpp"
+#include "alpaka/idx/Traits.hpp"
+#include "alpaka/kernel/Traits.hpp"
+#include "alpaka/mem/view/Traits.hpp"
+#include "alpaka/vec/Vec.hpp"
+#include "alpaka/workdiv/WorkDivHelpers.hpp"
+
+#include <iterator>
+#include <type_traits>
+
+namespace alpaka
+{
+
+    namespace detail
+    {
+
+        template<typename TFn>
+        struct TransformKernel
+        {
+            TFn fn;
+
+            template<typename TAcc, typename T>
+            ALPAKA_FN_ACC void operator()(TAcc const& acc, T const* in_ptr, T* out_ptr, alpaka::Idx<TAcc> size) const
+            {
+                static_assert(std::is_invocable_r_v<T, TFn, T> or std::is_invocable_r_v<T, TFn, TAcc const&, T>);
+
+                static_assert(alpaka::Dim<TAcc>::value == 1u);
+                using Idx = alpaka::Idx<TAcc>;
+
+                for(Idx i : alpaka::uniformElements(acc, size))
+                {
+                    if constexpr(std::is_invocable_r_v<T, TFn, T>)
+                    {
+                        // std::is_invocable_r_v<T, TFn, T>
+                        out_ptr[i] = fn(in_ptr[i]);
+                    }
+                    else
+                    {
+                        // std::is_invocable_r_v<T, TFn, TAcc const&, T>
+                        out_ptr[i] = fn(acc, in_ptr[i]);
+                    }
+                }
+            }
+        };
+
+        template<typename TFn>
+        struct TransformKernelND
+        {
+            TFn fn;
+
+            template<typename TAcc, typename T>
+            ALPAKA_FN_ACC void operator()(
+                TAcc const& acc,
+                T const* in_ptr,
+                alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> in_pithces,
+                T* out_ptr,
+                alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> out_pitches,
+                alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> in_size) const
+            {
+                static_assert(std::is_invocable_r_v<T, TFn, T> or std::is_invocable_r_v<T, TFn, TAcc const&, T>);
+
+                using Dim = alpaka::Dim<TAcc>;
+                using Idx = alpaka::Idx<TAcc>;
+                using Vec = alpaka::Vec<Dim, Idx>;
+
+                for(Vec idx : alpaka::uniformElementsND(acc, in_size))
+                {
+                    auto p_in = reinterpret_cast<T const*>(
+                        reinterpret_cast<uintptr_t>(in_ptr) + static_cast<uintptr_t>((idx * in_pithces).sum()));
+                    auto p_out = reinterpret_cast<T*>(
+                        reinterpret_cast<uintptr_t>(out_ptr) + static_cast<uintptr_t>((idx * out_pitches).sum()));
+                    if constexpr(std::is_invocable_r_v<T, TFn, T>)
+                    {
+                        // std::is_invocable_r_v<T, TFn, T>
+                        *p_out = fn(*p_in);
+                    }
+                    else
+                    {
+                        // std::is_invocable_r_v<T, TFn, TAcc const&, T>
+                        *p_out = fn(acc, *p_in);
+                    }
+                }
+            }
+        };
+
+    } // namespace detail
+
+    /*
+     * Applies asynchronously the given function `fn` to the elements of the input range starting at `in`,
+     * and stores the result in the semi-open output range [`out_begin`,`out_end`), using the accelerator
+     * back-end identified by `Tag`.
+     */
+    template<alpaka::concepts::Tag TTag, typename TQueue, typename T, typename TFn>
+    void transform(TQueue& queue, T* out_begin, T* out_end, TFn&& fn, T* in)
+    {
+        using Idx = typename std::iterator_traits<T*>::difference_type;
+        using Acc1D = alpaka::TagToAcc<TTag, alpaka::DimInt<1>, Idx>;
+
+        static_assert(
+            std::is_invocable_r_v<T, TFn, T> or std::is_invocable_r_v<T, TFn, Acc1D const&, T>,
+            "TFn must accept either one argument (of type T) or two arguments (an accelerator and an argument of type "
+            "T), and return a value of type T.");
+
+        Idx size = std::distance(out_begin, out_end);
+        detail::TransformKernel<TFn> kernel{fn};
+
+        // Find a valid work division. This could be further optimised.
+        auto const config
+            = alpaka::KernelCfg<Acc1D>{size, Idx{1}, false, alpaka::GridBlockExtentSubDivRestrictions::Unrestricted};
+        auto const grid = alpaka::getValidWorkDiv(config, alpaka::getDev(queue), kernel, in, out_begin, size);
+
+        // Apply the fn function to all elements of the input range.
+        alpaka::exec<Acc1D>(queue, grid, kernel, in, out_begin, size);
+    }
+
+    /*
+     * Applies asynchronously the given function `fn` to the elements of the input buffer `in`,
+     * and stores the result in the corresponding elements of the output buffer `out`,
+     * using the accelerator back-end identified by `Tag`.
+     */
+    template<alpaka::concepts::Tag TTag, typename TQueue, typename TBuf, typename TFn, typename TConstBuf>
+    void transform(TQueue& queue, TBuf& out, TFn&& fn, TConstBuf const& in)
+    {
+        // Check that the input and output buffers have compatible types.
+        using Idx = alpaka::Idx<TConstBuf>;
+        static_assert(
+            std::is_same_v<alpaka::Idx<TBuf>, Idx>,
+            "The input and output buffers must have the same index type.");
+        using Dim = alpaka::Dim<TConstBuf>;
+        static_assert(
+            std::is_same_v<alpaka::Dim<TBuf>, Dim>,
+            "The input and output buffers must have the same dimension.");
+        using In = std::remove_const_t<alpaka::Elem<TConstBuf>>;
+        using Out = alpaka::Elem<TBuf>;
+        using Vec = alpaka::Vec<Dim, Idx>;
+        using Acc = alpaka::TagToAcc<TTag, Dim, Idx>;
+
+        static_assert(
+            std::is_invocable_r_v<Out, TFn, In const> or std::is_invocable_r_v<Out, TFn, Acc const&, In const>,
+            "TFn must accept either one argument (of the buffer's element type) or two arguments (an accelerator and "
+            "the element type), and return a value of the buffer's element type.");
+
+        // Check that the input and output buffers have the same size.
+        Vec size = alpaka::getExtents(in);
+        assert(alpaka::getExtents(out) == size and "The input and output buffers must have the same extents.");
+
+        // Pass details of the input and output buffers to the kernel:
+        //   - address of the first elements
+        //   - pitches (in bytes) along all dimensions
+        //   - number of elements along all dimensions
+        detail::TransformKernelND<TFn> kernel{fn};
+
+        // Find a valid work division. This could be further optimised.
+        auto const config = alpaka::KernelCfg<Acc>{
+            size,
+            Vec::ones(),
+            false,
+            alpaka::GridBlockExtentSubDivRestrictions::Unrestricted};
+        auto const grid = alpaka::getValidWorkDiv(
+            config,
+            alpaka::getDev(queue),
+            kernel,
+            in.data(),
+            alpaka::getPitchesInBytes(in),
+            out.data(),
+            alpaka::getPitchesInBytes(out),
+            size);
+
+        // Apply the fn function to all elements of the input buffer.
+        alpaka::exec<Acc>(
+            queue,
+            grid,
+            kernel,
+            in.data(),
+            alpaka::getPitchesInBytes(in),
+            out.data(),
+            alpaka::getPitchesInBytes(out),
+            size);
+    }
+
+} // namespace alpaka

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -25,6 +25,8 @@
 #include "alpaka/acc/Tag.hpp"
 #include "alpaka/acc/TagAccIsEnabled.hpp"
 #include "alpaka/acc/Traits.hpp"
+// algo
+#include "alpaka/algo/Transform.hpp"
 // atomic
 #include "alpaka/atomic/AtomicCpu.hpp"
 #include "alpaka/atomic/AtomicGenericSycl.hpp"

--- a/include/alpaka/mem/buf/uniformCudaHip/traits/BufUniformCudaHipRtTraits.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/traits/BufUniformCudaHipRtTraits.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/mem/buf/Traits.hpp"
 #include "alpaka/mem/buf/cpu/BufCpu.hpp"
 #include "alpaka/mem/buf/uniformCudaHip/BufUniformCudaHipRt.hpp"
+#include "alpaka/mem/view/Traits.hpp"
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
@@ -256,7 +257,7 @@ namespace alpaka::trait
 
     //! The CUDA/HIP stream-ordered memory allocation capability trait specialization.
     template<typename TApi, typename TDim>
-    struct HasAsyncBufSupport<TDim, DevUniformCudaHipRt<TApi>> : std::bool_constant<TDim::value <= 1>
+    struct HasAsyncBufSupport<TDim, DevUniformCudaHipRt<TApi>> : std::true_type
     {
     };
 
@@ -264,27 +265,58 @@ namespace alpaka::trait
     template<typename TApi, typename TElem, typename TDim, typename TIdx>
     struct AsyncBufAlloc<TElem, TDim, TIdx, DevUniformCudaHipRt<TApi>>
     {
-        static_assert(
-            TDim::value <= 1,
-            "CUDA/HIP devices support only one-dimensional stream-ordered memory buffers.");
-
-        template<typename TQueue, typename TExtent>
-        ALPAKA_FN_HOST static auto allocAsyncBuf(TQueue queue, [[maybe_unused]] TExtent const& extent)
+        template<typename TQueue>
+        ALPAKA_FN_HOST static auto allocAsyncBuf(TQueue queue, [[maybe_unused]] Vec<TDim, TIdx> const& extent)
             -> BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>
         {
             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-            static_assert(TDim::value == Dim<TExtent>::value, "extent must have the same dimension as the buffer");
-            auto const width = getExtentProduct(extent); // handles 1D and 0D buffers
+            std::size_t bytes, pitch;
+            if constexpr(TDim::value == 0)
+            {
+                bytes = pitch = sizeof(TElem);
+            }
+            else if constexpr(TDim::value == 1)
+            {
+                bytes = pitch = static_cast<std::size_t>(extent.back()) * sizeof(TElem);
+            }
+            else
+            {
+                std::size_t const width = static_cast<std::size_t>(extent.back()) * sizeof(TElem);
+                // On all tested NVIDIA and AMD GPUs the alignment used for pitched allocations is the same value
+                // reported by the textureAlignment device property (512 bytes on NVIDA GPUs, 256 bytes on AMD GPUs).
+                // This was tested on: NVIDIA Tesla T4, A100, L40S, H100, and RTX 3050 Ti Laptop GPUs,
+                // and on AMD Radeon Pro WX 9100, Radeon Pro W7800/W7900, Instinct MI250X, and Instinct MI300X.
+                // However, it is expected that an alignment of 128 bytes (32 threads per warp times 4 bytes per float
+                // or int) should be sufficient to achieve coalesced memory accesses, and would reduce the amount of
+                // wasted memory.
+                constexpr std::size_t alignment = 128;
+                pitch = (width + alignment - 1) / alignment * alignment;
+                // Replace the last entry in the extent vector (i.e. the number of elements per row) with the pitch
+                // (the number of bytes per row, including padding), and compute the total size in bytes, removing
+                // the padding after the last row.
+                auto aligned = alpaka::castVec<std::size_t>(extent);
+                aligned.back() = pitch;
+                bytes = aligned.prod() - pitch + width;
+            }
 
             auto const& dev = getDev(queue);
             ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
             void* memPtr = nullptr;
-            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                TApi::mallocAsync(&memPtr, static_cast<std::size_t>(width) * sizeof(TElem), queue.getNativeHandle()));
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::mallocAsync(&memPtr, bytes, queue.getNativeHandle()));
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-            std::cout << __func__ << " ew: " << width << " ptr: " << memPtr << std::endl;
+            std::cout << __func__;
+            if constexpr(Dim::value >= 1)
+                std::cout << " ew: " << getWidth(extent);
+            if constexpr(Dim::value >= 2)
+                std::cout << " eh: " << getHeight(extent);
+            if constexpr(Dim::value >= 3)
+                std::cout << " ed: " << getDepth(extent);
+            std::cout << " ptr: " << memPtr;
+            if constexpr(Dim::value >= 2)
+                std::cout << " rowpitch: " << pitch;
+            std::cout << std::endl;
 #    endif
             return {
                 dev,
@@ -292,7 +324,7 @@ namespace alpaka::trait
                 [q = std::move(queue)](TElem* ptr)
                 { ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::freeAsync(ptr, q.getNativeHandle())); },
                 extent,
-                static_cast<std::size_t>(width) * sizeof(TElem)};
+                pitch};
         }
     };
 

--- a/include/alpaka/mem/buf/uniformCudaHip/traits/ConstBufUniformCudaHipRtTraits.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/traits/ConstBufUniformCudaHipRtTraits.hpp
@@ -9,6 +9,7 @@
 #include "alpaka/mem/buf/cpu/BufCpu.hpp"
 #include "alpaka/mem/buf/uniformCudaHip/BufUniformCudaHipRt.hpp"
 #include "alpaka/mem/buf/uniformCudaHip/ConstBufUniformCudaHipRt.hpp"
+#include "alpaka/mem/view/Traits.hpp"
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
@@ -99,18 +100,16 @@ namespace alpaka::trait
         ALPAKA_FN_HOST auto operator()(ConstBufUniformCudaHipRt<TApi, TElem, TDim, TIdx> const& buf) const
             -> Vec<TDim, TIdx>
         {
-            Vec<TDim, TIdx> v{};
-            if constexpr(TDim::value > 0)
+            if constexpr(TDim::value <= 1)
             {
-                v.back() = sizeof(TElem);
-                if constexpr(TDim::value > 1)
-                {
-                    v[TDim::value - 2] = static_cast<TIdx>(buf.m_spBufImpl->m_rowPitchInBytes);
-                    for(TIdx i = TDim::value - 2; i > 0; i--)
-                        v[i - 1] = buf.m_spBufImpl->m_extentElements[i] * v[i];
-                }
+                return alpaka::detail::calculatePitchesFromExtents<TElem>(buf.m_spBufImpl->m_extentElements);
             }
-            return v;
+            else
+            {
+                return alpaka::detail::calculatePitchesFromExtentsAndPitch<TElem>(
+                    buf.m_spBufImpl->m_extentElements,
+                    buf.m_spBufImpl->m_rowPitchInBytes);
+            }
         }
     };
 

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -19,6 +19,7 @@
 #include "alpaka/vec/Vec.hpp"
 
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <iosfwd>
 #include <type_traits>
@@ -44,6 +45,31 @@ namespace alpaka
                     pitchBytes[i - 1] = extent[i] * pitchBytes[i];
             return pitchBytes;
         }
+
+        //! Calculate the pitches from the extents and the one-dimensional pitch.
+        template<typename TElem, typename TDim, typename TIdx>
+        ALPAKA_FN_HOST_ACC inline constexpr auto calculatePitchesFromExtentsAndPitch(
+            Vec<TDim, TIdx> const& extent,
+            std::size_t pitch)
+        {
+            Vec<TDim, TIdx> pitchBytes{};
+            constexpr auto dim = TIdx{TDim::value};
+            if constexpr(dim > 0)
+                pitchBytes.back() = static_cast<TIdx>(sizeof(TElem));
+            if constexpr(dim > 1)
+            {
+                if(pitch == 0)
+                    pitchBytes[TDim::value - 2] = extent.back() * pitchBytes.back();
+                else
+                    pitchBytes[TDim::value - 2] = static_cast<TIdx>(
+                        (static_cast<std::size_t>(extent.back() * pitchBytes.back()) + pitch - 1) / pitch * pitch);
+            }
+            if constexpr(dim > 2)
+                for(TIdx i = TDim::value - 2; i > 0; i--)
+                    pitchBytes[i - 1] = extent[i] * pitchBytes[i];
+            return pitchBytes;
+        }
+
     } // namespace detail
 
     //! The view traits.

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -14,6 +14,7 @@ cmake_minimum_required(VERSION 3.25)
 ################################################################################
 
 add_subdirectory("acc/")
+add_subdirectory("algo/")
 add_subdirectory("atomic/")
 add_subdirectory("block/shared/")
 add_subdirectory("block/sharedSharing/")

--- a/test/unit/algo/CMakeLists.txt
+++ b/test/unit/algo/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Copyright 2014-2025 Benjamin Worpitz, Axel Huebl, Jan Stephan, Andrea Bocci
+# SPDX-License-Identifier: MPL-2.0
+#
+
+set(_TARGET_NAME "algoTest")
+
+append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
+
+alpaka_add_executable(
+    ${_TARGET_NAME}
+    ${_FILES_SOURCE})
+target_link_libraries(
+    ${_TARGET_NAME}
+    PRIVATE common)
+
+set_target_properties(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
+target_compile_definitions(${_TARGET_NAME} PRIVATE "-DTEST_UNIT_ALGO")
+
+add_test(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME} ${_alpaka_TEST_OPTIONS})

--- a/test/unit/algo/src/Transform.cpp
+++ b/test/unit/algo/src/Transform.cpp
@@ -1,0 +1,157 @@
+/* Copyright 2025 Andrea Bocci
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/test/Extent.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
+#include <alpaka/test/queue/Queue.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cmath>
+#include <random>
+
+// A functor that takes a single argument of type float and returns a value of type float
+struct Duplicate
+{
+    template<typename T>
+    ALPAKA_FN_HOST_ACC T operator()(T value) const
+    {
+        return value * 2;
+    }
+};
+
+// A functor that takes two arguments (an accelerator object and a float) and returns a value of type float
+struct Sin
+{
+    template<typename TAcc, typename T>
+    ALPAKA_FN_HOST_ACC T operator()(TAcc const& acc, T value) const
+    {
+        return alpaka::math::sin(acc, value);
+    }
+};
+
+using TestAccs1D = alpaka::test::EnabledAccs<alpaka::DimInt<1u>, uint32_t>;
+
+TEMPLATE_LIST_TEST_CASE("transform_pointers", "[algo]", TestAccs1D)
+{
+    using Acc = TestType;
+    using Tag = alpaka::AccToTag<Acc>;
+    using Platform = alpaka::Platform<Acc>;
+    using Device = alpaka::Dev<Acc>;
+    using Queue = alpaka::Queue<Device, alpaka::NonBlocking>;
+
+    using Idx = alpaka::Idx<Acc>;
+    // using Dim = alpaka::Dim<Acc>;
+    // using Vec = alpaka::Vec<Dim, Idx>;
+
+    const alpaka::PlatformCpu host_platform{};
+    auto const host = alpaka::getDevByIdx(host_platform, 0u);
+
+    const Platform platform{};
+    const Device device = alpaka::getDevByIdx(platform, 0);
+    Queue queue{device};
+
+    // Random number generator with a gaussian distribution.
+    std::random_device rd{};
+    std::default_random_engine rand{rd()};
+    std::normal_distribution<float> dist{0.f, 1.f};
+
+    Idx size = 1000;
+
+    // Allocate input and output buffers on the host.
+    auto sample = alpaka::allocMappedBuf<float, Idx>(host, platform, size);
+    auto result = alpaka::allocMappedBuf<float, Idx>(host, platform, size);
+
+    // Fill the input buffer with random numbers.
+    for(Idx i = 0; i < size; ++i)
+    {
+        sample[i] = dist(rand);
+    }
+
+    // Allocate input and output buffers on the device.
+    auto sample_d = alpaka::allocAsyncBufIfSupported<float, Idx>(queue, size);
+    auto result_d = alpaka::allocAsyncBufIfSupported<float, Idx>(queue, size);
+
+    // Copy the input random numbers to the device.
+    alpaka::memcpy(queue, sample_d, sample);
+
+    // Apply the transform algorithm on the device.
+    alpaka::transform<Tag>(queue, result_d.data(), result_d.data() + size, Duplicate{}, sample_d.data());
+
+    // Copy the result to the host.
+    alpaka::memcpy(queue, result, result_d);
+
+    // Wait for all asynchronous operations to complete.
+    alpaka::wait(queue);
+
+    // Check the correctness of the results.
+    for(Idx i = 0; i < size; ++i)
+    {
+        float expected = Duplicate{}(sample[i]);
+        REQUIRE_THAT(result[i], Catch::Matchers::WithinULP(expected, 4));
+    }
+}
+
+TEMPLATE_LIST_TEST_CASE("transform_buffer", "[algo]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+    using Tag = alpaka::AccToTag<Acc>;
+    using Platform = alpaka::Platform<Acc>;
+    using Device = alpaka::Dev<Acc>;
+    using Queue = alpaka::test::DefaultQueue<Device>;
+
+    using Idx = alpaka::Idx<Acc>;
+    using Dim = alpaka::Dim<Acc>;
+    using Vec = alpaka::Vec<Dim, Idx>;
+
+    const alpaka::PlatformCpu host_platform{};
+    auto const host = alpaka::getDevByIdx(host_platform, 0u);
+
+    const Platform platform{};
+    const Device device = alpaka::getDevByIdx(platform, 0);
+    Queue queue{device};
+
+    // Random number generator with a gaussian distribution.
+    std::random_device rd{};
+    std::default_random_engine rand{rd()};
+    std::normal_distribution<float> dist{0.f, 1.f};
+
+    Vec size = alpaka::test::extentBuf<Dim, Idx>;
+
+    // Allocate input and output buffers on the host.
+    auto sample = alpaka::allocMappedBuf<float, Idx>(host, platform, size);
+    auto result = alpaka::allocMappedBuf<float, Idx>(host, platform, size);
+
+    // Fill the input buffer with random numbers.
+    for(Idx i = 0; i < size.prod(); ++i)
+    {
+        sample.data()[i] = dist(rand);
+    }
+
+    // Allocate input and output buffers on the device.
+    auto sample_d = alpaka::allocAsyncBufIfSupported<float, Idx>(queue, size);
+    auto result_d = alpaka::allocAsyncBufIfSupported<float, Idx>(queue, size);
+
+    // Copy the input random numbers to the device.
+    alpaka::memcpy(queue, sample_d, sample);
+
+    // Apply the transform algorithm on the device.
+    alpaka::transform<Tag>(queue, result_d, Sin{}, sample_d);
+
+    // Copy the result to the host.
+    alpaka::memcpy(queue, result, result_d);
+
+    // Wait for all asynchronous operations to complete.
+    alpaka::wait(queue);
+
+    // Check the correctness of the results.
+    for(Idx i = 0; i < size.prod(); ++i)
+    {
+        float expected = std::sin(sample.data()[i]);
+        REQUIRE_THAT(result.data()[i], Catch::Matchers::WithinULP(expected, 4));
+    }
+}


### PR DESCRIPTION
- [x] rebase against #2566 before merging

Implement two version of `alpaka::transform`.

The iterator range version

    alpaka::transform<Tag>(queue, first_in, last_in, first_out, op)

applies asynchronously the given function `op` to the elements of the semi-open input range `[first_in, last_in)`, and stores the result in an output range starting from `first_out`, using the accelerator back-end identified by `Tag`.

The buffer version

    alpaka::transform<Tag>(queue, out, op, in)

applies asynchronously the given function `op` to the elements of the input buffer `in` and stores the result in the corresponding elements of the output buffer `out`, using the accelerator back-end identified by `Tag`.

The function `op` should accept either a single argument (of the iterator's or buffer's element type) or two arguments (an accelerator and an element), and return a value of the element type.

Note that the range version is always one-dimensional, while the buffer version uses the dimensionality of the buffer.