### PR TITLE
Separate `ViewAccessOps` for host and device views

### DIFF
--- a/include/alpaka/mem/buf/cpu/BufCpu.hpp
+++ b/include/alpaka/mem/buf/cpu/BufCpu.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     //! The CPU memory buffer template implementing muting accessors.
     template<typename TElem, typename TDim, typename TIdx>
-    class BufCpu : public internal::ViewAccessOps<BufCpu<TElem, TDim, TIdx>>
+    class BufCpu : public internal::ViewAccessorType<DevCpu, BufCpu<TElem, TDim, TIdx>>
     {
         using TBufImpl = detail::BufCpuImpl<TElem, TDim, TIdx>;
 

--- a/include/alpaka/mem/buf/cpu/ConstBufCpu.hpp
+++ b/include/alpaka/mem/buf/cpu/ConstBufCpu.hpp
@@ -32,7 +32,7 @@ namespace alpaka
 
     //! The CPU memory buffer.
     template<typename TElem, typename TDim, typename TIdx>
-    class ConstBufCpu : public internal::ViewAccessOps<ConstBufCpu<TElem, TDim, TIdx>>
+    class ConstBufCpu : public internal::ViewAccessorType<DevCpu, ConstBufCpu<TElem, TDim, TIdx>>
     {
     public:
         template<typename TExtent, typename Deleter>

--- a/include/alpaka/mem/buf/sycl/BufGenericSycl.hpp
+++ b/include/alpaka/mem/buf/sycl/BufGenericSycl.hpp
@@ -24,7 +24,7 @@ namespace alpaka
 {
     //! The generic memory buffer template implementing muting accessors.
     template<typename TElem, typename TDim, typename TIdx, concepts::Tag TTag>
-    class BufGenericSycl : public internal::ViewAccessOps<BufGenericSycl<TElem, TDim, TIdx, TTag>>
+    class BufGenericSycl : public internal::ViewAccessorType<DevGenericSycl, BufGenericSycl<TElem, TDim, TIdx, TTag>>
     {
         using TBufImpl = detail::BufGenericSyclImpl<TElem, TDim, TIdx, TTag>;
 

--- a/include/alpaka/mem/buf/sycl/BufGenericSycl.hpp
+++ b/include/alpaka/mem/buf/sycl/BufGenericSycl.hpp
@@ -24,7 +24,8 @@ namespace alpaka
 {
     //! The generic memory buffer template implementing muting accessors.
     template<typename TElem, typename TDim, typename TIdx, concepts::Tag TTag>
-    class BufGenericSycl : public internal::ViewAccessorType<DevGenericSycl, BufGenericSycl<TElem, TDim, TIdx, TTag>>
+    class BufGenericSycl
+        : public internal::ViewAccessorType<DevGenericSycl<TTag>, BufGenericSycl<TElem, TDim, TIdx, TTag>>
     {
         using TBufImpl = detail::BufGenericSyclImpl<TElem, TDim, TIdx, TTag>;
 

--- a/include/alpaka/mem/buf/sycl/ConstBufGenericSycl.hpp
+++ b/include/alpaka/mem/buf/sycl/ConstBufGenericSycl.hpp
@@ -29,7 +29,8 @@ namespace alpaka
 
     //! The SYCL memory buffer.
     template<typename TElem, typename TDim, typename TIdx, concepts::Tag TTag>
-    class ConstBufGenericSycl : public internal::ViewAccessOps<ConstBufGenericSycl<TElem, TDim, TIdx, TTag>>
+    class ConstBufGenericSycl
+        : public internal::ViewAccessorType<DevGenericSycl, ConstBufGenericSycl<TElem, TDim, TIdx, TTag>>
     {
     public:
         //! Constructor

--- a/include/alpaka/mem/buf/sycl/ConstBufGenericSycl.hpp
+++ b/include/alpaka/mem/buf/sycl/ConstBufGenericSycl.hpp
@@ -30,7 +30,7 @@ namespace alpaka
     //! The SYCL memory buffer.
     template<typename TElem, typename TDim, typename TIdx, concepts::Tag TTag>
     class ConstBufGenericSycl
-        : public internal::ViewAccessorType<DevGenericSycl, ConstBufGenericSycl<TElem, TDim, TIdx, TTag>>
+        : public internal::ViewAccessorType<DevGenericSycl<TTag>, ConstBufGenericSycl<TElem, TDim, TIdx, TTag>>
     {
     public:
         //! Constructor

--- a/include/alpaka/mem/buf/uniformCudaHip/BufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/BufUniformCudaHipRt.hpp
@@ -24,7 +24,8 @@ namespace alpaka
 
     //! The generic memory buffer template implementing muting accessors.
     template<typename TApi, typename TElem, typename TDim, typename TIdx>
-    class BufUniformCudaHipRt : public internal::ViewAccessOps<BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>>
+    class BufUniformCudaHipRt
+        : public internal::ViewAccessorType<DevUniformCudaHipRt<TApi>, BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>>
     {
         using TBufImpl = detail::BufUniformCudaHipRtImpl<TApi, TElem, TDim, TIdx>;
 

--- a/include/alpaka/mem/buf/uniformCudaHip/ConstBufUniformCudaHipRt.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/ConstBufUniformCudaHipRt.hpp
@@ -34,7 +34,8 @@ namespace alpaka
 
     //! The CUDA/HIP memory buffer.
     template<typename TApi, typename TElem, typename TDim, typename TIdx>
-    struct ConstBufUniformCudaHipRt : internal::ViewAccessOps<ConstBufUniformCudaHipRt<TApi, TElem, TDim, TIdx>>
+    struct ConstBufUniformCudaHipRt
+        : internal::ViewAccessorType<DevUniformCudaHipRt<TApi>, ConstBufUniformCudaHipRt<TApi, TElem, TDim, TIdx>>
     {
         static_assert(!std::is_const_v<TElem>, "The elem type of the buffer must not be const");
         static_assert(!std::is_const_v<TIdx>, "The idx type of the buffer must not be const!");

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "alpaka/acc/Tag.hpp"
+#include "alpaka/dev/DevGenericSycl.hpp"
 #include "alpaka/extent/Traits.hpp"
 #include "alpaka/mem/view/Traits.hpp"
 
@@ -16,8 +18,10 @@
 namespace alpaka
 {
 
-    struct DevCpu;
-    struct DevCpuSycl;
+    class DevCpu;
+
+    template<concepts::Tag TTag>
+    class DevGenericSycl;
 
 } // namespace alpaka
 
@@ -28,9 +32,15 @@ namespace alpaka::internal
     concept ViewType = requires {
         typename Idx<TView>;
         typename Dim<TView>;
-        { getPtrNative(std::declval<TView>()) };
-        { getPitchesInBytes(std::declval<TView>()) };
-        { getExtents(std::declval<TView>()) };
+        {
+            getPtrNative(std::declval<TView>())
+        };
+        {
+            getPitchesInBytes(std::declval<TView>())
+        };
+        {
+            getExtents(std::declval<TView>())
+        };
     };
 
     template<ViewType TView>
@@ -188,7 +198,7 @@ namespace alpaka::internal
     };
 
     template<>
-    struct ViewAccessor<alpaka::DevCpuSycl>
+    struct ViewAccessor<alpaka::DevGenericSycl<alpaka::TagCpuSycl>>
     {
         template<ViewType TView>
         using AccessorType = HostViewAccessor<TView>;

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "alpaka/dim/Traits.hpp"
+#include "alpaka/dev/DevCpu.hpp"
 #include "alpaka/extent/Traits.hpp"
 #include "alpaka/mem/view/Traits.hpp"
 
@@ -172,20 +172,18 @@ namespace alpaka::internal
         }
     };
 
-    struct DevCpu;
-
     template<typename TDev>
     struct ViewAccessor
     {
         template<ViewType TView>
-        using AccessorType = HostViewAccessor<TView>;
+        using AccessorType = DeviceViewAccessor<TView>;
     };
 
     template<>
     struct ViewAccessor<DevCpu>
     {
         template<ViewType TView>
-        using AccessorType = DeviceViewAccessor<TView>;
+        using AccessorType = HostViewAccessor<TView>;
     };
 
     template<typename TDev, ViewType TView>

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "alpaka/dev/DevCpu.hpp"
 #include "alpaka/extent/Traits.hpp"
 #include "alpaka/mem/view/Traits.hpp"
 
@@ -14,6 +13,14 @@
 #include <type_traits>
 #include <utility>
 
+namespace alpaka
+{
+
+    struct DevCpu;
+    struct DevCpuSycl;
+
+} // namespace alpaka
+
 namespace alpaka::internal
 {
 
@@ -21,15 +28,9 @@ namespace alpaka::internal
     concept ViewType = requires {
         typename Idx<TView>;
         typename Dim<TView>;
-        {
-            getPtrNative(std::declval<TView>())
-        };
-        {
-            getPitchesInBytes(std::declval<TView>())
-        };
-        {
-            getExtents(std::declval<TView>())
-        };
+        { getPtrNative(std::declval<TView>()) };
+        { getPitchesInBytes(std::declval<TView>()) };
+        { getExtents(std::declval<TView>()) };
     };
 
     template<ViewType TView>
@@ -180,7 +181,14 @@ namespace alpaka::internal
     };
 
     template<>
-    struct ViewAccessor<DevCpu>
+    struct ViewAccessor<alpaka::DevCpu>
+    {
+        template<ViewType TView>
+        using AccessorType = HostViewAccessor<TView>;
+    };
+
+    template<>
+    struct ViewAccessor<alpaka::DevCpuSycl>
     {
         template<ViewType TView>
         using AccessorType = HostViewAccessor<TView>;

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -51,7 +51,7 @@ namespace alpaka::internal
         using Dim = alpaka::Dim<TView>;
 
     public:
-        ALPAKA_FN_HOST auto data() -> pointer
+        [[nodiscard]] ALPAKA_FN_HOST auto data() -> pointer
         {
             return getPtrNative(*static_cast<TView*>(this));
         }
@@ -75,7 +75,7 @@ namespace alpaka::internal
         using Dim = alpaka::Dim<TView>;
 
     public:
-        ALPAKA_FN_HOST auto data() -> pointer
+        [[nodiscard]] ALPAKA_FN_HOST auto data() -> pointer
         {
             return getPtrNative(*static_cast<TView*>(this));
         }

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -17,12 +17,7 @@
 
 namespace alpaka
 {
-
     class DevCpu;
-
-    template<concepts::Tag TTag>
-    class DevGenericSycl;
-
 } // namespace alpaka
 
 namespace alpaka::internal
@@ -197,12 +192,14 @@ namespace alpaka::internal
         using AccessorType = HostViewAccessor<TView>;
     };
 
+#ifdef ALPAKA_ACC_SYCL_ENABLED
     template<>
     struct ViewAccessor<alpaka::DevGenericSycl<alpaka::TagCpuSycl>>
     {
         template<ViewType TView>
         using AccessorType = HostViewAccessor<TView>;
     };
+#endif
 
     template<typename TDev, ViewType TView>
     using ViewAccessorType = typename ViewAccessor<TDev>::template AccessorType<TView>;

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -16,26 +16,49 @@
 
 namespace alpaka::internal
 {
-    template<typename T, typename SFINAE = void>
-    inline constexpr bool isView = false;
-
-    // TODO(bgruber): replace this by a concept in C++20
-    template<typename TView>
-    inline constexpr bool isView<
-        TView,
-        std::void_t<
-            Idx<TView>,
-            Dim<TView>,
-            decltype(getPtrNative(std::declval<TView>())),
-            decltype(getPitchesInBytes(std::declval<TView>())),
-            decltype(getExtents(std::declval<TView>()))>>
-        = true;
 
     template<typename TView>
-    struct ViewAccessOps
+    concept ViewType = requires {
+        typename Idx<TView>;
+        typename Dim<TView>;
+        {
+            getPtrNative(std::declval<TView>())
+        };
+        {
+            getPitchesInBytes(std::declval<TView>())
+        };
+        {
+            getExtents(std::declval<TView>())
+        };
+    };
+
+    template<ViewType TView>
+    struct DeviceViewAccessor
     {
-        static_assert(isView<TView>);
+    private:
+        using value_type = Elem<TView>;
+        using pointer = value_type*;
+        using const_pointer = value_type const*;
+        using reference = value_type&;
+        using const_reference = value_type const&;
+        using Idx = alpaka::Idx<TView>;
+        using Dim = alpaka::Dim<TView>;
 
+    public:
+        ALPAKA_FN_HOST auto data() -> pointer
+        {
+            return getPtrNative(*static_cast<TView*>(this));
+        }
+
+        [[nodiscard]] ALPAKA_FN_HOST auto data() const -> const_pointer
+        {
+            return getPtrNative(*static_cast<TView const*>(this));
+        }
+    };
+
+    template<ViewType TView>
+    struct HostViewAccessor
+    {
     private:
         using value_type = Elem<TView>;
         using pointer = value_type*;
@@ -148,4 +171,24 @@ namespace alpaka::internal
             return *ptr_at(index);
         }
     };
+
+    struct DevCpu;
+
+    template<typename TDev>
+    struct ViewAccessor
+    {
+        template<ViewType TView>
+        using AccessorType = HostViewAccessor<TView>;
+    };
+
+    template<>
+    struct ViewAccessor<DevCpu>
+    {
+        template<ViewType TView>
+        using AccessorType = DeviceViewAccessor<TView>;
+    };
+
+    template<typename TDev, ViewType TView>
+    using ViewAccessorType = typename ViewAccessor<TDev>::template AccessorType<TView>;
+
 } // namespace alpaka::internal

--- a/include/alpaka/mem/view/ViewConst.hpp
+++ b/include/alpaka/mem/view/ViewConst.hpp
@@ -18,7 +18,7 @@ namespace alpaka
     //! A non-modifiable wrapper around a view. This view acts as the wrapped view, but the underlying data is only
     //! exposed const-qualified.
     template<typename TView>
-    struct ViewConst : internal::ViewAccessOps<ViewConst<TView>>
+    struct ViewConst : internal::ViewAccessorType<decltype(alpaka::getDev(std::declval<TView>())), ViewConst<TView>>
     {
         static_assert(!std::is_const_v<TView>, "ViewConst must be instantiated with a non-const type");
         static_assert(

--- a/include/alpaka/mem/view/ViewConst.hpp
+++ b/include/alpaka/mem/view/ViewConst.hpp
@@ -18,7 +18,7 @@ namespace alpaka
     //! A non-modifiable wrapper around a view. This view acts as the wrapped view, but the underlying data is only
     //! exposed const-qualified.
     template<typename TView>
-    struct ViewConst : internal::ViewAccessorType<decltype(alpaka::getDev(std::declval<TView>())), ViewConst<TView>>
+    struct ViewConst : internal::ViewAccessorType<alpaka::Dev<TView>, ViewConst<TView>>
     {
         static_assert(!std::is_const_v<TView>, "ViewConst must be instantiated with a non-const type");
         static_assert(

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -20,7 +20,7 @@ namespace alpaka
 {
     //! The memory view to wrap plain pointers.
     template<typename TDev, typename TElem, typename TDim, typename TIdx>
-    struct ViewPlainPtr final : internal::ViewAccessOps<ViewPlainPtr<TDev, TElem, TDim, TIdx>>
+    struct ViewPlainPtr final : internal::ViewAccessorType<TDev, ViewPlainPtr<TDev, TElem, TDim, TIdx>>
     {
         static_assert(!std::is_const_v<TIdx>, "The idx type of the view can not be const!");
 

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -23,7 +23,7 @@ namespace alpaka
 {
     //! A sub-view to a view.
     template<typename TDev, typename TElem, typename TDim, typename TIdx>
-    class ViewSubView : public internal::ViewAccessOps<ViewSubView<TDev, TElem, TDim, TIdx>>
+    class ViewSubView : public internal::ViewAccessorType<TDev, ViewSubView<TDev, TElem, TDim, TIdx>>
     {
         static_assert(!std::is_const_v<TIdx>, "The idx type of the view can not be const!");
 

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -15,6 +15,14 @@
 #include <numeric>
 #include <type_traits>
 
+namespace alpaka
+{
+
+    template<concepts::Tag TTag>
+    struct PlatformGenericSycl;
+
+} // namespace alpaka
+
 namespace buftest
 {
     template<typename TDim, typename TDev, typename TElem, typename TIdx, typename TExtent>
@@ -275,16 +283,18 @@ static auto testBufferAccessorAdaptor(
     auto const base = reinterpret_cast<uintptr_t>(std::data(buf));
     auto const expected = base + static_cast<uintptr_t>((pitch * index).sum());
     INFO("element " << index << " expected at offset " << expected - base);
-#if not defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_ACC_GPU_HIP_ENABLED)                              \
-    and not defined(ALPAKA_SYCL_ONEAPI_GPU) and not defined(ALPAKA_SYCL_ONEAPI_FPGA)
-    INFO("element " << index << " returned at offset " << reinterpret_cast<uintptr_t>(&buf[index]) - base);
+    using Platform = alpaka::Platform<TAcc>;
+    if constexpr(
+        std::is_same_v<Platform, alpaka::PlatformCpu> or std::is_same_v<alpaka::AccToTag<TAcc>, alpaka::TagCpuSycl>)
+    {
+        INFO("element " << index << " returned at offset " << reinterpret_cast<uintptr_t>(&buf[index]) - base);
 
-    CHECK(reinterpret_cast<Elem*>(expected) == &buf[index]);
+        CHECK(reinterpret_cast<Elem*>(expected) == &buf[index]);
 
-    // check that an out-of-bound access is detected
-    if constexpr(Dim::value > 0)
-        CHECK_THROWS_AS((void) buf.at(extent), std::out_of_range);
-#endif
+        // check that an out-of-bound access is detected
+        if constexpr(Dim::value > 0)
+            CHECK_THROWS_AS((void) buf.at(extent), std::out_of_range);
+    }
 }
 
 TEMPLATE_LIST_TEST_CASE("memBufAccessorAdaptorTest", "[memBuf]", alpaka::test::TestAccs)

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -275,12 +275,16 @@ static auto testBufferAccessorAdaptor(
     auto const base = reinterpret_cast<uintptr_t>(std::data(buf));
     auto const expected = base + static_cast<uintptr_t>((pitch * index).sum());
     INFO("element " << index << " expected at offset " << expected - base);
+#if not defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_ACC_GPU_HIP_ENABLED)                              \
+    and not defined(ALPAKA_SYCL_ONEAPI_GPU) and not defined(ALPAKA_SYCL_ONEAPI_FPGA)
     INFO("element " << index << " returned at offset " << reinterpret_cast<uintptr_t>(&buf[index]) - base);
+
     CHECK(reinterpret_cast<Elem*>(expected) == &buf[index]);
 
     // check that an out-of-bound access is detected
     if constexpr(Dim::value > 0)
         CHECK_THROWS_AS((void) buf.at(extent), std::out_of_range);
+#endif
 }
 
 TEMPLATE_LIST_TEST_CASE("memBufAccessorAdaptorTest", "[memBuf]", alpaka::test::TestAccs)

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -15,14 +15,6 @@
 #include <numeric>
 #include <type_traits>
 
-namespace alpaka
-{
-
-    template<concepts::Tag TTag>
-    struct PlatformGenericSycl;
-
-} // namespace alpaka
-
 namespace buftest
 {
     template<typename TDim, typename TDev, typename TElem, typename TIdx, typename TExtent>

--- a/test/unit/mem/buf/src/ConstBufTest.cpp
+++ b/test/unit/mem/buf/src/ConstBufTest.cpp
@@ -41,9 +41,7 @@ namespace buftest
 
     template<typename TBuf>
     concept onlyConstNativePtr = requires(TBuf t) {
-        {
-            alpaka::getPtrNative(t)
-        } -> std::same_as<alpaka::Elem<std::remove_const_t<TBuf>> const*>;
+        { alpaka::getPtrNative(t) } -> std::same_as<alpaka::Elem<std::remove_const_t<TBuf>> const*>;
     };
 } // namespace buftest
 
@@ -80,8 +78,11 @@ static auto testConstBuffer(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> co
     // *getPtrNative(c_buf) = 0.f;  // <- this does not compile, as desired
 
     // check return types of the buffers
+#if not defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_ACC_GPU_HIP_ENABLED)                              \
+    and not defined(ALPAKA_SYCL_ONEAPI_GPU) and not defined(ALPAKA_SYCL_ONEAPI_FPGA)
     STATIC_REQUIRE(std::is_same_v<decltype(buf[0]), Elem&>);
     STATIC_REQUIRE(std::is_same_v<decltype(c_buf[0]), Elem const&>);
+#endif
 
     // check movability construction of buffers
     STATIC_REQUIRE(std::movable<TBuf>);

--- a/test/unit/mem/buf/src/ConstBufTest.cpp
+++ b/test/unit/mem/buf/src/ConstBufTest.cpp
@@ -15,14 +15,6 @@
 #include <numeric>
 #include <type_traits>
 
-namespace alpaka
-{
-
-    template<concepts::Tag TTag>
-    struct PlatformGenericSycl;
-
-} // namespace alpaka
-
 namespace buftest
 {
     template<typename TDev, typename TDim, typename TElem, typename TIdx, typename TExtent>

--- a/test/unit/mem/buf/src/ConstBufTest.cpp
+++ b/test/unit/mem/buf/src/ConstBufTest.cpp
@@ -41,7 +41,9 @@ namespace buftest
 
     template<typename TBuf>
     concept onlyConstNativePtr = requires(TBuf t) {
-        { alpaka::getPtrNative(t) } -> std::same_as<alpaka::Elem<std::remove_const_t<TBuf>> const*>;
+        {
+            alpaka::getPtrNative(t)
+        } -> std::same_as<alpaka::Elem<std::remove_const_t<TBuf>> const*>;
     };
 } // namespace buftest
 

--- a/test/unit/mem/buf/src/ConstBufTest.cpp
+++ b/test/unit/mem/buf/src/ConstBufTest.cpp
@@ -15,6 +15,14 @@
 #include <numeric>
 #include <type_traits>
 
+namespace alpaka
+{
+
+    template<concepts::Tag TTag>
+    struct PlatformGenericSycl;
+
+} // namespace alpaka
+
 namespace buftest
 {
     template<typename TDev, typename TDim, typename TElem, typename TIdx, typename TExtent>
@@ -80,11 +88,13 @@ static auto testConstBuffer(alpaka::Vec<alpaka::Dim<TAcc>, alpaka::Idx<TAcc>> co
     // *getPtrNative(c_buf) = 0.f;  // <- this does not compile, as desired
 
     // check return types of the buffers
-#if not defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_ACC_GPU_HIP_ENABLED)                              \
-    and not defined(ALPAKA_SYCL_ONEAPI_GPU) and not defined(ALPAKA_SYCL_ONEAPI_FPGA)
-    STATIC_REQUIRE(std::is_same_v<decltype(buf[0]), Elem&>);
-    STATIC_REQUIRE(std::is_same_v<decltype(c_buf[0]), Elem const&>);
-#endif
+    using Platform = alpaka::Platform<TAcc>;
+    if constexpr(
+        std::is_same_v<Platform, alpaka::PlatformCpu> or std::is_same_v<alpaka::AccToTag<TAcc>, alpaka::TagCpuSycl>)
+    {
+        STATIC_REQUIRE(std::is_same_v<decltype(buf[0]), Elem&>);
+        STATIC_REQUIRE(std::is_same_v<decltype(c_buf[0]), Elem const&>);
+    }
 
     // check movability construction of buffers
     STATIC_REQUIRE(std::movable<TBuf>);

--- a/test/unit/mem/view/src/ViewConst.cpp
+++ b/test/unit/mem/view/src/ViewConst.cpp
@@ -15,14 +15,6 @@
 #include <numeric>
 #include <type_traits>
 
-namespace alpaka
-{
-
-    template<concepts::Tag TTag>
-    struct PlatformGenericSycl;
-
-} // namespace alpaka
-
 namespace alpaka::test
 {
     template<typename TAcc, typename TQualifiedView, typename TDev, typename TQueue, typename TDim, typename TIdx>

--- a/test/unit/mem/view/src/ViewConst.cpp
+++ b/test/unit/mem/view/src/ViewConst.cpp
@@ -43,6 +43,8 @@ namespace alpaka::test
 
         // test view accessors
         STATIC_REQUIRE(std::is_same_v<decltype(view.data()), float const*>);
+#if not defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_ACC_GPU_HIP_ENABLED)                              \
+    and not defined(ALPAKA_SYCL_ONEAPI_GPU) and not defined(ALPAKA_SYCL_ONEAPI_FPGA)
         if constexpr(TDim::value == 0)
         {
             STATIC_REQUIRE(std::is_same_v<decltype(*view), float const&>);
@@ -54,6 +56,7 @@ namespace alpaka::test
 
         STATIC_REQUIRE(std::is_same_v<decltype(view[alpaka::Vec<TDim, TIdx>::zeros()]), float const&>);
         STATIC_REQUIRE(std::is_same_v<decltype(view.at(alpaka::Vec<TDim, TIdx>::zeros())), float const&>);
+#endif
     }
 } // namespace alpaka::test
 

--- a/test/unit/mem/view/src/ViewConst.cpp
+++ b/test/unit/mem/view/src/ViewConst.cpp
@@ -2,7 +2,9 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
+#include <alpaka/acc/Tag.hpp>
 #include <alpaka/mem/view/ViewConst.hpp>
+#include <alpaka/platform/Traits.hpp>
 #include <alpaka/test/Extent.hpp>
 #include <alpaka/test/acc/TestAccs.hpp>
 #include <alpaka/test/mem/view/ViewTest.hpp>
@@ -12,6 +14,14 @@
 
 #include <numeric>
 #include <type_traits>
+
+namespace alpaka
+{
+
+    template<concepts::Tag TTag>
+    struct PlatformGenericSycl;
+
+} // namespace alpaka
 
 namespace alpaka::test
 {
@@ -43,20 +53,23 @@ namespace alpaka::test
 
         // test view accessors
         STATIC_REQUIRE(std::is_same_v<decltype(view.data()), float const*>);
-#if not defined(ALPAKA_ACC_GPU_CUDA_ENABLED) and not defined(ALPAKA_ACC_GPU_HIP_ENABLED)                              \
-    and not defined(ALPAKA_SYCL_ONEAPI_GPU) and not defined(ALPAKA_SYCL_ONEAPI_FPGA)
-        if constexpr(TDim::value == 0)
+        using Platform = alpaka::Platform<TAcc>;
+        if constexpr(
+            std::is_same_v<Platform, alpaka::PlatformCpu>
+            or std::is_same_v<alpaka::AccToTag<TAcc>, alpaka::TagCpuSycl>)
         {
-            STATIC_REQUIRE(std::is_same_v<decltype(*view), float const&>);
-        }
-        else if constexpr(TDim::value == 1)
-        {
-            STATIC_REQUIRE(std::is_same_v<decltype(view[0]), float const&>);
-        }
+            if constexpr(TDim::value == 0)
+            {
+                STATIC_REQUIRE(std::is_same_v<decltype(*view), float const&>);
+            }
+            else if constexpr(TDim::value == 1)
+            {
+                STATIC_REQUIRE(std::is_same_v<decltype(view[0]), float const&>);
+            }
 
-        STATIC_REQUIRE(std::is_same_v<decltype(view[alpaka::Vec<TDim, TIdx>::zeros()]), float const&>);
-        STATIC_REQUIRE(std::is_same_v<decltype(view.at(alpaka::Vec<TDim, TIdx>::zeros())), float const&>);
-#endif
+            STATIC_REQUIRE(std::is_same_v<decltype(view[alpaka::Vec<TDim, TIdx>::zeros()]), float const&>);
+            STATIC_REQUIRE(std::is_same_v<decltype(view.at(alpaka::Vec<TDim, TIdx>::zeros())), float const&>);
+        }
     }
 } // namespace alpaka::test
 


### PR DESCRIPTION
Currently all types of Buffers and Views inherit from `ViewAccessOps`, and this provides accessors `operator*`, `operator[]`, etc even for device buffers, although using those methods would result in a seg fault.
In this PR I separated `ViewAccessOps` in a `HostViewAccessor` and `DeviceViewAccessor`, and a matryoshka template `ViewAccessorType` that selects the correct accessor depending on the device type. 

Note: I also rewrote the `isView` trait as a concept, since it was marked as TODO.
FYI @fwyzard 