### PR TITLE
Implement wrapper type for warp masks

### DIFF
--- a/include/alpaka/warp/Traits.hpp
+++ b/include/alpaka/warp/Traits.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Sergei Bastrakov, David M. Rogers, Bernhard Manfred Gruber, Aurora Perego
+/* Copyright 2026 Sergei Bastrakov, David M. Rogers, Bernhard Manfred Gruber, Aurora Perego, Simone Balducci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -118,8 +118,7 @@ namespace alpaka::warp
     //! \return 32-bit or 64-bit unsigned type depending on the accelerator.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TWarp>
-    ALPAKA_FN_ACC auto activemask(TWarp const& warp)
-        -> decltype(trait::Activemask<interface::ImplementationBase<ConceptWarp, TWarp>>::activemask(warp))
+    ALPAKA_FN_ACC auto activemask(TWarp const& warp) -> typename TWarp::mask_type
     {
         using ImplementationBase = interface::ImplementationBase<ConceptWarp, TWarp>;
         return trait::Activemask<ImplementationBase>::activemask(warp);
@@ -192,7 +191,7 @@ namespace alpaka::warp
     //! \return 32-bit or 64-bit unsigned type depending on the accelerator.
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TWarp>
-    ALPAKA_FN_ACC auto ballot(TWarp const& warp, std::int32_t predicate)
+    ALPAKA_FN_ACC auto ballot(TWarp const& warp, std::int32_t predicate) -> typename TWarp::mask_type
     {
         using ImplementationBase = interface::ImplementationBase<ConceptWarp, TWarp>;
         return trait::Ballot<ImplementationBase>::ballot(warp, predicate);

--- a/include/alpaka/warp/WarpGenericSycl.hpp
+++ b/include/alpaka/warp/WarpGenericSycl.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Jan Stephan, Luca Ferragina, Andrea Bocci, Aurora Perego
+/* Copyright 2026 Jan Stephan, Luca Ferragina, Andrea Bocci, Aurora Perego, Simone Balducci
  * SPDX-License-Identifier: MPL-2.0
  *
  * The implementations of Shfl::shfl(), ShflUp::shfl_up(), ShflDown::shfl_down() and ShflXor::shfl_xor() are derived
@@ -26,6 +26,8 @@ namespace alpaka::warp
     class WarpGenericSycl : public interface::Implements<alpaka::warp::ConceptWarp, WarpGenericSycl<TDim>>
     {
     public:
+        using mask_type = std::uint32_t;
+
         WarpGenericSycl(sycl::nd_item<TDim::value> my_item) : m_item_warp{my_item}
         {
         }
@@ -36,6 +38,7 @@ namespace alpaka::warp
 
 namespace alpaka::warp::trait
 {
+
     template<typename TDim>
     struct GetSize<warp::WarpGenericSycl<TDim>>
     {
@@ -73,7 +76,7 @@ namespace alpaka::warp::trait
         // FIXME This should be std::uint64_t on AMD GCN architectures and on CPU,
         // but the former is not targeted in alpaka and CPU case is not supported in SYCL yet.
         // Restrict to warpSize <= 32 for now.
-        static auto activemask(warp::WarpGenericSycl<TDim> const& /*warp*/) -> std::uint32_t
+        static auto activemask(warp::WarpGenericSycl<TDim> const& /*warp*/) -> warp::WarpGenericSycl<TDim>::mask_type
         {
             sycl::sub_group sg = sycl::ext::oneapi::this_work_item::get_sub_group();
             auto const mask = sycl::ext::oneapi::group_ballot(sg, true);
@@ -109,7 +112,8 @@ namespace alpaka::warp::trait
         // FIXME This should be std::uint64_t on AMD GCN architectures and on CPU,
         // but the former is not targeted in alpaka and CPU case is not supported in SYCL yet.
         // Restrict to warpSize <= 32 for now.
-        static auto ballot(warp::WarpGenericSycl<TDim> const& /*warp*/, std::int32_t predicate) -> std::uint32_t
+        static auto ballot(warp::WarpGenericSycl<TDim> const& /*warp*/, std::int32_t predicate)
+            -> warp::WarpGenericSycl<TDim>::mask_type
         {
             auto sub_group = sycl::ext::oneapi::this_work_item::get_sub_group();
             auto const mask = sycl::ext::oneapi::group_ballot(sub_group, static_cast<bool>(predicate));

--- a/include/alpaka/warp/WarpSingleThread.hpp
+++ b/include/alpaka/warp/WarpSingleThread.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2022 Sergei Bastrakov, David M. Rogers, Bernhard Manfred Gruber, Aurora Perego
+/* Copyright 2026 Sergei Bastrakov, David M. Rogers, Bernhard Manfred Gruber, Aurora Perego, Simone Balducci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -11,12 +11,14 @@
 namespace alpaka::warp
 {
     //! The single-threaded warp to emulate it on CPUs.
-    class WarpSingleThread : public interface::Implements<ConceptWarp, WarpSingleThread>
+    struct WarpSingleThread : public interface::Implements<ConceptWarp, WarpSingleThread>
     {
+        using mask_type = std::uint32_t;
     };
 
     namespace trait
     {
+
         template<>
         struct GetSize<WarpSingleThread>
         {
@@ -47,7 +49,7 @@ namespace alpaka::warp
         template<>
         struct Activemask<WarpSingleThread>
         {
-            static auto activemask(warp::WarpSingleThread const& /*warp*/)
+            static auto activemask(warp::WarpSingleThread const& /*warp*/) -> WarpSingleThread::mask_type
             {
                 return 1u;
             }
@@ -75,6 +77,7 @@ namespace alpaka::warp
         struct Ballot<WarpSingleThread>
         {
             static auto ballot(warp::WarpSingleThread const& /*warp*/, std::int32_t predicate)
+                -> WarpSingleThread::mask_type
             {
                 return predicate ? 1u : 0u;
             }

--- a/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
@@ -1,4 +1,5 @@
-/* Copyright 2023 Sergei Bastrakov, David M. Rogers, Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber, Aurora Perego
+/* Copyright 2026 Sergei Bastrakov, David M. Rogers, Jan Stephan, Andrea Bocci, Bernhard Manfred Gruber, Aurora Perego,
+ * Simone Balducci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -15,8 +16,13 @@
 namespace alpaka::warp
 {
     //! The GPU CUDA/HIP warp.
-    class WarpUniformCudaHipBuiltIn : public interface::Implements<ConceptWarp, WarpUniformCudaHipBuiltIn>
+    struct WarpUniformCudaHipBuiltIn : public interface::Implements<ConceptWarp, WarpUniformCudaHipBuiltIn>
     {
+#    if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
+        using mask_type = std::uint32_t;
+#    else
+        using mask_type = std::uint64_t;
+#    endif
     };
 
 #    if !defined(ALPAKA_HOST_ONLY)
@@ -31,6 +37,7 @@ namespace alpaka::warp
 
     namespace trait
     {
+
         template<>
         struct GetSize<WarpUniformCudaHipBuiltIn>
         {
@@ -106,11 +113,7 @@ namespace alpaka::warp
         struct Activemask<WarpUniformCudaHipBuiltIn>
         {
             static __device__ auto activemask(warp::WarpUniformCudaHipBuiltIn const& /*warp*/)
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                -> std::uint32_t
-#        else
-                -> std::uint64_t
-#        endif
+                -> WarpUniformCudaHipBuiltIn::mask_type
             {
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
             || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
@@ -159,13 +162,7 @@ namespace alpaka::warp
         {
             static __device__ auto ballot(
                 [[maybe_unused]] warp::WarpUniformCudaHipBuiltIn const& warp,
-                std::int32_t predicate)
-            // return type is required by the compiler
-#        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-                -> std::uint32_t
-#        else
-                -> std::uint64_t
-#        endif
+                std::int32_t predicate) -> WarpUniformCudaHipBuiltIn::mask_type
             {
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
             || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))


### PR DESCRIPTION
This PR addresses issue #2615 from @fwyzard, implementing a wrapper type `alpaka::warp::Mask` around the type returned by `activeMask` and `ballot`, providing the same interface for all the backends.