### PR TITLE
Fix noexcept warnings for gcc 15.2.1

### DIFF
--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -108,22 +108,22 @@ namespace alpaka
             return all(static_cast<TVal>(1));
         }
 
-        ALPAKA_FN_HOST_ACC constexpr auto begin() -> TVal*
+        ALPAKA_FN_HOST_ACC constexpr auto begin() noexcept -> TVal*
         {
             return m_data;
         }
 
-        ALPAKA_FN_HOST_ACC constexpr auto begin() const -> TVal const*
+        ALPAKA_FN_HOST_ACC constexpr auto begin() const noexcept -> TVal const*
         {
             return m_data;
         }
 
-        ALPAKA_FN_HOST_ACC constexpr auto end() -> TVal*
+        ALPAKA_FN_HOST_ACC constexpr auto end() noexcept -> TVal*
         {
             return m_data + TDim::value;
         }
 
-        ALPAKA_FN_HOST_ACC constexpr auto end() const -> TVal const*
+        ALPAKA_FN_HOST_ACC constexpr auto end() const noexcept -> TVal const*
         {
             return m_data + TDim::value;
         }


### PR DESCRIPTION
compiling the Philox test, gcc 15.2.1 throws noexcept warnings 
```
/usr/include/c++/15.2.1/bits/range_access.h:66:46: warning:
noexcept-expression evaluates to ‘false’ because of a call to ‘constexpr
const TVal* alpaka::Vec<TDim, TVal>::begin() const [with TDim =
std::integral_constant<long unsigned int, 4>; TVal = unsigned int]’
[-Wnoexcept]
   66 |     begin(const _Container& __cont)
noexcept(noexcept(__cont.begin()))
      |
^~~~~~~~~~~~~~~~~~~~~~~~
In file included from
src/alpaka/include/alpaka/meta/IsArrayOrVector.hpp:7,
                 from src/alpaka/include/alpaka/rand/RandPhilox.hpp:8:
src/alpaka/include/alpaka/vec/Vec.hpp:116:43: note: but ‘constexpr const
TVal* alpaka::Vec<TDim, TVal>::begin() const [with TDim =
std::integral_constant<long unsigned int, 4>; TVal = unsigned int]’ does
not throw; perhaps it should be declared ‘noexcept’
  116 |         ALPAKA_FN_HOST_ACC constexpr auto begin() const -> TVal
const*
      |                                           ^~~~~
```