### PR TITLE
add warp mask functions

### DIFF
--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -13,7 +13,7 @@
 #endif
 
 #if ALPAKA_LANG_HIP
-#    if HIP_VERSION >= 60200000 && HIP_VERSION < 70000000
+#    if HIP_VERSION >= 60'200'000 && HIP_VERSION < 70'000'000
 #        define HIP_ENABLE_WARP_SYNC_BUILTINS
 #    endif
 // HIP defines some keywords like __forceinline__ in header files.

--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -13,6 +13,9 @@
 #endif
 
 #if ALPAKA_LANG_HIP
+#    if HIP_VERSION >= 60200000 && HIP_VERSION < 70000000
+#        define HIP_ENABLE_WARP_SYNC_BUILTINS
+#    endif
 // HIP defines some keywords like __forceinline__ in header files.
 #    include <hip/hip_runtime.h>
 #endif

--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -13,7 +13,7 @@
 #endif
 
 #if ALPAKA_LANG_HIP
-#    if HIP_VERSION >= 60'200'000 && HIP_VERSION < 70'000'000
+#    if ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0) && ALPAKA_COMP_HIP < ALPAKA_VERSION_NUMBER(7, 0, 0)
 #        define HIP_ENABLE_WARP_SYNC_BUILTINS
 #    endif
 // HIP defines some keywords like __forceinline__ in header files.

--- a/include/alpaka/core/CudaHipCommon.hpp
+++ b/include/alpaka/core/CudaHipCommon.hpp
@@ -23,6 +23,9 @@
 #    endif
 
 #    ifdef ALPAKA_ACC_GPU_HIP_ENABLED
+#        if HIP_VERSION >= 60200000 && HIP_VERSION < 70000000
+#            define HIP_ENABLE_WARP_SYNC_BUILTINS
+#        endif
 #        include <hip/hip_runtime.h>
 #    endif
 

--- a/include/alpaka/core/CudaHipCommon.hpp
+++ b/include/alpaka/core/CudaHipCommon.hpp
@@ -23,7 +23,7 @@
 #    endif
 
 #    ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-#        if HIP_VERSION >= 60200000 && HIP_VERSION < 70000000
+#        if HIP_VERSION >= 60'200'000 && HIP_VERSION < 70'000'000
 #            define HIP_ENABLE_WARP_SYNC_BUILTINS
 #        endif
 #        include <hip/hip_runtime.h>

--- a/include/alpaka/core/CudaHipCommon.hpp
+++ b/include/alpaka/core/CudaHipCommon.hpp
@@ -23,7 +23,7 @@
 #    endif
 
 #    ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-#        if HIP_VERSION >= 60'200'000 && HIP_VERSION < 70'000'000
+#        if ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0) && ALPAKA_COMP_HIP < ALPAKA_VERSION_NUMBER(7, 0, 0)
 #            define HIP_ENABLE_WARP_SYNC_BUILTINS
 #        endif
 #        include <hip/hip_runtime.h>

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -476,7 +476,7 @@ namespace alpaka::trait
 
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
 
-#    if HIP_VERSION >= 60200000 && HIP_VERSION < 70000000
+#    if HIP_VERSION >= 60'200'000 && HIP_VERSION < 70'000'000
 #        define HIP_ENABLE_WARP_SYNC_BUILTINS
 #    endif
 #    include <hip/hip_runtime.h>

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -476,7 +476,7 @@ namespace alpaka::trait
 
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
 
-#    if HIP_VERSION >= 60'200'000 && HIP_VERSION < 70'000'000
+#    if ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0) && ALPAKA_COMP_HIP < ALPAKA_VERSION_NUMBER(7, 0, 0)
 #        define HIP_ENABLE_WARP_SYNC_BUILTINS
 #    endif
 #    include <hip/hip_runtime.h>

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -476,6 +476,9 @@ namespace alpaka::trait
 
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
 
+#    if HIP_VERSION >= 60200000 && HIP_VERSION < 70000000
+#        define HIP_ENABLE_WARP_SYNC_BUILTINS
+#    endif
 #    include <hip/hip_runtime.h>
 
 #    if !ALPAKA_LANG_HIP && !defined(ALPAKA_HOST_ONLY)

