### PR TITLE
Feature accessors and span conversion for buffers

### DIFF
--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -10,6 +10,7 @@
 #include "alpaka/mem/view/Traits.hpp"
 
 #include <cstdint>
+#include <span>
 #include <sstream>
 #include <stdexcept>
 #include <type_traits>
@@ -39,7 +40,7 @@ namespace alpaka::internal
     };
 
     template<ViewType TView>
-    struct DeviceViewAccessor
+    struct BaseViewAccessor
     {
     private:
         using value_type = Elem<TView>;
@@ -59,11 +60,76 @@ namespace alpaka::internal
         [[nodiscard]] ALPAKA_FN_HOST auto data() const -> const_pointer
         {
             return getPtrNative(*static_cast<TView const*>(this));
+        }
+
+        ALPAKA_FN_HOST auto begin() -> pointer requires(Dim::value == 1)
+        {
+            return data();
+        }
+
+        ALPAKA_FN_HOST auto begin() const -> pointer requires(Dim::value == 1)
+        {
+            return data();
+        }
+
+        ALPAKA_FN_HOST auto cbegin() const -> pointer requires(Dim::value == 1)
+        {
+            return data();
+        }
+
+        ALPAKA_FN_HOST auto end() -> pointer requires(Dim::value == 1)
+        {
+            return data() + getExtents(*static_cast<TView*>(this))[0];
+        }
+
+        ALPAKA_FN_HOST auto end() const -> pointer requires(Dim::value == 1)
+        {
+            return data() + getExtents(*static_cast<TView const*>(this))[0];
+        }
+
+        ALPAKA_FN_HOST auto cend() const -> pointer requires(Dim::value == 1)
+        {
+            return data() + getExtents(*static_cast<TView const*>(this))[0];
+        }
+
+        ALPAKA_FN_HOST auto rank() const -> Idx
+        {
+            return Dim::value;
+        }
+
+        ALPAKA_FN_HOST auto size() const -> Idx requires(Dim::value == 1)
+        {
+            return getExtents(*static_cast<TView const*>(this))[0];
+        }
+
+        ALPAKA_FN_HOST auto size() const -> Idx requires(Dim::value > 1)
+        {
+            return getExtents(*static_cast<TView const*>(this)).prod();
+        }
+
+        ALPAKA_FN_HOST auto extent(Idx dim) const -> Idx
+        {
+            return getExtents(*static_cast<TView const*>(this))[dim];
+        }
+
+        ALPAKA_FN_HOST auto extents() const -> Vec<Dim, Idx>;
+
+        ALPAKA_FN_HOST operator std::span<value_type const>() const requires(Dim::value == 1)
+        {
+            return std::span<value_type const>{data(), static_cast<std::size_t>(size())};
+        }
+
+        ALPAKA_FN_HOST operator std::span<value_type>() requires(Dim::value == 1)
+        {
+            return std::span<value_type>{data(), static_cast<std::size_t>(size())};
         }
     };
 
     template<ViewType TView>
-    struct HostViewAccessor
+    using DeviceViewAccessor = BaseViewAccessor<TView>;
+
+    template<ViewType TView>
+    struct HostViewAccessor : BaseViewAccessor<TView>
     {
     private:
         using value_type = Elem<TView>;
@@ -75,50 +141,40 @@ namespace alpaka::internal
         using Dim = alpaka::Dim<TView>;
 
     public:
-        [[nodiscard]] ALPAKA_FN_HOST auto data() -> pointer
-        {
-            return getPtrNative(*static_cast<TView*>(this));
-        }
-
-        [[nodiscard]] ALPAKA_FN_HOST auto data() const -> const_pointer
-        {
-            return getPtrNative(*static_cast<TView const*>(this));
-        }
-
         ALPAKA_FN_HOST auto operator*() -> reference
         {
             static_assert(Dim::value == 0, "operator* is only valid for Buffers and Views of dimension 0");
-            return *data();
+            return *(this->data());
         }
 
         ALPAKA_FN_HOST auto operator*() const -> const_reference
         {
             static_assert(Dim::value == 0, "operator* is only valid for Buffers and Views of dimension 0");
-            return *data();
+            return *(this->data());
         }
 
         ALPAKA_FN_HOST auto operator->() -> pointer
         {
             static_assert(Dim::value == 0, "operator-> is only valid for Buffers and Views of dimension 0");
-            return data();
+            return *(this->data());
         }
 
         ALPAKA_FN_HOST auto operator->() const -> const_pointer
         {
             static_assert(Dim::value == 0, "operator-> is only valid for Buffers and Views of dimension 0");
-            return data();
+            return this->data();
         }
 
         ALPAKA_FN_HOST auto operator[](Idx i) -> reference
         {
             static_assert(Dim::value == 1, "operator[i] is only valid for Buffers and Views of dimension 1");
-            return data()[i];
+            return this->data()[i];
         }
 
         ALPAKA_FN_HOST auto operator[](Idx i) const -> const_reference
         {
             static_assert(Dim::value == 1, "operator[i] is only valid for Buffers and Views of dimension 1");
-            return data()[i];
+            return this->data()[i];
         }
 
     private:
@@ -129,7 +185,7 @@ namespace alpaka::internal
                 std::is_convertible_v<TIdx, Idx>,
                 "the index type must be convertible to the index of the Buffer or View");
 
