### PR TITLE
Implement compile-time warp size, when available

### DIFF
--- a/include/alpaka/warp/Traits.hpp
+++ b/include/alpaka/warp/Traits.hpp
@@ -23,6 +23,14 @@ namespace alpaka::warp
         template<typename TWarp, typename TSfinae = void>
         struct GetSize;
 
+        //! The compile-time warp size trait.
+        template<typename TWarp, typename TSfinae = void>
+        struct GetSizeCompileTime;
+
+        //! The warp size upper-limit trait.
+        template<typename TWarp, typename TSfinae = void>
+        struct GetSizeUpperLimit;
+
         //! The all warp vote trait.
         template<typename TWarp, typename TSfinae = void>
         struct All;
@@ -68,12 +76,35 @@ namespace alpaka::warp
         return trait::GetSize<ImplementationBase>::getSize(warp);
     }
 
+    //! If the warp size is available as a compile-time constant returns its value; otherwise returns 0.
+    //!
+    //! \tparam TWarp The warp implementation type.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TWarp>
+    ALPAKA_FN_ACC constexpr auto getSizeCompileTime() -> std::int32_t
+    {
+        using ImplementationBase = interface::ImplementationBase<ConceptWarp, std::remove_cvref_t<TWarp>>;
+        return trait::GetSizeCompileTime<ImplementationBase>::getSizeCompileTime();
+    }
+
+    //! If the warp size is available as a compile-time constant returns its value; otherwise returns an upper limit on
+    //! the possible warp size values.
+    //!
+    //! \tparam TWarp The warp implementation type.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TWarp>
+    ALPAKA_FN_ACC constexpr auto getSizeUpperLimit() -> std::int32_t
+    {
+        using ImplementationBase = interface::ImplementationBase<ConceptWarp, std::remove_cvref_t<TWarp>>;
+        return trait::GetSizeUpperLimit<ImplementationBase>::getSizeUpperLimit();
+    }
+
     //! Returns a 32- or 64-bit unsigned integer (depending on the
     //! accelerator) whose Nth bit is set if and only if the Nth thread
     //! of the warp is active.
     //!
     //! Note: decltype for return type is required there, otherwise
-    //! compilcation with a CPU and a GPU accelerator enabled fails as it
+    //! compilation with a CPU and a GPU accelerator enabled fails as it
     //! tries to call device function from a host-device one. The reason
     //! is unclear, but likely related to deducing the return type.
     //!

--- a/include/alpaka/warp/WarpGenericSycl.hpp
+++ b/include/alpaka/warp/WarpGenericSycl.hpp
@@ -48,6 +48,26 @@ namespace alpaka::warp::trait
     };
 
     template<typename TDim>
