### PR TITLE
fix `SYCL_SUBGROUP_SIZE` macro for Sycl

### DIFF
--- a/include/alpaka/kernel/SyclSubgroupSize.hpp
+++ b/include/alpaka/kernel/SyclSubgroupSize.hpp
@@ -4,6 +4,9 @@
 
 #ifdef ALPAKA_ACC_SYCL_ENABLED
 
+// defines can be taken from
+// https://github.com/llvm/llvm-project/blob/3cfe6aa46e06a8caa3f07057838d31c6ce840076/clang/include/clang/Basic/OffloadArch.h#L18-L28
+
 #    ifdef __SYCL_DEVICE_ONLY__
 
 #        if /* Broadwell Intel graphics architecture */                                                               \
@@ -72,33 +75,55 @@
 #            define SYCL_SUBGROUP_SIZE (4 | 8 | 16 | 32 | 64)
 
 #        elif /* NVIDIA Maxwell architecture (compute capability 5.0) */                                              \
-            (defined(__SYCL_TARGET_NVIDIA_GPU_SM50__) && __SYCL_TARGET_NVIDIA_GPU_SM50__)                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_50__) && __SYCL_TARGET_NVIDIA_GPU_SM_50__)                           \
             || /* NVIDIA Maxwell architecture (compute capability 5.2) */                                             \
-            (defined(__SYCL_TARGET_NVIDIA_GPU_SM52__) && __SYCL_TARGET_NVIDIA_GPU_SM52__)                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_52__) && __SYCL_TARGET_NVIDIA_GPU_SM_52__)                           \
             || /* NVIDIA Jetson TX1 / Nano (compute capability 5.3) */                                                \
-            (defined(__SYCL_TARGET_NVIDIA_GPU_SM53__) && __SYCL_TARGET_NVIDIA_GPU_SM53__)                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_53__) && __SYCL_TARGET_NVIDIA_GPU_SM_53__)                           \
             || /* NVIDIA Pascal architecture (compute capability 6.0) */                                              \
-            (defined(__SYCL_TARGET_NVIDIA_GPU_SM60__) && __SYCL_TARGET_NVIDIA_GPU_SM60__)                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_60__) && __SYCL_TARGET_NVIDIA_GPU_SM_60__)                           \
             || /* NVIDIA Pascal architecture (compute capability 6.1) */                                              \
-            (defined(__SYCL_TARGET_NVIDIA_GPU_SM61__) && __SYCL_TARGET_NVIDIA_GPU_SM61__)                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_61__) && __SYCL_TARGET_NVIDIA_GPU_SM_61__)                           \
             || /* NVIDIA Jetson TX2 (compute capability 6.2) */                                                       \
-            (defined(__SYCL_TARGET_NVIDIA_GPU_SM62__) && __SYCL_TARGET_NVIDIA_GPU_SM62__)                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_62__) && __SYCL_TARGET_NVIDIA_GPU_SM_62__)                           \
             || /* NVIDIA Volta architecture (compute capability 7.0) */                                               \
-            (defined(__SYCL_TARGET_NVIDIA_GPU_SM70__) && __SYCL_TARGET_NVIDIA_GPU_SM70__)                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_70__) && __SYCL_TARGET_NVIDIA_GPU_SM_70__)                           \
             || /* NVIDIA Jetson AGX (compute capability 7.2) */                                                       \
-            (defined(__SYCL_TARGET_NVIDIA_GPU_SM72__) && __SYCL_TARGET_NVIDIA_GPU_SM72__)                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_72__) && __SYCL_TARGET_NVIDIA_GPU_SM_72__)                           \
             || /* NVIDIA Turing architecture (compute capability 7.5) */                                              \
-            (defined(__SYCL_TARGET_NVIDIA_GPU_SM75__) && __SYCL_TARGET_NVIDIA_GPU_SM75__)                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_75__) && __SYCL_TARGET_NVIDIA_GPU_SM_75__)                           \
             || /* NVIDIA Ampere architecture (compute capability 8.0) */                                              \
-            (defined(__SYCL_TARGET_NVIDIA_GPU_SM80__) && __SYCL_TARGET_NVIDIA_GPU_SM80__)                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_80__) && __SYCL_TARGET_NVIDIA_GPU_SM_80__)                           \
             || /* NVIDIA Ampere architecture (compute capability 8.6) */                                              \
-            (defined(__SYCL_TARGET_NVIDIA_GPU_SM86__) && __SYCL_TARGET_NVIDIA_GPU_SM86__)                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_86__) && __SYCL_TARGET_NVIDIA_GPU_SM_86__)                           \
             || /* NVIDIA Jetson/Drive AGX Orin (compute capability 8.7) */                                            \