--- a/include/alpaka/warp/WarpGenericSycl.hpp
+++ b/include/alpaka/warp/WarpGenericSycl.hpp
@@ -126,7 +126,11 @@ namespace alpaka::warp::trait
     struct Shfl<warp::WarpGenericSycl<TDim>>
     {
         template<typename T>
-        static auto shfl(warp::WarpGenericSycl<TDim> const& /*warp*/, T value, std::int32_t srcLane, std::int32_t width)
+        static auto shfl(
+            warp::WarpGenericSycl<TDim> const& /*warp*/,
+            T value,
+            std::int32_t srcLane,
+            std::int32_t width)
         {
             ALPAKA_ASSERT_ACC(width > 0);
             ALPAKA_ASSERT_ACC(srcLane >= 0);
@@ -194,7 +198,11 @@ namespace alpaka::warp::trait
     struct ShflXor<warp::WarpGenericSycl<TDim>>
     {
         template<typename T>
-        static auto shfl_xor(warp::WarpGenericSycl<TDim> const& /*warp*/, T value, std::int32_t mask, std::int32_t width)
+        static auto shfl_xor(
+            warp::WarpGenericSycl<TDim> const& /*warp*/,
+            T value,
+            std::int32_t mask,
+            std::int32_t width)
         {
             auto actual_group = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
             std::uint32_t const w = static_cast<std::uint32_t>(width);
@@ -207,4 +215,3 @@ namespace alpaka::warp::trait
 } // namespace alpaka::warp::trait
 
 #endif
-

--- a/include/alpaka/warp/WarpGenericSycl.hpp
+++ b/include/alpaka/warp/WarpGenericSycl.hpp
@@ -73,10 +73,13 @@ namespace alpaka::warp::trait
         // FIXME This should be std::uint64_t on AMD GCN architectures and on CPU,
         // but the former is not targeted in alpaka and CPU case is not supported in SYCL yet.
         // Restrict to warpSize <= 32 for now.
-        static auto activemask(warp::WarpGenericSycl<TDim> const& /*warp*/)
-            -> sycl::ext::oneapi::experimental::opportunistic_group
+        static auto activemask(warp::WarpGenericSycl<TDim> const& /*warp*/) -> std::uint32_t
         {
-            return sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
+            sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
+            auto const mask = sycl::ext::oneapi::group_ballot(sg, true);
+            std::uint32_t bits = 0;
+            mask.extract_bits(bits);
+            return bits;
         }
     };
 
@@ -85,7 +88,8 @@ namespace alpaka::warp::trait
     {
         static auto all(warp::WarpGenericSycl<TDim> const& warp, std::int32_t predicate) -> std::int32_t
         {
-            return static_cast<std::int32_t>(sycl::all_of_group(activemask(warp), static_cast<bool>(predicate)));
+            auto activegroup = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
+            return static_cast<std::int32_t>(sycl::all_of_group(activegroup, static_cast<bool>(predicate)));
         }
     };
 
@@ -94,7 +98,8 @@ namespace alpaka::warp::trait
     {
         static auto any(warp::WarpGenericSycl<TDim> const& warp, std::int32_t predicate) -> std::int32_t
         {
-            return static_cast<std::int32_t>(sycl::any_of_group(activemask(warp), static_cast<bool>(predicate)));
+            auto activegroup = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
+            return static_cast<std::int32_t>(sycl::any_of_group(activegroup, static_cast<bool>(predicate)));
         }
     };
 
@@ -132,7 +137,7 @@ namespace alpaka::warp::trait
                Example: If we assume a sub-group size of 32 and a width of 16 we will receive two subdivisions:
                The first starts at sub-group index 0 and the second at sub-group index 16. For srcLane = 4 the
                first subdivision will access the value at sub-group index 4 and the second at sub-group index 20. */
-            auto const actual_group = activemask(warp);
+            auto actual_group = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
             std::uint32_t const w = static_cast<std::uint32_t>(width);
             std::uint32_t const start_index = actual_group.get_local_linear_id() / w * w;
             return sycl::select_from_group(actual_group, value, start_index + static_cast<std::uint32_t>(srcLane) % w);
@@ -149,7 +154,7 @@ namespace alpaka::warp::trait
             std::uint32_t offset, /* must be the same for all work-items in the group */
             std::int32_t width)
         {
-            auto const actual_group = activemask(warp);
+            auto actual_group = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
             std::uint32_t const w = static_cast<std::uint32_t>(width);
             std::uint32_t const id = actual_group.get_local_linear_id();
             std::uint32_t const start_index = id / w * w;
@@ -172,7 +177,7 @@ namespace alpaka::warp::trait
             std::uint32_t offset,
             std::int32_t width)
         {
-            auto const actual_group = activemask(warp);
+            auto actual_group = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
             std::uint32_t const w = static_cast<std::uint32_t>(width);
             std::uint32_t const id = actual_group.get_local_linear_id();
             std::uint32_t const end_index = (id / w + 1) * w;
@@ -191,7 +196,7 @@ namespace alpaka::warp::trait
         template<typename T>
         static auto shfl_xor(warp::WarpGenericSycl<TDim> const& warp, T value, std::int32_t mask, std::int32_t width)
         {
-            auto const actual_group = activemask(warp);
+            auto actual_group = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
             std::uint32_t const w = static_cast<std::uint32_t>(width);
             std::uint32_t const id = actual_group.get_local_linear_id();
             std::uint32_t const start_index = id / w * w;

--- a/include/alpaka/warp/WarpGenericSycl.hpp
+++ b/include/alpaka/warp/WarpGenericSycl.hpp
@@ -86,7 +86,7 @@ namespace alpaka::warp::trait
     template<typename TDim>
     struct All<warp::WarpGenericSycl<TDim>>
     {
-        static auto all(warp::WarpGenericSycl<TDim> const& warp, std::int32_t predicate) -> std::int32_t
+        static auto all(warp::WarpGenericSycl<TDim> const& /*warp*/, std::int32_t predicate) -> std::int32_t
         {
             auto activegroup = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
             return static_cast<std::int32_t>(sycl::all_of_group(activegroup, static_cast<bool>(predicate)));
@@ -96,7 +96,7 @@ namespace alpaka::warp::trait
     template<typename TDim>
     struct Any<warp::WarpGenericSycl<TDim>>
     {
-        static auto any(warp::WarpGenericSycl<TDim> const& warp, std::int32_t predicate) -> std::int32_t
+        static auto any(warp::WarpGenericSycl<TDim> const& /*warp*/, std::int32_t predicate) -> std::int32_t
         {
             auto activegroup = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
             return static_cast<std::int32_t>(sycl::any_of_group(activegroup, static_cast<bool>(predicate)));
@@ -126,7 +126,7 @@ namespace alpaka::warp::trait
     struct Shfl<warp::WarpGenericSycl<TDim>>
     {
         template<typename T>
-        static auto shfl(warp::WarpGenericSycl<TDim> const& warp, T value, std::int32_t srcLane, std::int32_t width)
+        static auto shfl(warp::WarpGenericSycl<TDim> const& /*warp*/, T value, std::int32_t srcLane, std::int32_t width)
         {
             ALPAKA_ASSERT_ACC(width > 0);
             ALPAKA_ASSERT_ACC(srcLane >= 0);
@@ -149,7 +149,7 @@ namespace alpaka::warp::trait
     {
         template<typename T>
         static auto shfl_up(
-            warp::WarpGenericSycl<TDim> const& warp,
+            warp::WarpGenericSycl<TDim> const& /*warp*/,
             T value,
             std::uint32_t offset, /* must be the same for all work-items in the group */
             std::int32_t width)
@@ -172,7 +172,7 @@ namespace alpaka::warp::trait
     {
         template<typename T>
         static auto shfl_down(
-            warp::WarpGenericSycl<TDim> const& warp,
+            warp::WarpGenericSycl<TDim> const& /*warp*/,
             T value,
             std::uint32_t offset,
             std::int32_t width)
@@ -194,7 +194,7 @@ namespace alpaka::warp::trait
     struct ShflXor<warp::WarpGenericSycl<TDim>>
     {
         template<typename T>
-        static auto shfl_xor(warp::WarpGenericSycl<TDim> const& warp, T value, std::int32_t mask, std::int32_t width)
+        static auto shfl_xor(warp::WarpGenericSycl<TDim> const& /*warp*/, T value, std::int32_t mask, std::int32_t width)
         {
             auto actual_group = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
             std::uint32_t const w = static_cast<std::uint32_t>(width);

--- a/include/alpaka/warp/WarpGenericSycl.hpp
+++ b/include/alpaka/warp/WarpGenericSycl.hpp
@@ -73,24 +73,10 @@ namespace alpaka::warp::trait
         // FIXME This should be std::uint64_t on AMD GCN architectures and on CPU,
         // but the former is not targeted in alpaka and CPU case is not supported in SYCL yet.
         // Restrict to warpSize <= 32 for now.
-        static auto activemask(warp::WarpGenericSycl<TDim> const& warp) -> std::uint32_t
+        static auto activemask(warp::WarpGenericSycl<TDim> const& /*warp*/)
+            -> sycl::ext::oneapi::experimental::opportunistic_group
         {
-            static_assert(!sizeof(warp), "activemask is not supported on SYCL");
-            // SYCL does not have an API to get the activemask. It is also questionable (to me, bgruber) whether an
-            // "activemask" even exists on some hardware architectures, since the idea is bound to threads being
-            // "turned off" when they take different control flow in a warp. A SYCL implementation could run each
-            // thread as a SIMD lane, in which cause the "thread" is always active, but some SIMD lanes are either
-            // predicated off, or side-effects are masked out when writing them back.
-            //
-            // An implementation via oneAPI's sycl::ext::oneapi::group_ballot causes UB, because activemask is expected
-            // to be callable when less than all threads are active in a warp (CUDA). But SYCL requires all threads of
-            // a group to call the function.
-            //
-            // Intel's CUDA -> SYCL migration tool also suggests that there is no direct equivalent and the user must
-            // rewrite their kernel logic. See also:
-            // https://oneapi-src.github.io/SYCLomatic/dev_guide/diagnostic_ref/dpct1086.html
-
-            return ~std::uint32_t{0};
+            return sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
         }
     };
 
@@ -99,8 +85,7 @@ namespace alpaka::warp::trait
     {
         static auto all(warp::WarpGenericSycl<TDim> const& warp, std::int32_t predicate) -> std::int32_t
         {
-            auto const sub_group = warp.m_item_warp.get_sub_group();
-            return static_cast<std::int32_t>(sycl::all_of_group(sub_group, static_cast<bool>(predicate)));
+            return static_cast<std::int32_t>(sycl::all_of_group(activemask(warp), static_cast<bool>(predicate)));
         }
     };
 
@@ -109,8 +94,7 @@ namespace alpaka::warp::trait
     {
         static auto any(warp::WarpGenericSycl<TDim> const& warp, std::int32_t predicate) -> std::int32_t
         {
-            auto const sub_group = warp.m_item_warp.get_sub_group();
-            return static_cast<std::int32_t>(sycl::any_of_group(sub_group, static_cast<bool>(predicate)));
+            return static_cast<std::int32_t>(sycl::any_of_group(activemask(warp), static_cast<bool>(predicate)));
         }
     };
 
@@ -120,9 +104,9 @@ namespace alpaka::warp::trait
         // FIXME This should be std::uint64_t on AMD GCN architectures and on CPU,
         // but the former is not targeted in alpaka and CPU case is not supported in SYCL yet.
         // Restrict to warpSize <= 32 for now.
-        static auto ballot(warp::WarpGenericSycl<TDim> const& warp, std::int32_t predicate) -> std::uint32_t
+        static auto ballot(warp::WarpGenericSycl<TDim> const& /*warp*/, std::int32_t predicate) -> std::uint32_t
         {
-            auto const sub_group = warp.m_item_warp.get_sub_group();
+            auto sub_group = sycl::ext::oneapi::this_work_item::get_sub_group();
             auto const mask = sycl::ext::oneapi::group_ballot(sub_group, static_cast<bool>(predicate));
             // FIXME This should be std::uint64_t on AMD GCN architectures and on CPU,
             // but the former is not targeted in alpaka and CPU case is not supported in SYCL yet.
@@ -148,7 +132,7 @@ namespace alpaka::warp::trait
                Example: If we assume a sub-group size of 32 and a width of 16 we will receive two subdivisions:
                The first starts at sub-group index 0 and the second at sub-group index 16. For srcLane = 4 the
                first subdivision will access the value at sub-group index 4 and the second at sub-group index 20. */
-            auto const actual_group = warp.m_item_warp.get_sub_group();
+            auto const actual_group = activemask(warp);
             std::uint32_t const w = static_cast<std::uint32_t>(width);
             std::uint32_t const start_index = actual_group.get_local_linear_id() / w * w;
             return sycl::select_from_group(actual_group, value, start_index + static_cast<std::uint32_t>(srcLane) % w);
@@ -165,7 +149,7 @@ namespace alpaka::warp::trait
             std::uint32_t offset, /* must be the same for all work-items in the group */
             std::int32_t width)
         {
-            auto const actual_group = warp.m_item_warp.get_sub_group();
+            auto const actual_group = activemask(warp);
             std::uint32_t const w = static_cast<std::uint32_t>(width);
             std::uint32_t const id = actual_group.get_local_linear_id();
             std::uint32_t const start_index = id / w * w;
@@ -188,7 +172,7 @@ namespace alpaka::warp::trait
             std::uint32_t offset,
             std::int32_t width)
         {
-            auto const actual_group = warp.m_item_warp.get_sub_group();
+            auto const actual_group = activemask(warp);
             std::uint32_t const w = static_cast<std::uint32_t>(width);
             std::uint32_t const id = actual_group.get_local_linear_id();
             std::uint32_t const end_index = (id / w + 1) * w;
@@ -207,7 +191,7 @@ namespace alpaka::warp::trait
         template<typename T>
         static auto shfl_xor(warp::WarpGenericSycl<TDim> const& warp, T value, std::int32_t mask, std::int32_t width)
         {
-            auto const actual_group = warp.m_item_warp.get_sub_group();
+            auto const actual_group = activemask(warp);
             std::uint32_t const w = static_cast<std::uint32_t>(width);
             std::uint32_t const id = actual_group.get_local_linear_id();
             std::uint32_t const start_index = id / w * w;
@@ -218,3 +202,4 @@ namespace alpaka::warp::trait
 } // namespace alpaka::warp::trait
 
 #endif
+

--- a/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
@@ -123,7 +123,8 @@ namespace alpaka::warp
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
                 std::int32_t predicate) -> std::int32_t
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60'200'000)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
                 return __all_sync(activemask(warp), predicate);
 #        else
                 return __all(predicate);
@@ -138,7 +139,8 @@ namespace alpaka::warp
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
                 std::int32_t predicate) -> std::int32_t
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60'200'000)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
                 return __any_sync(activemask(warp), predicate);
 #        else
                 return __any(predicate);
@@ -159,7 +161,8 @@ namespace alpaka::warp
                 -> std::uint64_t
 #        endif
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60'200'000)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
                 return __ballot_sync(activemask(warp), predicate);
             }
 #        else
@@ -177,7 +180,8 @@ namespace alpaka::warp
                 int srcLane,
                 std::int32_t width) -> T
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60'200'000)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
                 return __shfl_sync(activemask(warp), val, srcLane, width);
 #        else
                     return __shfl(val, srcLane, width);
@@ -195,7 +199,8 @@ namespace alpaka::warp
                 std::uint32_t offset,
                 std::int32_t width) -> T
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60'200'000)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
                 return __shfl_up_sync(activemask(warp), val, offset, width);
 #        else
                     return __shfl_up(val, offset, width);
@@ -213,7 +218,8 @@ namespace alpaka::warp
                 std::uint32_t offset,
                 std::int32_t width) -> T
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60'200'000)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
                 return __shfl_down_sync(activemask(warp), val, offset, width);
 #        else
                     return __shfl_down(val, offset, width);
@@ -231,7 +237,8 @@ namespace alpaka::warp
                 std::int32_t mask,
                 std::int32_t width) -> T
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60'200'000)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
                 return __shfl_xor_sync(activemask(warp), val, mask, width);
 #        else
                     return __shfl_xor(val, mask, width);

