### PR TITLE
HIP: add `ALPAKA_ARCH_AMD` definition

### DIFF
--- a/include/alpaka/core/Config.hpp
+++ b/include/alpaka/core/Config.hpp
@@ -5,24 +5,12 @@
 
 #pragma once
 
+#include "alpaka/core/PP.hpp"
+
 #ifdef __INTEL_COMPILER
 #    warning                                                                                                          \
         "The Intel Classic compiler (icpc) is no longer supported. Please upgrade to the Intel LLVM compiler (ipcx)."
 #endif
-
-#define ALPAKA_VERSION_NUMBER(major, minor, patch)                                                                    \
-    ((((major) % 10000llu) * 100'000'000llu) + (((minor) % 1000llu) * 100000llu) + ((patch) % 100000llu))
-
-#define ALPAKA_VERSION_NUMBER_NOT_AVAILABLE ALPAKA_VERSION_NUMBER(0llu, 0llu, 0llu)
-
-#define ALPAKA_YYYYMMDD_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 10000llu), ((V) / 100llu) % 100llu, (V) % 100llu)
-
-#define ALPAKA_YYYYMM_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 100llu) % 10000llu, (V) % 100llu, 0llu)
-
-#define ALPAKA_VVRRP_10_TO_VERSION(V)                                                                                 \
-    ALPAKA_VERSION_NUMBER(((V) / 1000llu) % 100llu, ((V) / 10llu) % 100llu, (V) % 10llu)
-
-#define ALPAKA_VRP_TO_VERSION(V) ALPAKA_VERSION_NUMBER((V) / 100llu, ((V) / 10llu) % 10llu, (V) % 10llu)
 
 // ######## detect operating systems ########
 
@@ -97,18 +85,36 @@
 #    if defined(__CUDA_ARCH__)
 #        define ALPAKA_ARCH_PTX ALPAKA_VRP_TO_VERSION(__CUDA_ARCH__)
 #    else
-#        define ALPAKA_ARCH_PTX 0
+#        define ALPAKA_ARCH_PTX ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
 #    endif
 #endif
 
-// HIP device compile
-#if !defined(ALPAKA_ARCH_HSA)
+/** HIP device compile
+ *
+ * The version on the host side will always be ALPAKA_VERSION_NUMBER_NOT_AVAILABLE.
+ * On the device side unknown version will be set to ALPAKA_VERSION_NUMBER_NOT_AVAILABLE.
+ *
+ *  Rules:
+ *   - the last two digits will be handled as HEX values and support 0-9 and a-f
+ *   - gfx9xy (numeric): 9xy -> ALPAKA_VERSION_NUMBER(9,x,y)
+ *   - gfx10xy / gfx11xy: stxy -> ALPAKA_VERSION_NUMBER(st,x,y)
+ *   - Suffix: a == 10, b == 11, c == 12
+ *      - gfx90a -> ALPAKA_VERSION_NUMBER(9,0,10)
+ *      - gfx90c -> ALPAKA_VERSION_NUMBER(9,0,12)
+ */
+#if !defined(ALPAKA_ARCH_AMD)
 #    if defined(__HIP__) && defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__ == 1
-#        define ALPAKA_ARCH_HSA 1
+#        define ALPAKA_ARCH_AMD ALPAKA_AMDGPU_ARCH
 #    else
-#        define ALPAKA_ARCH_HSA 0
+#        define ALPAKA_ARCH_AMD ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
 #    endif
 #endif
+
+/** HSA device compile
+ *
+ * This version is equal to ALPAKA_ARCH_AMD and is only carried for backwards compatibility to older ALPAKA versions.
+ */
+#define ALPAKA_ARCH_HSA ALPAKA_ARCH_AMD
 
 // ######## compiler ########
 
@@ -209,7 +215,7 @@
 #    if defined(__CUDACC__) || defined(__CUDA__)
 #        include <cuda.h>
 // CUDA doesn't give us a patch level for the last entry, just zero.
-#        define ALPAKA_LANG_CUDA ALPAKA_VVRRP_10_TO_VERSION(CUDART_VERSION)
+#        define ALPAKA_LANG_CUDA ALPAKA_VVRRP_TO_VERSION(CUDART_VERSION)
 #    else
 #        define ALPAKA_LANG_CUDA ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
 #    endif