-            auto ptr = reinterpret_cast<std::uintptr_t>(data());
+            auto ptr = reinterpret_cast<std::uintptr_t>(this->data());
             if constexpr(Dim::value > 0)
             {
                 ptr += static_cast<std::uintptr_t>(

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Andrea Bocci, Bernhard Manfred Gruber, Jan Stephan
+/* Copyright 2025 Andrea Bocci, Bernhard Manfred Gruber, Jan Stephan, Simone Balducci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -114,6 +114,12 @@ namespace alpaka::internal
 
         ALPAKA_FN_HOST auto extents() const -> Vec<Dim, Idx>;
 
+#if ALPAKA_COMP_CLANG
+#    pragma clang diagnostic push
+#    if __has_warning("-Wunsafe-buffer-usage-in-container")
+#        pragma clang diagnostic ignored "-Wunsafe-buffer-usage-in-container"
+#    endif
+#endif
         ALPAKA_FN_HOST operator std::span<value_type const>() const requires(Dim::value == 1)
         {
             return std::span<value_type const>{begin(), end()};
@@ -123,6 +129,9 @@ namespace alpaka::internal
         {
             return std::span<value_type>{begin(), end()};
         }
+#if ALPAKA_COMP_CLANG
+#    pragma clang diagnostic pop
+#endif
     };
 
     template<ViewType TView>

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -67,12 +67,12 @@ namespace alpaka::internal
             return data();
         }
 
-        ALPAKA_FN_HOST auto begin() const -> pointer requires(Dim::value == 1)
+        ALPAKA_FN_HOST auto begin() const -> const_pointer requires(Dim::value == 1)
         {
             return data();
         }
 
-        ALPAKA_FN_HOST auto cbegin() const -> pointer requires(Dim::value == 1)
+        ALPAKA_FN_HOST auto cbegin() const -> const_pointer requires(Dim::value == 1)
         {
             return data();
         }
@@ -82,12 +82,12 @@ namespace alpaka::internal
             return data() + getExtents(*static_cast<TView*>(this))[0];
         }
 
-        ALPAKA_FN_HOST auto end() const -> pointer requires(Dim::value == 1)
+        ALPAKA_FN_HOST auto end() const -> const_pointer requires(Dim::value == 1)
         {
             return data() + getExtents(*static_cast<TView const*>(this))[0];
         }
 
-        ALPAKA_FN_HOST auto cend() const -> pointer requires(Dim::value == 1)
+        ALPAKA_FN_HOST auto cend() const -> const_pointer requires(Dim::value == 1)
         {
             return data() + getExtents(*static_cast<TView const*>(this))[0];
         }
@@ -116,12 +116,12 @@ namespace alpaka::internal
 
         ALPAKA_FN_HOST operator std::span<value_type const>() const requires(Dim::value == 1)
         {
-            return std::span<value_type const>{data(), static_cast<std::size_t>(size())};
+            return std::span<value_type const>{begin(), end()};
         }
 
         ALPAKA_FN_HOST operator std::span<value_type>() requires(Dim::value == 1)
         {
-            return std::span<value_type>{data(), static_cast<std::size_t>(size())};
+            return std::span<value_type>{begin(), end()};
         }
     };
 

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -1,5 +1,5 @@
 /* Copyright 2025 Axel Huebl, Benjamin Worpitz, Andrea Bocci, Bernhard Manfred Gruber, Jeffrey Kelling, Jan Stephan,
- *                Aurora Perego
+ *                Aurora Perego, Simone Balducci
  * SPDX-License-Identifier: MPL-2.0
  */
 

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -359,3 +359,33 @@ TEMPLATE_LIST_TEST_CASE("memBufMove", "[memBuf]", alpaka::test::TestAccs)
         CHECK(read(buf2) == 1);
     } // both buffers destruct fine here
 }
+
+TEMPLATE_LIST_TEST_CASE("memBufAccessors", "[memBuf]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+    using Idx = alpaka::Idx<Acc>;
+    using Elem = std::size_t;
+    using Dim = alpaka::Dim<Acc>;
+
+    if constexpr(Dim::value == 1)
+    {
+        auto const platformHost = alpaka::PlatformCpu{};
+        auto const devHost = alpaka::getDevByIdx(platformHost, 0);
+        auto const platformAcc = alpaka::Platform<Acc>{};
+        auto const dev = alpaka::getDevByIdx(platformAcc, 0);
+        auto queue = alpaka::Queue<Acc, alpaka::Blocking>{dev};
+        auto const extent = alpaka::Vec<Dim, Idx>{};
+        auto foo = [](std::span<Elem>) { return true; };
+
+        auto buf = buftest::allocBuf<Dim, Elem, Idx>(dev, extent);
+
+        CHECK(buf.size() == extent[0]);
+        CHECK(buf.begin() == buf.data());
+        CHECK(buf.cbegin() == buf.data());
+        CHECK(buf.end() == buf.data() + buf.size());
+        CHECK(buf.cend() == buf.data() + buf.size());
+        CHECK((buf.end() - buf.begin()) == static_cast<long>(buf.size()));
+        CHECK((buf.cend() - buf.cbegin()) == static_cast<long>(buf.size()));
+        CHECK(foo(buf));
+    }
+}


### PR DESCRIPTION
This PR adds accessor methods for buffers, such as `begin`, `end` and `size`. It also provides operators for conversion to `std::span`.