--- a/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
@@ -123,7 +123,12 @@ namespace alpaka::warp
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
                 std::int32_t predicate) -> std::int32_t
             {
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60200000)
                 return __all_sync(activemask(warp), predicate);
+#        else
+                return __all(predicate);
+#        endif
+
             }
         };
 
@@ -134,7 +139,11 @@ namespace alpaka::warp
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
                 std::int32_t predicate) -> std::int32_t
             {
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60200000)
                 return __any_sync(activemask(warp), predicate);
+#        else
+                return __any(predicate);
+#        endif
             }
         };
 
@@ -151,8 +160,12 @@ namespace alpaka::warp
                 -> std::uint64_t
 #        endif
             {
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60200000)
                 return __ballot_sync(activemask(warp), predicate);
             }
+#        else
+                return __ballot(predicate);
+#        endif
         };
 
         template<>
@@ -165,7 +178,11 @@ namespace alpaka::warp
                 int srcLane,
                 std::int32_t width) -> T
             {
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60200000)
                 return __shfl_sync(activemask(warp), val, srcLane, width);
+#        else
+                return __shfl(val, srcLane, width);
+#        endif
             }
         };
 
@@ -179,7 +196,11 @@ namespace alpaka::warp
                 std::uint32_t offset,
                 std::int32_t width) -> T
             {
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60200000)
                 return __shfl_up_sync(activemask(warp), val, offset, width);
+#        else
+                return __shfl_up(val, offset, width);
+#        endif
             }
         };
 
@@ -193,7 +214,11 @@ namespace alpaka::warp
                 std::uint32_t offset,
                 std::int32_t width) -> T
             {
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60200000)
                 return __shfl_down_sync(activemask(warp), val, offset, width);
+#        else
+                return __shfl_down(val, offset, width);
+#        endif
             }
         };
 
@@ -207,7 +232,11 @@ namespace alpaka::warp
                 std::int32_t mask,
                 std::int32_t width) -> T
             {
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60200000)
                 return __shfl_xor_sync(activemask(warp), val, mask, width);
+#        else
+                return __shfl_xor(val, mask, width);
+#        endif
             }
         };
 

--- a/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
@@ -112,7 +112,13 @@ namespace alpaka::warp
                 -> std::uint64_t
 #        endif
             {
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
                 return __activemask();
+#        else
+                // No HIP intrinsic for it, emulate via ballot
+                return __ballot(1);
+#        endif
             }
         };
 
@@ -164,10 +170,10 @@ namespace alpaka::warp
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
             || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
                 return __ballot_sync(activemask(warp), predicate);
-            }
 #        else
                 return __ballot(predicate);
 #        endif
+            }
         };
 
         template<>
@@ -184,7 +190,7 @@ namespace alpaka::warp
             || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
                 return __shfl_sync(activemask(warp), val, srcLane, width);
 #        else
-                    return __shfl(val, srcLane, width);
+                return __shfl(val, srcLane, width);
 #        endif
             }
         };
@@ -203,7 +209,7 @@ namespace alpaka::warp
             || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
                 return __shfl_up_sync(activemask(warp), val, offset, width);
 #        else
-                    return __shfl_up(val, offset, width);
+                return __shfl_up(val, offset, width);
 #        endif
             }
         };
@@ -222,7 +228,7 @@ namespace alpaka::warp
             || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
                 return __shfl_down_sync(activemask(warp), val, offset, width);
 #        else
-                    return __shfl_down(val, offset, width);
+                return __shfl_down(val, offset, width);
 #        endif
             }
         };
@@ -241,7 +247,7 @@ namespace alpaka::warp
             || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
                 return __shfl_xor_sync(activemask(warp), val, mask, width);
 #        else
-                    return __shfl_xor(val, mask, width);
+                return __shfl_xor(val, mask, width);
 #        endif
             }
         };

