### PR TITLE
Implement `alpaka::exec<Tag>`

### DIFF
--- a/example/helloWorld/src/helloWorld.cpp
+++ b/example/helloWorld/src/helloWorld.cpp
@@ -64,7 +64,8 @@ auto example(TAccTag const&) -> int
     using Idx = std::size_t;
 
     // Define the accelerator
-    using Acc = alpaka::TagToAcc<TAccTag, Dim, Idx>;
+    using Tag = TAccTag;
+    using Acc = alpaka::TagToAcc<Tag, Dim, Idx>;
     std::cout << "Using alpaka accelerator: " << alpaka::getAccName<Acc>() << std::endl;
 
     // Defines the synchronization behavior of a queue
@@ -149,7 +150,7 @@ auto example(TAccTag const&) -> int
     // The queue can be blocking or non-blocking
     // depending on the chosen queue type (see type definitions above).
     // Here it is synchronous which means that the kernel is directly executed.
-    alpaka::exec<Acc>(
+    alpaka::exec<Tag>(
         queue,
         workDiv,
         helloWorldKernel

--- a/example/helloWorldLambda/src/helloWorldLambda.cpp
+++ b/example/helloWorldLambda/src/helloWorldLambda.cpp
@@ -56,7 +56,8 @@ auto example(TAccTag const&) -> int
     using Idx = std::size_t;
 
     // Define the accelerator
-    using Acc = alpaka::TagToAcc<TAccTag, Dim, Idx>;
+    using Tag = TAccTag;
+    using Acc = alpaka::TagToAcc<Tag, Dim, Idx>;
     std::cout << "Using alpaka accelerator: " << alpaka::getAccName<Acc>() << std::endl;
 
     // Defines the synchronization behavior of a queue
@@ -122,7 +123,7 @@ auto example(TAccTag const&) -> int
     // Let alpaka calculate good block and grid sizes given our full problem extent
     auto const workDiv = alpaka::getValidWorkDiv(kernelCfg, devAcc, kernelLambda, nExclamationMarks);
 
-    alpaka::exec<Acc>(queue, workDiv, kernelLambda, nExclamationMarks);
+    alpaka::exec<Tag>(queue, workDiv, kernelLambda, nExclamationMarks);
     alpaka::wait(queue);
 
     return EXIT_SUCCESS;

--- a/example/tagSpecialization/src/tagSpecialization.cpp
+++ b/example/tagSpecialization/src/tagSpecialization.cpp
@@ -15,7 +15,7 @@
 //!   - entry kernels, which are executed with alpaka::exec cannot be specialized with tags
 
 //! Function specialization via template specialization
-template<typename TAcc>
+template<typename TTag>
 std::string host_function_ver1()
 {
     return "generic host function v1";
@@ -85,7 +85,8 @@ auto example(TAccTag const&) -> int
 {
     // Define the accelerator
     // For simplicity this examples always uses 1 dimensional indexing, and index type size_t
-    using Acc = alpaka::TagToAcc<TAccTag, alpaka::DimInt<1>, std::size_t>;
+    using Tag = TAccTag;
+    using Acc = alpaka::TagToAcc<Tag, alpaka::DimInt<1>, std::size_t>;
     std::cout << "Using alpaka accelerator: " << alpaka::getAccName<Acc>() << std::endl;
 
     // Call the specialized functions
@@ -112,7 +113,7 @@ auto example(TAccTag const&) -> int
     // Run the wrapper kernel, which calls the actual specialized
     // Specializing the entry kernel with tags is not possible. Therefore pre processor guards are required, see
     // kernelSpecialization example.
-    alpaka::exec<Acc>(queue, workDiv, WrapperKernel{});
+    alpaka::exec<Tag>(queue, workDiv, WrapperKernel{});
     alpaka::wait(queue);
     return EXIT_SUCCESS;
 }

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "alpaka/acc/Tag.hpp"
 #include "alpaka/acc/Traits.hpp"
 #include "alpaka/core/Common.hpp"
 #include "alpaka/core/Config.hpp"
@@ -381,4 +382,32 @@ namespace alpaka
     {
         enqueue(queue, createTaskKernel<TAcc>(workDiv, kernelFnObj, std::forward<TArgs>(args)...));
     }
+
+#if ALPAKA_COMP_CLANG
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored                                                                                  \
+        "-Wdocumentation" // clang does not support the syntax for variadic template arguments "args,..."
+#endif
+//! Executes the given kernel in the given queue.
+//!
+//! \tparam TTag The tag type.
+//! \param queue The queue to enqueue the view copy task into.
+//! \param workDiv The index domain work division.
+//! \param kernelFnObj The kernel function object which should be executed.
+//! \param args,... The kernel invocation arguments.
+#if ALPAKA_COMP_CLANG
+#    pragma clang diagnostic pop
+#endif
+    template<concepts::Tag TTag, typename TQueue, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
+    ALPAKA_FN_HOST auto exec(TQueue& queue, TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
+        -> void
+    {
+        enqueue(
+            queue,
+            createTaskKernel<TagToAcc<TTag, Dim<std::decay_t<TWorkDiv>>, Idx<std::decay_t<TWorkDiv>>>>(
+                workDiv,
+                kernelFnObj,
+                std::forward<TArgs>(args)...));
+    }
+
 } // namespace alpaka

--- a/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/include/alpaka/test/KernelExecutionFixture.hpp
@@ -27,6 +27,7 @@ namespace alpaka::test
     {
     public:
         using Acc = TAcc;
+        using Tag = alpaka::AccToTag<Acc>;
         using Dim = alpaka::Dim<Acc>;
         using Idx = alpaka::Idx<Acc>;
         using Platform = alpaka::Platform<Acc>;
@@ -80,7 +81,7 @@ namespace alpaka::test
                     getPtrNative(bufAccResult),
                     std::forward<TArgs>(args)...);
 
-            exec<Acc>(m_queue, m_workDiv, kernelFnObj, getPtrNative(bufAccResult), std::forward<TArgs>(args)...);
+            exec<Tag>(m_queue, m_workDiv, kernelFnObj, getPtrNative(bufAccResult), std::forward<TArgs>(args)...);
 
             // Copy the result value to the host
             auto bufHostResult = allocBuf<bool, Idx>(m_devHost, static_cast<Idx>(1u));


### PR DESCRIPTION
Similar to `alpaka::exec<Acc>`, takes the dimensionality and index type from the work division.

Update some tests and examples to use the new `alpaka::exec<Tag>` form.