### PR TITLE
Update the reference `mdspan` library to 2025.12.11

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -909,9 +909,10 @@ if (alpaka_USE_MDSPAN STREQUAL "SYSTEM")
 elseif (alpaka_USE_MDSPAN STREQUAL "FETCH")
     include(FetchContent)
     FetchContent_Declare(
+        # kokkos/mdspan as of 2025.12.11
         mdspan
         GIT_REPOSITORY https://github.com/kokkos/mdspan.git
-        GIT_TAG 973ef6415a6396e5f0a55cb4c99afd1d1d541681
+        GIT_TAG bcfcc9ea8fc5390b99261a4d8450c3f2fc18a7f2
     )
     # we don't use FetchContent_MakeAvailable(mdspan) since it would also install mdspan
     # see also: https://stackoverflow.com/questions/65527126/how-to-disable-installation-a-fetchcontent-dependency
@@ -925,10 +926,10 @@ elseif (alpaka_USE_MDSPAN STREQUAL "FETCH")
         endif()
     endif()
     if(${CMAKE_VERSION} VERSION_LESS "3.25.0")
-        get_target_property(mdspan_include_dir std::mdspan INTERFACE_INCLUDE_DIRECTORIES)
+        get_target_property(mdspan_include_dir mdspan::mdspan INTERFACE_INCLUDE_DIRECTORIES)
         target_include_directories(alpaka SYSTEM INTERFACE ${mdspan_include_dir})
     else()
-        target_link_libraries(alpaka INTERFACE std::mdspan)
+        target_link_libraries(alpaka INTERFACE mdspan::mdspan)
     endif()
     target_compile_definitions(alpaka INTERFACE ALPAKA_USE_MDSPAN)
 elseif (alpaka_USE_MDSPAN STREQUAL "OFF")

--- a/example/matrixMulWithMdspan/src/matrixMulMdSpan.cpp
+++ b/example/matrixMulWithMdspan/src/matrixMulMdSpan.cpp
@@ -6,22 +6,21 @@
 // Needed for running example for all backends available; one by one
 #include <alpaka/example/ExecuteForEachAccTag.hpp>
 
-#include <experimental/mdspan>
 #include <iostream>
 
 //! Matrix multiplication example by using mdspan data structure
 
 //! Some simple type traits for checking the types
-//! isMdspan simply checks if a type is of type std::experimental::mdspan or not
+//! isMdspan simply checks if a type is of type alpaka::experimental::mdspan or not
 //! Primary template for is_mdspan (defaults to false)
 template<typename T>
 struct IsMdspan : std::false_type
 {
 };
 
-//! Specialization for mdspan with four template arguments
-template<typename ElementType, typename Extents, typename LayoutPolicy, typename AccessorPolicy>
-struct IsMdspan<std::experimental::mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy>> : std::true_type
+//! Specialization for mdspan
+template<typename... TArgs>
+struct IsMdspan<alpaka::experimental::mdspan<TArgs...>> : std::true_type
 {
 };
 

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -24,8 +24,62 @@
 #include <iosfwd>
 #include <type_traits>
 #include <vector>
+
 #ifdef ALPAKA_USE_MDSPAN
-#    include <experimental/mdspan>
+#    ifdef ALPAKA_HAS_STD_MDSPAN
+//       mdspan from the standard library
+#        include <mdspan>
+#        include <version>
+
+namespace alpaka::experimental
+{
+    // Import C++23 mdspan into alpaka::experimental namespace.
+    // See https://wg21.link/P0009R18 .
+    using ::std::default_accessor;
+    using ::std::dextents;
+    using ::std::extents;
+    using ::std::layout_left;
+    using ::std::layout_right;
+    using ::std::layout_stride;
+    using ::std::mdspan;
+#        ifdef __cpp_lib_submdspan
+    // Import C++26 submdspan into alpaka::experimental namespace.
+    // See https://wg21.link/P2630R4 .
+    using ::std::full_extent;
+    using ::std::submdspan;
+#        endif
+} // namespace alpaka::experimental
+
+#    else
+
+#        ifdef ALPAKA_ACC_SYCL_ENABLED
+//           do not expose the macro definition of printf
+#            pragma push_macro("printf")
+#            ifdef printf
+#                undef printf
+#            endif
+#        endif // ALPAKA_ACC_SYCL_ENABLED
+
+#        if defined(ALPAKA_ACC_SYCL_ENABLED) && (defined(ALPAKA_SYCL_ONEAPI_FPGA) || defined(ALPAKA_SYCL_TARGET_FPGA))
+//           the fpga compiler does not handle well the [[no_unique_address]] attribute, resulting in:
+//               GEP has !intel-tbaa annotation but its "shape" is unexpected!
+//               /opt/intel/oneapi/compiler/2025.0/bin/compiler/llvm-link: error: linked module is broken!
+//               icpx: error: sycl-link command failed with exit code 1 (use -v to see invocation)
+#            include <experimental/__p0009_bits/config.hpp>
+#            undef MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS
+#            undef MDSPAN_IMPL_NO_UNIQUE_ADDRESS
+#            define MDSPAN_IMPL_NO_UNIQUE_ADDRESS
+#        endif
+
+//       mdspan from the Kokkos reference implementation
+#        define MDSPAN_IMPL_STANDARD_NAMESPACE alpaka::experimental
+#        include <experimental/mdspan>
+
+#        ifdef ALPAKA_ACC_SYCL_ENABLED
+//           restore the macro definition of printf
+#            pragma pop_macro("printf")
+#        endif // ALPAKA_ACC_SYCL_ENABLED
+#    endif
 #endif
 
 namespace alpaka
@@ -554,18 +608,6 @@ namespace alpaka
 #ifdef ALPAKA_USE_MDSPAN
     namespace experimental
     {
-        // import mdspan into alpaka::experimental namespace. see: https://eel.is/c++draft/mdspan.syn
-        using std::experimental::default_accessor;
-        using std::experimental::dextents;
-        using std::experimental::extents;
-        using std::experimental::layout_left;
-        using std::experimental::layout_right;
-        using std::experimental::layout_stride;
-        using std::experimental::mdspan;
-        // import submdspan as well, which is not standardized yet
-        using std::experimental::full_extent;
-        using std::experimental::submdspan;
-
         namespace traits
         {
             namespace detail
@@ -598,7 +640,7 @@ namespace alpaka
                 ALPAKA_FN_HOST auto makeExtents(TView const& view, std::index_sequence<Is...>)
                 {
                     auto const ex = getExtents(view);
-                    return std::experimental::dextents<Idx<TView>, Dim<TView>::value>{ex[Is]...};
+                    return dextents<Idx<TView>, Dim<TView>::value>{ex[Is]...};
                 }
             } // namespace detail
 


### PR DESCRIPTION
The latest tagged version, 0.6.0, has issues building with `hipcc` and the `clang -x cu`  GPU compilers. As of 2023.06.09 these issues were resolved.

More recent versions reworked the namespace used for `mdspan`, so we can directly define it in the `alpaka::experimental` namespace, without touching the `std` namespace.

The version as of 2025.12.11 passes all tests, with minimal adjustments for SYCL:
  - we need to not expose the macro implementation of `printf`;
  - we need a workaround for the `[[no_unique_address]]` attribute that breaks the FPGA compiler.