### PR TITLE
Memory ordered atomics

### DIFF
--- a/include/alpaka/atomic/AtomicAtomicRef.hpp
+++ b/include/alpaka/atomic/AtomicAtomicRef.hpp
@@ -10,6 +10,8 @@
 
 #    include "alpaka/atomic/Traits.hpp"
 #    include "alpaka/core/Config.hpp"
+#    include "alpaka/mem/order/MemOrderStl.hpp"
+#    include "alpaka/mem/order/MemoryOrder.hpp"
 
 #    include <array>
 #    include <atomic>
@@ -17,6 +19,8 @@
 
 #    ifndef ALPAKA_DISABLE_ATOMIC_ATOMICREF
 #        ifndef ALPAKA_HAS_STD_ATOMIC_REF
+#            include "alpaka/mem/order/MemOrderBoost.hpp"
+
 #            include <boost/atomic.hpp>
 #        endif
 
@@ -27,9 +31,11 @@ namespace alpaka
 #        if defined(ALPAKA_HAS_STD_ATOMIC_REF)
         template<typename T>
         using atomic_ref = std::atomic_ref<T>;
+        using MemOrderCpu = MemOrderStl;
 #        else
         template<typename T>
         using atomic_ref = boost::atomic_ref<T>;
+        using MemOrderCpu = MemOrderBoost;
 #        endif
     } // namespace detail
 
@@ -54,41 +60,44 @@ namespace alpaka
     namespace trait
     {
         //! The CPU accelerators AtomicAdd.
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicAdd, AtomicAtomicRef, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicAdd, AtomicAtomicRef, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value, TMemOrder order)
+                -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 alpaka::detail::atomic_ref<T> ref(*addr);
-                return ref.fetch_add(value);
+                return ref.fetch_add(value, detail::MemOrderCpu::get(order));
             }
         };
 
         //! The CPU accelerators AtomicSub.
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicSub, AtomicAtomicRef, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicSub, AtomicAtomicRef, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value, TMemOrder order)
+                -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 alpaka::detail::atomic_ref<T> ref(*addr);
-                return ref.fetch_sub(value);
+                return ref.fetch_sub(value, detail::MemOrderCpu::get(order));
             }
         };
 
         //! The CPU accelerators AtomicMin.
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicMin, AtomicAtomicRef, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicMin, AtomicAtomicRef, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value, TMemOrder order)
+                -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 alpaka::detail::atomic_ref<T> ref(*addr);
-                T old = ref;
+                T old = ref.load(detail::MemOrderCpu::get(order));
                 T result = old;
                 result = std::min(result, value);
-                while(!ref.compare_exchange_weak(old, result))
+                while(!ref.compare_exchange_weak(old, result, detail::MemOrderCpu::get(order)))
                 {
                     result = old;
                     result = std::min(result, value);
@@ -98,17 +107,18 @@ namespace alpaka
         };
 
         //! The CPU accelerators AtomicMax.
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicMax, AtomicAtomicRef, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicMax, AtomicAtomicRef, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value, TMemOrder order)
+                -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 alpaka::detail::atomic_ref<T> ref(*addr);
-                T old = ref;
+                T old = ref.load(detail::MemOrderCpu::get(order));
                 T result = old;
                 result = std::max(result, value);
-                while(!ref.compare_exchange_weak(old, result))
+                while(!ref.compare_exchange_weak(old, result, detail::MemOrderCpu::get(order)))
                 {
                     result = old;
                     result = std::max(result, value);
@@ -118,16 +128,17 @@ namespace alpaka
         };
 
         //! The CPU accelerators AtomicExch.
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicExch, AtomicAtomicRef, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicExch, AtomicAtomicRef, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value, TMemOrder order)
+                -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 alpaka::detail::atomic_ref<T> ref(*addr);
-                T old = ref;
+                T old = ref.load(detail::MemOrderCpu::get(order));
                 T result = value;
-                while(!ref.compare_exchange_weak(old, result))
+                while(!ref.compare_exchange_weak(old, result, detail::MemOrderCpu::get(order)))
                 {
                     result = value;
                 }
@@ -136,16 +147,17 @@ namespace alpaka
         };
 
         //! The CPU accelerators AtomicInc.
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicInc, AtomicAtomicRef, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicInc, AtomicAtomicRef, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value, TMemOrder order)
+                -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 alpaka::detail::atomic_ref<T> ref(*addr);
-                T old = ref;
+                T old = ref.load(detail::MemOrderCpu::get(order));
                 T result = ((old >= value) ? 0 : static_cast<T>(old + 1));
-                while(!ref.compare_exchange_weak(old, result))
+                while(!ref.compare_exchange_weak(old, result, detail::MemOrderCpu::get(order)))
                 {
                     result = ((old >= value) ? 0 : static_cast<T>(old + 1));
                 }
@@ -154,16 +166,17 @@ namespace alpaka
         };
 
         //! The CPU accelerators AtomicDec.
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicDec, AtomicAtomicRef, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicDec, AtomicAtomicRef, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value, TMemOrder order)
+                -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 alpaka::detail::atomic_ref<T> ref(*addr);
-                T old = ref;
+                T old = ref.load(detail::MemOrderCpu::get(order));
                 T result = (old == static_cast<T>(0) || old > value) ? value : (old - static_cast<T>(1));
-                while(!ref.compare_exchange_weak(old, result))
+                while(!ref.compare_exchange_weak(old, result, detail::MemOrderCpu::get(order)))
                 {
                     result = (old == static_cast<T>(0) || old > value) ? value : (old - static_cast<T>(1));
                 }
@@ -172,54 +185,58 @@ namespace alpaka
         };
 
         //! The CPU accelerators AtomicAnd.
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicAnd, AtomicAtomicRef, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicAnd, AtomicAtomicRef, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value, TMemOrder order)
+                -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 alpaka::detail::atomic_ref<T> ref(*addr);
-                return ref.fetch_and(value);
+                return ref.fetch_and(value, detail::MemOrderCpu::get(order));
             }
         };
 
         //! The CPU accelerators AtomicOr.
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicOr, AtomicAtomicRef, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicOr, AtomicAtomicRef, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value, TMemOrder order)
+                -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 alpaka::detail::atomic_ref<T> ref(*addr);
-                return ref.fetch_or(value);
+                return ref.fetch_or(value, detail::MemOrderCpu::get(order));
             }
         };
 
         //! The CPU accelerators AtomicXor.
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicXor, AtomicAtomicRef, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicXor, AtomicAtomicRef, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicAtomicRef const&, T* const addr, T const& value, TMemOrder order)
+                -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 alpaka::detail::atomic_ref<T> ref(*addr);
-                return ref.fetch_xor(value);
+                return ref.fetch_xor(value, detail::MemOrderCpu::get(order));
             }
         };
 
         //! The CPU accelerators AtomicCas.
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicCas, AtomicAtomicRef, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicCas, AtomicAtomicRef, T, TMemOrder, THierarchy>
         {
             ALPAKA_FN_HOST static auto atomicOp(
                 AtomicAtomicRef const&,
                 T* const addr,
                 T const& compare,
-                T const& value) -> T
+                T const& value,
+                TMemOrder order) -> T
             {
                 isSupportedByAtomicAtomicRef<T>();
                 alpaka::detail::atomic_ref<T> ref(*addr);
-                T old = ref;
+                T old = ref.load(detail::MemOrderCpu::get(order));
                 T result;
                 do
                 {
@@ -231,7 +248,7 @@ namespace alpaka
 #        if ALPAKA_COMP_GNUC || ALPAKA_COMP_CLANG
 #            pragma GCC diagnostic pop
 #        endif
-                } while(!ref.compare_exchange_weak(old, result));
+                } while(!ref.compare_exchange_weak(old, result, detail::MemOrderCpu::get(order)));
                 return old;
             }
         };

--- a/include/alpaka/atomic/AtomicGenericSycl.hpp
+++ b/include/alpaka/atomic/AtomicGenericSycl.hpp
@@ -7,6 +7,8 @@
 #include "alpaka/atomic/Op.hpp"
 #include "alpaka/atomic/Traits.hpp"
 #include "alpaka/core/Positioning.hpp"
+#include "alpaka/mem/order/MemOrderGenericSycl.hpp"
+#include "alpaka/mem/order/MemoryOrder.hpp"
 #include "alpaka/meta/DependentFalseType.hpp"
 
 #include <cstdint>
@@ -51,13 +53,14 @@ namespace alpaka
             static constexpr auto value = sycl::memory_scope::work_group;
         };
 
-        template<typename T, typename THierarchy>
-        using sycl_atomic_ref = sycl::atomic_ref<T, sycl::memory_order::relaxed, SyclMemoryScope<THierarchy>::value>;
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        using sycl_atomic_ref
+            = sycl::atomic_ref<T, MemOrderSycl::get(TMemOrder{}), SyclMemoryScope<THierarchy>::value>;
 
-        template<typename THierarchy, typename T, typename TOp>
+        template<MemoryOrder TMemOrder, typename THierarchy, typename T, typename TOp>
         inline auto callAtomicOp(T* const addr, TOp&& op)
         {
-            auto ref = sycl_atomic_ref<T, THierarchy>{*addr};
+            auto ref = sycl_atomic_ref<T, TMemOrder, THierarchy>{*addr};
             return op(ref);
         }
 
@@ -81,14 +84,14 @@ namespace alpaka::trait
 {
     // Add.
     //! The SYCL accelerator atomic operation.
-    template<typename T, typename THierarchy>
-    struct AtomicOp<AtomicAdd, AtomicGenericSycl, T, THierarchy>
+    template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+    struct AtomicOp<AtomicAdd, AtomicGenericSycl, T, TMemOrder, THierarchy>
     {
         static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>, "SYCL atomics do not support this type");
 
-        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value) -> T
+        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value, TMemOrder) -> T
         {
-            return alpaka::detail::callAtomicOp<THierarchy>(
+            return alpaka::detail::callAtomicOp<TMemOrder, THierarchy>(
                 addr,
                 [&value](auto& ref) { return ref.fetch_add(value); });
         }
@@ -96,14 +99,14 @@ namespace alpaka::trait
 
     // Sub.
     //! The SYCL accelerator atomic operation.
-    template<typename T, typename THierarchy>
-    struct AtomicOp<AtomicSub, AtomicGenericSycl, T, THierarchy>
+    template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+    struct AtomicOp<AtomicSub, AtomicGenericSycl, T, TMemOrder, THierarchy>
     {
         static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>, "SYCL atomics do not support this type");
 
-        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value) -> T
+        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value, TMemOrder) -> T
         {
-            return alpaka::detail::callAtomicOp<THierarchy>(
+            return alpaka::detail::callAtomicOp<TMemOrder, THierarchy>(
                 addr,
                 [&value](auto& ref) { return ref.fetch_sub(value); });
         }
@@ -111,14 +114,14 @@ namespace alpaka::trait
 
     // Min.
     //! The SYCL accelerator atomic operation.
-    template<typename T, typename THierarchy>
-    struct AtomicOp<AtomicMin, AtomicGenericSycl, T, THierarchy>
+    template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+    struct AtomicOp<AtomicMin, AtomicGenericSycl, T, TMemOrder, THierarchy>
     {
         static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>, "SYCL atomics do not support this type");
 
-        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value) -> T
+        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value, TMemOrder) -> T
         {
-            return alpaka::detail::callAtomicOp<THierarchy>(
+            return alpaka::detail::callAtomicOp<TMemOrder, THierarchy>(
                 addr,
                 [&value](auto& ref) { return ref.fetch_min(value); });
         }
@@ -126,14 +129,14 @@ namespace alpaka::trait
 
     // Max.
     //! The SYCL accelerator atomic operation.
-    template<typename T, typename THierarchy>
-    struct AtomicOp<AtomicMax, AtomicGenericSycl, T, THierarchy>
+    template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+    struct AtomicOp<AtomicMax, AtomicGenericSycl, T, TMemOrder, THierarchy>
     {
         static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>, "SYCL atomics do not support this type");
 
-        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value) -> T
+        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value, TMemOrder) -> T
         {
-            return alpaka::detail::callAtomicOp<THierarchy>(
+            return alpaka::detail::callAtomicOp<TMemOrder, THierarchy>(
                 addr,
                 [&value](auto& ref) { return ref.fetch_max(value); });
         }
@@ -141,63 +144,69 @@ namespace alpaka::trait
 
     // Exch.
     //! The SYCL accelerator atomic operation.
-    template<typename T, typename THierarchy>
-    struct AtomicOp<AtomicExch, AtomicGenericSycl, T, THierarchy>
+    template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+    struct AtomicOp<AtomicExch, AtomicGenericSycl, T, TMemOrder, THierarchy>
     {
         static_assert(
-            (std::is_integral_v<T> || std::is_floating_point_v<T>) and(sizeof(T) == 4 || sizeof(T) == 8),
+            (std::is_integral_v<T> || std::is_floating_point_v<T>) &&(sizeof(T) == 4 || sizeof(T) == 8),
             "SYCL atomics do not support this type");
 
-        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value) -> T
+        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value, TMemOrder) -> T
         {
-            return alpaka::detail::callAtomicOp<THierarchy>(addr, [&value](auto& ref) { return ref.exchange(value); });
+            return alpaka::detail::callAtomicOp<TMemOrder, THierarchy>(
+                addr,
+                [&value](auto& ref) { return ref.exchange(value); });
         }
     };
 
     // Inc.
     //! The SYCL accelerator atomic operation.
-    template<typename T, typename THierarchy>
-    struct AtomicOp<AtomicInc, AtomicGenericSycl, T, THierarchy>
+    template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+    struct AtomicOp<AtomicInc, AtomicGenericSycl, T, TMemOrder, THierarchy>
     {
         static_assert(
             std::is_unsigned_v<T> && (sizeof(T) == 4 || sizeof(T) == 8),
             "SYCL atomics support only 32- and 64-bits unsigned integral types");
 
-        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value) -> T
+        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value, TMemOrder) -> T
         {
             auto inc = [&value](auto old_val)
             { return (old_val >= value) ? static_cast<T>(0) : (old_val + static_cast<T>(1)); };
-            return alpaka::detail::casWithCondition<alpaka::detail::sycl_atomic_ref<T, THierarchy>>(addr, inc);
+            return alpaka::detail::casWithCondition<alpaka::detail::sycl_atomic_ref<T, TMemOrder, THierarchy>>(
+                addr,
+                inc);
         }
     };
 
     // Dec.
     //! The SYCL accelerator atomic operation.
-    template<typename T, typename THierarchy>
-    struct AtomicOp<AtomicDec, AtomicGenericSycl, T, THierarchy>
+    template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+    struct AtomicOp<AtomicDec, AtomicGenericSycl, T, TMemOrder, THierarchy>
     {
         static_assert(
             std::is_unsigned_v<T> && (sizeof(T) == 4 || sizeof(T) == 8),
             "SYCL atomics support only 32- and 64-bits unsigned integral types");
 
-        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value) -> T
+        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value, TMemOrder) -> T
         {
             auto dec = [&value](auto& old_val)
             { return ((old_val == 0) || (old_val > value)) ? value : (old_val - static_cast<T>(1)); };
-            return alpaka::detail::casWithCondition<alpaka::detail::sycl_atomic_ref<T, THierarchy>>(addr, dec);
+            return alpaka::detail::casWithCondition<alpaka::detail::sycl_atomic_ref<T, TMemOrder, THierarchy>>(
+                addr,
+                dec);
         }
     };
 
     // And.
     //! The SYCL accelerator atomic operation.
-    template<typename T, typename THierarchy>
-    struct AtomicOp<AtomicAnd, AtomicGenericSycl, T, THierarchy>
+    template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+    struct AtomicOp<AtomicAnd, AtomicGenericSycl, T, TMemOrder, THierarchy>
     {
         static_assert(std::is_integral_v<T>, "Bitwise operations only supported for integral types.");
 
-        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value) -> T
+        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value, TMemOrder) -> T
         {
-            return alpaka::detail::callAtomicOp<THierarchy>(
+            return alpaka::detail::callAtomicOp<TMemOrder, THierarchy>(
                 addr,
                 [&value](auto& ref) { return ref.fetch_and(value); });
         }
@@ -205,27 +214,29 @@ namespace alpaka::trait
 
     // Or.
     //! The SYCL accelerator atomic operation.
-    template<typename T, typename THierarchy>
-    struct AtomicOp<AtomicOr, AtomicGenericSycl, T, THierarchy>
+    template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+    struct AtomicOp<AtomicOr, AtomicGenericSycl, T, TMemOrder, THierarchy>
     {
         static_assert(std::is_integral_v<T>, "Bitwise operations only supported for integral types.");
 
-        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value) -> T
+        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value, TMemOrder) -> T
         {
-            return alpaka::detail::callAtomicOp<THierarchy>(addr, [&value](auto& ref) { return ref.fetch_or(value); });
+            return alpaka::detail::callAtomicOp<TMemOrder, THierarchy>(
+                addr,
+                [&value](auto& ref) { return ref.fetch_or(value); });
         }
     };
 
     // Xor.
     //! The SYCL accelerator atomic operation.
