### PR TITLE
fix shared memory test

### DIFF
--- a/test/integ/sharedMem/src/sharedMem.cpp
+++ b/test/integ/sharedMem/src/sharedMem.cpp
@@ -95,10 +95,10 @@ namespace alpaka::trait
         ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
             SharedMemKernel<TnumUselessWork, Val> const& /* sharedMemKernel */,
             TVec const& blockThreadExtent,
-            TVec const& threadElemExtent,
+            TVec const& /* threadElemExtent */,
             TArgs&&...) -> std::size_t
         {
-            return static_cast<std::size_t>(blockThreadExtent.prod() * threadElemExtent.prod()) * sizeof(Val);
+            return static_cast<std::size_t>(blockThreadExtent.prod()) * sizeof(Val);
         }
     };
 } // namespace alpaka::trait


### PR DESCRIPTION
The integration test for shared memory was allocating shared memory for the full grid instead of the block only.
The amount on exeets the typical available 64kiB, it was only passing because on CPU we allocate dynamic shared memory via `new` and it looks like on GPU there is no test.