--- a/include/alpaka/core/HipConfig.hpp
+++ b/include/alpaka/core/HipConfig.hpp
@@ -1,0 +1,134 @@
+/* Copyright 2025 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/PP.hpp"
+
+// We can not use ALPAKA_LANG_HIP because this file is required by core/config.hpp where ALPAKA_LANG_HIP is defined.
+#if defined(__HIP__)
+
+#    include <hip/hip_version.h>
+
+// version numbers are only defined on the device side
+#    if !defined(ALPAKA_AMDGPU_ARCH) && defined(__HIP__) && __HIP_DEVICE_COMPILE__ == 1
+
+/* Map AMDGPU arch macro -> ALPAKA_VRRPP_TO_VERSION(wrapped code)
+ *  Rules:
+ *   - gfx9xy (numeric): 9xy -> 90x0y  (e.g., 908->90008, 906->90006, 942->90402)
+ *   - gfx10xy / gfx11xy: stxy -> st0x0y (e.g., 1036->100306, 1103->110003)
+ *   - Suffix: a == 10 (90a->90010), b == 11, c == 11
+ *
+ * An overview of AMD GPU architectures can be found here:
+ * https://llvm.org/docs/AMDGPUUsage.html#processors
+ */
+
+#        if defined(__gfx1200__)
+/* RDNA 4 dGPU (RX 9060 XT) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(120000)
+#        elif defined(__gfx1201__)
+/* RDNA 4 dGPU (RX 9070 / 9070 XT) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(120001)
+#        elif defined(__gfx1250__)
+/* RDNA 4 APU (APU) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(120500)
+#        elif defined(__gfx1251__)
+/* RDNA 4 APU variant */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(120501)
+
+#        elif defined(__gfx1153__)
+/* RDNA 3.5 iGPU (Medusa Point / Strix Halo successor) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110503)
+#        elif defined(__gfx1152__)
+/* RDNA 3.5 iGPU (Krackan Point) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110502)
+#        elif defined(__gfx1151__)
+/* RDNA 3.5 iGPU (Strix Halo) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110501)
+#        elif defined(__gfx1150__)
+/* RDNA 3.5 iGPU (Radeon 890M on Strix Point) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110500)
+
+#        elif defined(__gfx1103__)
+/* RDNA 3 APU (Radeon 780M, 760M, ROG Ally Extreme) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110003)
+#        elif defined(__gfx1102__)
+/* RDNA 3 Desktop (RX 7600 / 7600 XT) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110002)
+#        elif defined(__gfx1101__)
+/* RDNA 3 Desktop (RX 7700 / 7700 XT, Pro W7700 / V710) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110001)
+#        elif defined(__gfx1100__)
+/* RDNA 3 Desktop (RX 7900 XT, XTX, Pro W7900) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(110000)
+
+#        elif defined(__gfx1036__)
+/* RDNA 2 APU (Radeon Graphics 128-SP iGPU) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100306)
+#        elif defined(__gfx1035__)
+/* RDNA 2 APU (Radeon 660M, 680M) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100305)
+#        elif defined(__gfx1034__)
+/* RDNA 2 Mobile (Pro W6300/W6400, RX 6400-6500) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100304)
+#        elif defined(__gfx1033__)
+/* RDNA 2 APU (Steam Deck) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100303)
+#        elif defined(__gfx1032__)
+/* RDNA 2 Desktop (RX 6600 XT, 6650 XT/S, 6700S) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100302)
+#        elif defined(__gfx1031__)
+/* RDNA 2 Desktop (RX 6700 series, 6750/6850M XT) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100301)
+#        elif defined(__gfx1030__)
+/* RDNA 2 Desktop (RX 6800 / 6900 XT, Pro W6800) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100300)
+
+#        elif defined(__gfx1013__)
+/* RDNA 1 Mobile (RX 5300M / 5500M) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100103)
+#        elif defined(__gfx1012__)
+/* RDNA 1 Desktop (RX 5500 / 5500 XT) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100102)
+#        elif defined(__gfx1011__)
+/* RDNA 1 Desktop (Pro V520) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100101)
+#        elif defined(__gfx1010__)
+/* RDNA 1 Desktop (RX 5700 / 5700 XT, Pro 5600 XT/M) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(100100)
+
+#        elif defined(__gfx942__)
+/* CDNA 3 (Instinct MI300 series: MI300/MI300A/MI300X) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90402)
+#        elif defined(__gfx941__)
+/* CDNA 2/3 (Instinct MI210) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90401)
+#        elif defined(__gfx940__)
+/* CDNA 2 (Instinct MI200) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90400)
+
+#        elif defined(__gfx90c__)
+/* CDNA 1 (Renoir APUs), c -> 12 */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90012)
+#        elif defined(__gfx90b__)
+/* (If present) b -> 11 */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90011)
+#        elif defined(__gfx90a__)
+/* CDNA 2 (Instinct MI250 / MI250X), a -> 10 */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90010)
+#        elif defined(__gfx908__)
+/* CDNA 1 (Instinct MI100) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90008)
+#        elif defined(__gfx906__)
+/* Vega 20 (Radeon VII, Instinct MI50/60) */
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VRRPP_TO_VERSION(90006)
+
+#        else
+#            error                                                                                                    \
+                "Unknown AMDGPU architecture, please define __gfxXXX__ macro for your target. Until alpaka is updated you can define the macro ALPAKA_AMDGPU_ARCH to avoid this error."
+#            define ALPAKA_AMDGPU_ARCH ALPAKA_VERSION_NUMBER_NOT_AVAILABLE
+#        endif
+
+#    endif
+#endif