-    template<typename T, typename THierarchy>
-    struct AtomicOp<AtomicXor, AtomicGenericSycl, T, THierarchy>
+    template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+    struct AtomicOp<AtomicXor, AtomicGenericSycl, T, TMemOrder, THierarchy>
     {
         static_assert(std::is_integral_v<T>, "Bitwise operations only supported for integral types.");
 
-        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value) -> T
+        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& value, TMemOrder) -> T
         {
-            return alpaka::detail::callAtomicOp<THierarchy>(
+            return alpaka::detail::callAtomicOp<TMemOrder, THierarchy>(
                 addr,
                 [&value](auto& ref) { return ref.fetch_xor(value); });
         }
@@ -233,12 +244,13 @@ namespace alpaka::trait
 
     // Cas.
     //! The SYCL accelerator atomic operation.
-    template<typename T, typename THierarchy>
-    struct AtomicOp<AtomicCas, AtomicGenericSycl, T, THierarchy>
+    template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+    struct AtomicOp<AtomicCas, AtomicGenericSycl, T, TMemOrder, THierarchy>
     {
         static_assert(std::is_integral_v<T> || std::is_floating_point_v<T>, "SYCL atomics do not support this type");
 
-        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& expected, T const& desired) -> T
+        static auto atomicOp(AtomicGenericSycl const&, T* const addr, T const& expected, T const& desired, TMemOrder)
+            -> T
         {
             auto cas = [&expected, &desired](auto& ref)
             {
@@ -255,7 +267,7 @@ namespace alpaka::trait
                 return expected_;
             };
 
-            return alpaka::detail::callAtomicOp<THierarchy>(addr, cas);
+            return alpaka::detail::callAtomicOp<TMemOrder, THierarchy>(addr, cas);
         }
     };
 } // namespace alpaka::trait

--- a/include/alpaka/atomic/AtomicNoOp.hpp
+++ b/include/alpaka/atomic/AtomicNoOp.hpp
@@ -16,10 +16,14 @@ namespace alpaka
     namespace trait
     {
         //! The NoOp atomic operation.
-        template<typename TOp, typename T, typename THierarchy>
-        struct AtomicOp<TOp, AtomicNoOp, T, THierarchy>
+        template<typename TOp, typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<TOp, AtomicNoOp, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicNoOp const& /* atomic */, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(
+                AtomicNoOp const& /* atomic */,
+                T* const addr,
+                T const& value,
+                TMemOrder) -> T
             {
                 return TOp()(addr, value);
             }

--- a/include/alpaka/atomic/AtomicOmpBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicOmpBuiltIn.hpp
@@ -4,11 +4,14 @@
 
 #pragma once
 
+#include "alpaka/atomic/AtomicOmpMacros.hpp"
 #include "alpaka/atomic/Op.hpp"
 #include "alpaka/atomic/Traits.hpp"
 #include "alpaka/core/Config.hpp"
+#include "alpaka/mem/order/MemoryOrder.hpp"
 
 #ifdef _OPENMP
+
 
 namespace alpaka
 {
@@ -27,10 +30,10 @@ namespace alpaka
 #    if _OPENMP >= 201107
 
         //! The OpenMP accelerators atomic operation: ADD
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicAdd, AtomicOmpBuiltIn, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicAdd, AtomicOmpBuiltIn, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value, TMemOrder) -> T
             {
                 T old;
                 auto& ref(*addr);
@@ -39,11 +42,10 @@ namespace alpaka
 #            pragma GCC diagnostic push
 #            pragma GCC diagnostic ignored "-Wconversion"
 #        endif
-#        pragma omp atomic capture
-                {
+                ALPAKA_OMP_ATOMIC_CAPTURE_ORDER(TMemOrder, {
                     old = ref;
                     ref += value;
-                }
+                });
 #        if ALPAKA_COMP_GNUC
 #            pragma GCC diagnostic pop
 #        endif
@@ -52,10 +54,10 @@ namespace alpaka
         };
 
         //! The OpenMP accelerators atomic operation: SUB
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicSub, AtomicOmpBuiltIn, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicSub, AtomicOmpBuiltIn, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value, TMemOrder) -> T
             {
                 T old;
                 auto& ref(*addr);
@@ -64,11 +66,10 @@ namespace alpaka
 #            pragma GCC diagnostic push
 #            pragma GCC diagnostic ignored "-Wconversion"
 #        endif
-#        pragma omp atomic capture
-                {
+                ALPAKA_OMP_ATOMIC_CAPTURE_ORDER(TMemOrder, {
                     old = ref;
                     ref -= value;
-                }
+                });
 #        if ALPAKA_COMP_GNUC
 #            pragma GCC diagnostic pop
 #        endif
@@ -77,28 +78,27 @@ namespace alpaka
         };
 
         //! The OpenMP accelerators atomic operation: EXCH
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicExch, AtomicOmpBuiltIn, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicExch, AtomicOmpBuiltIn, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value, TMemOrder) -> T
             {
                 T old;
                 auto& ref(*addr);
-// atomically update ref, but capture the original value in old
-#        pragma omp atomic capture
-                {
+                // atomically update ref, but capture the original value in old
+                ALPAKA_OMP_ATOMIC_CAPTURE_ORDER(TMemOrder, {
                     old = ref;
                     ref = value;
-                }
+                });
                 return old;
             }
         };
 
         //! The OpenMP accelerators atomic operation: AND
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicAnd, AtomicOmpBuiltIn, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicAnd, AtomicOmpBuiltIn, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value, TMemOrder) -> T
             {
                 T old;
                 auto& ref(*addr);
@@ -107,11 +107,10 @@ namespace alpaka
 #            pragma GCC diagnostic push
 #            pragma GCC diagnostic ignored "-Wconversion"
 #        endif
-#        pragma omp atomic capture
-                {
+                ALPAKA_OMP_ATOMIC_CAPTURE_ORDER(TMemOrder, {
                     old = ref;
                     ref &= value;
-                }
+                });
 #        if ALPAKA_COMP_GNUC
 #            pragma GCC diagnostic pop
 #        endif
@@ -120,10 +119,10 @@ namespace alpaka
         };
 
         //! The OpenMP accelerators atomic operation: OR
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicOr, AtomicOmpBuiltIn, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicOr, AtomicOmpBuiltIn, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value, TMemOrder) -> T
             {
                 T old;
                 auto& ref(*addr);
@@ -132,11 +131,10 @@ namespace alpaka
 #            pragma GCC diagnostic push
 #            pragma GCC diagnostic ignored "-Wconversion"
 #        endif
-#        pragma omp atomic capture
-                {
+                ALPAKA_OMP_ATOMIC_CAPTURE_ORDER(TMemOrder, {
                     old = ref;
                     ref |= value;
-                }
+                });
 #        if ALPAKA_COMP_GNUC
 #            pragma GCC diagnostic pop
 #        endif
@@ -145,10 +143,10 @@ namespace alpaka
         };
 
         //! The OpenMP accelerators atomic operation: XOR
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicXor, AtomicOmpBuiltIn, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicXor, AtomicOmpBuiltIn, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value, TMemOrder) -> T
             {
                 T old;
                 auto& ref(*addr);
@@ -157,11 +155,10 @@ namespace alpaka
 #            pragma GCC diagnostic push
 #            pragma GCC diagnostic ignored "-Wconversion"
 #        endif
-#        pragma omp atomic capture
-                {
+                ALPAKA_OMP_ATOMIC_CAPTURE_ORDER(TMemOrder, {
                     old = ref;
                     ref ^= value;
-                }
+                });
 #        if ALPAKA_COMP_GNUC
 #            pragma GCC diagnostic pop
 #        endif
@@ -176,16 +173,15 @@ namespace alpaka
 #    if _OPENMP >= 202011
 
         //! The OpenMP accelerators atomic operation: Min
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicMin, AtomicOmpBuiltIn, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicMin, AtomicOmpBuiltIn, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T value, TMemOrder) -> T
             {
                 T old;
                 auto& ref(*addr);
-// atomically update ref, but capture the original value in old
-#        pragma omp atomic capture compare
-                {
+                // atomically update ref, but capture the original value in old
+                ALPAKA_OMP_ATOMIC_CAPTURE_COMPARE_ORDER(TMemOrder, {
                     old = ref;
                     // Do not remove the curly brackets of the if body else
                     // icpx 2024.0 is not able to compile the atomics.
@@ -193,22 +189,21 @@ namespace alpaka
                     {
                         ref = value;
                     }
-                }
+                });
                 return old;
             }
         };
 
         //! The OpenMP accelerators atomic operation: Max
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicMax, AtomicOmpBuiltIn, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicMax, AtomicOmpBuiltIn, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T value, TMemOrder) -> T
             {
                 T old;
                 auto& ref(*addr);
-// atomically update ref, but capture the original value in old
-#        pragma omp atomic capture compare
-                {
+                // atomically update ref, but capture the original value in old
+                ALPAKA_OMP_ATOMIC_CAPTURE_COMPARE_ORDER(TMemOrder, {
                     old = ref;
                     // Do not remove the curly brackets of the if body else
                     // icpx 2024.0 is not able to compile the atomics.
@@ -216,16 +211,16 @@ namespace alpaka
                     {
                         ref = value;
                     }
-                }
+                });
                 return old;
             }
         };
 
         //! The OpenMP accelerators atomic operation: Inc
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicInc, AtomicOmpBuiltIn, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicInc, AtomicOmpBuiltIn, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value, TMemOrder) -> T
             {
                 // TODO(bgruber): atomic increment with wrap around is not implementable in OpenMP 5.1
                 T old;
@@ -238,10 +233,10 @@ namespace alpaka
         };
 
         //! The OpenMP accelerators atomic operation: Dec
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicDec, AtomicOmpBuiltIn, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicDec, AtomicOmpBuiltIn, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value, TMemOrder) -> T
             {
                 // TODO(bgruber): atomic decrement with wrap around is not implementable in OpenMP 5.1
                 T old;
@@ -254,16 +249,16 @@ namespace alpaka
         };
 
         //! The OpenMP accelerators atomic operation: Cas
-        template<typename T, typename THierarchy>
-        struct AtomicOp<AtomicCas, AtomicOmpBuiltIn, T, THierarchy>
+        template<typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<AtomicCas, AtomicOmpBuiltIn, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T compare, T value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T compare, T value, TMemOrder)
+                -> T
             {
                 T old;
                 auto& ref(*addr);
-// atomically update ref, but capture the original value in old
-#        pragma omp atomic capture compare
-                {
+                // atomically update ref, but capture the original value in old
+                ALPAKA_OMP_ATOMIC_CAPTURE_COMPARE_ORDER(TMemOrder, {
                     old = ref;
                     // Do not remove the curly brackets of the if body else
                     // icpx 2024.0 is not able to compile the atomics.
@@ -271,7 +266,7 @@ namespace alpaka
                     {
                         ref = value;
                     }
-                }
+                });
                 return old;
             }
         };
@@ -280,10 +275,10 @@ namespace alpaka
         //! The OpenMP accelerators atomic operation
         //
         // generic implementations for operations where native atomics are not available
-        template<typename TOp, typename T, typename THierarchy>
-        struct AtomicOp<TOp, AtomicOmpBuiltIn, T, THierarchy>
+        template<typename TOp, typename T, MemoryOrder TMemOrder, typename THierarchy>
+        struct AtomicOp<TOp, AtomicOmpBuiltIn, T, TMemOrder, THierarchy>
         {
-            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value) -> T
+            ALPAKA_FN_HOST static auto atomicOp(AtomicOmpBuiltIn const&, T* const addr, T const& value, TMemOrder) -> T
             {
                 T old;
                 // \TODO: Currently not only the access to the same memory location is protected by a mutex but all
@@ -299,7 +294,8 @@ namespace alpaka
                 AtomicOmpBuiltIn const&,
                 T* const addr,
                 T const& compare,
-                T const& value) -> T
+                T const& value,
+                TMemOrder) -> T
             {
                 T old;
                 // \TODO: Currently not only the access to the same memory location is protected by a mutex but all

--- a/include/alpaka/atomic/AtomicOmpMacros.hpp
+++ b/include/alpaka/atomic/AtomicOmpMacros.hpp
@@ -1,0 +1,97 @@
+/* Copyright 2022 Tapish Narwal
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#include "alpaka/core/Config.hpp"
+#include "alpaka/core/PP.hpp"
+
+#include <type_traits>
+
+// OpenMP 5.0+ support memory orders seq_cst, acq_rel, release, acquire, relaxed
+#if ALPAKA_OMP >= ALPAKA_VERSION_NUMBER(2018, 11, 0)
+
+#    define ALPAKA_OMP_ATOMIC_CAPTURE_ORDER(TMemOrder, ...)                                                           \
+        do                                                                                                            \
+        {                                                                                                             \
+            if constexpr(std::is_same_v<TMemOrder, mem_order::Relaxed>)                                               \
+            {                                                                                                         \
+                _Pragma("omp atomic capture relaxed") __VA_ARGS__                                                     \
+            }                                                                                                         \
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::Acquire>)                                          \
+            {                                                                                                         \
+                _Pragma("omp atomic capture acquire") __VA_ARGS__                                                     \
+            }                                                                                                         \
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::Release>)                                          \
+            {                                                                                                         \
+                _Pragma("omp atomic capture release") __VA_ARGS__                                                     \
+            }                                                                                                         \
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::AcqRel>)                                           \
+            {                                                                                                         \
+                _Pragma("omp atomic capture acq_rel") __VA_ARGS__                                                     \
+            }                                                                                                         \
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::SeqCst>)                                           \
+            {                                                                                                         \
+                _Pragma("omp atomic capture seq_cst") __VA_ARGS__                                                     \
+            }                                                                                                         \
+        } while(0)
+
+// OpenMP 4.0+ supports seq_cst and relaxed (default)
+#elif ALPAKA_OMP >= ALPAKA_VERSION_NUMBER(2013, 7, 0)
+
+#    define ALPAKA_OMP_ATOMIC_CAPTURE_ORDER(TMemOrder, ...)                                                           \
+        do                                                                                                            \
+        {                                                                                                             \
+            if constexpr(std::is_same_v<TMemOrder, mem_order::Relaxed>)                                               \
+            {                                                                                                         \
+                _Pragma("omp atomic capture") __VA_ARGS__                                                             \
+            }                                                                                                         \
+            else                                                                                                      \
+            {                                                                                                         \
+                /** we fall back to a stronger atomic guarantee which may be slow */                                  \
+                _Pragma("omp atomic capture seq_cst") __VA_ARGS__                                                     \
+            }                                                                                                         \
+        } while(0)
+
+#else
+// OpenMP 3.1 and below have a limited memory model and we emulate stronger atomics with flush. This may be slow
+#    define ALPAKA_OMP_ATOMIC_CAPTURE_ORDER(TMemOrder, ...)                                                           \
+        do                                                                                                            \
+        {                                                                                                             \
+            if constexpr(std::is_same_v<TMemOrder, mem_order::Relaxed>)                                               \
+            {                                                                                                         \
+                _Pragma("omp atomic capture") __VA_ARGS__                                                             \
+            }                                                                                                         \
+            else                                                                                                      \
+            {                                                                                                         \
+                _Pragma("omp flush") _Pragma("omp atomic capture") __VA_ARGS__ _Pragma("omp flush")                   \
+            }                                                                                                         \
+        } while(0)
+#endif
+
+// Capture compare requires OpenMP 5.1
+#if ALPAKA_OMP >= ALPAKA_VERSION_NUMBER(2020, 11, 0)
+#    define ALPAKA_OMP_ATOMIC_CAPTURE_COMPARE_ORDER(TMemOrder, ...)                                                   \
+        do                                                                                                            \
+        {                                                                                                             \
+            if constexpr(std::is_same_v<TMemOrder, mem_order::Relaxed>)                                               \
+            {                                                                                                         \
+                _Pragma("omp atomic capture compare relaxed") __VA_ARGS__                                             \
+            }                                                                                                         \
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::Acquire>)                                          \
+            {                                                                                                         \
+                _Pragma("omp atomic capture compare acquire") __VA_ARGS__                                             \
+            }                                                                                                         \
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::Release>)                                          \
+            {                                                                                                         \
+                _Pragma("omp atomic capture compare release") __VA_ARGS__                                             \
+            }                                                                                                         \
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::AcqRel>)                                           \
+            {                                                                                                         \
+                _Pragma("omp atomic capture compare acq_rel") __VA_ARGS__                                             \
+            }                                                                                                         \
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::SeqCst>)                                           \
+            {                                                                                                         \
+                _Pragma("omp atomic capture compare seq_cst") __VA_ARGS__                                             \
+            }                                                                                                         \
+        } while(0)
+#endif

