### PR TITLE
Fix the buffer and view arrow operator [2.1.x]

### DIFF
--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -165,7 +165,7 @@ namespace alpaka::internal
         ALPAKA_FN_HOST auto operator->() -> pointer
         {
             static_assert(Dim::value == 0, "operator-> is only valid for Buffers and Views of dimension 0");
-            return *(this->data());
+            return this->data();
         }
 
         ALPAKA_FN_HOST auto operator->() const -> const_pointer


### PR DESCRIPTION
Bugfix: return a pointer instead of a reference.