### PR TITLE
Index type deduction in buffer allocation

### DIFF
--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -1,5 +1,5 @@
 /* Copyright 2025 Alexander Matthes, Benjamin Worpitz, Andrea Bocci, Bernhard Manfred Gruber, Jan Stephan,
- *                Christian Kaever, Maria Michailidi
+ *                Christian Kaever, Maria Michailidi, Simone Balducci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -71,16 +71,17 @@ namespace alpaka
     //! Allocates memory on the given device.
     //!
     //! \tparam TElem The element type of the returned buffer.
-    //! \tparam TIdx The linear index type of the buffer.
     //! \tparam TExtent The extent type of the buffer.
     //! \tparam TDev The type of device the buffer is allocated on.
     //! \param dev The device to allocate the buffer on.
     //! \param extent The extent of the buffer.
     //! \return The newly allocated buffer.
-    template<typename TElem, typename TIdx, typename TExtent, typename TDev>
+    template<typename TElem, typename TIdx = void, typename TExtent = void, typename TDev = void>
     ALPAKA_FN_HOST auto allocBuf(TDev const& dev, TExtent const& extent = TExtent())
     {
-        return trait::BufAlloc<TElem, Dim<TExtent>, TIdx, TDev>::allocBuf(dev, extent);
+        using Idx = std::conditional_t<std::is_void_v<TIdx>, Idx<TExtent>, TIdx>;
+
+        return trait::BufAlloc<TElem, Dim<TExtent>, Idx, TDev>::allocBuf(dev, extent);
     }
 
     //! Allocates stream-ordered memory on the given device.
@@ -92,10 +93,12 @@ namespace alpaka
     //! \param queue The queue used to order the buffer allocation.
     //! \param extent The extent of the buffer.
     //! \return The newly allocated buffer.
-    template<typename TElem, typename TIdx, typename TExtent, typename TQueue>
+    template<typename TElem, typename TIdx = void, typename TExtent = void, typename TQueue = void>
     ALPAKA_FN_HOST auto allocAsyncBuf(TQueue queue, TExtent const& extent = TExtent())
     {
-        return trait::AsyncBufAlloc<TElem, Dim<TExtent>, TIdx, alpaka::Dev<TQueue>>::allocAsyncBuf(queue, extent);
+        using Idx = std::conditional_t<std::is_void_v<TIdx>, Idx<TExtent>, TIdx>;
+
+        return trait::AsyncBufAlloc<TElem, Dim<TExtent>, Idx, alpaka::Dev<TQueue>>::allocAsyncBuf(queue, extent);
     }
 
     /* TODO: Remove this pragma block once support for clang versions <= 13 is removed. These versions are unable to
@@ -127,16 +130,18 @@ namespace alpaka
     //! \param queue The queue used to order the buffer allocation.
     //! \param extent The extent of the buffer.
     //! \return The newly allocated buffer.
-    template<typename TElem, typename TIdx, typename TExtent, typename TQueue>
+    template<typename TElem, typename TIdx = void, typename TExtent = void, typename TQueue = void>
     ALPAKA_FN_HOST auto allocAsyncBufIfSupported(TQueue queue, TExtent const& extent = TExtent())
     {
+        using Idx = std::conditional_t<std::is_void_v<TIdx>, Idx<TExtent>, TIdx>;
+
         if constexpr(hasAsyncBufSupport<alpaka::Dev<TQueue>, Dim<TExtent>>)
         {
-            return allocAsyncBuf<TElem, TIdx>(queue, extent);
+            return allocAsyncBuf<TElem, Idx>(queue, extent);
         }
         else
         {
-            return allocBuf<TElem, TIdx>(getDev(queue), extent);
+            return allocBuf<TElem, Idx>(getDev(queue), extent);
         }
 
         ALPAKA_UNREACHABLE(allocBuf<TElem, TIdx>(getDev(queue), extent));
@@ -151,13 +156,15 @@ namespace alpaka
     //! \param host The host device to allocate the buffer on.
     //! \param extent The extent of the buffer.
     //! \return The newly allocated buffer.
-    template<typename TElem, typename TIdx, typename TExtent, typename TPlatform>
+    template<typename TElem, typename TIdx = void, typename TExtent = void, typename TPlatform = void>
     ALPAKA_FN_HOST auto allocMappedBuf(
         DevCpu const& host,
         TPlatform const& platform,
         TExtent const& extent = TExtent())
     {
-        return trait::BufAllocMapped<TPlatform, TElem, Dim<TExtent>, TIdx>::allocMappedBuf(host, platform, extent);
+        using Idx = std::conditional_t<std::is_void_v<TIdx>, Idx<TExtent>, TIdx>;
+
+        return trait::BufAllocMapped<TPlatform, TElem, Dim<TExtent>, Idx>::allocMappedBuf(host, platform, extent);
     }
 
     //! Allocates unified/managed memory, accessible by all devices in the given platform.
@@ -169,13 +176,15 @@ namespace alpaka
     //! \param host The host device to allocate the buffer on.
     //! \param extent The extent of the buffer.
     //! \return The newly allocated buffer.
-    template<typename TElem, typename TIdx, typename TExtent, typename TPlatform>
+    template<typename TElem, typename TIdx = void, typename TExtent = void, typename TPlatform = void>
     ALPAKA_FN_HOST auto allocManagedBuf(
         DevCpu const& host,
         TPlatform const& platform,
         TExtent const& extent = TExtent())
     {
-        return trait::BufAllocManaged<TPlatform, TElem, Dim<TExtent>, TIdx>::allocManagedBuf(host, platform, extent);
+        using Idx = std::conditional_t<std::is_void_v<TIdx>, Idx<TExtent>, TIdx>;
+
+        return trait::BufAllocManaged<TPlatform, TElem, Dim<TExtent>, Idx>::allocManagedBuf(host, platform, extent);
     }
 
     /* TODO: Remove this pragma block once support for clang versions <= 13 is removed. These versions are unable to
@@ -206,20 +215,22 @@ namespace alpaka
     //! \param host The host device to allocate the buffer on.
     //! \param extent The extent of the buffer.
     //! \return The newly allocated buffer.
-    template<typename TElem, typename TIdx, typename TExtent, typename TPlatform>
+    template<typename TElem, typename TIdx = void, typename TExtent = void, typename TPlatform = void>
     ALPAKA_FN_HOST auto allocMappedBufIfSupported(
         DevCpu const& host,
         TPlatform const& platform,
         TExtent const& extent = TExtent())
     {
+        using Idx = std::conditional_t<std::is_void_v<TIdx>, Idx<TExtent>, TIdx>;
         using Platform = alpaka::Platform<TPlatform>;
+
         if constexpr(hasMappedBufSupport<Platform>)
         {
-            return allocMappedBuf<TElem, TIdx>(host, platform, extent);
+            return allocMappedBuf<TElem, Idx>(host, platform, extent);
         }
         else
         {
-            return allocBuf<TElem, TIdx>(host, extent);
+            return allocBuf<TElem, Idx>(host, extent);
         }
 
         ALPAKA_UNREACHABLE(allocBuf<TElem, TIdx>(host, extent));

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -389,3 +389,22 @@ TEMPLATE_LIST_TEST_CASE("memBufAccessors", "[memBuf]", alpaka::test::TestAccs)
         CHECK(foo(buf));
     }
 }
+
+TEMPLATE_LIST_TEST_CASE("memBufAllocDeducedIdx", "[memBuf]", alpaka::test::TestAccs)
+{
+    using Acc = TestType;
+    using Idx = alpaka::Idx<Acc>;
+    using Elem = std::size_t;
+    using Dim = alpaka::Dim<Acc>;
+    auto const extent = alpaka::Vec<Dim, Idx>{};
+    auto const devHost = alpaka::getDevByIdx(alpaka::PlatformCpu{}, 0);
+    auto const devAcc = alpaka::getDevByIdx(alpaka::Platform<Acc>{}, 0);
+    auto queue = alpaka::Queue<Acc, alpaka::Blocking>{devAcc};
+
+    auto host_buf = alpaka::allocBuf<Elem>(devHost, extent);
+    auto dev_buf = alpaka::allocBuf<Elem>(devAcc, extent);
+    auto dev_buf_async = alpaka::allocAsyncBuf<Elem>(queue, extent);
+    auto dev_buf_async_supported = alpaka::allocAsyncBufIfSupported<Elem>(queue, extent);
+    auto buf_mapped = alpaka::allocMappedBuf<Elem>(devHost, alpaka::PlatformCpu{}, extent);
+    auto buf_managed = alpaka::allocManagedBuf<Elem>(devHost, alpaka::PlatformCpu{}, extent);
+}


### PR DESCRIPTION
This PR implements type-deduction for the buffer index types in the `allocBuf*` functions from the extents, so that they don't have to be specified explicitly.

So, now to allocate a buffer users can do:
```cpp
auto buf = alpaka::allocBuf<value_type>(dev, size)
```
instead of:
```cpp
auto buf = alpaka::allocBuf<value_type, idx_type>(dev, size)
```