+    struct GetSizeCompileTime<warp::WarpGenericSycl<TDim>>
+    {
+        static constexpr auto getSizeCompileTime() -> std::int32_t
+        {
+            // SYCL sub-groups size is usually not known at compile time
+            return 0;
+        }
+    };
+
+    template<typename TDim>
+    struct GetSizeUpperLimit<warp::WarpGenericSycl<TDim>>
+    {
+        static constexpr auto getSizeUpperLimit() -> std::int32_t
+        {
+            // See include/alpaka/kernel/SyclSubgroupSize.hpp for possible sub-group sizes.
+            return 64;
+        }
+    };
+
+    template<typename TDim>
     struct Activemask<warp::WarpGenericSycl<TDim>>
     {
         // FIXME This should be std::uint64_t on AMD GCN architectures and on CPU,

--- a/include/alpaka/warp/WarpSingleThread.hpp
+++ b/include/alpaka/warp/WarpSingleThread.hpp
@@ -20,7 +20,25 @@ namespace alpaka::warp
         template<>
         struct GetSize<WarpSingleThread>
         {
-            static auto getSize(warp::WarpSingleThread const& /*warp*/)
+            static auto getSize(warp::WarpSingleThread const& /*warp*/) -> std::int32_t
+            {
+                return 1;
+            }
+        };
+
+        template<>
+        struct GetSizeCompileTime<WarpSingleThread>
+        {
+            static constexpr auto getSizeCompileTime() -> std::int32_t
+            {
+                return 1;
+            }
+        };
+
+        template<>
+        struct GetSizeUpperLimit<WarpSingleThread>
+        {
+            static constexpr auto getSizeUpperLimit() -> std::int32_t
             {
                 return 1;
             }

--- a/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
@@ -41,6 +41,58 @@ namespace alpaka::warp
         };
 
         template<>
+        struct GetSizeCompileTime<WarpUniformCudaHipBuiltIn>
+        {
+            static constexpr auto getSizeCompileTime() -> std::int32_t
+            {
+#        if defined(__CUDA_ARCH__)
+                // CUDA always has a warp size of 32
+                return 32;
+#        elif defined(__HIP_DEVICE_COMPILE__)
+                // HIP/ROCm may have a wavefront of 32 or 64 depending on the target device
+#            if defined(__GFX9__)
+                // GCN 5.0 and CDNA GPUs have a wavefront size of 64
+                return 64;
+#            elif defined(__GFX10__) or defined(__GFX11__) or defined(__GFX12__)
+                // RDNA GPUs have a wavefront size of 32
+                return 32;
+#            else
+                // Unknown AMD GPU architecture
+                return 0;
+#            endif
+#        endif
+                // Host compilation
+                return 0;
+            }
+        };
+
+        template<>
+        struct GetSizeUpperLimit<WarpUniformCudaHipBuiltIn>
+        {
+            static constexpr auto getSizeUpperLimit() -> std::int32_t
+            {
+#        if defined(__CUDA_ARCH__)
+                // CUDA always has a warp size of 32
+                return 32;
+#        elif defined(__HIP_DEVICE_COMPILE__)
+                // HIP/ROCm may have a wavefront of 32 or 64 depending on the target device
+#            if defined(__GFX9__)
+                // GCN 5.0 and CDNA GPUs have a wavefront size of 64
+                return 64;
+#            elif defined(__GFX10__) or defined(__GFX11__) or defined(__GFX12__)
+                // RDNA GPUs have a wavefront size of 32
+                return 32;
+#            else
+                // Unknown AMD GPU architecture
+                return 64;
+#            endif
+#        endif
+                // Host compilation
+                return 64;
+            }
+        };
+
+        template<>
         struct Activemask<WarpUniformCudaHipBuiltIn>
         {
             __device__ static auto activemask(warp::WarpUniformCudaHipBuiltIn const& /*warp*/)

--- a/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
@@ -43,7 +43,7 @@ namespace alpaka::warp
         template<>
         struct GetSizeCompileTime<WarpUniformCudaHipBuiltIn>
         {
-            static constexpr auto getSizeCompileTime() -> std::int32_t
+            __device__ static constexpr auto getSizeCompileTime() -> std::int32_t
             {
 #        if defined(__CUDA_ARCH__)
                 // CUDA always has a warp size of 32
@@ -58,7 +58,12 @@ namespace alpaka::warp
                 return 32;
 #            else
                 // Unknown AMD GPU architecture
+#                ifdef ALPAKA_DEFAULT_AMD_WAVEFRONT_SIZE
+                return ALPAKA_DEFAULT_AMD_WAVEFRONT_SIZE
+#                else
+#                    error The current AMD GPU architucture is not supported by this version of alpaka. You can define a default wavefront size setting the preprocessor macro ALPAKA_DEFAULT_AMD_WAVEFRONT_SIZE
                 return 0;
+#                endif
 #            endif
 #        endif
                 // Host compilation
@@ -69,7 +74,7 @@ namespace alpaka::warp
         template<>
         struct GetSizeUpperLimit<WarpUniformCudaHipBuiltIn>
         {
-            static constexpr auto getSizeUpperLimit() -> std::int32_t
+            __device__ static constexpr auto getSizeUpperLimit() -> std::int32_t
             {
 #        if defined(__CUDA_ARCH__)
                 // CUDA always has a warp size of 32
@@ -84,7 +89,12 @@ namespace alpaka::warp
                 return 32;
 #            else
                 // Unknown AMD GPU architecture
+#                ifdef ALPAKA_DEFAULT_AMD_WAVEFRONT_SIZE
+                return ALPAKA_DEFAULT_AMD_WAVEFRONT_SIZE
+#                else
+#                    error The current AMD GPU architucture is not supported by this version of alpaka. You can define a default wavefront size setting the preprocessor macro ALPAKA_DEFAULT_AMD_WAVEFRONT_SIZE
                 return 64;
+#                endif
 #            endif
 #        endif
                 // Host compilation

--- a/test/unit/warp/src/GetSize.cpp
+++ b/test/unit/warp/src/GetSize.cpp
@@ -19,7 +19,20 @@ struct GetSizeTestKernel
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(TAcc const& acc, bool* success, std::int32_t expectedWarpSize) const -> void
     {
-        ALPAKA_CHECK(*success, alpaka::warp::getSize(acc) == expectedWarpSize);
+        // run-time warp size
+        std::int32_t size = alpaka::warp::getSize(acc);
+        ALPAKA_CHECK(*success, size != 0);
+        // compare with the warp size requested when launching the kernel
+        ALPAKA_CHECK(*success, size == expectedWarpSize);
+        // compare with the compile-time upper limit on the warp size
+        constexpr std::int32_t upperLimit = alpaka::warp::getSizeUpperLimit<TAcc>();
+        ALPAKA_CHECK(*success, size <= upperLimit);
+        // if the warp size is defined at compile-time, compare it with the run-time value
+        constexpr std::int32_t constexprSize = alpaka::warp::getSizeCompileTime<TAcc>();
+        if constexpr(constexprSize != 0)
+        {
+            ALPAKA_CHECK(*success, size == constexprSize);
+        }
     }
 };
 


### PR DESCRIPTION
Still to do:
  - [x] add tests
  - [ ] ~~define the warp size at compile time for SYCL kernels, when specialised~~