--- a/include/alpaka/atomic/AtomicStdLibLock.hpp
+++ b/include/alpaka/atomic/AtomicStdLibLock.hpp
@@ -6,6 +6,7 @@
 
 #include "alpaka/atomic/Traits.hpp"
 #include "alpaka/core/Config.hpp"
+#include "alpaka/mem/order/MemoryOrder.hpp"
 
 #include <array>
 #include <mutex>
@@ -25,7 +26,7 @@ namespace alpaka
     class AtomicStdLibLock
     {
     public:
-        template<typename TAtomic, typename TOp, typename T, typename THierarchy, typename TSfinae>
+        template<typename TOp, typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy>
         friend struct trait::AtomicOp;
 
         static constexpr auto nextPowerOf2(size_t const value, size_t const bit = 0u) -> size_t
@@ -75,14 +76,17 @@ namespace alpaka
     namespace trait
     {
         //! The CPU threads accelerator atomic operation.
-        template<typename TOp, typename T, typename THierarchy, size_t THashTableSize>
-        struct AtomicOp<TOp, AtomicStdLibLock<THashTableSize>, T, THierarchy>
+        template<typename TOp, typename T, MemoryOrder TMemOrder, typename THierarchy, size_t THashTableSize>
+        struct AtomicOp<TOp, AtomicStdLibLock<THashTableSize>, T, TMemOrder, THierarchy>
         {
             ALPAKA_FN_HOST static auto atomicOp(
                 AtomicStdLibLock<THashTableSize> const& atomic,
                 T* const addr,
-                T const& value) -> T
+                T const& value,
+                TMemOrder) -> T
             {
+                // Note: Memory order is ignored for mutex-based implementation
+                // as mutexes provide full sequential consistency
                 std::lock_guard<std::mutex> lock(atomic.getMutex(addr));
                 return TOp()(addr, value);
             }
@@ -91,8 +95,11 @@ namespace alpaka
                 AtomicStdLibLock<THashTableSize> const& atomic,
                 T* const addr,
                 T const& compare,
-                T const& value) -> T
+                T const& value,
+                TMemOrder) -> T
             {
+                // Note: Memory order is ignored for mutex-based implementation
+                // as mutexes provide full sequential consistency
                 std::lock_guard<std::mutex> lock(atomic.getMutex(addr));
                 return TOp()(addr, compare, value);
             }

--- a/include/alpaka/atomic/AtomicUniformCudaHip.hpp
+++ b/include/alpaka/atomic/AtomicUniformCudaHip.hpp
@@ -6,8 +6,13 @@
 
 #include "alpaka/atomic/Op.hpp"
 #include "alpaka/core/Config.hpp"
+#include "alpaka/core/PP.hpp"
 #include "alpaka/core/Positioning.hpp"
 #include "alpaka/core/Utility.hpp"
+#include "alpaka/mem/fence/Traits.hpp"
+#include "alpaka/mem/order/MemOrderCuda.hpp"
+#include "alpaka/mem/order/MemOrderHip.hpp"
+#include "alpaka/mem/order/MemoryOrder.hpp"
 
 #include <type_traits>
 
@@ -22,6 +27,13 @@ namespace alpaka
     class AtomicUniformCudaHipBuiltIn
     {
     };
+
+    //! Note for CUDA
+    // We have scoped atomics instructions available from SM70, which can be used alongside weaker fences
+    // https://docs.nvidia.com/cuda/ptx-writers-guide-to-interoperability/index.html#atomics-application-binary-interface
+    // We dont do this as it would require mapping types to the correct PTX atomic call which will be very verbose
+    // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-atom
+
 } // namespace alpaka
 
 #    if !defined(ALPAKA_HOST_ONLY)
@@ -38,6 +50,101 @@ namespace alpaka
 #        define CLANG_CUDA_PTX_WORKAROUND                                                                             \
             (ALPAKA_COMP_CLANG && ALPAKA_LANG_CUDA && ALPAKA_ARCH_PTX < ALPAKA_VERSION_NUMBER(6, 0, 0))
 
+#        if defined(ALPAKA_ARCH_PTX) || defined(ALPAKA_ARCH_AMD)
+namespace detail
+{
+    // Generic atomic wrapper that handles memory ordering with fences
+    template<typename TAtomicFunc, typename T, alpaka::MemoryOrder TMemOrder, alpaka::MemoryScope TMemScope>
+    [[maybe_unused]] static constexpr __device__ T atomicOrderEmulated(
+        [[maybe_unused]] auto const& acc,
+        TAtomicFunc atomic_func,
+        T* address,
+        T value,
+        TMemOrder,
+        [[maybe_unused]] TMemScope scope)
+    {
+        if constexpr(std::is_same_v<TMemOrder, alpaka::mem_order::Relaxed>)
+        {
+            return atomic_func(address, value);
+        }
+        else if constexpr(std::is_same_v<TMemOrder, alpaka::mem_order::Acquire>)
+        {
+            auto ret = atomic_func(address, value);
+            mem_fence(acc, alpaka::mem_order::acquire, scope);
+            return ret;
+        }
+        else if constexpr(std::is_same_v<TMemOrder, alpaka::mem_order::Release>)
+        {
+            mem_fence(acc, alpaka::mem_order::release, scope);
+            return atomic_func(address, value);
+        }
+        else if constexpr(std::is_same_v<TMemOrder, alpaka::mem_order::AcqRel>)
+        {
+            mem_fence(acc, alpaka::mem_order::release, scope);
+            auto ret = atomic_func(address, value);
+            mem_fence(acc, alpaka::mem_order::acquire, scope);
+            return ret;
+        }
+        else
+        { // sequentially consistent
+            mem_fence(acc, alpaka::mem_order::seq_cst, scope);
+            auto ret = atomic_func(address, value);
+            // acquire fence is sufficient here for seq_cst guarantee
+            // https://docs.nvidia.com/cuda/ptx-writers-guide-to-interoperability/index.html#atomics-application-binary-interface
+            // TODO find documentation that this is sufficient for HIP
+            mem_fence(acc, alpaka::mem_order::acquire, scope);
+            return ret;
+        }
+    }
+
+    // Generic atomic wrapper that handles memory ordering with fences
+    template<typename TAtomicFunc, typename T, alpaka::MemoryOrder TMemOrder, alpaka::MemoryScope TMemScope>
+    [[maybe_unused]] static constexpr __device__ T atomicCASOrderEmulated(
+        [[maybe_unused]] auto const& acc,
+        TAtomicFunc atomic_func,
+        T* address,
+        T compare,
+        T value,
+        [[maybe_unused]] TMemOrder order,
+        [[maybe_unused]] TMemScope scope)
+    {
+        if constexpr(std::is_same_v<TMemOrder, alpaka::mem_order::Relaxed>)
+        {
+            return atomic_func(address, compare, value);
+        }
+        else if constexpr(std::is_same_v<TMemOrder, alpaka::mem_order::Acquire>)
+        {
+            auto ret = atomic_func(address, compare, value);
+            mem_fence(acc, alpaka::mem_order::acquire, scope);
+            return ret;
+        }
+        else if constexpr(std::is_same_v<TMemOrder, alpaka::mem_order::Release>)
+        {
+            mem_fence(acc, alpaka::mem_order::release, scope);
+            return atomic_func(address, compare, value);
+        }
+        else if constexpr(std::is_same_v<TMemOrder, alpaka::mem_order::AcqRel>)
+        {
+            mem_fence(acc, alpaka::mem_order::release, scope);
+            auto ret = atomic_func(address, compare, value);
+            mem_fence(acc, alpaka::mem_order::acquire, scope);
+            return ret;
+        }
+        else
+        { // sequentially consistent
+            mem_fence(acc, alpaka::mem_order::seq_cst, scope);
+            auto ret = atomic_func(address, compare, value);
+            // acquire fence is sufficient here for seq_cst guarantee
+            // https://docs.nvidia.com/cuda/ptx-writers-guide-to-interoperability/index.html#atomics-application-binary-interface
+            // TODO find documentation that this is sufficient for HIP
+            mem_fence(acc, alpaka::mem_order::acquire, scope);
+            return ret;
+        }
+    }
+
+
+} // namespace detail
+
 //! These types must be in the global namespace for checking existence of respective functions in global namespace via
 //! SFINAE, so we use inline namespace.
 inline namespace alpakaGlobal
@@ -52,459 +159,865 @@ inline namespace alpakaGlobal
     // interfaces.
     // \code{.cpp}
     //    // interface for all atomics except atomicCas
-    //    __device__ static T atomic( T* add, T value);
+    //    __device__ static T atomic( T* add, T value, TMemOrder order);
     //    // interface for atomicCas only
-    //    __device__ static T atomic( T* add, T compare, T value);
+    //    __device__ static T atomic( T* add, T compare, T value, TMemOrder order);
     // \endcode
-    template<typename TOp, typename T, typename THierarchy, typename TSfinae = void>
+    template<typename TOp, typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy, typename TSfinae = void>
     struct AlpakaBuiltInAtomic : std::false_type
     {
     };
 
     // Cas.
-    template<typename T, typename THierarchy>
+    template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicCas,
         T,
+        TMemOrder,
         THierarchy,
         typename std::void_t<
             decltype(atomicCAS(alpaka::core::declval<T*>(), alpaka::core::declval<T>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T compare, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T compare, T value, TMemOrder order)
         {
-            return atomicCAS(add, compare, value);
+#            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
+#                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_compare_exchange(
+                add,
+                &compare,
+                value,
+                alpaka::MemOrderCuda::get(order),
+                alpaka::MemOrderCuda::get(order),
+                __NV_THREAD_SCOPE_DEVICE);
+#                else
+            return detail::atomicCASOrderEmulated(
+                acc,
+                [](T* addr, T cmp, T val) { return atomicCAS(addr, cmp, val); },
+                add,
+                compare,
+                value,
+                order,
+                alpaka::memory_scope::device);
+#                endif
+#            else
+#                if ALPAKA_LANG_HIP
+            return __hip_atomic_compare_exchange_strong(
+                add,
+                &compare,
+                value,
+                alpaka::MemOrderHip::get(order),
+                alpaka::MemOrderHip::get(order),
+                __HIP_MEMORY_SCOPE_AGENT);
+#                endif
+#            endif
         }
     };
 
-#        if !CLANG_CUDA_PTX_WORKAROUND
-    template<typename T>
+#            if !CLANG_CUDA_PTX_WORKAROUND
+    template<typename T, alpaka::MemoryOrder TMemOrder>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicCas,
         T,
+        TMemOrder,
         alpaka::hierarchy::Threads,
         typename std::void_t<decltype(atomicCAS_block(
             alpaka::core::declval<T*>(),
             alpaka::core::declval<T>(),
             alpaka::core::declval<T>()))>> : std::true_type
     {
-        static __device__ T atomic(T* add, T compare, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T compare, T value, TMemOrder order)
         {
-            return atomicCAS_block(add, compare, value);
+#                if defined ALPAKA_ACC_GPU_CUDA_ENABLED
+#                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_compare_exchange(
+                add,
+                &compare,
+                value,
+                alpaka::MemOrderCuda::get(order),
+                alpaka::MemOrderCuda::get(order),
+                __NV_THREAD_SCOPE_BLOCK);
+#                    else
+            return detail::atomicCASOrderEmulated(
+                acc,
+                [](T* addr, T cmp, T val) { return atomicCAS_block(addr, cmp, val); },
+                add,
+                compare,
+                value,
+                order,
+                alpaka::memory_scope::block);
+#                    endif
+#                else
+#                    if ALPAKA_LANG_HIP
+            return __hip_atomic_compare_exchange_strong(
+                add,
+                &compare,
+                value,
+                alpaka::MemOrderHip::get(order),
+                alpaka::MemOrderHip::get(order),
+                __HIP_MEMORY_SCOPE_WORKGROUP);
+#                    endif
+#                endif
         }
     };
-#        endif
+#            endif
 
 
     // Add.
-    template<typename T, typename THierarchy>
+    template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicAdd,
         T,
+        TMemOrder,
         THierarchy,
         typename std::void_t<decltype(atomicAdd(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicAdd(add, value);
+#            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
+#                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_fetch_add(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_DEVICE);
+#                else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicAdd(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::device);
+#                endif
+#            else
+#                if ALPAKA_LANG_HIP
+            return __hip_atomic_fetch_add(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_AGENT);
+#                endif
+#            endif
         }
     };
 
 
-#        if !CLANG_CUDA_PTX_WORKAROUND
-    template<typename T>
+#            if !CLANG_CUDA_PTX_WORKAROUND
+    template<typename T, alpaka::MemoryOrder TMemOrder>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicAdd,
         T,
+        TMemOrder,
         alpaka::hierarchy::Threads,
         typename std::void_t<decltype(atomicAdd_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicAdd_block(add, value);
+#                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_fetch_add(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_BLOCK);
+#                    else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicAdd_block(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::block);
+#                    endif
+#                else
+#                    if ALPAKA_LANG_HIP
+            return __hip_atomic_fetch_add(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_WORKGROUP);
+#                    endif
+#                endif
         }
     };
-#        endif
+#            endif
 
-#        if CLANG_CUDA_PTX_WORKAROUND
+#            if CLANG_CUDA_PTX_WORKAROUND
     // clang is providing a builtin for atomicAdd even if these is not supported by the current architecture
-    template<typename THierarchy>
-    struct AlpakaBuiltInAtomic<alpaka::AtomicAdd, double, THierarchy> : std::false_type
+    template<alpaka::MemoryOrder TMemOrder, typename THierarchy>
+    struct AlpakaBuiltInAtomic<alpaka::AtomicAdd, double, TMemOrder, THierarchy> : std::false_type
     {
     };
-#        endif
+#            endif
 
-#        if(ALPAKA_LANG_HIP)
+#            if(ALPAKA_LANG_HIP)
     // HIP shows bad performance with builtin atomicAdd(float*,float) for the hierarchy threads therefore we do not
     // call the buildin method and instead use the atomicCAS emulation. For details see:
     // https://github.com/alpaka-group/alpaka/issues/1657
-    template<>
-    struct AlpakaBuiltInAtomic<alpaka::AtomicAdd, float, alpaka::hierarchy::Threads> : std::false_type
+    template<alpaka::MemoryOrder TMemOrder>
+    struct AlpakaBuiltInAtomic<alpaka::AtomicAdd, float, TMemOrder, alpaka::hierarchy::Threads> : std::false_type
     {
     };
-#        endif
+#            endif
 
     // Sub.
 
-    template<typename T, typename THierarchy>
+    template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicSub,
         T,
+        TMemOrder,
         THierarchy,
         typename std::void_t<decltype(atomicSub(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicSub(add, value);
+#            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
+#                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_fetch_sub(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_DEVICE);
+#                else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicSub(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::device);
+#                endif
+#            else
+#                if ALPAKA_LANG_HIP
+#                    if __has_builtin(__hip_atomic_fetch_sub)
+            return __hip_atomic_fetch_sub(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_AGENT);
+#                    else
+            // emulate with fetch add
+            if constexpr(std::is_unsigned_v<T>)
+            {
+                using signed_t = std::make_signed_t<T>;
+                return __hip_atomic_fetch_add(
+                    add,
+                    static_cast<T>(-static_cast<signed_t>(value)),
+                    alpaka::MemOrderHip::get(order),
+                    __HIP_MEMORY_SCOPE_AGENT);
+            }
+            else
+            {
+                return __hip_atomic_fetch_add(add, -value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_AGENT);
+            }
+#                    endif
+#                endif
+#            endif
         }
     };
 
-#        if !CLANG_CUDA_PTX_WORKAROUND
-    template<typename T>
+#            if !CLANG_CUDA_PTX_WORKAROUND
+    template<typename T, alpaka::MemoryOrder TMemOrder>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicSub,
         T,