--- a/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
@@ -34,7 +34,7 @@ namespace alpaka::warp
         template<>
         struct GetSize<WarpUniformCudaHipBuiltIn>
         {
-            __device__ static auto getSize(warp::WarpUniformCudaHipBuiltIn const& /*warp*/) -> std::int32_t
+            static __device__ auto getSize(warp::WarpUniformCudaHipBuiltIn const& /*warp*/) -> std::int32_t
             {
                 return warpSize;
             }
@@ -43,7 +43,7 @@ namespace alpaka::warp
         template<>
         struct GetSizeCompileTime<WarpUniformCudaHipBuiltIn>
         {
-            __device__ static constexpr auto getSizeCompileTime() -> std::int32_t
+            static constexpr __device__ auto getSizeCompileTime() -> std::int32_t
             {
 #        if defined(__CUDA_ARCH__)
                 // CUDA always has a warp size of 32
@@ -74,7 +74,7 @@ namespace alpaka::warp
         template<>
         struct GetSizeUpperLimit<WarpUniformCudaHipBuiltIn>
         {
-            __device__ static constexpr auto getSizeUpperLimit() -> std::int32_t
+            static constexpr __device__ auto getSizeUpperLimit() -> std::int32_t
             {
 #        if defined(__CUDA_ARCH__)
                 // CUDA always has a warp size of 32
@@ -105,7 +105,7 @@ namespace alpaka::warp
         template<>
         struct Activemask<WarpUniformCudaHipBuiltIn>
         {
-            __device__ static auto activemask(warp::WarpUniformCudaHipBuiltIn const& /*warp*/)
+            static __device__ auto activemask(warp::WarpUniformCudaHipBuiltIn const& /*warp*/)
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                 -> std::uint32_t
 #        else
@@ -119,27 +119,26 @@ namespace alpaka::warp
         template<>
         struct All<WarpUniformCudaHipBuiltIn>
         {
-            __device__ static auto all(
+            static __device__ auto all(
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
                 std::int32_t predicate) -> std::int32_t
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60200000)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60'200'000)
                 return __all_sync(activemask(warp), predicate);
 #        else
                 return __all(predicate);
 #        endif
-
             }
         };
 
         template<>
         struct Any<WarpUniformCudaHipBuiltIn>
         {
-            __device__ static auto any(
+            static __device__ auto any(
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
                 std::int32_t predicate) -> std::int32_t
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60200000)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60'200'000)
                 return __any_sync(activemask(warp), predicate);
 #        else
                 return __any(predicate);
@@ -150,7 +149,7 @@ namespace alpaka::warp
         template<>
         struct Ballot<WarpUniformCudaHipBuiltIn>
         {
-            __device__ static auto ballot(
+            static __device__ auto ballot(
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
                 std::int32_t predicate)
             // return type is required by the compiler
@@ -160,7 +159,7 @@ namespace alpaka::warp
                 -> std::uint64_t
 #        endif
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60200000)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60'200'000)
                 return __ballot_sync(activemask(warp), predicate);
             }
 #        else
@@ -172,16 +171,16 @@ namespace alpaka::warp
         struct Shfl<WarpUniformCudaHipBuiltIn>
         {
             template<typename T>
-            __device__ static auto shfl(
+            static __device__ auto shfl(
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
                 T val,
                 int srcLane,
                 std::int32_t width) -> T
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60200000)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60'200'000)
                 return __shfl_sync(activemask(warp), val, srcLane, width);
 #        else
-                return __shfl(val, srcLane, width);
+                    return __shfl(val, srcLane, width);
 #        endif
             }
         };
@@ -190,16 +189,16 @@ namespace alpaka::warp
         struct ShflUp<WarpUniformCudaHipBuiltIn>
         {
             template<typename T>
-            __device__ static auto shfl_up(
+            static __device__ auto shfl_up(
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
                 T val,
                 std::uint32_t offset,
                 std::int32_t width) -> T
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60200000)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60'200'000)
                 return __shfl_up_sync(activemask(warp), val, offset, width);
 #        else
-                return __shfl_up(val, offset, width);
+                    return __shfl_up(val, offset, width);
 #        endif
             }
         };
@@ -208,16 +207,16 @@ namespace alpaka::warp
         struct ShflDown<WarpUniformCudaHipBuiltIn>
         {
             template<typename T>
-            __device__ static auto shfl_down(
+            static __device__ auto shfl_down(
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
                 T val,
                 std::uint32_t offset,
                 std::int32_t width) -> T
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60200000)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60'200'000)
                 return __shfl_down_sync(activemask(warp), val, offset, width);
 #        else
-                return __shfl_down(val, offset, width);
+                    return __shfl_down(val, offset, width);
 #        endif
             }
         };
@@ -226,16 +225,16 @@ namespace alpaka::warp
         struct ShflXor<WarpUniformCudaHipBuiltIn>
         {
             template<typename T>
-            __device__ static auto shfl_xor(
+            static __device__ auto shfl_xor(
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
                 T val,
                 std::int32_t mask,
                 std::int32_t width) -> T
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60200000)
+#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && HIP_VERSION >= 60'200'000)
                 return __shfl_xor_sync(activemask(warp), val, mask, width);
 #        else
-                return __shfl_xor(val, mask, width);
+                    return __shfl_xor(val, mask, width);
 #        endif
             }
         };

--- a/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
@@ -112,12 +112,7 @@ namespace alpaka::warp
                 -> std::uint64_t
 #        endif
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
                 return __activemask();
-#        else
-                // No HIP intrinsic for it, emulate via ballot
-                return __ballot(1);
-#        endif
             }
         };
 
@@ -128,11 +123,7 @@ namespace alpaka::warp
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
                 std::int32_t predicate) -> std::int32_t
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                return __all_sync(0xffff'ffff, predicate);
-#        else
-                return __all(predicate);
-#        endif
+                return __all_sync(activemask(warp), predicate);
             }
         };
 
@@ -143,11 +134,7 @@ namespace alpaka::warp
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
                 std::int32_t predicate) -> std::int32_t
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                return __any_sync(0xffff'ffff, predicate);
-#        else
-                return __any(predicate);
-#        endif
+                return __any_sync(activemask(warp), predicate);
             }
         };
 
@@ -164,11 +151,7 @@ namespace alpaka::warp
                 -> std::uint64_t
 #        endif
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                return __ballot_sync(0xffff'ffff, predicate);
-#        else
-                return __ballot(predicate);
-#        endif
+                return __ballot_sync(activemask(warp), predicate);
             }
         };
 
@@ -182,11 +165,7 @@ namespace alpaka::warp
                 int srcLane,
                 std::int32_t width) -> T
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                return __shfl_sync(0xffff'ffff, val, srcLane, width);
-#        else
-                return __shfl(val, srcLane, width);
-#        endif
+                return __shfl_sync(activemask(warp), val, srcLane, width);
             }
         };
 
@@ -200,11 +179,7 @@ namespace alpaka::warp
                 std::uint32_t offset,
                 std::int32_t width) -> T
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                return __shfl_up_sync(0xffff'ffff, val, offset, width);
-#        else
-                return __shfl_up(val, offset, width);
-#        endif
+                return __shfl_up_sync(activemask(warp), val, offset, width);
             }
         };
 
@@ -218,11 +193,7 @@ namespace alpaka::warp
                 std::uint32_t offset,
                 std::int32_t width) -> T
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                return __shfl_down_sync(0xffff'ffff, val, offset, width);
-#        else
-                return __shfl_down(val, offset, width);
-#        endif
+                return __shfl_down_sync(activemask(warp), val, offset, width);
             }
         };
 
@@ -236,11 +207,7 @@ namespace alpaka::warp
                 std::int32_t mask,
                 std::int32_t width) -> T
             {
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                return __shfl_xor_sync(0xffff'ffff, val, mask, width);
-#        else
-                return __shfl_xor(val, mask, width);
-#        endif
+                return __shfl_xor_sync(activemask(warp), val, mask, width);
             }
         };
 

--- a/test/unit/warp/src/Activemask.cpp
+++ b/test/unit/warp/src/Activemask.cpp
@@ -65,6 +65,21 @@ struct alpaka::trait::WarpSize<ActivemaskMultipleThreadWarpTestKernel<TWarpSize>
 TEMPLATE_LIST_TEST_CASE("activemask", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
+
+#if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20'250'300
+    if constexpr(alpaka::accMatchesTags<
+                     Acc,
+                     alpaka::TagCpuSycl,
+                     alpaka::TagGpuSyclIntel,
+                     alpaka::TagGpuSyclNvidia,
+                     alpaka::TagGpuSyclAmd,
+                     alpaka::TagFpgaSyclIntel,
+                     alpaka::TagGenericSycl>)
+    {
+        WARN("Test disabled for SYCL");
+        return;
+    }
+#else
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
@@ -126,4 +141,5 @@ TEMPLATE_LIST_TEST_CASE("activemask", "[warp]", alpaka::test::TestAccs)
             }
         }
     }
+#endif
 }

