### PR TITLE
remove unused CI rules and enable clang cuda

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -396,11 +396,9 @@ if(alpaka_ACC_GPU_CUDA_ENABLE)
         if(CMAKE_CUDA_COMPILER_ID STREQUAL "Clang")
             message(STATUS "clang is used as CUDA compiler")
 
-            if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 14.0)
-                # clang-14 is the first version to fully support CUDA 11.x
-                message(FATAL_ERROR "clang as CUDA compiler requires at least clang-14.")
-            else()
-                message(WARNING "If you are using CUDA 11.3 please note of the following issue: https://github.com/alpaka-group/alpaka/issues/1857")
+            if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 17.0)
+                # clang-17 is the first version to support CUDA 12.x
+                message(FATAL_ERROR "clang as CUDA compiler requires at least clang-17.")
             endif()
 
             # workaround: ISA code parsing when compiling as debug with clang as CUDA compiler

--- a/script/install_clang.sh
+++ b/script/install_clang.sh
@@ -68,6 +68,12 @@ else
         travis_retry sudo apt-get -y --quiet --allow-unauthenticated --no-install-recommends install "${LIBOMP_PACKAGE}"
     fi
 
+    # Modern clang uses clang-linker-wrapper to create linked device images for offloading and the necessary runtime calls to register them
+    if { [ "${ALPAKA_CI_CLANG_VER}" -ge 20 ]; }
+    then
+        travis_retry sudo apt-get -y --quiet --allow-unauthenticated --no-install-recommends install clang-tools-${ALPAKA_CI_CLANG_VER}
+    fi
+
     which clang++-${ALPAKA_CI_CLANG_VER}
     export CMAKE_CXX_COMPILER=$(which clang++-${ALPAKA_CI_CLANG_VER})
 

--- a/script/job_generator/alpaka_filter.py
+++ b/script/job_generator/alpaka_filter.py
@@ -17,51 +17,11 @@ from alpaka_job_coverage.util import (
 
 
 def alpaka_post_filter(row: List) -> bool:
-    # debug builds with clang 15 and 16 as CUDA compiler produce a compiler error
-    # see here: https://github.com/llvm/llvm-project/issues/58491
-    if (
-        is_in_row(row, BUILD_TYPE)
-        and row[param_map[BUILD_TYPE]][VERSION] == CMAKE_DEBUG
-        and row_check_name(row, DEVICE_COMPILER, "==", CLANG_CUDA)
-    ):
-        for clang_cuda_version in ["15", "16", "17"]:
-            if row_check_version(row, HOST_COMPILER, "==", clang_cuda_version):
-                return False
-
-    # Debug builds with nvcc <= 11.6 produce compiler errors
-    if (
-        is_in_row(row, BUILD_TYPE)
-        and row[param_map[BUILD_TYPE]][VERSION] == CMAKE_DEBUG
-        and row_check_name(row, DEVICE_COMPILER, "==", NVCC)
-        and row_check_version(row, DEVICE_COMPILER, "<=", "11.6")
-    ):
-        return False
-
-    # because of a compiler bug, we disable mdspan for NVCC <= 11.2
-    if (
-        row_check_version(row, MDSPAN, "==", ON_VER)
-        and row_check_name(row, DEVICE_COMPILER, "==", NVCC)
-        and row_check_version(row, DEVICE_COMPILER, "<=", "11.2")
-    ):
-        return False
-
     # OpenMP is not supported for clang as cuda compiler
     # https://github.com/alpaka-group/alpaka/issues/639
     if row_check_name(row, DEVICE_COMPILER, "==", CLANG_CUDA) and (
         row_check_backend_version(row, ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE, "==", ON_VER)
         or row_check_backend_version(row, ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE, "==", ON_VER)
-    ):
-        return False
-
-    # there is a compiler bug in GCC 11.4 which avoids working with NVCC 11.5
-    if (
-        row_check_name(row, DEVICE_COMPILER, "==", NVCC)
-        and (
-            row_check_version(row, DEVICE_COMPILER, "==", "11.4")
-            or row_check_version(row, DEVICE_COMPILER, "==", "11.5")
-        )
-        and row_check_name(row, HOST_COMPILER, "==", GCC)
-        and row_check_version(row, HOST_COMPILER, "==", "11")
     ):
         return False
 
@@ -100,60 +60,68 @@ def alpaka_post_filter(row: List) -> bool:
     ):
         return False
 
-    # Clang-CUDA 18 only supports up to CUDA SDK 12.1
-    # if (
-    #     row_check_name(row, DEVICE_COMPILER, "==", CLANG_CUDA)
-    #     and row_check_version(row, DEVICE_COMPILER, "==", "18")
-    #     and row_check_backend_version(row, ALPAKA_ACC_GPU_CUDA_ENABLE, ">", "12.1")
-    # ):
-    #     return False
+    # Clang-CUDA has three support levels, full support, partial support, and if newer, then it throws a warning and continues.
+    # We only test unitl the partially supported version in the CI
 