+        TMemOrder,
         alpaka::hierarchy::Threads,
         typename std::void_t<decltype(atomicSub_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicSub_block(add, value);
+#                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_fetch_sub(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_BLOCK);
+#                    else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicSub_block(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::block);
+#                    endif
+#                else
+#                    if ALPAKA_LANG_HIP
+#                        if __has_builtin(__hip_atomic_fetch_sub)
+            return __hip_atomic_fetch_sub(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_WORKGROUP);
+#                        else
+            // emulate with fetch add
+            if constexpr(std::is_unsigned_v<T>)
+            {
+                using signed_t = std::make_signed_t<T>;
+                return __hip_atomic_fetch_add(
+                    add,
+                    static_cast<T>(-static_cast<signed_t>(value)),
+                    alpaka::MemOrderHip::get(order),
+                    __HIP_MEMORY_SCOPE_WORKGROUP);
+            }
+            else
+            {
+                return __hip_atomic_fetch_add(
+                    add,
+                    -value,
+                    alpaka::MemOrderHip::get(order),
+                    __HIP_MEMORY_SCOPE_WORKGROUP);
+            }
+#                        endif
+#                    endif
+#                endif
         }
     };
-#        endif
+#            endif
 
     // Min.
-    template<typename T, typename THierarchy>
+    template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicMin,
         T,
+        TMemOrder,
         THierarchy,
         typename std::void_t<decltype(atomicMin(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicMin(add, value);
+#            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
+
+#                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_fetch_min(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_DEVICE);
+#                else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicMin(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::device);
+#                endif
+#            else
+#                if ALPAKA_LANG_HIP
+            return __hip_atomic_fetch_min(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_AGENT);
+#                endif
+#            endif
         }
     };
 
-#        if !CLANG_CUDA_PTX_WORKAROUND
-    template<typename T>
+#            if !CLANG_CUDA_PTX_WORKAROUND
+    template<typename T, alpaka::MemoryOrder TMemOrder>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicMin,
         T,
+        TMemOrder,
         alpaka::hierarchy::Threads,
         typename std::void_t<decltype(atomicMin_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicMin_block(add, value);
+#                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_fetch_min(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_BLOCK);
+#                    else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicMin_block(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::block);
+#                    endif
+#                else
+#                    if ALPAKA_LANG_HIP
+            return __hip_atomic_fetch_min(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_WORKGROUP);
+#                    endif
+#                endif
         }
     };
-#        endif
+#            endif
 
 // disable HIP atomicMin: see https://github.com/ROCm-Developer-Tools/hipamd/pull/40
-#        if(ALPAKA_LANG_HIP)
-    template<typename THierarchy>
-    struct AlpakaBuiltInAtomic<alpaka::AtomicMin, float, THierarchy> : std::false_type
+#            if(ALPAKA_LANG_HIP)
+    template<alpaka::MemoryOrder TMemOrder, typename THierarchy>
+    struct AlpakaBuiltInAtomic<alpaka::AtomicMin, float, TMemOrder, THierarchy> : std::false_type
     {
     };
 
-    template<>
-    struct AlpakaBuiltInAtomic<alpaka::AtomicMin, float, alpaka::hierarchy::Threads> : std::false_type
+    template<alpaka::MemoryOrder TMemOrder>
+    struct AlpakaBuiltInAtomic<alpaka::AtomicMin, float, TMemOrder, alpaka::hierarchy::Threads> : std::false_type
     {
     };
 
-    template<typename THierarchy>
-    struct AlpakaBuiltInAtomic<alpaka::AtomicMin, double, THierarchy> : std::false_type
+    template<alpaka::MemoryOrder TMemOrder, typename THierarchy>
+    struct AlpakaBuiltInAtomic<alpaka::AtomicMin, double, TMemOrder, THierarchy> : std::false_type
     {
     };
 
-    template<>
-    struct AlpakaBuiltInAtomic<alpaka::AtomicMin, double, alpaka::hierarchy::Threads> : std::false_type
+    template<alpaka::MemoryOrder TMemOrder>
+    struct AlpakaBuiltInAtomic<alpaka::AtomicMin, double, TMemOrder, alpaka::hierarchy::Threads> : std::false_type
     {
     };
 
-#            if !__has_builtin(__hip_atomic_compare_exchange_strong)
-    template<typename THierarchy>
-    struct AlpakaBuiltInAtomic<alpaka::AtomicMin, unsigned long long, THierarchy> : std::false_type
+#                if !__has_builtin(__hip_atomic_compare_exchange_strong)
+    template<alpaka::MemoryOrder TMemOrder, typename THierarchy>
+    struct AlpakaBuiltInAtomic<alpaka::AtomicMin, unsigned long long, TMemOrder, THierarchy> : std::false_type
     {
     };
 
-    template<>
-    struct AlpakaBuiltInAtomic<alpaka::AtomicMin, unsigned long long, alpaka::hierarchy::Threads> : std::false_type
+    template<alpaka::MemoryOrder TMemOrder>
+    struct AlpakaBuiltInAtomic<alpaka::AtomicMin, unsigned long long, TMemOrder, alpaka::hierarchy::Threads>
+        : std::false_type
     {
     };
+#                endif
 #            endif
-#        endif
 
     // Max.
 
-    template<typename T, typename THierarchy>
+    template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicMax,
         T,
+        TMemOrder,
         THierarchy,
         typename std::void_t<decltype(atomicMax(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicMax(add, value);
+#            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
+#                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_fetch_max(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_DEVICE);
+#                else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicMax(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::device);
+#                endif
+#            else
+#                if ALPAKA_LANG_HIP
+            return __hip_atomic_fetch_max(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_AGENT);
+#                endif
+#            endif
         }
     };
 
-#        if !CLANG_CUDA_PTX_WORKAROUND
-    template<typename T>
+#            if !CLANG_CUDA_PTX_WORKAROUND
+    template<typename T, alpaka::MemoryOrder TMemOrder>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicMax,
         T,
+        TMemOrder,
         alpaka::hierarchy::Threads,
         typename std::void_t<decltype(atomicMax_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicMax_block(add, value);
+#                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_fetch_max(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_BLOCK);
+#                    else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicMax_block(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::block);
+#                    endif
+#                else
+#                    if ALPAKA_LANG_HIP
+            return __hip_atomic_fetch_max(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_WORKGROUP);
+#                    endif
+#                endif
         }
     };
-#        endif
+#            endif
 
     // disable HIP atomicMax: see https://github.com/ROCm-Developer-Tools/hipamd/pull/40
-#        if(ALPAKA_LANG_HIP)
-    template<typename THierarchy>
-    struct AlpakaBuiltInAtomic<alpaka::AtomicMax, float, THierarchy> : std::false_type
+#            if(ALPAKA_LANG_HIP)
+    template<alpaka::MemoryOrder TMemOrder, typename THierarchy>
+    struct AlpakaBuiltInAtomic<alpaka::AtomicMax, float, TMemOrder, THierarchy> : std::false_type
     {
     };
 
-    template<>
-    struct AlpakaBuiltInAtomic<alpaka::AtomicMax, float, alpaka::hierarchy::Threads> : std::false_type
+    template<alpaka::MemoryOrder TMemOrder>
+    struct AlpakaBuiltInAtomic<alpaka::AtomicMax, float, TMemOrder, alpaka::hierarchy::Threads> : std::false_type
     {
     };
 
-    template<typename THierarchy>
-    struct AlpakaBuiltInAtomic<alpaka::AtomicMax, double, THierarchy> : std::false_type
+    template<alpaka::MemoryOrder TMemOrder, typename THierarchy>
+    struct AlpakaBuiltInAtomic<alpaka::AtomicMax, double, TMemOrder, THierarchy> : std::false_type
     {
     };
 
-    template<>
-    struct AlpakaBuiltInAtomic<alpaka::AtomicMax, double, alpaka::hierarchy::Threads> : std::false_type
+    template<alpaka::MemoryOrder TMemOrder>
+    struct AlpakaBuiltInAtomic<alpaka::AtomicMax, double, TMemOrder, alpaka::hierarchy::Threads> : std::false_type
     {
     };
 
-#            if !__has_builtin(__hip_atomic_compare_exchange_strong)
-    template<typename THierarchy>
-    struct AlpakaBuiltInAtomic<alpaka::AtomicMax, unsigned long long, THierarchy> : std::false_type
+#                if !__has_builtin(__hip_atomic_compare_exchange_strong)
+    template<alpaka::MemoryOrder TMemOrder, typename THierarchy>
+    struct AlpakaBuiltInAtomic<alpaka::AtomicMax, unsigned long long, TMemOrder, THierarchy> : std::false_type
     {
     };
 
-    template<>
-    struct AlpakaBuiltInAtomic<alpaka::AtomicMax, unsigned long long, alpaka::hierarchy::Threads> : std::false_type
+    template<alpaka::MemoryOrder TMemOrder>
+    struct AlpakaBuiltInAtomic<alpaka::AtomicMax, unsigned long long, TMemOrder, alpaka::hierarchy::Threads>
+        : std::false_type
     {
     };
+#                endif
 #            endif
-#        endif
 
 
     // Exch.
 
-    template<typename T, typename THierarchy>
+    template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicExch,
         T,
+        TMemOrder,
         THierarchy,
         typename std::void_t<decltype(atomicExch(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicExch(add, value);
+#            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
+#                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_exchange(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_DEVICE);
+#                else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicExch(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::device);
+#                endif
+#            else
+#                if ALPAKA_LANG_HIP
+            return __hip_atomic_exchange(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_AGENT);
+#                endif
+#            endif
         }
     };
 
-#        if !CLANG_CUDA_PTX_WORKAROUND
-    template<typename T>
+#            if !CLANG_CUDA_PTX_WORKAROUND
+    template<typename T, alpaka::MemoryOrder TMemOrder>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicExch,
         T,
+        TMemOrder,
         alpaka::hierarchy::Threads,
         typename std::void_t<decltype(atomicExch_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicExch_block(add, value);
+#                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_exchange(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_BLOCK);
+#                    else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicExch_block(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::block);
+#                    endif
+#                else
+#                    if ALPAKA_LANG_HIP
+            return __hip_atomic_exchange(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_WORKGROUP);
+#                    endif
+#                endif
         }
     };
-#        endif
+#            endif
 
     // Inc.
 
-    template<typename T, typename THierarchy>
+    template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicInc,
         T,
+        TMemOrder,
         THierarchy,
         typename std::void_t<decltype(atomicInc(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicInc(add, value);
+            // Note atomicInc doesn't have a direct __nv/hip_atomic equivalent, so we use the fence emulation
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicInc(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::device);
         }
     };
 
-#        if !CLANG_CUDA_PTX_WORKAROUND
-    template<typename T>
+#            if !CLANG_CUDA_PTX_WORKAROUND
+    template<typename T, alpaka::MemoryOrder TMemOrder>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicInc,
         T,
+        TMemOrder,
         alpaka::hierarchy::Threads,
         typename std::void_t<decltype(atomicInc_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicInc_block(add, value);
+            // Note atomicInc_block doesn't have a direct __nv/hip_atomic equivalent, so we use the fence emulation
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicInc_block(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::block);
         }
     };
-#        endif
+#            endif
 
     // Dec.
 
-    template<typename T, typename THierarchy>
+    template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicDec,
         T,
+        TMemOrder,
         THierarchy,
         typename std::void_t<decltype(atomicDec(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicDec(add, value);
+            // Note atomicDec doesn't have a direct __nv/hip_atomic or equivalent, so we use the fence emulation
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicDec(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::device);
         }
     };
 
-#        if !CLANG_CUDA_PTX_WORKAROUND
-    template<typename T>
+#            if !CLANG_CUDA_PTX_WORKAROUND
+    template<typename T, alpaka::MemoryOrder TMemOrder>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicDec,
         T,
+        TMemOrder,
         alpaka::hierarchy::Threads,
         typename std::void_t<decltype(atomicDec_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicDec_block(add, value);
+            // Note atomicDec_block doesn't have a direct __nv/hip_atomic equivalent, so we use the fence emulation
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicDec_block(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::block);
         }
     };
-#        endif
+#            endif
 
     // And.
 
-    template<typename T, typename THierarchy>
+    template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicAnd,
         T,
+        TMemOrder,
         THierarchy,
         typename std::void_t<decltype(atomicAnd(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicAnd(add, value);
+#            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
+#                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_fetch_and(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_DEVICE);
+#                else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicAnd(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::device);
+#                endif
+#            else
+#                if ALPAKA_LANG_HIP
+            return __hip_atomic_fetch_and(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_AGENT);
+#                endif
+#            endif
         }
     };
 
-#        if !CLANG_CUDA_PTX_WORKAROUND
-    template<typename T>
+#            if !CLANG_CUDA_PTX_WORKAROUND
+    template<typename T, alpaka::MemoryOrder TMemOrder>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicAnd,
         T,
+        TMemOrder,
         alpaka::hierarchy::Threads,
         typename std::void_t<decltype(atomicAnd_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicAnd_block(add, value);
+#                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_fetch_and(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_BLOCK);
+#                    else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicAnd_block(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::block);
+#                    endif
+#                else
+#                    if ALPAKA_LANG_HIP
+            return __hip_atomic_fetch_and(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_WORKGROUP);
+#                    endif
+#                endif
         }
     };
-#        endif
+#            endif
 
     // Or.
 
-    template<typename T, typename THierarchy>
+    template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicOr,
         T,
+        TMemOrder,
         THierarchy,
         typename std::void_t<decltype(atomicOr(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicOr(add, value);
+#            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
+#                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_fetch_or(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_DEVICE);
+#                else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicOr(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::device);
+#                endif
+#            else
+#                if ALPAKA_LANG_HIP
+            return __hip_atomic_fetch_or(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_AGENT);
+#                endif
+#            endif
         }
     };
 
-#        if !CLANG_CUDA_PTX_WORKAROUND
-    template<typename T>
+#            if !CLANG_CUDA_PTX_WORKAROUND
+    template<typename T, alpaka::MemoryOrder TMemOrder>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicOr,
         T,
+        TMemOrder,
         alpaka::hierarchy::Threads,
         typename std::void_t<decltype(atomicOr_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicOr_block(add, value);
+#                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_fetch_or(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_BLOCK);
+#                    else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicOr_block(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::block);
+#                    endif
+#                else
+#                    if ALPAKA_LANG_HIP
+            return __hip_atomic_fetch_or(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_WORKGROUP);
+#                    endif
+#                endif
         }
     };
-#        endif
+#            endif
 
     // Xor.
 
-    template<typename T, typename THierarchy>
+    template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicXor,
         T,
+        TMemOrder,
         THierarchy,
         typename std::void_t<decltype(atomicXor(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicXor(add, value);
+#            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
+#                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_fetch_xor(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_DEVICE);
+#                else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicXor(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::device);
+#                endif
+#            else
+#                if ALPAKA_LANG_HIP
+            return __hip_atomic_fetch_xor(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_AGENT);
+#                endif
+#            endif
         }
     };
 
-#        if !CLANG_CUDA_PTX_WORKAROUND
-    template<typename T>
+#            if !CLANG_CUDA_PTX_WORKAROUND
+    template<typename T, alpaka::MemoryOrder TMemOrder>
     struct AlpakaBuiltInAtomic<
         alpaka::AtomicXor,
         T,
+        TMemOrder,
         alpaka::hierarchy::Threads,
         typename std::void_t<decltype(atomicXor_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic(T* add, T value)
+        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
         {
-            return atomicXor_block(add, value);
+#                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+            return __nv_atomic_fetch_xor(add, value, alpaka::MemOrderCuda::get(order), __NV_THREAD_SCOPE_BLOCK);
+#                    else
+            return detail::atomicOrderEmulated(
+                acc,
+                [](T* addr, T val) { return atomicXor_block(addr, val); },
+                add,
+                value,
+                order,
+                alpaka::memory_scope::block);
+#                    endif
+#                else
+#                    if ALPAKA_LANG_HIP
+            return __hip_atomic_fetch_xor(add, value, alpaka::MemOrderHip::get(order), __HIP_MEMORY_SCOPE_WORKGROUP);
+#                    endif
+#                endif
         }
     };
-#        endif
+#            endif
 
 } // namespace alpakaGlobal
+#        endif
 
 #        undef CLANG_CUDA_PTX_WORKAROUND
 #    endif