--- a/test/unit/warp/src/Activemask.cpp
+++ b/test/unit/warp/src/Activemask.cpp
@@ -68,77 +68,63 @@ TEMPLATE_LIST_TEST_CASE("activemask", "[warp]", alpaka::test::TestAccs)
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    if constexpr(alpaka::accMatchesTags<
-                     Acc,
-                     alpaka::TagCpuSycl,
-                     alpaka::TagGpuSyclIntel,
-                     alpaka::TagGpuSyclNvidia,
-                     alpaka::TagGpuSyclAmd,
-                     alpaka::TagFpgaSyclIntel,
-                     alpaka::TagGenericSycl>)
+    auto const platform = alpaka::Platform<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
     {
-        WARN("Test disabled for SYCL");
-    }
-    else
-    {
-        auto const platform = alpaka::Platform<Acc>{};
-        auto const dev = alpaka::getDevByIdx(platform, 0);
-        auto const warpExtents = alpaka::getWarpSizes(dev);
-        for(auto const warpExtent : warpExtents)
+        auto const scalar = Dim::value == 0 || warpExtent == 1;
+        if(scalar)
         {
-            auto const scalar = Dim::value == 0 || warpExtent == 1;
-            if(scalar)
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+            CHECK(fixture(ActivemaskSingleThreadWarpTestKernel{}));
+        }
+        else
+        {
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            if(warpExtent == 4)
             {
-                alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
-                CHECK(fixture(ActivemaskSingleThreadWarpTestKernel{}));
+                for(auto inactiveThreadIdx = 0u; inactiveThreadIdx < warpExtent; inactiveThreadIdx++)
+                {
+                    CHECK(fixture(ActivemaskMultipleThreadWarpTestKernel<4>{}, inactiveThreadIdx));
+                }
             }
-            else
+            else if(warpExtent == 8)
             {
-                using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-                auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-                // Enforce one warp per thread block
-                auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-                blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-                auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-                auto workDiv =
-                    typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-                auto fixture = ExecutionFixture{workDiv};
-                if(warpExtent == 4)
+                for(auto inactiveThreadIdx = 0u; inactiveThreadIdx < warpExtent; inactiveThreadIdx++)
                 {
-                    for(auto inactiveThreadIdx = 0u; inactiveThreadIdx < warpExtent; inactiveThreadIdx++)
-                    {
-                        CHECK(fixture(ActivemaskMultipleThreadWarpTestKernel<4>{}, inactiveThreadIdx));
-                    }
+                    CHECK(fixture(ActivemaskMultipleThreadWarpTestKernel<8>{}, inactiveThreadIdx));
                 }
-                else if(warpExtent == 8)
+            }
+            else if(warpExtent == 16)
+            {
+                for(auto inactiveThreadIdx = 0u; inactiveThreadIdx < warpExtent; inactiveThreadIdx++)
                 {
-                    for(auto inactiveThreadIdx = 0u; inactiveThreadIdx < warpExtent; inactiveThreadIdx++)
-                    {
-                        CHECK(fixture(ActivemaskMultipleThreadWarpTestKernel<8>{}, inactiveThreadIdx));
-                    }
+                    CHECK(fixture(ActivemaskMultipleThreadWarpTestKernel<16>{}, inactiveThreadIdx));
                 }
-                else if(warpExtent == 16)
+            }
+            else if(warpExtent == 32)
+            {
+                for(auto inactiveThreadIdx = 0u; inactiveThreadIdx < warpExtent; inactiveThreadIdx++)
                 {
-                    for(auto inactiveThreadIdx = 0u; inactiveThreadIdx < warpExtent; inactiveThreadIdx++)
-                    {
-                        CHECK(fixture(ActivemaskMultipleThreadWarpTestKernel<16>{}, inactiveThreadIdx));
-                    }
+                    CHECK(fixture(ActivemaskMultipleThreadWarpTestKernel<32>{}, inactiveThreadIdx));
                 }
-                else if(warpExtent == 32)
+            }
+            else if(warpExtent == 64)
+            {
+                for(auto inactiveThreadIdx = 0u; inactiveThreadIdx < warpExtent; inactiveThreadIdx++)
                 {
-                    for(auto inactiveThreadIdx = 0u; inactiveThreadIdx < warpExtent; inactiveThreadIdx++)
-                    {
-                        CHECK(fixture(ActivemaskMultipleThreadWarpTestKernel<32>{}, inactiveThreadIdx));
-                    }
-                }
-                else if(warpExtent == 64)
-                {
-                    for(auto inactiveThreadIdx = 0u; inactiveThreadIdx < warpExtent; inactiveThreadIdx++)
-                    {
-                        CHECK(fixture(ActivemaskMultipleThreadWarpTestKernel<64>{}, inactiveThreadIdx));
-                    }
+                    CHECK(fixture(ActivemaskMultipleThreadWarpTestKernel<64>{}, inactiveThreadIdx));
                 }
             }
         }
     }
 }
+

--- a/test/unit/warp/src/Activemask.cpp
+++ b/test/unit/warp/src/Activemask.cpp
@@ -127,4 +127,3 @@ TEMPLATE_LIST_TEST_CASE("activemask", "[warp]", alpaka::test::TestAccs)
         }
     }
 }
-

--- a/test/unit/warp/src/All.cpp
+++ b/test/unit/warp/src/All.cpp
@@ -114,4 +114,3 @@ TEMPLATE_LIST_TEST_CASE("all", "[warp]", alpaka::test::TestAccs)
         }
     }
 }
-

--- a/test/unit/warp/src/All.cpp
+++ b/test/unit/warp/src/All.cpp
@@ -70,60 +70,48 @@ TEMPLATE_LIST_TEST_CASE("all", "[warp]", alpaka::test::TestAccs)
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    if constexpr(alpaka::accMatchesTags<
-                     Acc,
-                     alpaka::TagCpuSycl,
-                     alpaka::TagGpuSyclIntel,
-                     alpaka::TagFpgaSyclIntel,
-                     alpaka::TagGenericSycl>)
+    auto const platform = alpaka::Platform<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
     {
-        WARN("Test disabled for SYCL");
-    }
-    else
-    {
-        auto const platform = alpaka::Platform<Acc>{};
-        auto const dev = alpaka::getDevByIdx(platform, 0);
-        auto const warpExtents = alpaka::getWarpSizes(dev);
-        for(auto const warpExtent : warpExtents)
+        auto const scalar = Dim::value == 0 || warpExtent == 1;
+        if(scalar)
         {
-            auto const scalar = Dim::value == 0 || warpExtent == 1;
-            if(scalar)
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+            REQUIRE(fixture(AllSingleThreadWarpTestKernel{}));
+        }
+        else
+        {
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            if(warpExtent == 4)
             {
-                alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
-                REQUIRE(fixture(AllSingleThreadWarpTestKernel{}));
+                REQUIRE(fixture(AllMultipleThreadWarpTestKernel<4>{}));
             }
-            else
+            else if(warpExtent == 8)
             {
-                using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-                auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-                // Enforce one warp per thread block
-                auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-                blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-                auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-                auto workDiv =
-                    typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-                auto fixture = ExecutionFixture{workDiv};
-                if(warpExtent == 4)
-                {
-                    REQUIRE(fixture(AllMultipleThreadWarpTestKernel<4>{}));
-                }
-                else if(warpExtent == 8)
-                {
-                    REQUIRE(fixture(AllMultipleThreadWarpTestKernel<8>{}));
-                }
-                else if(warpExtent == 16)
-                {
-                    REQUIRE(fixture(AllMultipleThreadWarpTestKernel<16>{}));
-                }
-                else if(warpExtent == 32)
-                {
-                    REQUIRE(fixture(AllMultipleThreadWarpTestKernel<32>{}));
-                }
-                else if(warpExtent == 64)
-                {
-                    REQUIRE(fixture(AllMultipleThreadWarpTestKernel<64>{}));
-                }
+                REQUIRE(fixture(AllMultipleThreadWarpTestKernel<8>{}));
+            }
+            else if(warpExtent == 16)
+            {
+                REQUIRE(fixture(AllMultipleThreadWarpTestKernel<16>{}));
+            }
+            else if(warpExtent == 32)
+            {
+                REQUIRE(fixture(AllMultipleThreadWarpTestKernel<32>{}));
+            }
+            else if(warpExtent == 64)
+            {
+                REQUIRE(fixture(AllMultipleThreadWarpTestKernel<64>{}));
             }
         }
     }
 }
