### PR TITLE
Specialize `DevType` for accelerator Tags

### DIFF
--- a/include/alpaka/acc/TagAccIsEnabled.hpp
+++ b/include/alpaka/acc/TagAccIsEnabled.hpp
@@ -34,4 +34,15 @@ namespace alpaka
     //! list of all tags where the related accelerator is enabled
     using EnabledAccTags = alpaka::meta::Filter<AccTags, alpaka::AccIsEnabled>;
 
+    namespace trait
+    {
+
+        template<concepts::Tag TTag>
+        struct DevType<TTag>
+        {
+            using type = DevType<alpaka::TagToAcc<TTag, alpaka::DimInt<1>, int>>::type;
+        };
+
+    } // namespace trait
+
 } // namespace alpaka

--- a/include/alpaka/acc/TagAccIsEnabled.hpp
+++ b/include/alpaka/acc/TagAccIsEnabled.hpp
@@ -40,7 +40,7 @@ namespace alpaka
         template<concepts::Tag TTag>
         struct DevType<TTag>
         {
-            using type = DevType<alpaka::TagToAcc<TTag, alpaka::DimInt<1>, int>>::type;
+            using type = typename DevType<alpaka::TagToAcc<TTag, alpaka::DimInt<1>, int>>::type;
         };
 
     } // namespace trait

--- a/include/alpaka/acc/TagAccIsEnabled.hpp
+++ b/include/alpaka/acc/TagAccIsEnabled.hpp
@@ -1,3 +1,7 @@
+/* Copyright 2025 Simeon Ehrig, Simone Balducci
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
 #pragma once
 
 // include all Acc's because of the struct AccIsEnabled

--- a/test/unit/dev/src/TagToDevTest.cpp
+++ b/test/unit/dev/src/TagToDevTest.cpp
@@ -1,0 +1,17 @@
+/* Copyright 2025 Simone Balducci
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include <alpaka/dev/Traits.hpp>
+#include <alpaka/test/acc/TestAccs.hpp>
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+TEMPLATE_LIST_TEST_CASE("tagToDevice", "[dev]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+    using Tag = alpaka::AccToTag<Acc>;
+
+    STATIC_REQUIRE(std::is_same_v<alpaka::Dev<Tag>, alpaka::Dev<Acc>>);
+}


### PR DESCRIPTION
This PR closes issue #2553 buy specializing the `alpaka::Dev` struct for Tag types, thus making it less verbose to obtain the Device type from the accelerator Tag.