### PR TITLE
Extend `alpaka::allocAsyncBuf()` to N-dimensional buffers on CUDA/HIP devices

### DIFF
--- a/docs/source/dev/backends.rst
+++ b/docs/source/dev/backends.rst
@@ -381,7 +381,7 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMallocArray            | --                                                                                         |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMallocAsync            | alpaka::allocAsyncBuf<TElement>(queue, extents1D)                                          |
+    | cudaMallocAsync            | alpaka::allocAsyncBuf<TElement>(queue, extents) 1D, 2D, 3D supported!                      |
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMallocHost             | alpaka::allocMappedBuf<TElement, TIdx>(host, platform, extents) 1D, 2D, 3D supported! [1]  |
     +----------------------------+--------------------------------------------------------------------------------------------+
@@ -454,7 +454,7 @@ The following tables list the functions available in the `CUDA Runtime API <http
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMemset2D               | alpaka::memset(queue, memBufDst, byte, extents2D)                                          |
     +----------------------------+--------------------------------------------------------------------------------------------+
-    | cudaMemset2DAsync          | alpaka::memset(queue, memBufDst, byte, extents2D, queue)                                   |
+    | cudaMemset2DAsync          | alpaka::memset(queue, memBufDst, byte, extents2D)                                          |
     +----------------------------+--------------------------------------------------------------------------------------------+
     | cudaMemset3D               | alpaka::memset(queue, memBufDst, byte, extents3D)                                          |
     +----------------------------+--------------------------------------------------------------------------------------------+

--- a/include/alpaka/mem/buf/uniformCudaHip/traits/BufUniformCudaHipRtTraits.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/traits/BufUniformCudaHipRtTraits.hpp
@@ -7,6 +7,7 @@
 #include "alpaka/mem/buf/Traits.hpp"
 #include "alpaka/mem/buf/cpu/BufCpu.hpp"
 #include "alpaka/mem/buf/uniformCudaHip/BufUniformCudaHipRt.hpp"
+#include "alpaka/mem/view/Traits.hpp"
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
@@ -256,7 +257,7 @@ namespace alpaka::trait
 
     //! The CUDA/HIP stream-ordered memory allocation capability trait specialization.
     template<typename TApi, typename TDim>
-    struct HasAsyncBufSupport<TDim, DevUniformCudaHipRt<TApi>> : std::bool_constant<TDim::value <= 1>
+    struct HasAsyncBufSupport<TDim, DevUniformCudaHipRt<TApi>> : std::true_type
     {
     };
 
@@ -264,27 +265,58 @@ namespace alpaka::trait
     template<typename TApi, typename TElem, typename TDim, typename TIdx>
     struct AsyncBufAlloc<TElem, TDim, TIdx, DevUniformCudaHipRt<TApi>>
     {
-        static_assert(
-            TDim::value <= 1,
-            "CUDA/HIP devices support only one-dimensional stream-ordered memory buffers.");
-
-        template<typename TQueue, typename TExtent>
-        ALPAKA_FN_HOST static auto allocAsyncBuf(TQueue queue, [[maybe_unused]] TExtent const& extent)
+        template<typename TQueue>
+        ALPAKA_FN_HOST static auto allocAsyncBuf(TQueue queue, [[maybe_unused]] Vec<TDim, TIdx> const& extent)
             -> BufUniformCudaHipRt<TApi, TElem, TDim, TIdx>
         {
             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-            static_assert(TDim::value == Dim<TExtent>::value, "extent must have the same dimension as the buffer");
-            auto const width = getExtentProduct(extent); // handles 1D and 0D buffers
+            std::size_t bytes, pitch;
+            if constexpr(TDim::value == 0)
+            {
+                bytes = pitch = sizeof(TElem);
+            }
+            else if constexpr(TDim::value == 1)
+            {
+                bytes = pitch = static_cast<std::size_t>(extent.back()) * sizeof(TElem);
+            }
+            else
+            {
+                std::size_t const width = static_cast<std::size_t>(extent.back()) * sizeof(TElem);
+                // On all tested NVIDIA and AMD GPUs the alignment used for pitched allocations is the same value
+                // reported by the textureAlignment device property (512 bytes on NVIDA GPUs, 256 bytes on AMD GPUs).
+                // This was tested on: NVIDIA Tesla T4, A100, L40S, H100, and RTX 3050 Ti Laptop GPUs,
+                // and on AMD Radeon Pro WX 9100, Radeon Pro W7800/W7900, Instinct MI250X, and Instinct MI300X.
+                // However, it is expected that an alignment of 128 bytes (32 threads per warp times 4 bytes per float
+                // or int) should be sufficient to achieve coalesced memory accesses, and would reduce the amount of
+                // wasted memory.
+                constexpr std::size_t alignment = 128;
+                pitch = (width + alignment - 1) / alignment * alignment;
+                // Replace the last entry in the extent vector (i.e. the number of elements per row) with the pitch
+                // (the number of bytes per row, including padding), and compute the total size in bytes, removing
+                // the padding after the last row.
+                auto aligned = alpaka::castVec<std::size_t>(extent);
+                aligned.back() = pitch;
+                bytes = aligned.prod() - pitch + width;
+            }
 
             auto const& dev = getDev(queue);
             ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::setDevice(dev.getNativeHandle()));
             void* memPtr = nullptr;
-            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(
-                TApi::mallocAsync(&memPtr, static_cast<std::size_t>(width) * sizeof(TElem), queue.getNativeHandle()));
+            ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK(TApi::mallocAsync(&memPtr, bytes, queue.getNativeHandle()));
 
 #    if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-            std::cout << __func__ << " ew: " << width << " ptr: " << memPtr << std::endl;
+            std::cout << __func__;
+            if constexpr(Dim::value >= 1)
+                std::cout << " ew: " << getWidth(extent);
+            if constexpr(Dim::value >= 2)
+                std::cout << " eh: " << getHeight(extent);
+            if constexpr(Dim::value >= 3)
+                std::cout << " ed: " << getDepth(extent);
+            std::cout << " ptr: " << memPtr;
+            if constexpr(Dim::value >= 2)
+                std::cout << " rowpitch: " << pitch;
+            std::cout << std::endl;
 #    endif
             return {
                 dev,
@@ -292,7 +324,7 @@ namespace alpaka::trait
                 [q = std::move(queue)](TElem* ptr)
                 { ALPAKA_UNIFORM_CUDA_HIP_RT_CHECK_NOEXCEPT(TApi::freeAsync(ptr, q.getNativeHandle())); },
                 extent,
-                static_cast<std::size_t>(width) * sizeof(TElem)};
+                pitch};
         }
     };
 

--- a/include/alpaka/mem/buf/uniformCudaHip/traits/ConstBufUniformCudaHipRtTraits.hpp
+++ b/include/alpaka/mem/buf/uniformCudaHip/traits/ConstBufUniformCudaHipRtTraits.hpp
@@ -9,6 +9,7 @@
 #include "alpaka/mem/buf/cpu/BufCpu.hpp"
 #include "alpaka/mem/buf/uniformCudaHip/BufUniformCudaHipRt.hpp"
 #include "alpaka/mem/buf/uniformCudaHip/ConstBufUniformCudaHipRt.hpp"
+#include "alpaka/mem/view/Traits.hpp"
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
@@ -99,18 +100,16 @@ namespace alpaka::trait
         ALPAKA_FN_HOST auto operator()(ConstBufUniformCudaHipRt<TApi, TElem, TDim, TIdx> const& buf) const
             -> Vec<TDim, TIdx>
         {
-            Vec<TDim, TIdx> v{};
-            if constexpr(TDim::value > 0)
+            if constexpr(TDim::value <= 1)
             {
-                v.back() = sizeof(TElem);
-                if constexpr(TDim::value > 1)
-                {
-                    v[TDim::value - 2] = static_cast<TIdx>(buf.m_spBufImpl->m_rowPitchInBytes);
-                    for(TIdx i = TDim::value - 2; i > 0; i--)
-                        v[i - 1] = buf.m_spBufImpl->m_extentElements[i] * v[i];
-                }
+                return alpaka::detail::calculatePitchesFromExtents<TElem>(buf.m_spBufImpl->m_extentElements);
             }
-            return v;
+            else
+            {
+                return alpaka::detail::calculatePitchesFromExtentsAndPitch<TElem>(
+                    buf.m_spBufImpl->m_extentElements,
+                    buf.m_spBufImpl->m_rowPitchInBytes);
+            }
         }
     };
 

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -19,6 +19,7 @@
 #include "alpaka/vec/Vec.hpp"
 
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <iosfwd>
 #include <type_traits>
@@ -44,6 +45,31 @@ namespace alpaka
                     pitchBytes[i - 1] = extent[i] * pitchBytes[i];
             return pitchBytes;
         }
+
+        //! Calculate the pitches from the extents and the one-dimensional pitch.
+        template<typename TElem, typename TDim, typename TIdx>
+        ALPAKA_FN_HOST_ACC inline constexpr auto calculatePitchesFromExtentsAndPitch(
+            Vec<TDim, TIdx> const& extent,
+            std::size_t pitch)
+        {
+            Vec<TDim, TIdx> pitchBytes{};
+            constexpr auto dim = TIdx{TDim::value};
+            if constexpr(dim > 0)
+                pitchBytes.back() = static_cast<TIdx>(sizeof(TElem));
+            if constexpr(dim > 1)
+            {
+                if(pitch == 0)
+                    pitchBytes[TDim::value - 2] = extent.back() * pitchBytes.back();
+                else
+                    pitchBytes[TDim::value - 2] = static_cast<TIdx>(
+                        (static_cast<std::size_t>(extent.back() * pitchBytes.back()) + pitch - 1) / pitch * pitch);
+            }
+            if constexpr(dim > 2)
+                for(TIdx i = TDim::value - 2; i > 0; i--)
+                    pitchBytes[i - 1] = extent[i] * pitchBytes[i];
+            return pitchBytes;
+        }
+
     } // namespace detail
 
     //! The view traits.


### PR DESCRIPTION
CUDA and HIP do not provide an asynchronous equivalent of `cuda`/`hipMallocPitch` or `cuda`/`hipMalloc3D`, and do not document the how the pitch is determined by those functions.

However, on all tested platforms, the alignment used for the pitch matches the value of the `textureAlignment` device attribute: 512 bytes on NVIDIA GPUs, 256 bytes on AMD GPUs.

The asynchronous allocation of N-dimensional buffers can be implemented in alpaka using `cuda`/`hipMallocAsync` and handling the pitch based on the `textureAlignment` value (which is currently hard-coded).