+

--- a/test/unit/warp/src/All.cpp
+++ b/test/unit/warp/src/All.cpp
@@ -67,6 +67,21 @@ struct alpaka::trait::WarpSize<AllMultipleThreadWarpTestKernel<TWarpSize>, TAcc>
 TEMPLATE_LIST_TEST_CASE("all", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
+
+#if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20'250'300
+    if constexpr(alpaka::accMatchesTags<
+                     Acc,
+                     alpaka::TagCpuSycl,
+                     alpaka::TagGpuSyclIntel,
+                     alpaka::TagGpuSyclNvidia,
+                     alpaka::TagGpuSyclAmd,
+                     alpaka::TagFpgaSyclIntel,
+                     alpaka::TagGenericSycl>)
+    {
+        WARN("Test disabled for SYCL");
+        return;
+    }
+#else
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
@@ -113,4 +128,5 @@ TEMPLATE_LIST_TEST_CASE("all", "[warp]", alpaka::test::TestAccs)
             }
         }
     }
+#endif
 }

--- a/test/unit/warp/src/Any.cpp
+++ b/test/unit/warp/src/Any.cpp
@@ -70,59 +70,46 @@ TEMPLATE_LIST_TEST_CASE("any", "[warp]", alpaka::test::TestAccs)
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    if constexpr(alpaka::accMatchesTags<
-                     Acc,
-                     alpaka::TagCpuSycl,
-                     alpaka::TagGpuSyclIntel,
-                     alpaka::TagFpgaSyclIntel,
-                     alpaka::TagGenericSycl>)
+    auto const platform = alpaka::Platform<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
     {
-        WARN("Test disabled for SYCL");
-    }
-    else
-    {
-        auto const platform = alpaka::Platform<Acc>{};
-        auto const dev = alpaka::getDevByIdx(platform, 0);
-        auto const warpExtents = alpaka::getWarpSizes(dev);
-        for(auto const warpExtent : warpExtents)
+        auto const scalar = Dim::value == 0 || warpExtent == 1;
+        if(scalar)
         {
-            auto const scalar = Dim::value == 0 || warpExtent == 1;
-            if(scalar)
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+            REQUIRE(fixture(AnySingleThreadWarpTestKernel{}));
+        }
+        else
+        {
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            if(warpExtent == 4)
             {
-                alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
-                REQUIRE(fixture(AnySingleThreadWarpTestKernel{}));
+                REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<4>{}));
             }
-            else
+            else if(warpExtent == 8)
             {
-                using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-                auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-                // Enforce one warp per thread block
-                auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-                blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-                auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-                auto workDiv =
-                    typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-                auto fixture = ExecutionFixture{workDiv};
-                if(warpExtent == 4)
-                {
-                    REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<4>{}));
-                }
-                else if(warpExtent == 8)
-                {
-                    REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<8>{}));
-                }
-                else if(warpExtent == 16)
-                {
-                    REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<16>{}));
-                }
-                else if(warpExtent == 32)
-                {
-                    REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<32>{}));
-                }
-                else if(warpExtent == 64)
-                {
-                    REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<64>{}));
-                }
+                REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<8>{}));
+            }
+            else if(warpExtent == 16)
+            {
+                REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<16>{}));
+            }
+            else if(warpExtent == 32)
+            {
+                REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<32>{}));
+            }
+            else if(warpExtent == 64)
+            {
+                REQUIRE(fixture(AnyMultipleThreadWarpTestKernel<64>{}));
             }
         }
     }

--- a/test/unit/warp/src/Any.cpp
+++ b/test/unit/warp/src/Any.cpp
@@ -67,6 +67,21 @@ struct alpaka::trait::WarpSize<AnyMultipleThreadWarpTestKernel<TWarpSize>, TAcc>
 TEMPLATE_LIST_TEST_CASE("any", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
+
+#if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20'250'300
+    if constexpr(alpaka::accMatchesTags<
+                     Acc,
+                     alpaka::TagCpuSycl,
+                     alpaka::TagGpuSyclIntel,
+                     alpaka::TagGpuSyclNvidia,
+                     alpaka::TagGpuSyclAmd,
+                     alpaka::TagFpgaSyclIntel,
+                     alpaka::TagGenericSycl>)
+    {
+        WARN("Test disabled for SYCL");
+        return;
+    }
+#else
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
@@ -113,4 +128,5 @@ TEMPLATE_LIST_TEST_CASE("any", "[warp]", alpaka::test::TestAccs)
             }
         }
     }
+#endif
 }

--- a/test/unit/warp/src/Ballot.cpp
+++ b/test/unit/warp/src/Ballot.cpp
@@ -75,6 +75,21 @@ struct alpaka::trait::WarpSize<BallotMultipleThreadWarpTestKernel<TWarpSize>, TA
 TEMPLATE_LIST_TEST_CASE("ballot", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
+
+#if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20'250'300
+    if constexpr(alpaka::accMatchesTags<
+                     Acc,
+                     alpaka::TagCpuSycl,
+                     alpaka::TagGpuSyclIntel,
+                     alpaka::TagGpuSyclNvidia,
+                     alpaka::TagGpuSyclAmd,
+                     alpaka::TagFpgaSyclIntel,
+                     alpaka::TagGenericSycl>)
+    {
+        WARN("Test disabled for SYCL");
+        return;
+    }
+#else
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
@@ -121,4 +136,5 @@ TEMPLATE_LIST_TEST_CASE("ballot", "[warp]", alpaka::test::TestAccs)
             }
         }
     }
+#endif
 }

--- a/test/unit/warp/src/Ballot.cpp
+++ b/test/unit/warp/src/Ballot.cpp
@@ -78,59 +78,46 @@ TEMPLATE_LIST_TEST_CASE("ballot", "[warp]", alpaka::test::TestAccs)
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    if constexpr(alpaka::accMatchesTags<
-                     Acc,
-                     alpaka::TagCpuSycl,
-                     alpaka::TagGpuSyclIntel,
-                     alpaka::TagFpgaSyclIntel,
-                     alpaka::TagGenericSycl>)
+    auto const platform = alpaka::Platform<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
     {
-        WARN("Test disabled for SYCL");
-    }
-    else
-    {
-        auto const platform = alpaka::Platform<Acc>{};
-        auto const dev = alpaka::getDevByIdx(platform, 0);
-        auto const warpExtents = alpaka::getWarpSizes(dev);
-        for(auto const warpExtent : warpExtents)
+        auto const scalar = Dim::value == 0 || warpExtent == 1;
+        if(scalar)
         {
-            auto const scalar = Dim::value == 0 || warpExtent == 1;
-            if(scalar)
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+            REQUIRE(fixture(BallotSingleThreadWarpTestKernel{}));
+        }
+        else
+        {
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            if(warpExtent == 4)
             {
-                alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
-                REQUIRE(fixture(BallotSingleThreadWarpTestKernel{}));
+                REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<4>{}));
             }
-            else
+            else if(warpExtent == 8)
             {
-                using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-                auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-                // Enforce one warp per thread block
-                auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-                blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-                auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-                auto workDiv =
-                    typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-                auto fixture = ExecutionFixture{workDiv};
-                if(warpExtent == 4)
-                {
-                    REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<4>{}));
-                }
-                else if(warpExtent == 8)
-                {
-                    REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<8>{}));
-                }
-                else if(warpExtent == 16)
-                {
-                    REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<16>{}));
-                }
-                else if(warpExtent == 32)
-                {
-                    REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<32>{}));
-                }
-                else if(warpExtent == 64)
-                {
-                    REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<64>{}));
-                }
+                REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<8>{}));
+            }
+            else if(warpExtent == 16)
+            {
+                REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<16>{}));
+            }
+            else if(warpExtent == 32)
+            {
+                REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<32>{}));
+            }
+            else if(warpExtent == 64)
+            {
+                REQUIRE(fixture(BallotMultipleThreadWarpTestKernel<64>{}));
             }
         }
     }

