### PR TITLE
Implement `alpaka::allocAsyncBuf()` for SYCL devices

### DIFF
--- a/include/alpaka/mem/buf/cpu/traits/BufCpuTraits.hpp
+++ b/include/alpaka/mem/buf/cpu/traits/BufCpuTraits.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2025 Anton Reinhard
+/* Copyright 2025 Alexander Matthes, Axel Huebl, Benjamin Worpitz, Andrea Bocci, Jan Stephan, Bernhard Manfred Gruber,
+ *                Anton Reinhard
  * SPDX-License-Identifier: MPL-2.0
  */
 #pragma once
@@ -164,7 +165,7 @@ namespace alpaka::trait
         }
     };
 
-    //! The ConstBufCpu stream-ordered memory allocation capability trait specialization.
+    //! The BufCpu stream-ordered memory allocation capability trait specialization.
     template<typename TDim>
     struct HasAsyncBufSupport<TDim, DevCpu> : public std::true_type
     {

--- a/include/alpaka/mem/buf/sycl/traits/BufGenericSyclTraits.hpp
+++ b/include/alpaka/mem/buf/sycl/traits/BufGenericSyclTraits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Anton Reinhard
+/* Copyright 2025 Jan Stephan, Luca Ferragina, Aurora Perego, Andrea Bocci, Anton Reinhard
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -6,6 +6,7 @@
 
 #include "alpaka/mem/buf/Traits.hpp"
 #include "alpaka/mem/buf/sycl/BufGenericSycl.hpp"
+#include "alpaka/queue/sycl/QueueGenericSyclBase.hpp"
 
 #ifdef ALPAKA_ACC_SYCL_ENABLED
 
@@ -195,8 +196,76 @@ namespace alpaka::trait
 
     //! The BufGenericSycl stream-ordered memory allocation capability trait specialization.
     template<typename TDim, concepts::Tag TTag>
-    struct HasAsyncBufSupport<TDim, DevGenericSycl<TTag>> : std::false_type
+    struct HasAsyncBufSupport<TDim, DevGenericSycl<TTag>> : std::true_type
     {
+    };
+
+    //! The BufGenericSycl stream-ordered memory allocation trait specialization.
+    template<typename TElem, typename TDim, typename TIdx, concepts::Tag TTag>
+    struct AsyncBufAlloc<TElem, TDim, TIdx, DevGenericSycl<TTag>>
+    {
+        template<bool TBlocking, typename TExtent>
+        ALPAKA_FN_HOST static auto allocAsyncBuf(
+            detail::QueueGenericSyclBase<TTag, TBlocking> queue,
+            TExtent const& extent) -> BufGenericSycl<TElem, TDim, TIdx, TTag>
+        {
+            ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+#    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+            if constexpr(TDim::value == 0)
+                std::cout << __func__ << " ewb: " << sizeof(TElem) << '\n';
+            else if constexpr(TDim::value == 1)
+            {
+                auto const width = getWidth(extent);
+
+                auto const widthBytes = width * static_cast<TIdx>(sizeof(TElem));
+                std::cout << __func__ << " ew: " << width << " ewb: " << widthBytes << '\n';
+            }
+            else if constexpr(TDim::value == 2)
+            {
+                auto const width = getWidth(extent);
+                auto const height = getHeight(extent);
+
+                auto const widthBytes = width * static_cast<TIdx>(sizeof(TElem));
+                std::cout << __func__ << " ew: " << width << " eh: " << height << " ewb: " << widthBytes
+                          << " pitch: " << widthBytes << '\n';
+            }
+            else if constexpr(TDim::value == 3)
+            {
+                auto const width = getWidth(extent);
+                auto const height = getHeight(extent);
+                auto const depth = getDepth(extent);
+
+                auto const widthBytes = width * static_cast<TIdx>(sizeof(TElem));
+                std::cout << __func__ << " ew: " << width << " eh: " << height << " ed: " << depth
+                          << " ewb: " << widthBytes << " pitch: " << widthBytes << '\n';
+            }
+#    endif
+
+            sycl::queue q = queue.getNativeHandle();
+            TElem* memPtr = sycl::malloc_device<TElem>(static_cast<std::size_t>(getExtentProduct(extent)), q);
+            auto deleter = [q](TElem* ptr) mutable
+            {
+                if constexpr(TBlocking)
+                {
+                    // If the queue is blocking, all operations submitted when the buffer goes out of scope should
+                    // always have completed. Free the memory immediately, and wait for the free operation to complete.
+                    // From SYCL 4.8.3.6: Note: Whether free is blocking or non-blocking is unspecified. Applications
+                    // should not rely on free for synchronization, nor assume that free cannot cause deadlocks.
+                    sycl::free(ptr, q);
+                    q.wait();
+                }
+                else
+                {
+                    // If the queue is non-blocking, enqueue the free() operation in a host_task.
+                    q.submit([&](sycl::handler& cgh) { //
+                        cgh.host_task([=]() { sycl::free(ptr, q); });
+                    });
+                }
+            };
+
+            return BufGenericSycl<TElem, TDim, TIdx, TTag>(getDev(queue), memPtr, std::move(deleter), extent);
+        }
     };
 
     //! The pinned/mapped memory allocation capability trait specialization.

--- a/include/alpaka/mem/buf/sycl/traits/ConstBufGenericSyclTraits.hpp
+++ b/include/alpaka/mem/buf/sycl/traits/ConstBufGenericSyclTraits.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "alpaka/mem/buf/Traits.hpp"
+#include "alpaka/mem/buf/cpu/BufCpu.hpp"
 #include "alpaka/mem/buf/sycl/ConstBufGenericSycl.hpp"
 
 #ifdef ALPAKA_ACC_SYCL_ENABLED


### PR DESCRIPTION
The behaviour is emulated using regular SYCL device allocations and a delayed deallocation, as SYCL does not provide asynchronous, queue-ordered memory allocation/deallocation primitives.

The allocation uses `sycl::malloc_device()` and is always immediate and blocking.

The deallocation depends on the properties of the queue:
  * if the queue is blocking, all operations submitted when the buffer goes out of scope should already have completed; free the memory immediately, and wait for the free operation to complete;
  * if the queue is non-blocking, enqueue the call to `sycl::free()` in a host_task.