-            (defined(__SYCL_TARGET_NVIDIA_GPU_SM87__) && __SYCL_TARGET_NVIDIA_GPU_SM87__)                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_87__) && __SYCL_TARGET_NVIDIA_GPU_SM_87__)                           \
             || /* NVIDIA Ada Lovelace arch. (compute capability 8.9) */                                               \
-            (defined(__SYCL_TARGET_NVIDIA_GPU_SM89__) && __SYCL_TARGET_NVIDIA_GPU_SM89__)                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_89__) && __SYCL_TARGET_NVIDIA_GPU_SM_89__)                           \
             || /* NVIDIA Hopper architecture (compute capability 9.0) */                                              \
-            (defined(__SYCL_TARGET_NVIDIA_GPU_SM90__) && __SYCL_TARGET_NVIDIA_GPU_SM90__)
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_90__) && __SYCL_TARGET_NVIDIA_GPU_SM_90__)                           \
+            || /*NVIDIA Hopper architecture variant(compute capability 9.0a) */                                       \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_90a__) && __SYCL_TARGET_NVIDIA_GPU_SM_90a__)                         \
+            || /* NVIDIA Blackwell architecture (compute capability 10.0) */                                          \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_100__) && __SYCL_TARGET_NVIDIA_GPU_SM_100__)                         \
+            || /* NVIDIA Blackwell architecture variant (compute capability 10.0a) */                                 \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_100a__) && __SYCL_TARGET_NVIDIA_GPU_SM_100a__)                       \
+            || /* NVIDIA Blackwell Next architecture (compute capability 10.1) */                                     \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_101__) && __SYCL_TARGET_NVIDIA_GPU_SM_101__)                         \
+            || /* NVIDIA Blackwell Next architecture variant (compute capability 10.1a) */                            \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_101a__) && __SYCL_TARGET_NVIDIA_GPU_SM_101a__)                       \
+            || /* NVIDIA Next-generation architecture (compute capability 10.3) */                                    \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_103__) && __SYCL_TARGET_NVIDIA_GPU_SM_103__)                         \
+            || /* NVIDIA Next-generation architecture variant (compute capability 10.3a) */                           \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_103a__) && __SYCL_TARGET_NVIDIA_GPU_SM_103a__)                       \
+            || /* NVIDIA Future architecture (compute capability 12.0) */                                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_120__) && __SYCL_TARGET_NVIDIA_GPU_SM_120__)                         \
+            || /* NVIDIA Future architecture variant (compute capability 12.0a) */                                    \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_120a__) && __SYCL_TARGET_NVIDIA_GPU_SM_120a__)                       \
+            || /* NVIDIA Future architecture (compute capability 12.1) */                                             \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_121__) && __SYCL_TARGET_NVIDIA_GPU_SM_121__)                         \
+            || /* NVIDIA Future architecture variant (compute capability 12.1a) */                                    \
+            (defined(__SYCL_TARGET_NVIDIA_GPU_SM_121a__) && __SYCL_TARGET_NVIDIA_GPU_SM_121a__)
 
 #            define SYCL_SUBGROUP_SIZE (32) /* CUDA supports warp size 32 */
 
@@ -134,12 +159,18 @@
             (defined(__SYCL_TARGET_AMD_GPU_GFX90A__) && __SYCL_TARGET_AMD_GPU_GFX90A__)                               \
             || /* AMD GCN 5.1 Renoir architecture (gfx 9.0) */                                                        \
             (defined(__SYCL_TARGET_AMD_GPU_GFX90C__) && __SYCL_TARGET_AMD_GPU_GFX90C__)                               \
+            || /* AMD CDNA 3.x generic architecture (gfx 9.4) */                                                      \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX9_4_GENERIC__) && __SYCL_TARGET_AMD_GPU_GFX9_4_GENERIC__)               \
             || /* AMD CDNA 3.0 Aqua Vanjaram architecture (gfx 9.4) */                                                \
             (defined(__SYCL_TARGET_AMD_GPU_GFX940__) && __SYCL_TARGET_AMD_GPU_GFX940__)                               \
             || /* AMD CDNA 3.0 Aqua Vanjaram architecture (gfx 9.4) */                                                \
             (defined(__SYCL_TARGET_AMD_GPU_GFX941__) && __SYCL_TARGET_AMD_GPU_GFX941__)                               \
             || /* AMD CDNA 3.0 Aqua Vanjaram architecture (gfx 9.4) */                                                \
-            (defined(__SYCL_TARGET_AMD_GPU_GFX942__) && __SYCL_TARGET_AMD_GPU_GFX942__)
+            (defined(__SYCL_TARGET_AMD_GPU_GFX942__) && __SYCL_TARGET_AMD_GPU_GFX942__)                               \
+            || /* AMD CDNA 3.5 derivative architecture (gfx 9.5) */                                                   \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX950__) && __SYCL_TARGET_AMD_GPU_GFX950__)                               \
+            || /* AMD GCN 5.x generic architecture (gfx 9.x) */                                                       \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX9_GENERIC__) && __SYCL_TARGET_AMD_GPU_GFX9_GENERIC__)
 
 #            define SYCL_SUBGROUP_SIZE (64) /* up to gfx9, HIP supports wavefront size 64 */
 