-    # TODO(SimeonEhrig): disable Clang 18 and 19 as Clang-CUDA because of
-    # several bugs will be fixed in alpaka 2.0.0
+    # Clang-CUDA 16 and below officially only partially support as a maximum up to CUDA SDK 11.8, so we disable CI tests for these
+    if row_check_name(row, DEVICE_COMPILER, "==", CLANG_CUDA) and row_check_version(row, DEVICE_COMPILER, "<=", "16"):
+        return False
+
+    # Clang-CUDA 17 fully supports up to CUDA SDK 11.8 and partially upto 12.1
     if (
         row_check_name(row, DEVICE_COMPILER, "==", CLANG_CUDA)
-        and (
-            row_check_version(row, DEVICE_COMPILER, "==", "18")
-            or row_check_version(row, DEVICE_COMPILER, "==", "19")
-            or row_check_version(row, DEVICE_COMPILER, "==", "20")
-        )
-        and row_check_backend_version(row, ALPAKA_ACC_GPU_CUDA_ENABLE, "!=", OFF_VER)
+        and row_check_version(row, DEVICE_COMPILER, "==", "17")
+        and row_check_backend_version(row, ALPAKA_ACC_GPU_CUDA_ENABLE, ">", "12.1")
     ):
         return False
 
-    if row_check_name(row, DEVICE_COMPILER, "==", NVCC) and row_check_name(
-        row, HOST_COMPILER, "==", CLANG
+    # Clang-CUDA 18 fully supports up to CUDA SDK 12.3 (unless it is 18.0 which fully supports 12.1 only partially supports 12.3)
+    if (
+        row_check_name(row, DEVICE_COMPILER, "==", CLANG_CUDA)
+        and row_check_version(row, DEVICE_COMPILER, "==", "18")
+        and row_check_backend_version(row, ALPAKA_ACC_GPU_CUDA_ENABLE, ">", "12.3")
     ):
+        return False
+
+    # Clang-CUDA 19 fully supports up to CUDA SDK 12.3 and partially upto 12.5
+    if (
+        row_check_name(row, DEVICE_COMPILER, "==", CLANG_CUDA)
+        and row_check_version(row, DEVICE_COMPILER, "==", "19")
+        and row_check_backend_version(row, ALPAKA_ACC_GPU_CUDA_ENABLE, ">", "12.5")
+    ):
+        return False
+
+    # Clang-CUDA 20 fully supports up to CUDA SDK 12.3 and partially upto 12.8
+    if (
+        row_check_name(row, DEVICE_COMPILER, "==", CLANG_CUDA)
+        and row_check_version(row, DEVICE_COMPILER, "==", "20")
+        and row_check_backend_version(row, ALPAKA_ACC_GPU_CUDA_ENABLE, ">", "12.8")
+    ):
+        return False
+
+    if row_check_name(row, DEVICE_COMPILER, "==", NVCC) and row_check_name(row, HOST_COMPILER, "==", CLANG):
         # nvcc 12.5 is the minimum requirement for host compiler Clang 18
-        if row_check_version(row, HOST_COMPILER, "==", "18") and row_check_version(
-            row, DEVICE_COMPILER, "<=", "12.5"
-        ):
+        if row_check_version(row, HOST_COMPILER, "==", "18") and row_check_version(row, DEVICE_COMPILER, "<=", "12.5"):
             return False
 
         # nvcc 12.8 is the minimum requirement for host compiler Clang 19
-        if row_check_version(row, HOST_COMPILER, "==", "19") and row_check_version(
-            row, DEVICE_COMPILER, "<=", "12.6"
-        ):
+        if row_check_version(row, HOST_COMPILER, "==", "19") and row_check_version(row, DEVICE_COMPILER, "<=", "12.6"):
             return False
 
         # nvcc 13.0 is the minimum requirement for host compiler Clang 20
-        if row_check_version(row, HOST_COMPILER, "==", "20") and row_check_version(
-            row, DEVICE_COMPILER, "<=", "12.9"
-        ):
+        if row_check_version(row, HOST_COMPILER, "==", "20") and row_check_version(row, DEVICE_COMPILER, "<=", "12.9"):
             return False
 
     # the SYCL backends needs to be enabled if the icpx compiler is used
     if row_check_name(row, DEVICE_COMPILER, "==", ICPX):
-        if is_in_row(row, BACKENDS) and (
-            (ALPAKA_ACC_SYCL_ENABLE, ON_VER) not in row[param_map[BACKENDS]]
-        ):
+        if is_in_row(row, BACKENDS) and ((ALPAKA_ACC_SYCL_ENABLE, ON_VER) not in row[param_map[BACKENDS]]):
             return False
 
     # we use the Ubuntu 22.04 for
     # - HIP 6.0 until 6.2
     # - If Clang 14 and older is used
     # - If CUDA 12.3 and older is used, because the CUDA versions does not support the libstdc++ 13
-    #   which is provided by the Ubuntu host compiler GCC 13
+    # which is provided by the Ubuntu host compiler GCC 13
     # the ROCm Ubuntu support is handled by the alpaka-job-matrix-library
     if row_check_version(row, UBUNTU, "==", "22.04"):
         for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
@@ -162,17 +130,17 @@ def alpaka_post_filter(row: List) -> bool:
                     return False
 
             for compiler in (CLANG, CLANG_CUDA):
-                if row_check_name(
-                    row, compiler_type, "==", compiler
-                ) and row_check_version(row, compiler_type, ">", "14"):
+                if row_check_name(row, compiler_type, "==", compiler) and row_check_version(
+                    row, compiler_type, ">", "14"
+                ):
                     return False
 
     if row_check_version(row, UBUNTU, "==", "24.04"):
         for compiler_type in (HOST_COMPILER, DEVICE_COMPILER):
             for compiler in (CLANG, CLANG_CUDA):
-                if row_check_name(
-                    row, compiler_type, "==", compiler
-                ) and row_check_version(row, compiler_type, "<", "15"):
+                if row_check_name(row, compiler_type, "==", compiler) and row_check_version(
+                    row, compiler_type, "<", "15"
+                ):
                     return False
             if (
                 row_check_name(row, DEVICE_COMPILER, "==", NVCC)

--- a/script/job_generator/generate_job_yaml.py
+++ b/script/job_generator/generate_job_yaml.py
@@ -395,7 +395,7 @@ def job_variables(job: Dict[str, Tuple[str, str]]) -> Dict[str, str]:
         if job[SYCL_DEVICE][NAME] == SYCL_CPU:
             variables["alpaka_SYCL_ONEAPI_CPU"] = "ON"
             variables["alpaka_SYCL_ONEAPI_CPU_ISA"] = "avx2"
-        if job[SYCL_DEVICE][NAME] == SYCL_FPGA: 
+        if job[SYCL_DEVICE][NAME] == SYCL_FPGA:
             variables["alpaka_SYCL_ONEAPI_FPGA"] = "ON"
             variables["alpaka_SYCL_ONEAPI_FPGA_MODE"] = "emulation"
             variables["alpaka_SYCL_ONEAPI_FPGA_BOARD"] = ""
@@ -420,8 +420,7 @@ def job_tags(job: Dict[str, Tuple[str, str]]) -> List[str]:
     if ALPAKA_ACC_GPU_CUDA_ENABLE in job and job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION] != OFF_VER:
         # CUDA 13.0+ does not support Pascal anymore
         # therefore we need to use the Nvidia A100
-        if (packaging.version.parse(job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION]) 
-                >= packaging.version.parse("13")):
+        if packaging.version.parse(job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION]) >= packaging.version.parse("13"):
             return ["x86_64", "cuda", "a100"]
         return ["x86_64", "cuda"]
     if ALPAKA_ACC_GPU_HIP_ENABLE in job and job[ALPAKA_ACC_GPU_HIP_ENABLE][VERSION] != OFF_VER:

