### PR TITLE
fix `atomicDec()` for CPU

### DIFF
--- a/include/alpaka/atomic/AtomicAtomicRef.hpp
+++ b/include/alpaka/atomic/AtomicAtomicRef.hpp
@@ -162,10 +162,10 @@ namespace alpaka
                 isSupportedByAtomicAtomicRef<T>();
                 alpaka::detail::atomic_ref<T> ref(*addr);
                 T old = ref;
-                T result = ((old >= value) ? 0 : static_cast<T>(old - 1));
+                T result = (old == static_cast<T>(0) || old > value) ? value : (old - static_cast<T>(1));
                 while(!ref.compare_exchange_weak(old, result))
                 {
-                    result = ((old >= value) ? 0 : static_cast<T>(old - 1));
+                    result = (old == static_cast<T>(0) || old > value) ? value : (old - static_cast<T>(1));
                 }
                 return old;
             }


### PR DESCRIPTION
Atomic decrement implemented

```C++
((old >= value) ? 0 : static_cast<T>(old - 1))
```

instead of

```C++
(old == static_cast<T>(0) || old > value) ? value : static_cast<T>(old - static_cast<T>(1))
```

This bug was introduced with alpaka 0.9.0 in PR #1566, and it showed up in alpaka3 while porting test #1772, which we never merged into the mainline.

For reference, here is the link to the CUDA definition of `atomicDec` https://docs.nvidia.com/cuda/cuda-c-programming-guide/#atomicdec