--- a/include/alpaka/core/PP.hpp
+++ b/include/alpaka/core/PP.hpp
@@ -1,0 +1,31 @@
+/* Copyright 2024 René Widera
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+/** \file This files provides preprocessor utilities. */
+
+/* version number encoding
+ * 4 digits for major version (max 9999)
+ * 3 digits for minor version (max 999)
+ * 5 digits for patch version (max 99999)
+ * example: version 1.2.3 -> 0001 002 00003
+ */
+#define ALPAKA_VERSION_NUMBER(major, minor, patch)                                                                    \
+    ((((major) % 10000llu) * 100'000'000llu) + (((minor) % 1000llu) * 100000llu) + ((patch) % 100000llu))
+
+#define ALPAKA_VERSION_NUMBER_NOT_AVAILABLE ALPAKA_VERSION_NUMBER(0llu, 0llu, 0llu)
+
+// version number conversion from vendor format to ALPAKA_VERSION_NUMBER
+#define ALPAKA_YYYYMMDD_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 10000llu), ((V) / 100llu) % 100llu, (V) % 100llu)
+
+#define ALPAKA_YYYYMM_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 100llu) % 10000llu, (V) % 100llu, 0llu)
+
+#define ALPAKA_VVRRP_TO_VERSION(V)                                                                                    \
+    ALPAKA_VERSION_NUMBER(((V) / 1000llu) % 10000llu, ((V) / 10llu) % 100llu, (V) % 10llu)
+
+#define ALPAKA_VRP_TO_VERSION(V) ALPAKA_VERSION_NUMBER(((V) / 100llu) % 10000llu, ((V) / 10llu) % 10llu, (V) % 10llu)
+
+#define ALPAKA_VRRPP_TO_VERSION(V)                                                                                    \
+    ALPAKA_VERSION_NUMBER(((V) / 10000llu) % 10000llu, ((V) / 100llu) % 100llu, (V) % 100llu)

--- a/test/unit/core/src/ConfigTest.cpp
+++ b/test/unit/core/src/ConfigTest.cpp
@@ -39,19 +39,35 @@ TEST_CASE("printDefines", "[core]")
 TEST_CASE("configVersionMacros", "")
 {
     static_assert(ALPAKA_VERSION_NUMBER(2025, 2, 1) == 202'500'200'001);
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_VERSION_NUMBER(12025, 2, 1) == 202'500'200'001);
+    static_assert(ALPAKA_VERSION_NUMBER(12025, 2, 1) == ALPAKA_VERSION_NUMBER(2025, 2, 1));
 
     static_assert(ALPAKA_VERSION_NUMBER_NOT_AVAILABLE == 0000000000000);
     static_assert(ALPAKA_VERSION_NUMBER_NOT_AVAILABLE == ALPAKA_VERSION_NUMBER(0, 0, 0));
 
     static_assert(ALPAKA_YYYYMMDD_TO_VERSION(20'250'201) == 202'500'200'001);
     static_assert(ALPAKA_YYYYMMDD_TO_VERSION(20'250'201) == ALPAKA_VERSION_NUMBER(2025, 2, 1));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_YYYYMMDD_TO_VERSION(120'250'201) == ALPAKA_VERSION_NUMBER(2025, 2, 1));
 
     static_assert(ALPAKA_YYYYMM_TO_VERSION(202502) == 202'500'200'000);
     static_assert(ALPAKA_YYYYMM_TO_VERSION(202502) == ALPAKA_VERSION_NUMBER(2025, 2, 0));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_YYYYMM_TO_VERSION(1'202'502) == ALPAKA_VERSION_NUMBER(2025, 2, 0));
 
-    static_assert(ALPAKA_VVRRP_10_TO_VERSION(12081) == 1'200'800'001);
-    static_assert(ALPAKA_VVRRP_10_TO_VERSION(12081) == ALPAKA_VERSION_NUMBER(12, 8, 1));
+    static_assert(ALPAKA_VVRRP_TO_VERSION(12081) == 1'200'800'001);
+    static_assert(ALPAKA_VVRRP_TO_VERSION(12081) == ALPAKA_VERSION_NUMBER(12, 8, 1));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_VVRRP_TO_VERSION(12'345'081) == ALPAKA_VERSION_NUMBER(2345, 8, 1));
 
     static_assert(ALPAKA_VRP_TO_VERSION(751) == 700'500'001);
     static_assert(ALPAKA_VRP_TO_VERSION(751) == ALPAKA_VERSION_NUMBER(7, 5, 1));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_VRP_TO_VERSION(1'234'567) == ALPAKA_VERSION_NUMBER(2345, 6, 7));
+
+    static_assert(ALPAKA_VRRPP_TO_VERSION(120503) == 1'200'500'003);
+    static_assert(ALPAKA_VRRPP_TO_VERSION(120503) == ALPAKA_VERSION_NUMBER(12, 5, 3));
+    // to long major version should be cut to 4 digits
+    static_assert(ALPAKA_VRRPP_TO_VERSION(123'451'513) == ALPAKA_VERSION_NUMBER(2345, 15, 13));
 }


### PR DESCRIPTION
- add define `ALPAKA_ARCH_AMD` as replacement for `ALPAKA_COMP_HIP`
- set for backwards compatibility `ALPAKA_COMP_HIP` to `ALPAKA_ARCH_AMD`
- `ALPAKA_ARCH_AMD` behaves like `ALPAKA_ARCH_PTX` and provides the AMD architecture as version number
- move pre-prozessor version number generators to own file