--- a/test/unit/warp/src/Shfl.cpp
+++ b/test/unit/warp/src/Shfl.cpp
@@ -100,59 +100,46 @@ TEMPLATE_LIST_TEST_CASE("shfl", "[warp]", alpaka::test::TestAccs)
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    if constexpr(alpaka::accMatchesTags<
-                     Acc,
-                     alpaka::TagCpuSycl,
-                     alpaka::TagGpuSyclIntel,
-                     alpaka::TagFpgaSyclIntel,
-                     alpaka::TagGenericSycl>)
+    auto const platform = alpaka::Platform<Acc>{};
+    auto const dev = alpaka::getDevByIdx(platform, 0);
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
     {
-        WARN("Test disabled for SYCL");
-    }
-    else
-    {
-        auto const platform = alpaka::Platform<Acc>{};
-        auto const dev = alpaka::getDevByIdx(platform, 0);
-        auto const warpExtents = alpaka::getWarpSizes(dev);
-        for(auto const warpExtent : warpExtents)
+        auto const scalar = Dim::value == 0 || warpExtent == 1;
+        if(scalar)
         {
-            auto const scalar = Dim::value == 0 || warpExtent == 1;
-            if(scalar)
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+            REQUIRE(fixture(ShflSingleThreadWarpTestKernel{}));
+        }
+        else
+        {
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            if(warpExtent == 4)
             {
-                alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
-                REQUIRE(fixture(ShflSingleThreadWarpTestKernel{}));
+                REQUIRE(fixture(ShflMultipleThreadWarpTestKernel<4>{}));
             }
-            else
+            else if(warpExtent == 8)
             {
-                using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-                auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-                // Enforce one warp per thread block
-                auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-                blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-                auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-                auto workDiv =
-                    typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-                auto fixture = ExecutionFixture{workDiv};
-                if(warpExtent == 4)
-                {
-                    REQUIRE(fixture(ShflMultipleThreadWarpTestKernel<4>{}));
-                }
-                else if(warpExtent == 8)
-                {
-                    REQUIRE(fixture(ShflMultipleThreadWarpTestKernel<8>{}));
-                }
-                else if(warpExtent == 16)
-                {
-                    REQUIRE(fixture(ShflMultipleThreadWarpTestKernel<16>{}));
-                }
-                else if(warpExtent == 32)
-                {
-                    REQUIRE(fixture(ShflMultipleThreadWarpTestKernel<32>{}));
-                }
-                else if(warpExtent == 64)
-                {
-                    REQUIRE(fixture(ShflMultipleThreadWarpTestKernel<64>{}));
-                }
+                REQUIRE(fixture(ShflMultipleThreadWarpTestKernel<8>{}));
+            }
+            else if(warpExtent == 16)
+            {
+                REQUIRE(fixture(ShflMultipleThreadWarpTestKernel<16>{}));
+            }
+            else if(warpExtent == 32)
+            {
+                REQUIRE(fixture(ShflMultipleThreadWarpTestKernel<32>{}));
+            }
+            else if(warpExtent == 64)
+            {
+                REQUIRE(fixture(ShflMultipleThreadWarpTestKernel<64>{}));
             }
         }
     }

--- a/test/unit/warp/src/Shfl.cpp
+++ b/test/unit/warp/src/Shfl.cpp
@@ -97,6 +97,21 @@ struct alpaka::trait::WarpSize<ShflMultipleThreadWarpTestKernel<TWarpSize>, TAcc
 TEMPLATE_LIST_TEST_CASE("shfl", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
+
+#if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20'250'300
+    if constexpr(alpaka::accMatchesTags<
+                     Acc,
+                     alpaka::TagCpuSycl,
+                     alpaka::TagGpuSyclIntel,
+                     alpaka::TagGpuSyclNvidia,
+                     alpaka::TagGpuSyclAmd,
+                     alpaka::TagFpgaSyclIntel,
+                     alpaka::TagGenericSycl>)
+    {
+        WARN("Test disabled for SYCL");
+        return;
+    }
+#else
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
@@ -143,4 +158,5 @@ TEMPLATE_LIST_TEST_CASE("shfl", "[warp]", alpaka::test::TestAccs)
             }
         }
     }
+#endif
 }

--- a/test/unit/warp/src/ShflDown.cpp
+++ b/test/unit/warp/src/ShflDown.cpp
@@ -121,6 +121,21 @@ struct alpaka::trait::WarpSize<ShflDownMultipleThreadWarpTestKernel<TWarpSize>, 
 TEMPLATE_LIST_TEST_CASE("shfl_down", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
+
+#if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20'250'300
+    if constexpr(alpaka::accMatchesTags<
+                     Acc,
+                     alpaka::TagCpuSycl,
+                     alpaka::TagGpuSyclIntel,
+                     alpaka::TagGpuSyclNvidia,
+                     alpaka::TagGpuSyclAmd,
+                     alpaka::TagFpgaSyclIntel,
+                     alpaka::TagGenericSycl>)
+    {
+        WARN("Test disabled for SYCL");
+        return;
+    }
+#else
     using Dev = alpaka::Dev<Acc>;
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
@@ -168,6 +183,7 @@ TEMPLATE_LIST_TEST_CASE("shfl_down", "[warp]", alpaka::test::TestAccs)
             }
         }
     }
+#endif
 }
 
 #if ALPAKA_COMP_GNUC

--- a/test/unit/warp/src/ShflDown.cpp
+++ b/test/unit/warp/src/ShflDown.cpp
@@ -125,59 +125,46 @@ TEMPLATE_LIST_TEST_CASE("shfl_down", "[warp]", alpaka::test::TestAccs)
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    if constexpr(alpaka::accMatchesTags<
-                     Acc,
-                     alpaka::TagCpuSycl,
-                     alpaka::TagGpuSyclIntel,
-                     alpaka::TagFpgaSyclIntel,
-                     alpaka::TagGenericSycl>)
+    auto const platform = alpaka::Platform<Acc>{};
+    Dev const dev(alpaka::getDevByIdx(platform, 0u));
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
     {
-        WARN("Test disabled for SYCL");
-    }
-    else
-    {
-        auto const platform = alpaka::Platform<Acc>{};
-        Dev const dev(alpaka::getDevByIdx(platform, 0u));
-        auto const warpExtents = alpaka::getWarpSizes(dev);
-        for(auto const warpExtent : warpExtents)
+        auto const scalar = Dim::value == 0 || warpExtent == 1;
+        if(scalar)
         {
-            auto const scalar = Dim::value == 0 || warpExtent == 1;
-            if(scalar)
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+            REQUIRE(fixture(ShflDownSingleThreadWarpTestKernel{}));
+        }
+        else
+        {
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            if(warpExtent == 4)
             {
-                alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
-                REQUIRE(fixture(ShflDownSingleThreadWarpTestKernel{}));
+                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<4>{}));
             }
-            else
+            else if(warpExtent == 8)
             {
-                using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-                auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-                // Enforce one warp per thread block
-                auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-                blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-                auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-                auto workDiv =
-                    typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-                auto fixture = ExecutionFixture{workDiv};
-                if(warpExtent == 4)
-                {
-                    REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<4>{}));
-                }
-                else if(warpExtent == 8)
-                {
-                    REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<8>{}));
-                }
-                else if(warpExtent == 16)
-                {
-                    REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<16>{}));
-                }
-                else if(warpExtent == 32)
-                {
-                    REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<32>{}));
-                }
-                else if(warpExtent == 64)
-                {
-                    REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<64>{}));
-                }
+                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<8>{}));
+            }
+            else if(warpExtent == 16)
+            {
+                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<16>{}));
+            }
+            else if(warpExtent == 32)
+            {
+                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<32>{}));
+            }
+            else if(warpExtent == 64)
+            {
+                REQUIRE(fixture(ShflDownMultipleThreadWarpTestKernel<64>{}));
             }
         }
     }

--- a/test/unit/warp/src/ShflUp.cpp
+++ b/test/unit/warp/src/ShflUp.cpp
@@ -117,6 +117,21 @@ struct alpaka::trait::WarpSize<ShflUpMultipleThreadWarpTestKernel<TWarpSize>, TA
 TEMPLATE_LIST_TEST_CASE("shfl_up", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
+
+#if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20'250'300
+    if constexpr(alpaka::accMatchesTags<
+                     Acc,
+                     alpaka::TagCpuSycl,
+                     alpaka::TagGpuSyclIntel,
+                     alpaka::TagGpuSyclNvidia,
+                     alpaka::TagGpuSyclAmd,
+                     alpaka::TagFpgaSyclIntel,
+                     alpaka::TagGenericSycl>)
+    {
+        WARN("Test disabled for SYCL");
+        return;
+    }
+#else
     using Dev = alpaka::Dev<Acc>;
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
@@ -164,4 +179,5 @@ TEMPLATE_LIST_TEST_CASE("shfl_up", "[warp]", alpaka::test::TestAccs)
             }
         }
     }
