### PR TITLE
Increase the stack size for the CI jobs

### DIFF
--- a/script/set_default_env_vars.sh
+++ b/script/set_default_env_vars.sh
@@ -10,3 +10,7 @@ export CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:=""}
 export CMAKE_CUDA_FLAGS=${CMAKE_CUDA_FLAGS:=""}
 export CMAKE_HIP_FLAGS=${CMAKE_HIP_FLAGS:=""}
 export ALPAKA_CI_TBB_DIR=${ALPAKA_CI_TBB_DIR:=""}
+
+# increase the maximum stack size to work around a limitation of ROCm (see https://github.com/ROCm/ROCm/issues/4751)
+
+ulimit -s hard


### PR DESCRIPTION
Increase the maximum stack size to work around a limitation of ROCm.
See https://github.com/ROCm/ROCm/issues/4751 for more details.