### PR TITLE
Provide `atomicInc/Dec` overloads with deduced limit values

### DIFF
--- a/include/alpaka/atomic/Traits.hpp
+++ b/include/alpaka/atomic/Traits.hpp
@@ -210,6 +210,21 @@ namespace alpaka
         return atomicOp<AtomicInc>(atomic, addr, value, hier);
     }
 
+    //! Executes an atomic increment operation, using the numeric limit as ceiling.
+    //!
+    //! \tparam T The value type.
+    //! \tparam TAtomic The atomic implementation type.
+    //! \param addr The value to change atomically.
+    //! \param atomic The atomic implementation.
+    //! NOTE: The limit value is deduced as std::numeric_limits<T>::max()
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicInc(TAtomic const& atomic, T* const addr, THierarchy const& hier = THierarchy()) -> T
+    {
+        T const value = std::numeric_limits<T>::max();
+        return atomicOp<AtomicInc>(atomic, addr, value, hier);
+    }
+
     //! Executes an atomic decrement operation.
     //!
     //! \tparam T The value type.
@@ -225,6 +240,21 @@ namespace alpaka
         T const& value,
         THierarchy const& hier = THierarchy()) -> T
     {
+        return atomicOp<AtomicDec>(atomic, addr, value, hier);
+    }
+
+    //! Executes an atomic decrement operation.
+    //!
+    //! \tparam T The value type.
+    //! \tparam TAtomic The atomic implementation type.
+    //! \param addr The value to change atomically.
+    //! \param atomic The atomic implementation.
+    //! NOTE: The limit value is deduced as std::numeric_limits<T>::max()
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicDec(TAtomic const& atomic, T* const addr, THierarchy const& hier = THierarchy()) -> T
+    {
+        T const value = std::numeric_limits<T>::max();
         return atomicOp<AtomicDec>(atomic, addr, value, hier);
     }
 

--- a/include/alpaka/atomic/Traits.hpp
+++ b/include/alpaka/atomic/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Benjamin Worpitz, René Widera, Bernhard Manfred Gruber
+/* Copyright 2025 Benjamin Worpitz, René Widera, Bernhard Manfred Gruber, Simone Balducci
  * SPDX-License-Identifier: MPL-2.0
  */
 

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -1,5 +1,5 @@
-/* Copyright 2023 Axel Hübl, Benjamin Worpitz, Matthias Werner, Sergei Bastrakov, René Widera, Jan Stephan,
- *                Bernhard Manfred Gruber, Antonio Di Pilato, Andrea Bocci
+/* Copyright 2025 Axel Hübl, Benjamin Worpitz, Matthias Werner, Sergei Bastrakov, René Widera, Jan Stephan,
+ *                Bernhard Manfred Gruber, Antonio Di Pilato, Andrea Bocci, Simone Balducci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -155,6 +155,12 @@ ALPAKA_FN_ACC auto testAtomicInc(TAcc const& acc, bool* success, T operandOrig) 
         ALPAKA_CHECK(*success, equals(operandOrig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }
+    {
+        operand = operandOrig;
+        T const ret = alpaka::atomicInc(acc, &operand);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
+    }
 }
 
 ALPAKA_NO_HOST_ACC_WARNING
@@ -174,6 +180,12 @@ ALPAKA_FN_ACC auto testAtomicDec(TAcc const& acc, bool* success, T operandOrig) 
     {
         operand = operandOrig;
         T const ret = alpaka::atomicDec(acc, &operand, value);
+        ALPAKA_CHECK(*success, equals(operandOrig, ret));
+        ALPAKA_CHECK(*success, equals(operand, reference));
+    }
+    {
+        operand = operandOrig;
+        T const ret = alpaka::atomicDec(acc, &operand);
         ALPAKA_CHECK(*success, equals(operandOrig, ret));
         ALPAKA_CHECK(*success, equals(operand, reference));
     }


### PR DESCRIPTION
This PR addresses issue #2483, providing overloads of `atomicInc` and `atomicDec` that don't required the limit value and deduce it as `std::numeric_limits<T>::max()`.