+#endif
 }

--- a/test/unit/warp/src/ShflUp.cpp
+++ b/test/unit/warp/src/ShflUp.cpp
@@ -121,59 +121,46 @@ TEMPLATE_LIST_TEST_CASE("shfl_up", "[warp]", alpaka::test::TestAccs)
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    if constexpr(alpaka::accMatchesTags<
-                     Acc,
-                     alpaka::TagCpuSycl,
-                     alpaka::TagGpuSyclIntel,
-                     alpaka::TagFpgaSyclIntel,
-                     alpaka::TagGenericSycl>)
+    auto const platform = alpaka::Platform<Acc>{};
+    Dev const dev(alpaka::getDevByIdx(platform, 0u));
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
     {
-        WARN("Test disabled for SYCL");
-    }
-    else
-    {
-        auto const platform = alpaka::Platform<Acc>{};
-        Dev const dev(alpaka::getDevByIdx(platform, 0u));
-        auto const warpExtents = alpaka::getWarpSizes(dev);
-        for(auto const warpExtent : warpExtents)
+        auto const scalar = Dim::value == 0 || warpExtent == 1;
+        if(scalar)
         {
-            auto const scalar = Dim::value == 0 || warpExtent == 1;
-            if(scalar)
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+            REQUIRE(fixture(ShflUpSingleThreadWarpTestKernel{}));
+        }
+        else
+        {
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            if(warpExtent == 4)
             {
-                alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
-                REQUIRE(fixture(ShflUpSingleThreadWarpTestKernel{}));
+                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<4>{}));
             }
-            else
+            else if(warpExtent == 8)
             {
-                using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-                auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-                // Enforce one warp per thread block
-                auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-                blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-                auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-                auto workDiv =
-                    typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-                auto fixture = ExecutionFixture{workDiv};
-                if(warpExtent == 4)
-                {
-                    REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<4>{}));
-                }
-                else if(warpExtent == 8)
-                {
-                    REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<8>{}));
-                }
-                else if(warpExtent == 16)
-                {
-                    REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<16>{}));
-                }
-                else if(warpExtent == 32)
-                {
-                    REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<32>{}));
-                }
-                else if(warpExtent == 64)
-                {
-                    REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<64>{}));
-                }
+                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<8>{}));
+            }
+            else if(warpExtent == 16)
+            {
+                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<16>{}));
+            }
+            else if(warpExtent == 32)
+            {
+                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<32>{}));
+            }
+            else if(warpExtent == 64)
+            {
+                REQUIRE(fixture(ShflUpMultipleThreadWarpTestKernel<64>{}));
             }
         }
     }

--- a/test/unit/warp/src/ShflXor.cpp
+++ b/test/unit/warp/src/ShflXor.cpp
@@ -106,59 +106,46 @@ TEMPLATE_LIST_TEST_CASE("shfl_xor", "[warp]", alpaka::test::TestAccs)
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
 
-    if constexpr(alpaka::accMatchesTags<
-                     Acc,
-                     alpaka::TagCpuSycl,
-                     alpaka::TagGpuSyclIntel,
-                     alpaka::TagFpgaSyclIntel,
-                     alpaka::TagGenericSycl>)
+    auto const platform = alpaka::Platform<Acc>{};
+    Dev const dev(alpaka::getDevByIdx(platform, 0u));
+    auto const warpExtents = alpaka::getWarpSizes(dev);
+    for(auto const warpExtent : warpExtents)
     {
-        WARN("Test disabled for SYCL");
-    }
-    else
-    {
-        auto const platform = alpaka::Platform<Acc>{};
-        Dev const dev(alpaka::getDevByIdx(platform, 0u));
-        auto const warpExtents = alpaka::getWarpSizes(dev);
-        for(auto const warpExtent : warpExtents)
+        auto const scalar = Dim::value == 0 || warpExtent == 1;
+        if(scalar)
         {
-            auto const scalar = Dim::value == 0 || warpExtent == 1;
-            if(scalar)
+            alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
+            REQUIRE(fixture(ShflXorSingleThreadWarpTestKernel{}));
+        }
+        else
+        {
+            using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
+            auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
+            // Enforce one warp per thread block
+            auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
+            blockThreadExtent[0] = static_cast<Idx>(warpExtent);
+            auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
+            auto workDiv = typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
+            auto fixture = ExecutionFixture{workDiv};
+            if(warpExtent == 4)
             {
-                alpaka::test::KernelExecutionFixture<Acc> fixture(alpaka::Vec<Dim, Idx>::all(4));
-                REQUIRE(fixture(ShflXorSingleThreadWarpTestKernel{}));
+                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<4>{}));
             }
-            else
+            else if(warpExtent == 8)
             {
-                using ExecutionFixture = alpaka::test::KernelExecutionFixture<Acc>;
-                auto const gridBlockExtent = alpaka::Vec<Dim, Idx>::all(2);
-                // Enforce one warp per thread block
-                auto blockThreadExtent = alpaka::Vec<Dim, Idx>::ones();
-                blockThreadExtent[0] = static_cast<Idx>(warpExtent);
-                auto const threadElementExtent = alpaka::Vec<Dim, Idx>::ones();
-                auto workDiv =
-                    typename ExecutionFixture::WorkDiv{gridBlockExtent, blockThreadExtent, threadElementExtent};
-                auto fixture = ExecutionFixture{workDiv};
-                if(warpExtent == 4)
-                {
-                    REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<4>{}));
-                }
-                else if(warpExtent == 8)
-                {
-                    REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<8>{}));
-                }
-                else if(warpExtent == 16)
-                {
-                    REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<16>{}));
-                }
-                else if(warpExtent == 32)
-                {
-                    REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<32>{}));
-                }
-                else if(warpExtent == 64)
-                {
-                    REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<64>{}));
-                }
+                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<8>{}));
+            }
+            else if(warpExtent == 16)
+            {
+                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<16>{}));
+            }
+            else if(warpExtent == 32)
+            {
+                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<32>{}));
+            }
+            else if(warpExtent == 64)
+            {
+                REQUIRE(fixture(ShflXorMultipleThreadWarpTestKernel<64>{}));
             }
         }
     }

--- a/test/unit/warp/src/ShflXor.cpp
+++ b/test/unit/warp/src/ShflXor.cpp
@@ -102,6 +102,21 @@ struct alpaka::trait::WarpSize<ShflXorMultipleThreadWarpTestKernel<TWarpSize>, T
 TEMPLATE_LIST_TEST_CASE("shfl_xor", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
+
+#if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20'250'300
+    if constexpr(alpaka::accMatchesTags<
+                     Acc,
+                     alpaka::TagCpuSycl,
+                     alpaka::TagGpuSyclIntel,
+                     alpaka::TagGpuSyclNvidia,
+                     alpaka::TagGpuSyclAmd,
+                     alpaka::TagFpgaSyclIntel,
+                     alpaka::TagGenericSycl>)
+    {
+        WARN("Test disabled for SYCL");
+        return;
+    }
+#else
     using Dev = alpaka::Dev<Acc>;
     using Dim = alpaka::Dim<Acc>;
     using Idx = alpaka::Idx<Acc>;
@@ -149,4 +164,5 @@ TEMPLATE_LIST_TEST_CASE("shfl_xor", "[warp]", alpaka::test::TestAccs)
             }
         }
     }
+#endif
 }


### PR DESCRIPTION
Now that oneAPI 2025.3 is out and the bug related to the opportunistic group has been fixed, I've rebased the branch and updated it. Main changes:
- warp functions now support passing the mask
- `activemask` in HIP has now been implemented 
- I've defined the macro `HIP_ENABLE_WARP_SYNC_BUILTINS` directly in the code to enable sync functions in HIP starting from 6.2 to be independent from the way the code is compiled (`cmake`, `Makefile`.. )
- I've enabled the tests for SYCL

Note that using oneAPI < 2025.3 most likely will not work (but we won't notice since we are not running tests on the Intel GPU).
I don't know if it's ok to merge it or if it's best to move to 2025.3 first, but in the meantime we can discuss the implementation.