### PR TITLE
Restore and deprecate the `isAccelerator` trait

### DIFF
--- a/include/alpaka/acc/Traits.hpp
+++ b/include/alpaka/acc/Traits.hpp
@@ -30,6 +30,10 @@ namespace alpaka
         concept Acc = requires { requires alpaka::interface::ImplementsInterface<alpaka::InterfaceAcc, T>::value; };
     } // namespace concepts
 
+    //! True if TAcc is an accelerator, i.e. if it implements the InterfaceAcc concept.
+    template<typename TAcc>
+    [[deprecated("use the alpaka::concepts::Acc instead.")]] inline constexpr bool isAccelerator = concepts::Acc<TAcc>;
+
     //! The accelerator traits.
     namespace trait
     {


### PR DESCRIPTION
Emit a warning like
```
warning: ‘alpaka::isAccelerator<...>’ is deprecated: use the alpaka::concepts::Acc instead. [-Wdeprecated-declarations]
```