@@ -151,6 +182,8 @@
             (defined(__SYCL_TARGET_AMD_GPU_GFX1012__) && __SYCL_TARGET_AMD_GPU_GFX1012__)                             \
             || /* AMD RDNA 2.0 Oberon architecture (gfx 10.1) */                                                      \
             (defined(__SYCL_TARGET_AMD_GPU_GFX1013__) && __SYCL_TARGET_AMD_GPU_GFX1013__)                             \
+            || /* AMD RDNA 1.x generic architecture (gfx 10.1) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX10_1_GENERIC__) && __SYCL_TARGET_AMD_GPU_GFX10_1_GENERIC__)             \
             || /* AMD RDNA 2.0 Navi 21 architecture (gfx 10.3) */                                                     \
             (defined(__SYCL_TARGET_AMD_GPU_GFX1030__) && __SYCL_TARGET_AMD_GPU_GFX1030__)                             \
             || /* AMD RDNA 2.0 Navi 22 architecture (gfx 10.3) */                                                     \
@@ -165,6 +198,8 @@
             (defined(__SYCL_TARGET_AMD_GPU_GFX1035__) && __SYCL_TARGET_AMD_GPU_GFX1035__)                             \
             || /* AMD RDNA 2.0 Raphael architecture (gfx 10.3) */                                                     \
             (defined(__SYCL_TARGET_AMD_GPU_GFX1036__) && __SYCL_TARGET_AMD_GPU_GFX1036__)                             \
+            || /* AMD RDNA 2.x generic architecture (gfx 10.3) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX10_3_GENERIC__) && __SYCL_TARGET_AMD_GPU_GFX10_3_GENERIC__)             \
             || /* AMD RDNA 3.0 Navi 31 architecture (gfx 11.0) */                                                     \
             (defined(__SYCL_TARGET_AMD_GPU_GFX1100__) && __SYCL_TARGET_AMD_GPU_GFX1100__)                             \
             || /* AMD RDNA 3.0 Navi 32 architecture (gfx 11.0) */                                                     \
@@ -173,6 +208,8 @@
             (defined(__SYCL_TARGET_AMD_GPU_GFX1102__) && __SYCL_TARGET_AMD_GPU_GFX1102__)                             \
             || /* AMD RDNA 3.0 Phoenix mobile architecture (gfx 11.0) */                                              \
             (defined(__SYCL_TARGET_AMD_GPU_GFX1103__) && __SYCL_TARGET_AMD_GPU_GFX1103__)                             \
+            || /* AMD RDNA 3.x generic architecture (gfx 11.x) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX11_GENERIC__) && __SYCL_TARGET_AMD_GPU_GFX11_GENERIC__)                 \
             || /* AMD RDNA 3.5 Strix Point architecture (gfx 11.5) */                                                 \
             (defined(__SYCL_TARGET_AMD_GPU_GFX1150__) && __SYCL_TARGET_AMD_GPU_GFX1150__)                             \
             || /* AMD RDNA 3.5 Strix Halo architecture (gfx 11.5) */                                                  \
@@ -180,7 +217,13 @@
             || /* AMD RDNA 4.0 Navi 44 architecture (gfx 12.0) */                                                     \
             (defined(__SYCL_TARGET_AMD_GPU_GFX1200__) && __SYCL_TARGET_AMD_GPU_GFX1200__)                             \
             || /* AMD RDNA 4.0 Navi 48 architecture (gfx 12.0) */                                                     \
-            (defined(__SYCL_TARGET_AMD_GPU_GFX1201__) && __SYCL_TARGET_AMD_GPU_GFX1201__)
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1201__) && __SYCL_TARGET_AMD_GPU_GFX1201__)                             \
+            || /* AMD RDNA 4.x generic architecture (gfx 12.x) */                                                     \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX12_GENERIC__) && __SYCL_TARGET_AMD_GPU_GFX12_GENERIC__)                 \
+            || /* AMD RDNA 4.5 derivative architecture (gfx 12.5) */                                                  \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1250__) && __SYCL_TARGET_AMD_GPU_GFX1250__)                             \
+            || /* AMD RDNA 4.5 derivative architecture (gfx 12.5) */                                                  \
+            (defined(__SYCL_TARGET_AMD_GPU_GFX1251__) && __SYCL_TARGET_AMD_GPU_GFX1251__)
 
 #            define SYCL_SUBGROUP_SIZE (32) /* starting from gfx10, HIP supports wavefront size 32 */
 


### PR DESCRIPTION
- fix NVIDIA: `SM00` to `SM_00`
- add missing definitions