--- a/script/job_generator/job_modifier.py
+++ b/script/job_generator/job_modifier.py
@@ -113,8 +113,9 @@ def add_job_parameters(job_matrix: List[Dict[str, Tuple[str, str]]]):
     for job in job_matrix:
         # the old Runner has Quadro P5000
         STANDARD_SM_LEVEL = "61"
-        if (ALPAKA_ACC_GPU_CUDA_ENABLE in job and 
-            version.parse(job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION]) >= version.parse("13.0")):
+        if ALPAKA_ACC_GPU_CUDA_ENABLE in job and version.parse(
+            job[ALPAKA_ACC_GPU_CUDA_ENABLE][VERSION]
+        ) >= version.parse("13.0"):
             # only on the new runner with Nvidia A100, the CUDA 13.0 builds are executed
             STANDARD_SM_LEVEL = "80"
         if (
@@ -141,14 +142,14 @@ def add_job_parameters(job_matrix: List[Dict[str, Tuple[str, str]]]):
 
 
 def add_sycl_fpga_jobs(job_matrix: List[Dict[str, Tuple[str, str]]]) -> List[Dict[str, Tuple[str, str]]]:
-    """Duplicate each job with enabled backend ALPAKA_ACC_SYCL_ENABLE and set 
+    """Duplicate each job with enabled backend ALPAKA_ACC_SYCL_ENABLE and set
     the SYCL_DEVICE to SYCL_CPU for the first and SYCL_FPGA for the second job.
     All other jobs get a neutral SYCL_DEVICE entry.
 
     Args:
         job_matrix (List[Dict[str, Tuple[str, str]]]): Job matrix
     Return:
-        (List[Dict[str, Tuple[str, str]]]): Job matrix with duplicated and 
+        (List[Dict[str, Tuple[str, str]]]): Job matrix with duplicated and
         extended jobs
     """
     extended_job_matrix = []
@@ -167,7 +168,5 @@ def add_sycl_fpga_jobs(job_matrix: List[Dict[str, Tuple[str, str]]]) -> List[Dic
         else:
             job[SYCL_DEVICE] = ("", "")
             extended_job_matrix.append(job)
-            
-
 
     return extended_job_matrix


### PR DESCRIPTION
Enable compiling `CUDA` code with the `clang` compiler
Remove old `gcc` and `nvcc` rules