--- a/include/alpaka/atomic/AtomicUniformCudaHip.hpp
+++ b/include/alpaka/atomic/AtomicUniformCudaHip.hpp
@@ -273,7 +273,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicAdd(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
 #                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
@@ -306,7 +310,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicAdd_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 #                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
@@ -358,7 +366,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicSub(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
 #                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
@@ -407,7 +419,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicSub_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 #                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
@@ -461,7 +477,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicMin(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
 
@@ -494,7 +514,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicMin_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 #                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
@@ -564,7 +588,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicMax(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
 #                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
@@ -596,7 +624,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicMax_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 #                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
@@ -667,7 +699,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicExch(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
 #                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
@@ -699,7 +735,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicExch_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 #                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
@@ -733,7 +773,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicInc(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
             // Note atomicInc doesn't have a direct __nv/hip_atomic equivalent, so we use the fence emulation
             return detail::atomicOrderEmulated(
@@ -756,7 +800,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicInc_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
             // Note atomicInc_block doesn't have a direct __nv/hip_atomic equivalent, so we use the fence emulation
             return detail::atomicOrderEmulated(
@@ -781,7 +829,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicDec(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
             // Note atomicDec doesn't have a direct __nv/hip_atomic or equivalent, so we use the fence emulation
             return detail::atomicOrderEmulated(
@@ -804,7 +856,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicDec_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
             // Note atomicDec_block doesn't have a direct __nv/hip_atomic equivalent, so we use the fence emulation
             return detail::atomicOrderEmulated(
@@ -829,7 +885,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicAnd(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
 #                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
@@ -861,7 +921,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicAnd_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 #                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
@@ -895,7 +959,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicOr(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
 #                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
@@ -927,7 +995,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicOr_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 #                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
@@ -961,7 +1033,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicXor(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #            if defined ALPAKA_ACC_GPU_CUDA_ENABLED
 #                if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
@@ -993,7 +1069,11 @@ inline namespace alpakaGlobal
         typename std::void_t<decltype(atomicXor_block(alpaka::core::declval<T*>(), alpaka::core::declval<T>()))>>
         : std::true_type
     {
-        static __device__ T atomic([[maybe_unused]] auto const& acc, T* add, T value, TMemOrder order)
+        static __device__ T atomic(
+            [[maybe_unused]] auto const& acc,
+            [[maybe_unused]] T* add,
+            [[maybe_unused]] T value,
+            [[maybe_unused]] TMemOrder order)
         {
 #                ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 #                    if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX

--- a/include/alpaka/atomic/AtomicUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicUniformCudaHipBuiltIn.hpp
@@ -10,6 +10,7 @@
 #include "alpaka/core/Config.hpp"
 #include "alpaka/core/Decay.hpp"
 #include "alpaka/core/Unreachable.hpp"
+#include "alpaka/mem/order/MemoryOrder.hpp"
 
 #include <limits>
 #include <type_traits>
@@ -63,6 +64,7 @@ namespace alpaka::trait
             typename TOp,
             typename TAtomic,
             typename T,
+            alpaka::MemoryOrder TMemOrder,
             typename THierarchy,
             typename TSfinae = void,
             typename TDefer = void>
@@ -72,7 +74,8 @@ namespace alpaka::trait
             static __device__ auto atomic(
                 alpaka::AtomicUniformCudaHipBuiltIn const& ctx,
                 T* const addr,
-                T const& value) -> T
+                T const& value,
+                TMemOrder order) -> T
             {
                 auto* const addressAsIntegralType = reinterpretAddress(addr);
                 using EmulatedType = std::decay_t<decltype(*addressAsIntegralType)>;
@@ -94,9 +97,13 @@ namespace alpaka::trait
                     assumed = old;
                     T v = *(reinterpret_cast<T*>(&assumed));
                     TOp{}(&v, value);
-                    using Cas = alpaka::trait::
-                        AtomicOp<alpaka::AtomicCas, alpaka::AtomicUniformCudaHipBuiltIn, EmulatedType, THierarchy>;
-                    old = Cas::atomicOp(ctx, addressAsIntegralType, assumed, reinterpretValue(v));
+                    using Cas = alpaka::trait::AtomicOp<
+                        alpaka::AtomicCas,
+                        alpaka::AtomicUniformCudaHipBuiltIn,
+                        EmulatedType,
+                        TMemOrder,
+                        THierarchy>;
+                    old = Cas::atomicOp(ctx, addressAsIntegralType, assumed, reinterpretValue(v), order);
                     // Note: uses integer comparison to avoid hang in case of NaN (since NaN != NaN)
                 } while(assumed != old);
                 return *(reinterpret_cast<T*>(&old));
@@ -104,49 +111,56 @@ namespace alpaka::trait
         };
 
         //! Emulate AtomicCas with equivalent unisigned integral type
-        template<typename T, typename THierarchy>
-        struct EmulateAtomic<alpaka::AtomicCas, alpaka::AtomicUniformCudaHipBuiltIn, T, THierarchy>
+        template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
+        struct EmulateAtomic<alpaka::AtomicCas, alpaka::AtomicUniformCudaHipBuiltIn, T, TMemOrder, THierarchy>
             : private EmulationBase
         {
             static __device__ auto atomic(
                 alpaka::AtomicUniformCudaHipBuiltIn const& ctx,
                 T* const addr,
                 T const& compare,
-                T const& value) -> T
+                T const& value,
+                TMemOrder order) -> T
             {
                 auto* const addressAsIntegralType = reinterpretAddress(addr);
                 using EmulatedType = std::decay_t<decltype(*addressAsIntegralType)>;
                 EmulatedType reinterpretedCompare = reinterpretValue(compare);
                 EmulatedType reinterpretedValue = reinterpretValue(value);
 
-                auto old = alpaka::trait::
-                    AtomicOp<alpaka::AtomicCas, alpaka::AtomicUniformCudaHipBuiltIn, EmulatedType, THierarchy>::
-                        atomicOp(ctx, addressAsIntegralType, reinterpretedCompare, reinterpretedValue);
+                auto old = alpaka::trait::AtomicOp<
+                    alpaka::AtomicCas,
+                    alpaka::AtomicUniformCudaHipBuiltIn,
+                    EmulatedType,
+                    TMemOrder,
+                    THierarchy>::atomicOp(ctx, addressAsIntegralType, reinterpretedCompare, reinterpretedValue, order);
 
                 return *(reinterpret_cast<T*>(&old));
             }
         };
 
         //! Emulate AtomicSub with atomicAdd
-        template<typename T, typename THierarchy>
-        struct EmulateAtomic<alpaka::AtomicSub, alpaka::AtomicUniformCudaHipBuiltIn, T, THierarchy>
+        template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
+        struct EmulateAtomic<alpaka::AtomicSub, alpaka::AtomicUniformCudaHipBuiltIn, T, TMemOrder, THierarchy>
         {
             static __device__ auto atomic(
                 alpaka::AtomicUniformCudaHipBuiltIn const& ctx,
                 T* const addr,
-                T const& value) -> T
+                T const& value,
+                TMemOrder order) -> T
             {
-                return alpaka::trait::AtomicOp<alpaka::AtomicAdd, alpaka::AtomicUniformCudaHipBuiltIn, T, THierarchy>::
-                    atomicOp(ctx, addr, -value);
+                return alpaka::trait::
+                    AtomicOp<alpaka::AtomicAdd, alpaka::AtomicUniformCudaHipBuiltIn, T, TMemOrder, THierarchy>::
+                        atomicOp(ctx, addr, -value, order);
             }
         };
 
         //! AtomicDec can not be implemented for floating point types!
-        template<typename T, typename THierarchy>
+        template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
         struct EmulateAtomic<
             alpaka::AtomicDec,
             alpaka::AtomicUniformCudaHipBuiltIn,
             T,
+            TMemOrder,
             THierarchy,
             std::enable_if_t<std::is_floating_point_v<T>>>
         {
@@ -160,11 +174,12 @@ namespace alpaka::trait
         };
 
         //! AtomicInc can not be implemented for floating point types!
-        template<typename T, typename THierarchy>
+        template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
         struct EmulateAtomic<
             alpaka::AtomicInc,
             alpaka::AtomicUniformCudaHipBuiltIn,
             T,
+            TMemOrder,
             THierarchy,
             std::enable_if_t<std::is_floating_point_v<T>>>
         {
@@ -178,11 +193,12 @@ namespace alpaka::trait
         };
 
         //! AtomicAnd can not be implemented for floating point types!
-        template<typename T, typename THierarchy>
+        template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
         struct EmulateAtomic<
             alpaka::AtomicAnd,
             alpaka::AtomicUniformCudaHipBuiltIn,
             T,
+            TMemOrder,
             THierarchy,
             std::enable_if_t<std::is_floating_point_v<T>>>
         {
@@ -196,11 +212,12 @@ namespace alpaka::trait
         };
 
         //! AtomicOr can not be implemented for floating point types!
-        template<typename T, typename THierarchy>
+        template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
         struct EmulateAtomic<
             alpaka::AtomicOr,
             alpaka::AtomicUniformCudaHipBuiltIn,
             T,
+            TMemOrder,
             THierarchy,
             std::enable_if_t<std::is_floating_point_v<T>>>
         {
@@ -214,11 +231,12 @@ namespace alpaka::trait
         };
 
         //! AtomicXor can not be implemented for floating point types!
-        template<typename T, typename THierarchy>
+        template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
         struct EmulateAtomic<
             alpaka::AtomicXor,
             alpaka::AtomicUniformCudaHipBuiltIn,
             T,
+            TMemOrder,
             THierarchy,
             std::enable_if_t<std::is_floating_point_v<T>>>
         {
@@ -238,49 +256,60 @@ namespace alpaka::trait
     // - unsigned long int will be redirected to unsigned long long int or unsigned int implementation depending if
     //   unsigned long int is a 64 or 32bit data type.
     // - Atomics which are not available as builtin atomic will be emulated.
-    template<typename TOp, typename T, typename THierarchy>
-    struct AtomicOp<TOp, AtomicUniformCudaHipBuiltIn, T, THierarchy>
+    template<typename TOp, typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
+    struct AtomicOp<TOp, AtomicUniformCudaHipBuiltIn, T, TMemOrder, THierarchy>
     {
         static __device__ auto atomicOp(
-            AtomicUniformCudaHipBuiltIn const& ctx,
+            auto const& ctx,
             [[maybe_unused]] T* const addr,
-            [[maybe_unused]] T const& value) -> T
+            [[maybe_unused]] T const& value,
+            TMemOrder order) -> T
         {
             static_assert(
                 sizeof(T) == 4u || sizeof(T) == 8u,
                 "atomicOp<TOp, AtomicUniformCudaHipBuiltIn, T>(atomic, addr, value) is not supported! Only 64 and "
                 "32bit atomics are supported.");
 
-            if constexpr(::AlpakaBuiltInAtomic<TOp, T, THierarchy>::value)
-                return ::AlpakaBuiltInAtomic<TOp, T, THierarchy>::atomic(addr, value);
+            if constexpr(::AlpakaBuiltInAtomic<TOp, T, TMemOrder, THierarchy>::value)
+                return ::AlpakaBuiltInAtomic<TOp, T, TMemOrder, THierarchy>::atomic(ctx, addr, value, order);
 
             else if constexpr(std::is_same_v<unsigned long int, T>)
             {
-                if constexpr(sizeof(T) == 4u && ::AlpakaBuiltInAtomic<TOp, unsigned int, THierarchy>::value)
-                    return ::AlpakaBuiltInAtomic<TOp, unsigned int, THierarchy>::atomic(
+                if constexpr(sizeof(T) == 4u && ::AlpakaBuiltInAtomic<TOp, unsigned int, TMemOrder, THierarchy>::value)
+                    return ::AlpakaBuiltInAtomic<TOp, unsigned int, TMemOrder, THierarchy>::atomic(
+                        ctx,
                         reinterpret_cast<unsigned int*>(addr),
-                        static_cast<unsigned int>(value));
+                        static_cast<unsigned int>(value),
+                        order);
                 else if constexpr(
-                    sizeof(T) == 8u && ::AlpakaBuiltInAtomic<TOp, unsigned long long int, THierarchy>::value) // LP64
+                    sizeof(T) == 8u
+                    && ::AlpakaBuiltInAtomic<TOp, unsigned long long int, TMemOrder, THierarchy>::value) // LP64
                 {
-                    return ::AlpakaBuiltInAtomic<TOp, unsigned long long int, THierarchy>::atomic(
+                    return ::AlpakaBuiltInAtomic<TOp, unsigned long long int, TMemOrder, THierarchy>::atomic(
+                        ctx,
                         reinterpret_cast<unsigned long long int*>(addr),
-                        static_cast<unsigned long long int>(value));
+                        static_cast<unsigned long long int>(value),
+                        order);
                 }
             }
 
-            return detail::EmulateAtomic<TOp, AtomicUniformCudaHipBuiltIn, T, THierarchy>::atomic(ctx, addr, value);
+            return detail::EmulateAtomic<TOp, AtomicUniformCudaHipBuiltIn, T, TMemOrder, THierarchy>::atomic(
+                ctx,
+                addr,
+                value,
+                order);
         }
     };
 
-    template<typename T, typename THierarchy>
-    struct AtomicOp<AtomicCas, AtomicUniformCudaHipBuiltIn, T, THierarchy>
+    template<typename T, alpaka::MemoryOrder TMemOrder, typename THierarchy>
+    struct AtomicOp<AtomicCas, AtomicUniformCudaHipBuiltIn, T, TMemOrder, THierarchy>
     {
         static __device__ auto atomicOp(
-            [[maybe_unused]] AtomicUniformCudaHipBuiltIn const& ctx,
+            [[maybe_unused]] auto const& ctx,
             [[maybe_unused]] T* const addr,
             [[maybe_unused]] T const& compare,
-            [[maybe_unused]] T const& value) -> T
+            [[maybe_unused]] T const& value,
+            TMemOrder order) -> T
         {
             static_assert(
                 sizeof(T) == 4u || sizeof(T) == 8u,
@@ -288,32 +317,43 @@ namespace alpaka::trait
                 "supported! Only 64 and "
                 "32bit atomics are supported.");
 
-            if constexpr(::AlpakaBuiltInAtomic<AtomicCas, T, THierarchy>::value)
-                return ::AlpakaBuiltInAtomic<AtomicCas, T, THierarchy>::atomic(addr, compare, value);
+            if constexpr(::AlpakaBuiltInAtomic<AtomicCas, T, TMemOrder, THierarchy>::value)
+                return ::AlpakaBuiltInAtomic<AtomicCas, T, TMemOrder, THierarchy>::atomic(
+                    ctx,
+                    addr,
+                    compare,
+                    value,
+                    order);
 
             else if constexpr(std::is_same_v<unsigned long int, T>)
             {
-                if constexpr(sizeof(T) == 4u && ::AlpakaBuiltInAtomic<AtomicCas, unsigned int, THierarchy>::value)
-                    return ::AlpakaBuiltInAtomic<AtomicCas, unsigned int, THierarchy>::atomic(
+                if constexpr(
+                    sizeof(T) == 4u && ::AlpakaBuiltInAtomic<AtomicCas, unsigned int, TMemOrder, THierarchy>::value)
+                    return ::AlpakaBuiltInAtomic<AtomicCas, unsigned int, TMemOrder, THierarchy>::atomic(
+                        ctx,
                         reinterpret_cast<unsigned int*>(addr),
                         static_cast<unsigned int>(compare),
-                        static_cast<unsigned int>(value));
+                        static_cast<unsigned int>(value),
+                        order);
                 else if constexpr(
                     sizeof(T) == 8u
-                    && ::AlpakaBuiltInAtomic<AtomicCas, unsigned long long int, THierarchy>::value) // LP64
+                    && ::AlpakaBuiltInAtomic<AtomicCas, unsigned long long int, TMemOrder, THierarchy>::value) // LP64
                 {
-                    return ::AlpakaBuiltInAtomic<AtomicCas, unsigned long long int, THierarchy>::atomic(
+                    return ::AlpakaBuiltInAtomic<AtomicCas, unsigned long long int, TMemOrder, THierarchy>::atomic(
+                        ctx,
                         reinterpret_cast<unsigned long long int*>(addr),
                         static_cast<unsigned long long int>(compare),
-                        static_cast<unsigned long long int>(value));
+                        static_cast<unsigned long long int>(value),
+                        order);
                 }
             }
 
-            return detail::EmulateAtomic<AtomicCas, AtomicUniformCudaHipBuiltIn, T, THierarchy>::atomic(
+            return detail::EmulateAtomic<AtomicCas, AtomicUniformCudaHipBuiltIn, T, TMemOrder, THierarchy>::atomic(
                 ctx,
                 addr,
                 compare,
-                value);
+                value,
+                order);
         }
     };
 } // namespace alpaka::trait

--- a/include/alpaka/atomic/Op.hpp
+++ b/include/alpaka/atomic/Op.hpp
@@ -191,18 +191,8 @@ namespace alpaka
         {
             auto const old = *addr;
             auto& ref = *addr;
-
-// gcc-7.4.0 assumes for an optimization that a signed overflow does not occur here.
-// That's fine, so ignore that warning.
-#if ALPAKA_COMP_GNUC && (ALPAKA_COMP_GNUC == ALPAKA_VERSION_NUMBER(7, 4, 0))
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wstrict-overflow"
-#endif
             // check if values are bit-wise equal
             ref = ((old == compare) ? value : old);
-#if ALPAKA_COMP_GNUC && (ALPAKA_COMP_GNUC == ALPAKA_VERSION_NUMBER(7, 4, 0))
-#    pragma GCC diagnostic pop
-#endif
             return old;
         }
 
@@ -230,19 +220,10 @@ namespace alpaka
             auto const old = *addr;
             auto& ref = *addr;
 
-// gcc-7.4.0 assumes for an optimization that a signed overflow does not occur here.
-// That's fine, so ignore that warning.
-#if ALPAKA_COMP_GNUC && (ALPAKA_COMP_GNUC == ALPAKA_VERSION_NUMBER(7, 4, 0))
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wstrict-overflow"
-#endif
             BitUnion o{old};
             BitUnion c{compare};
 
             ref = ((o.r == c.r) ? value : old);
-#if ALPAKA_COMP_GNUC && (ALPAKA_COMP_GNUC == ALPAKA_VERSION_NUMBER(7, 4, 0))
-#    pragma GCC diagnostic pop
-#endif
             return old;
         }
     };

--- a/include/alpaka/atomic/Traits.hpp
+++ b/include/alpaka/atomic/Traits.hpp
@@ -8,6 +8,7 @@
 #include "alpaka/core/Common.hpp"
 #include "alpaka/core/Interface.hpp"
 #include "alpaka/core/Positioning.hpp"
+#include "alpaka/mem/order/MemoryOrder.hpp"
 
 #include <type_traits>
 
@@ -56,7 +57,13 @@ namespace alpaka
     namespace trait
     {
         //! The atomic operation trait.
-        template<typename TOp, typename TAtomic, typename T, typename THierarchy, typename TSfinae = void>
+        template<
+            typename TOp,
+            typename TAtomic,
+            typename T,
+            MemoryOrder TMemOrder,
+            typename THierarchy,
+            typename TSfinae = void>
         struct AtomicOp;
     } // namespace trait
 
@@ -65,22 +72,29 @@ namespace alpaka
     //! \tparam TOp The operation type.
     //! \tparam T The value type.
     //! \tparam TAtomic The atomic implementation type.
+    //! \tparam TMemOrder The memory order type.
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
     //! \param atomic The atomic implementation.
+    //! \param order The memory order.
     ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TOp, typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
+    template<typename TOp, typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
     ALPAKA_FN_HOST_ACC auto atomicOp(
         TAtomic const& atomic,
         T* const addr,
         T const& value,
+        TMemOrder order,
         THierarchy const& = THierarchy()) -> T
     {
         using ImplementationBase = typename interface::ImplementationBase<AtomicHierarchyConcept<THierarchy>, TAtomic>;
-        return trait::AtomicOp<TOp, ImplementationBase, T, THierarchy>::atomicOp(atomic, addr, value);
+        return trait::AtomicOp<TOp, ImplementationBase, T, TMemOrder, THierarchy>::atomicOp(
+            atomic,
+            addr,
+            value,
+            order);
     }
 
-    //! Executes the given operation atomically.
+    //! Executes the given operation atomically (compare-and-swap variant).
     //!
     //! \tparam TOp The operation type.
     //! \tparam TAtomic The atomic implementation type.
@@ -90,19 +104,72 @@ namespace alpaka
     //! \param compare The comparison value used in the atomic operation.
     //! \param value The value used in the atomic operation.
     ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TOp, typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicOp(
+        TAtomic const& atomic,
+        T* const addr,
+        T const& compare,
+        T const& value,
+        TMemOrder order,
+        THierarchy = THierarchy()) -> T
+    {
+        using ImplementationBase = typename interface::ImplementationBase<AtomicHierarchyConcept<THierarchy>, TAtomic>;
+        return trait::AtomicOp<TOp, ImplementationBase, T, TMemOrder, THierarchy>::atomicOp(
+            atomic,
+            addr,
+            compare,
+            value,
+            order);
+    }
+
+    //! Executes the given operation atomically (with default relaxed memory order).
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TOp, typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicOp(
+        TAtomic const& atomic,
+        T* const addr,
+        T const& value,
+        THierarchy hier = THierarchy()) -> T
+    {
+        return atomicOp<TOp>(atomic, addr, value, mem_order::relaxed, hier);
+    }
+
+    //! Executes the given operation atomically (compare-and-swap variant with default relaxed memory order).
+    ALPAKA_NO_HOST_ACC_WARNING
     template<typename TOp, typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
     ALPAKA_FN_HOST_ACC auto atomicOp(
         TAtomic const& atomic,
         T* const addr,
         T const& compare,
         T const& value,
-        THierarchy const& = THierarchy()) -> T
+        THierarchy hier = THierarchy()) -> T
     {
-        using ImplementationBase = typename interface::ImplementationBase<AtomicHierarchyConcept<THierarchy>, TAtomic>;
-        return trait::AtomicOp<TOp, ImplementationBase, T, THierarchy>::atomicOp(atomic, addr, compare, value);
+        return atomicOp<TOp>(atomic, addr, compare, value, mem_order::relaxed, hier);
     }
 
     //! Executes an atomic add operation.
+    //!
+    //! \tparam T The value type.
+    //! \tparam TAtomic The atomic implementation type.
+    //! \tparam TMemOrder The memory order type.
+    //! \param atomic The atomic implementation.
+    //! \param addr The value to change atomically.
+    //! \param value The value used in the atomic operation.
+    //! \param order The memory order.
+    //! \param hier The hierarchy level.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicAdd(
+        TAtomic const& atomic,
+        T* const addr,
+        T const& value,
+        TMemOrder order,
+        THierarchy const& hier = THierarchy()) -> T
+    {
+        return atomicOp<AtomicAdd>(atomic, addr, value, order, hier);
+    }
+
+    //! Executes an atomic add operation (with default memory order).
     //!
     //! \tparam T The value type.
     //! \tparam TAtomic The atomic implementation type.
@@ -124,9 +191,24 @@ namespace alpaka
     //!
     //! \tparam T The value type.
     //! \tparam TAtomic The atomic implementation type.
+    //! \param atomic The atomic implementation.
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
-    //! \param atomic The atomic implementation.
+    //! \param order The memory order.
+    //! \param hier The hierarchy level.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicSub(
+        TAtomic const& atomic,
+        T* const addr,
+        T const& value,
+        TMemOrder order,
+        THierarchy const& hier = THierarchy()) -> T
+    {
+        return atomicOp<AtomicSub>(atomic, addr, value, order, hier);
+    }
+
+    //! Executes an atomic sub operation (with default memory order).
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
     ALPAKA_FN_HOST_ACC auto atomicSub(
@@ -142,9 +224,24 @@ namespace alpaka
     //!
     //! \tparam T The value type.
     //! \tparam TAtomic The atomic implementation type.
+    //! \param atomic The atomic implementation.
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
-    //! \param atomic The atomic implementation.
+    //! \param order The memory order.
+    //! \param hier The hierarchy level.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicMin(
+        TAtomic const& atomic,
+        T* const addr,
+        T const& value,
+        TMemOrder order,
+        THierarchy const& hier = THierarchy()) -> T
+    {
+        return atomicOp<AtomicMin>(atomic, addr, value, order, hier);
+    }
+
+    //! Executes an atomic min operation (with default memory order).
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
     ALPAKA_FN_HOST_ACC auto atomicMin(
@@ -160,9 +257,24 @@ namespace alpaka
     //!
     //! \tparam T The value type.
     //! \tparam TAtomic The atomic implementation type.
+    //! \param atomic The atomic implementation.
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
-    //! \param atomic The atomic implementation.
+    //! \param order The memory order.
+    //! \param hier The hierarchy level.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicMax(
+        TAtomic const& atomic,
+        T* const addr,
+        T const& value,
+        TMemOrder order,
+        THierarchy const& hier = THierarchy()) -> T
+    {
+        return atomicOp<AtomicMax>(atomic, addr, value, order, hier);
+    }
+
+    //! Executes an atomic max operation (with default memory order).
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
     ALPAKA_FN_HOST_ACC auto atomicMax(
@@ -178,9 +290,24 @@ namespace alpaka
     //!
     //! \tparam T The value type.
     //! \tparam TAtomic The atomic implementation type.
+    //! \param atomic The atomic implementation.
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
-    //! \param atomic The atomic implementation.
+    //! \param order The memory order.
+    //! \param hier The hierarchy level.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicExch(
+        TAtomic const& atomic,
+        T* const addr,
+        T const& value,
+        TMemOrder order,
+        THierarchy const& hier = THierarchy()) -> T
+    {
+        return atomicOp<AtomicExch>(atomic, addr, value, order, hier);
+    }
+
+    //! Executes an atomic exchange operation (with default memory order).
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
     ALPAKA_FN_HOST_ACC auto atomicExch(
@@ -196,9 +323,24 @@ namespace alpaka
     //!
     //! \tparam T The value type.
     //! \tparam TAtomic The atomic implementation type.
+    //! \param atomic The atomic implementation.
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
-    //! \param atomic The atomic implementation.
+    //! \param order The memory order.
+    //! \param hier The hierarchy level.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicInc(
+        TAtomic const& atomic,
+        T* const addr,
+        T const& value,
+        TMemOrder order,
+        THierarchy const& hier = THierarchy()) -> T
+    {
+        return atomicOp<AtomicInc>(atomic, addr, value, order, hier);
+    }
+
+    //! Executes an atomic increment operation (with default memory order).
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
     ALPAKA_FN_HOST_ACC auto atomicInc(
@@ -214,9 +356,24 @@ namespace alpaka
     //!
     //! \tparam T The value type.
     //! \tparam TAtomic The atomic implementation type.
-    //! \param addr The value to change atomically.
     //! \param atomic The atomic implementation.
+    //! \param addr The value to change atomically.
+    //! \param order The memory order.
+    //! \param hier The hierarchy level.
     //! NOTE: The limit value is deduced as std::numeric_limits<T>::max()
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicInc(
+        TAtomic const& atomic,
+        T* const addr,
+        TMemOrder order,
+        THierarchy const& hier = THierarchy()) -> T
+    {
+        T const value = std::numeric_limits<T>::max();
+        return atomicOp<AtomicInc>(atomic, addr, value, order, hier);
+    }
+
+    //! Executes an atomic increment operation, using the numeric limit as ceiling (with default memory order).
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
     ALPAKA_FN_HOST_ACC auto atomicInc(TAtomic const& atomic, T* const addr, THierarchy const& hier = THierarchy()) -> T
@@ -229,9 +386,24 @@ namespace alpaka
     //!
     //! \tparam T The value type.
     //! \tparam TAtomic The atomic implementation type.
+    //! \param atomic The atomic implementation.
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
-    //! \param atomic The atomic implementation.
+    //! \param order The memory order.
+    //! \param hier The hierarchy level.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicDec(
+        TAtomic const& atomic,
+        T* const addr,
+        T const& value,
+        TMemOrder order,
+        THierarchy const& hier = THierarchy()) -> T
+    {
+        return atomicOp<AtomicDec>(atomic, addr, value, order, hier);
+    }
+
+    //! Executes an atomic decrement operation (with default memory order).
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
     ALPAKA_FN_HOST_ACC auto atomicDec(
@@ -247,9 +419,24 @@ namespace alpaka
     //!
     //! \tparam T The value type.
     //! \tparam TAtomic The atomic implementation type.
-    //! \param addr The value to change atomically.
     //! \param atomic The atomic implementation.
+    //! \param addr The value to change atomically.
+    //! \param order The memory order.
+    //! \param hier The hierarchy level.
     //! NOTE: The limit value is deduced as std::numeric_limits<T>::max()
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicDec(
+        TAtomic const& atomic,
+        T* const addr,
+        TMemOrder order,
+        THierarchy const& hier = THierarchy()) -> T
+    {
+        T const value = std::numeric_limits<T>::max();
+        return atomicOp<AtomicDec>(atomic, addr, value, order, hier);
+    }
+
+    //! Executes an atomic decrement operation, using the numeric limit as ceiling (with default memory order).
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
     ALPAKA_FN_HOST_ACC auto atomicDec(TAtomic const& atomic, T* const addr, THierarchy const& hier = THierarchy()) -> T
@@ -262,9 +449,24 @@ namespace alpaka
     //!
     //! \tparam T The value type.
     //! \tparam TAtomic The atomic implementation type.
+    //! \param atomic The atomic implementation.
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
-    //! \param atomic The atomic implementation.
+    //! \param order The memory order.
+    //! \param hier The hierarchy level.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicAnd(
+        TAtomic const& atomic,
+        T* const addr,
+        T const& value,
+        TMemOrder order,
+        THierarchy const& hier = THierarchy()) -> T
+    {
+        return atomicOp<AtomicAnd>(atomic, addr, value, order, hier);
+    }
+
+    //! Executes an atomic and operation (with default memory order).
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
     ALPAKA_FN_HOST_ACC auto atomicAnd(
@@ -280,9 +482,24 @@ namespace alpaka
     //!
     //! \tparam T The value type.
     //! \tparam TAtomic The atomic implementation type.
+    //! \param atomic The atomic implementation.
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
-    //! \param atomic The atomic implementation.
+    //! \param order The memory order.
+    //! \param hier The hierarchy level.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicOr(
+        TAtomic const& atomic,
+        T* const addr,
+        T const& value,
+        TMemOrder order,
+        THierarchy const& hier = THierarchy()) -> T
+    {
+        return atomicOp<AtomicOr>(atomic, addr, value, order, hier);
+    }
+
+    //! Executes an atomic or operation (with default memory order).
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
     ALPAKA_FN_HOST_ACC auto atomicOr(
@@ -298,9 +515,24 @@ namespace alpaka
     //!
     //! \tparam T The value type.
     //! \tparam TAtomic The atomic implementation type.
+    //! \param atomic The atomic implementation.
     //! \param addr The value to change atomically.
     //! \param value The value used in the atomic operation.
-    //! \param atomic The atomic implementation.
+    //! \param order The memory order.
+    //! \param hier The hierarchy level.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicXor(
+        TAtomic const& atomic,
+        T* const addr,
+        T const& value,
+        TMemOrder order,
+        THierarchy const& hier = THierarchy()) -> T
+    {
+        return atomicOp<AtomicXor>(atomic, addr, value, order, hier);
+    }
+
+    //! Executes an atomic xor operation (with default memory order).
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
     ALPAKA_FN_HOST_ACC auto atomicXor(
@@ -320,6 +552,22 @@ namespace alpaka
     //! \param addr The value to change atomically.
     //! \param compare The comparison value used in the atomic operation.
     //! \param value The value used in the atomic operation.
+    //! \param order The memory order.
+    //! \param hier The hierarchy level.
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAtomic, typename T, MemoryOrder TMemOrder, typename THierarchy = hierarchy::Grids>
+    ALPAKA_FN_HOST_ACC auto atomicCas(
+        TAtomic const& atomic,
+        T* const addr,
+        T const& compare,
+        T const& value,
+        TMemOrder order,
+        THierarchy const& hier = THierarchy()) -> T
+    {
+        return atomicOp<AtomicCas>(atomic, addr, compare, value, order, hier);
+    }
+
+    //! Executes an atomic compare-and-swap operation (with default memory order).
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAtomic, typename T, typename THierarchy = hierarchy::Grids>
     ALPAKA_FN_HOST_ACC auto atomicCas(
@@ -331,4 +579,6 @@ namespace alpaka
     {
         return atomicOp<AtomicCas>(atomic, addr, compare, value, hier);
     }
+
+
 } // namespace alpaka

--- a/include/alpaka/mem/fence/MemFenceCpu.hpp
+++ b/include/alpaka/mem/fence/MemFenceCpu.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2022 Jan Stephan, Bernhard Manfred Gruber, Tapish Narwal
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -6,6 +6,7 @@
 
 #include "alpaka/core/Interface.hpp"
 #include "alpaka/mem/fence/Traits.hpp"
+#include "alpaka/mem/order/MemOrderStl.hpp"
 
 #include <atomic>
 
@@ -18,10 +19,18 @@ namespace alpaka
 
     namespace trait
     {
-        template<typename TMemScope>
-        struct MemFence<MemFenceCpu, TMemScope>
+        template<>
+        struct MemFenceDefaultOrder<MemFenceCpu>
         {
-            static auto mem_fence(MemFenceCpu const&, TMemScope const&)
+            using type = mem_order::AcqRel;
+            static constexpr auto value = mem_order::acq_rel;
+        };
+
+        template<MemoryOrder TMemOrder, MemoryScope TMemScope>
+        struct MemFence<MemFenceCpu, TMemOrder, TMemScope>
+
+        {
+            static auto mem_fence(MemFenceCpu const&, TMemOrder order, TMemScope const&)
             {
                 /*
                  * Intuitively, std::atomic_thread_fence creates a fence on the block level.
@@ -54,7 +63,7 @@ namespace alpaka
                  *   a == 10 && b == 20
                  */
 
-                std::atomic_thread_fence(std::memory_order_acq_rel);
+                std::atomic_thread_fence(MemOrderStl::get(order));
             }
         };
     } // namespace trait

--- a/include/alpaka/mem/fence/MemFenceCpuSerial.hpp
+++ b/include/alpaka/mem/fence/MemFenceCpuSerial.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Jan Stephan, Andrea Bocci
+/* Copyright 2022 Jan Stephan, Andrea Bocci, Tapish Narwal
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -6,6 +6,7 @@
 
 #include "alpaka/core/Interface.hpp"
 #include "alpaka/mem/fence/Traits.hpp"
+#include "alpaka/mem/order/MemOrderStl.hpp"
 
 #include <atomic>
 
@@ -19,30 +20,37 @@ namespace alpaka
     namespace trait
     {
         template<>
-        struct MemFence<MemFenceCpuSerial, memory_scope::Block>
+        struct MemFenceDefaultOrder<MemFenceCpuSerial>
         {
-            static auto mem_fence(MemFenceCpuSerial const&, memory_scope::Block const&)
+            using type = mem_order::AcqRel;
+            static constexpr auto value = mem_order::acq_rel;
+        };
+
+        template<MemoryOrder TMemOrder>
+        struct MemFence<MemFenceCpuSerial, TMemOrder, memory_scope::Block>
+        {
+            static auto mem_fence(MemFenceCpuSerial const&, TMemOrder, memory_scope::Block const&)
             {
                 /* Nothing to be done on the block level for the serial case. */
             }
         };
 
-        template<>
-        struct MemFence<MemFenceCpuSerial, memory_scope::Grid>
+        template<MemoryOrder TMemOrder>
+        struct MemFence<MemFenceCpuSerial, TMemOrder, memory_scope::Grid>
         {
-            static auto mem_fence(MemFenceCpuSerial const&, memory_scope::Grid const&)
+            static auto mem_fence(MemFenceCpuSerial const&, TMemOrder, memory_scope::Grid const&)
             {
                 /* Nothing to be done on the grid level for the serial case. */
             }
         };
 
-        template<typename TMemScope>
-        struct MemFence<MemFenceCpuSerial, TMemScope>
+        template<MemoryOrder TMemOrder, MemoryScope TMemScope>
+        struct MemFence<MemFenceCpuSerial, TMemOrder, TMemScope>
         {
-            static auto mem_fence(MemFenceCpuSerial const&, TMemScope const&)
+            static auto mem_fence(MemFenceCpuSerial const&, TMemOrder order, TMemScope const&)
             {
                 /* Enable device fences because we may want to synchronize with other (serial) kernels. */
-                std::atomic_thread_fence(std::memory_order_acq_rel);
+                std::atomic_thread_fence(MemOrderStl::get(order));
             }
         };
     } // namespace trait

--- a/include/alpaka/mem/fence/MemFenceGenericSycl.hpp
+++ b/include/alpaka/mem/fence/MemFenceGenericSycl.hpp
@@ -1,10 +1,11 @@
-/* Copyright 2023 Jan Stephan, Luca Ferragina, Andrea Bocci
+/* Copyright 2023 Jan Stephan, Luca Ferragina, Andrea Bocci, Tapish Narwal
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
 #include "alpaka/mem/fence/Traits.hpp"
+#include "alpaka/mem/order/MemOrderGenericSycl.hpp"
 
 #ifdef ALPAKA_ACC_SYCL_ENABLED
 
@@ -46,13 +47,20 @@ namespace alpaka
 
 namespace alpaka::trait
 {
-    template<typename TMemScope>
-    struct MemFence<MemFenceGenericSycl, TMemScope>
+    template<>
+    struct MemFenceDefaultOrder<MemFenceGenericSycl>
     {
-        static auto mem_fence(MemFenceGenericSycl const&, TMemScope const&)
+        using type = mem_order::AcqRel;
+        static constexpr auto value = mem_order::acq_rel;
+    };
+
+    template<MemoryOrder TMemOrder, MemoryScope TMemScope>
+    struct MemFence<MemFenceGenericSycl, TMemOrder, TMemScope>
+    {
+        static auto mem_fence(MemFenceGenericSycl const&, TMemOrder order, TMemScope const&)
         {
             static constexpr auto scope = alpaka::detail::SyclFenceProps<TMemScope>::scope;
-            sycl::atomic_fence(sycl::memory_order::acq_rel, scope);
+            sycl::atomic_fence(MemOrderSycl::get(order), scope);
         }
     };
 } // namespace alpaka::trait

--- a/include/alpaka/mem/fence/MemFenceOmp2Blocks.hpp
+++ b/include/alpaka/mem/fence/MemFenceOmp2Blocks.hpp
@@ -1,10 +1,11 @@
-/* Copyright 2022 Jan Stephan, Bernhard Manfred Gruber, Andrea Bocci
+/* Copyright 2022 Jan Stephan, Bernhard Manfred Gruber, Andrea Bocci, Tapish Narwal
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
 #include "alpaka/core/Interface.hpp"
+#include "alpaka/mem/fence/MemFenceOmp2Order.hpp"
 #include "alpaka/mem/fence/Traits.hpp"
 
 #ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
@@ -23,29 +24,36 @@ namespace alpaka
     namespace trait
     {
         template<>
-        struct MemFence<MemFenceOmp2Blocks, memory_scope::Block>
+        struct MemFenceDefaultOrder<MemFenceOmp2Blocks>
         {
-            static auto mem_fence(MemFenceOmp2Blocks const&, memory_scope::Block const&)
+            using type = mem_order::AcqRel;
+            static constexpr auto value = mem_order::acq_rel;
+        };
+
+        template<MemoryOrder TMemOrder>
+        struct MemFence<MemFenceOmp2Blocks, TMemOrder, memory_scope::Block>
+        {
+            static auto mem_fence(MemFenceOmp2Blocks const&, TMemOrder, memory_scope::Block const&)
             {
                 // Only one thread per block allowed -> no memory fence required on block level
             }
         };
 
-        template<>
-        struct MemFence<MemFenceOmp2Blocks, memory_scope::Grid>
+        template<MemoryOrder TMemOrder>
+        struct MemFence<MemFenceOmp2Blocks, TMemOrder, memory_scope::Grid>
         {
-            static auto mem_fence(MemFenceOmp2Blocks const&, memory_scope::Grid const&)
+            static auto mem_fence(MemFenceOmp2Blocks const&, TMemOrder order, memory_scope::Grid const&)
             {
-#    pragma omp flush
+                alpaka::detail::flushOmp(order);
             }
         };
 
-        template<>
-        struct MemFence<MemFenceOmp2Blocks, memory_scope::Device>
+        template<MemoryOrder TMemOrder>
+        struct MemFence<MemFenceOmp2Blocks, TMemOrder, memory_scope::Device>
         {
-            static auto mem_fence(MemFenceOmp2Blocks const&, memory_scope::Device const&)
+            static auto mem_fence(MemFenceOmp2Blocks const&, TMemOrder order, memory_scope::Device const&)
             {
-#    pragma omp flush
+                alpaka::detail::flushOmp(order);
             }
         };
     } // namespace trait

--- a/include/alpaka/mem/fence/MemFenceOmp2Order.hpp
+++ b/include/alpaka/mem/fence/MemFenceOmp2Order.hpp
@@ -1,0 +1,76 @@
+/* Copyright 2022 Jan Stephan, Bernhard Manfred Gruber, Andrea Bocci, Tapish Narwal
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/Config.hpp"
+#include "alpaka/core/PP.hpp"
+#include "alpaka/core/Unreachable.hpp"
+#include "alpaka/mem/order/MemoryOrder.hpp"
+
+#include <atomic>
+#include <concepts>
+
+#if defined(ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED) || defined(ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED)
+
+#    if ALPAKA_OMP < ALPAKA_VERSION_NUMBER(2002, 03, 0)
+#        ifdef(ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
+#            error If ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED is set, the compiler has to support OpenMP 2.0 or higher!
+#        endif
+#        ifdef(ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED)
+#            error If ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED is set, the compiler has to support OpenMP 2.0 or higher!
+#        endif
+#    endif
+
+namespace alpaka::detail
+{
+
+    template<MemoryOrder TMemOrder>
+    inline auto flushOmp(TMemOrder)
+    {
+        if constexpr(std::same_as<TMemOrder, mem_order::SeqCst>)
+        {
+            // sequenital consistency in openMP is only enforced in implicit flush.
+            // We use std atomics since our openMP is limited to CPU backends
+            std::atomic_thread_fence(std::memory_order::seq_cst);
+        }
+        else if constexpr(std::same_as<TMemOrder, mem_order::AcqRel>)
+        {
+            // Flush orderings were introduced in OpenMP 5.0
+#    if ALPAKA_OMP >= ALPAKA_VERSION_NUMBER(2018, 11, 0)
+#        pragma omp flush acq_rel
+#    else
+#        pragma omp flush
+#    endif
+        }
+        else if constexpr(std::same_as<TMemOrder, mem_order::Release>)
+        {
+            // Flush orderings were introduced in OpenMP 5.0
+#    if ALPAKA_OMP >= ALPAKA_VERSION_NUMBER(2018, 11, 0)
+#        pragma omp flush release
+#    else
+#        pragma omp flush
+#    endif
+        }
+        else if constexpr(std::same_as<TMemOrder, mem_order::Acquire>)
+        {
+            // Flush orderings were introduced in OpenMP 5.0
+#    if ALPAKA_OMP >= ALPAKA_VERSION_NUMBER(2018, 11, 0)
+#        pragma omp flush acquire
+#    else
+#        pragma omp flush
+#    endif
+        }
+        else if constexpr(std::same_as<TMemOrder, mem_order::Relaxed>)
+        {
+            // Relaxed memory barrier is a no op
+        }
+        else
+        {
+            ALPAKA_UNREACHABLE();
+        }
+    }
+} // namespace alpaka::detail
+
+#endif

--- a/include/alpaka/mem/fence/MemFenceOmp2Threads.hpp
+++ b/include/alpaka/mem/fence/MemFenceOmp2Threads.hpp
@@ -1,10 +1,11 @@
-/* Copyright 2022 Jan Stephan, Bernhard Manfred Gruber
+/* Copyright 2022 Jan Stephan, Bernhard Manfred Gruber, Tapish Narwal
  * SPDX-License-Identifier: MPL-2.0
  */
 
 #pragma once
 
 #include "alpaka/core/Interface.hpp"
+#include "alpaka/mem/fence/MemFenceOmp2Order.hpp"
 #include "alpaka/mem/fence/Traits.hpp"
 
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
@@ -22,10 +23,17 @@ namespace alpaka
 
     namespace trait
     {
-        template<typename TMemScope>
-        struct MemFence<MemFenceOmp2Threads, TMemScope>
+        template<>
+        struct MemFenceDefaultOrder<MemFenceOmp2Threads>
         {
-            static auto mem_fence(MemFenceOmp2Threads const&, TMemScope const&)
+            using type = mem_order::AcqRel;
+            static constexpr auto value = mem_order::acq_rel;
+        };
+
+        template<MemoryOrder TMemOrder, MemoryScope TMemScope>
+        struct MemFence<MemFenceOmp2Threads, TMemOrder, TMemScope>
+        {
+            static auto mem_fence(MemFenceOmp2Threads const&, TMemOrder order, TMemScope const&)
             {
                 /*
                  * Intuitively, this pragma creates a fence on the block level.
@@ -57,7 +65,7 @@ namespace alpaka
                  *   a == 10 && b == 2
                  *   a == 10 && b == 20
                  */
-#    pragma omp flush
+                alpaka::detail::flushOmp(order);
 #    ifdef _MSC_VER
                 ; // MSVC needs an empty statement here or it diagnoses a syntax error
 #    endif

--- a/include/alpaka/mem/fence/MemFenceUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/mem/fence/MemFenceUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber
+/* Copyright 2022 Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber, Tapish Narwal
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -6,7 +6,12 @@
 
 #include "alpaka/core/Config.hpp"
 #include "alpaka/core/Interface.hpp"
+#include "alpaka/core/PP.hpp"
 #include "alpaka/mem/fence/Traits.hpp"
+#include "alpaka/mem/order/MemOrderCuda.hpp"
+#include "alpaka/mem/order/MemOrderHip.hpp"
+
+#include <alpaka/mem/order/MemoryOrder.hpp>
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)
 
@@ -18,7 +23,6 @@ namespace alpaka
     };
 
 #    if !defined(ALPAKA_HOST_ONLY)
-
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && !ALPAKA_LANG_CUDA
 #            error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #        endif
@@ -27,37 +31,184 @@ namespace alpaka
 #            error If ALPAKA_ACC_GPU_HIP_ENABLED is set, the compiler has to support HIP!
 #        endif
 
+
+    namespace detail
+    {
+        template<alpaka::MemoryOrder TMemOrder>
+        [[maybe_unused]] static constexpr __device__ void cuda_ptx_fence_device([[maybe_unused]] TMemOrder order)
+        {
+#        if ALPAKA_ARCH_PTX >= ALPAKA_VERSION_NUMBER(9, 0, 0)
+            // full acquire/release semantics support
+            if constexpr(std::is_same_v<TMemOrder, mem_order::Relaxed>)
+            { // Relaxed ordering requires no fence
+            }
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::Acquire>)
+            {
+                asm volatile("fence.acquire.sys;" ::);
+            }
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::Release>)
+            {
+                asm volatile("fence.release.sys;" ::);
+            }
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::AcqRel>)
+            {
+                asm volatile("fence.acq_rel.sys;" ::);
+            }
+            else
+            { // Sequential consistency
+                asm volatile("fence.sc.sys;" ::);
+            }
+#        else
+            // only acq_rel and sc available
+            if constexpr(std::is_same_v<TMemOrder, mem_order::Relaxed>)
+            { // Relaxed ordering requires no fence
+            }
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::Acquire>)
+            {
+                asm volatile("fence.acq_rel.sys;" ::);
+            }
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::Release>)
+            {
+                asm volatile("fence.acq_rel.sys;" ::);
+            }
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::AcqRel>)
+            {
+                asm volatile("fence.acq_rel.sys;" ::);
+            }
+            else
+            {
+                // Sequential consistency
+                asm volatile("fence.sc.sys;" ::);
+            }
+#        endif
+        }
+
+        template<alpaka::MemoryOrder TMemOrder>
+        [[maybe_unused]] static constexpr __device__ void cuda_ptx_fence_block([[maybe_unused]] TMemOrder order)
+        {
+#        if ALPAKA_ARCH_PTX >= ALPAKA_VERSION_NUMBER(9, 0, 0)
+            // full acquire/release semantics support
+            if constexpr(std::is_same_v<TMemOrder, mem_order::Relaxed>)
+            { // Relaxed ordering requires no fence
+            }
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::Acquire>)
+            {
+                asm volatile("fence.acquire.cta;" ::);
+            }
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::Release>)
+            {
+                asm volatile("fence.release.cta;" ::);
+            }
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::AcqRel>)
+            {
+                asm volatile("fence.acq_rel.cta;" ::);
+            }
+            else
+            { // Sequential consistency
+                asm volatile("fence.sc.cta;" ::);
+            }
+#        elif ALPAKA_ARCH_PTX >= ALPAKA_VERSION_NUMBER(7, 0, 0)
+            // only acq_rel and sc available
+            if constexpr(std::is_same_v<TMemOrder, mem_order::Relaxed>)
+            { // Relaxed ordering requires no fence
+            }
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::Acquire>)
+            {
+                asm volatile("fence.acq_rel.cta;" ::);
+            }
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::Release>)
+            {
+                asm volatile("fence.acq_rel.cta;" ::);
+            }
+            else if constexpr(std::is_same_v<TMemOrder, mem_order::AcqRel>)
+            {
+                asm volatile("fence.acq_rel.cta;" ::);
+            }
+            else
+            { // Sequential consistency
+                asm volatile("fence.sc.cta;" ::);
+            }
+#        endif
+        }
+
+        template<alpaka::MemoryOrder TMemOrder>
+        [[maybe_unused]] static constexpr __device__ void cuda_mem_fence_block([[maybe_unused]] TMemOrder order)
+        {
+            if constexpr(std::is_same_v<TMemOrder, mem_order::Relaxed>)
+            { // Relaxed ordering requires no fence
+                return;
+            }
+#        if ALPAKA_ARCH_PTX
+#            if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0)
+            __nv_atomic_thread_fence(MemOrderCuda::get(order), __NV_THREAD_SCOPE_BLOCK);
+#            elif ALPAKA_ARCH_PTX >= ALPAKA_VERSION_NUMBER(7, 0, 0)
+            cuda_ptx_fence_block(order);
+#            else
+            __threadfence_block();
+#            endif
+#        endif
+        }
+
+        template<alpaka::MemoryOrder TMemOrder>
+        [[maybe_unused]] static constexpr __device__ void cuda_mem_fence_device([[maybe_unused]] TMemOrder order)
+        {
+            if constexpr(std::is_same_v<TMemOrder, mem_order::Relaxed>)
+            { // Relaxed ordering requires no fence
+                return;
+            }
+#        if ALPAKA_ARCH_PTX
+#            if ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0)
+            __nv_atomic_thread_fence(MemOrderCuda::get(order), __NV_THREAD_SCOPE_DEVICE);
+#            elif ALPAKA_ARCH_PTX >= ALPAKA_VERSION_NUMBER(7, 0, 0)
+            cuda_ptx_fence_device(order);
+#            else
+            __threadfence();
+#            endif
+#        endif
+        }
+    } // namespace detail
+
     namespace trait
     {
         template<>
-        struct MemFence<MemFenceUniformCudaHipBuiltIn, memory_scope::Block>
+        struct MemFenceDefaultOrder<MemFenceUniformCudaHipBuiltIn>
         {
-            __device__ static auto mem_fence(MemFenceUniformCudaHipBuiltIn const&, memory_scope::Block const&)
+            using type = mem_order::SeqCst;
+            static constexpr auto value = mem_order::seq_cst;
+        };
+
+        template<MemoryOrder TMemOrder>
+        struct MemFence<MemFenceUniformCudaHipBuiltIn, TMemOrder, memory_scope::Block>
+        {
+            static __device__ auto mem_fence(
+                MemFenceUniformCudaHipBuiltIn const&,
+                TMemOrder order,
+                memory_scope::Block const&)
             {
-                __threadfence_block();
+#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+                alpaka::detail::cuda_mem_fence_block(order);
+#        else
+                __builtin_amdgcn_fence(MemOrderHip::get(order), "workgroup");
+#        endif
             }
         };
 
-        template<>
-        struct MemFence<MemFenceUniformCudaHipBuiltIn, memory_scope::Grid>
+        template<MemoryOrder TMemOrder, typename TMemScope>
+        struct MemFence<MemFenceUniformCudaHipBuiltIn, TMemOrder, TMemScope>
         {
-            __device__ static auto mem_fence(MemFenceUniformCudaHipBuiltIn const&, memory_scope::Grid const&)
+            static __device__ auto mem_fence(MemFenceUniformCudaHipBuiltIn const&, TMemOrder order, TMemScope const&)
             {
+                // Base case for grid and device scope fences.
                 // CUDA and HIP do not have a per-grid memory fence, so a device-level fence is used
-                __threadfence();
+#        ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+                alpaka::detail::cuda_mem_fence_device(order);
+#        else
+                __builtin_amdgcn_fence(MemOrderHip::get(order), "agent");
+#        endif
             }
         };
 
-        template<>
-        struct MemFence<MemFenceUniformCudaHipBuiltIn, memory_scope::Device>
-        {
-            __device__ static auto mem_fence(MemFenceUniformCudaHipBuiltIn const&, memory_scope::Device const&)
-            {
-                __threadfence();
-            }
-        };
     } // namespace trait
-
 #    endif
 
 } // namespace alpaka

--- a/include/alpaka/mem/fence/Traits.hpp
+++ b/include/alpaka/mem/fence/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Jan Stephan, Andrea Bocci
+/* Copyright 2022 Jan Stephan, Andrea Bocci, Tapish Narwal
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -6,6 +6,7 @@
 
 #include "alpaka/core/Common.hpp"
 #include "alpaka/core/Interface.hpp"
+#include "alpaka/mem/order/MemoryOrder.hpp"
 
 namespace alpaka
 {
@@ -15,28 +16,45 @@ namespace alpaka
 
     namespace memory_scope
     {
+        struct MemoryScopeTag
+        {
+        };
+
         //! Memory fences are observed by all threads in the same block.
-        struct Block
+        struct Block : MemoryScopeTag
         {
         };
 
         //! Memory fences are observed by all threads in the same grid.
-        struct Grid
+        struct Grid : MemoryScopeTag
         {
         };
 
         //! Memory fences are observed by all threads on the device.
-        struct Device
+        struct Device : MemoryScopeTag
         {
         };
     } // namespace memory_scope
+
+    template<typename T>
+    concept MemoryScope = std::derived_from<T, memory_scope::MemoryScopeTag>;
 
     //! The memory fence trait.
     namespace trait
     {
         //! The mem_fence trait.
-        template<typename TMemFence, typename TMemScope, typename TSfinae = void>
+        template<typename TMemFence, MemoryOrder TMemOrder, MemoryScope TMemScope, typename TSfinae = void>
         struct MemFence;
+
+        template<typename TAcc>
+        struct MemFenceDefaultOrder;
+
+        template<typename TAcc>
+        using MemFenceDefaultOrder_t = typename MemFenceDefaultOrder<TAcc>::type;
+
+        template<typename TAcc>
+        inline constexpr auto MemFenceDefaultOrder_v = MemFenceDefaultOrder<TAcc>::value;
+
     } // namespace trait
 
     //! Issues memory fence instructions.
@@ -54,13 +72,36 @@ namespace alpaka
     //
     //! \tparam TMemFence The memory fence implementation type.
     //! \tparam TMemScope The memory scope type.
+    //! \tparam TMemOrder The memory order type.
     //! \param fence The memory fence implementation.
     //! \param scope The memory scope.
     ALPAKA_NO_HOST_ACC_WARNING
-    template<typename TMemFence, typename TMemScope>
+    template<typename TMemFence, MemoryOrder TMemOrder, MemoryScope TMemScope>
+    ALPAKA_FN_ACC auto mem_fence(TMemFence const& fence, TMemOrder order, TMemScope const& scope) -> void
+    {
+        using ImplementationBase = interface::ImplementationBase<ConceptMemFence, TMemFence>;
+        if constexpr(std::is_same_v<TMemOrder, mem_order::Relaxed>)
+        {
+            // Relaxed ordering requires no fence.
+            // Relaxed memory fences make no sense at all anyway. It is an oxymoron. This should not be used.
+            // STL says it is a noop. https://en.cppreference.com/w/cpp/atomic/atomic_thread_fence.html
+            // OpenMP does not provide a relaxed flush at all. https://www.openmp.org/spec-html/5.0/openmpsu96.html
+            // Sycl says it is a noop. https://github.khronos.org/SYCL_Reference/iface/barriers-and-fences.html
+            // When using relaxed with mem fences, nvcc generates PTX for a sequenitally consistent fence
+            // This may be a problem also with HIP, so we explicitly skip it for all backends
+        }
+        else
+        {
+            trait::MemFence<ImplementationBase, TMemOrder, TMemScope>::mem_fence(fence, order, scope);
+        }
+    }
+
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TMemFence, MemoryScope TMemScope>
     ALPAKA_FN_ACC auto mem_fence(TMemFence const& fence, TMemScope const& scope) -> void
     {
         using ImplementationBase = interface::ImplementationBase<ConceptMemFence, TMemFence>;
-        trait::MemFence<ImplementationBase, TMemScope>::mem_fence(fence, scope);
+        mem_fence(fence, trait::MemFenceDefaultOrder_v<ImplementationBase>, scope);
     }
+
 } // namespace alpaka

--- a/include/alpaka/mem/fence/Traits.hpp
+++ b/include/alpaka/mem/fence/Traits.hpp
@@ -34,6 +34,11 @@ namespace alpaka
         struct Device : MemoryScopeTag
         {
         };
+
+        static constexpr auto device = Device{};
+        static constexpr auto grid = Grid{};
+        static constexpr auto block = Block{};
+
     } // namespace memory_scope
 
     template<typename T>

--- a/include/alpaka/mem/order/MemOrderBoost.hpp
+++ b/include/alpaka/mem/order/MemOrderBoost.hpp
@@ -6,37 +6,42 @@
 
 #include "alpaka/mem/order/MemoryOrder.hpp"
 
-#include <atomic>
 #include <concepts>
+
+#ifndef ALPAKA_DISABLE_ATOMIC_ATOMICREF
+#    ifndef ALPAKA_HAS_STD_ATOMIC_REF
+#        include <boost/memory_order.hpp>
 
 namespace alpaka
 {
-    struct MemOrderStl
+    struct MemOrderBoost
     {
         template<MemoryOrder TMemOrder>
         static constexpr auto get(TMemOrder)
         {
             if constexpr(std::same_as<TMemOrder, mem_order::SeqCst>)
             {
-                return std::memory_order::seq_cst;
+                return boost::memory_order::seq_cst;
             }
             if constexpr(std::same_as<TMemOrder, mem_order::AcqRel>)
             {
-                return std::memory_order::acq_rel;
+                return boost::memory_order::acq_rel;
             }
             if constexpr(std::same_as<TMemOrder, mem_order::Release>)
             {
-                return std::memory_order::release;
+                return boost::memory_order::release;
             }
             if constexpr(std::same_as<TMemOrder, mem_order::Acquire>)
             {
-                return std::memory_order::acquire;
+                return boost::memory_order_acquire;
             }
             if constexpr(std::same_as<TMemOrder, mem_order::Relaxed>)
             {
-                return std::memory_order::relaxed;
+                return boost::memory_order_relaxed;
             }
         }
     };
 
 } // namespace alpaka
+#    endif
+#endif

--- a/include/alpaka/mem/order/MemOrderCuda.hpp
+++ b/include/alpaka/mem/order/MemOrderCuda.hpp
@@ -1,0 +1,47 @@
+/* Copyright 2025 Tapish Narwal
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/core/Config.hpp"
+#include "alpaka/core/PP.hpp"
+#include "alpaka/mem/order/MemoryOrder.hpp"
+
+#include <concepts>
+
+#if defined ALPAKA_ACC_GPU_CUDA_ENABLED && ALPAKA_LANG_CUDA >= ALPAKA_VERSION_NUMBER(12, 8, 0) && ALPAKA_ARCH_PTX
+
+namespace alpaka
+{
+    struct MemOrderCuda
+    {
+        template<MemoryOrder TMemOrder>
+        static constexpr auto get(TMemOrder)
+        {
+            if constexpr(std::same_as<TMemOrder, mem_order::SeqCst>)
+            {
+                return __NV_ATOMIC_SEQ_CST;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::AcqRel>)
+            {
+                return __NV_ATOMIC_ACQ_REL;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::Release>)
+            {
+                return __NV_ATOMIC_RELEASE;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::Acquire>)
+            {
+                return __NV_ATOMIC_ACQUIRE;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::Relaxed>)
+            {
+                return __NV_ATOMIC_RELAXED;
+            }
+        }
+    };
+
+} // namespace alpaka
+
+#endif

--- a/include/alpaka/mem/order/MemOrderGenericSycl.hpp
+++ b/include/alpaka/mem/order/MemOrderGenericSycl.hpp
@@ -1,0 +1,48 @@
+/* Copyright 2025 Tapish Narwal
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/mem/order/MemoryOrder.hpp"
+
+#include <concepts>
+
+#ifdef ALPAKA_ACC_SYCL_ENABLED
+
+#    include <sycl/sycl.hpp>
+
+namespace alpaka
+{
+
+    struct MemOrderSycl
+    {
+        template<MemoryOrder TMemOrder>
+        static constexpr auto get(TMemOrder)
+        {
+            if constexpr(std::same_as<TMemOrder, mem_order::SeqCst>)
+            {
+                return sycl::memory_order::seq_cst;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::AcqRel>)
+            {
+                return sycl::memory_order::acq_rel;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::Release>)
+            {
+                return sycl::memory_order::release;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::Acquire>)
+            {
+                return sycl::memory_order::acquire;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::Relaxed>)
+            {
+                return sycl::memory_order::relaxed;
+            }
+        }
+    };
+
+} // namespace alpaka
+
+#endif

--- a/include/alpaka/mem/order/MemOrderHip.hpp
+++ b/include/alpaka/mem/order/MemOrderHip.hpp
@@ -1,0 +1,45 @@
+/* Copyright 2025 Tapish Narwal
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/mem/order/MemoryOrder.hpp"
+
+#include <concepts>
+
+#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
+
+namespace alpaka
+{
+    struct MemOrderHip
+    {
+        template<MemoryOrder TMemOrder>
+        static constexpr auto get(TMemOrder)
+        {
+            if constexpr(std::same_as<TMemOrder, mem_order::SeqCst>)
+            {
+                return __ATOMIC_SEQ_CST;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::AcqRel>)
+            {
+                return __ATOMIC_ACQ_REL;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::Release>)
+            {
+                return __ATOMIC_RELEASE;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::Acquire>)
+            {
+                return __ATOMIC_ACQUIRE;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::Relaxed>)
+            {
+                return __ATOMIC_RELAXED;
+            }
+        }
+    };
+
+} // namespace alpaka
+
+#endif

--- a/include/alpaka/mem/order/MemOrderStl.hpp
+++ b/include/alpaka/mem/order/MemOrderStl.hpp
@@ -1,0 +1,43 @@
+/* Copyright 2025 Tapish Narwal
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include "alpaka/mem/order/MemoryOrder.hpp"
+
+#include <atomic>
+#include <concepts>
+
+namespace alpaka
+{
+    struct MemOrderStl
+    {
+        template<MemoryOrder TMemOrder>
+        static constexpr auto get(TMemOrder)
+        {
+            if constexpr(std::same_as<TMemOrder, mem_order::SeqCst>)
+            {
+                return std::memory_order::seq_cst;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::AcqRel>)
+            {
+                return std::memory_order::acq_rel;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::Release>)
+            {
+                return std::memory_order::release;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::Acquire>)
+            {
+                return std::memory_order::acquire;
+            }
+            if constexpr(std::same_as<TMemOrder, mem_order::Relaxed>)
+            {
+                return std::memory_order::relaxed;
+            }
+        }
+    };
+
+
+} // namespace alpaka

--- a/include/alpaka/mem/order/MemoryOrder.hpp
+++ b/include/alpaka/mem/order/MemoryOrder.hpp
@@ -1,0 +1,55 @@
+/* Copyright 2025 Tapish Narwal
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+#pragma once
+
+#include <concepts>
+
+namespace alpaka
+{
+    namespace mem_order
+    {
+        /**
+         * The user requested memory order may be converted to a stronger memory order guarantee if the backend does
+         * not support the requested memory ordering
+         * If the user requests a memory ordering which is stronger than what is possible, we throw an error statically
+         */
+
+        struct MemoryOrderTag
+        {
+        };
+
+        struct SeqCst : MemoryOrderTag
+        {
+        };
+
+        struct AcqRel : MemoryOrderTag
+        {
+        };
+
+        struct Release : MemoryOrderTag
+        {
+        };
+
+        struct Acquire : MemoryOrderTag
+        {
+        };
+
+        struct Relaxed : MemoryOrderTag
+        {
+        };
+
+        static constexpr SeqCst seq_cst;
+        static constexpr AcqRel acq_rel;
+        static constexpr Release release;
+        static constexpr Acquire acquire;
+        static constexpr Relaxed relaxed;
+
+
+    } // namespace mem_order
+
+    template<typename T>
+    concept MemoryOrder = std::derived_from<T, mem_order::MemoryOrderTag>;
+
+} // namespace alpaka

--- a/include/alpaka/mem/order/MemoryOrder.hpp
+++ b/include/alpaka/mem/order/MemoryOrder.hpp
@@ -46,7 +46,6 @@ namespace alpaka
         static constexpr Acquire acquire;
         static constexpr Relaxed relaxed;
 
-
     } // namespace mem_order
 
     template<typename T>


### PR DESCRIPTION
Add support for memory ordered atomics. Closes #2123 
Sets the old behaviour of relaxed atomics as the default. 
Also makes atomic ref ordering relaxed by default. Closes #2172 

We emulate ordered atomics using fences when ordered atomics available natively.
We fall back to stronger guarantees if a backend does not support the requested order.
For CUDA in particular we do this according to [this resource](https://docs.nvidia.com/cuda/ptx-writers-guide-to-interoperability/index.html#atomics-application-binary-interface).

- [x] Needs #2581 to be merged before this, as it depends on the fence implementation to emulate atomic orderings.
- [ ] Need to check and re-enable atomic min and max for HIP