### PR TITLE
fix error when passing `std::function` to `enqueue` with SYCL

### DIFF
--- a/include/alpaka/queue/sycl/QueueGenericSyclBase.hpp
+++ b/include/alpaka/queue/sycl/QueueGenericSyclBase.hpp
@@ -127,30 +127,31 @@ namespace alpaka
             }
 
             template<bool TBlocking, typename TTask>
-            auto enqueue(TTask const& task) -> void
+            auto enqueue(TTask&& task) -> void
             {
                 {
+                    using TaskType = std::decay_t<TTask>;
                     std::lock_guard<std::shared_mutex> lock{m_mutex};
 
                     clean_dependencies();
 
                     // Execute task
-                    if constexpr(is_sycl_task<TTask> && !is_sycl_kernel<TTask>) // Copy / Fill
+                    if constexpr(is_sycl_task<TaskType> && !is_sycl_kernel<TaskType>) // Copy / Fill
                     {
                         m_last_event = task(m_queue, m_dependencies); // Will call queue.{copy, fill} internally
                     }
                     else
                     {
                         m_last_event = m_queue.submit(
-                            [this, &task](sycl::handler& cgh)
+                            [this, captured_task = std::forward<TTask>(task)](sycl::handler& cgh) mutable
                             {
                                 if(!m_dependencies.empty())
                                     cgh.depends_on(m_dependencies);
 
-                                if constexpr(is_sycl_kernel<TTask>) // Kernel
-                                    task(cgh); // Will call cgh.parallel_for internally
+                                if constexpr(is_sycl_kernel<TaskType>) // Kernel
+                                    captured_task(cgh); // Will call cgh.parallel_for internally
                                 else // Host
-                                    cgh.host_task(task);
+                                    cgh.host_task(std::move(captured_task));
                             });
                     }
 
@@ -241,11 +242,11 @@ namespace alpaka
         template<concepts::Tag TTag, bool TBlocking, typename TTask>
         struct Enqueue<alpaka::detail::QueueGenericSyclBase<TTag, TBlocking>, TTask>
         {
-            static auto enqueue(alpaka::detail::QueueGenericSyclBase<TTag, TBlocking>& queue, TTask const& task)
-                -> void
+            template<typename UTask>
+            static auto enqueue(alpaka::detail::QueueGenericSyclBase<TTag, TBlocking>& queue, UTask&& task) -> void
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
-                queue.m_spQueueImpl->template enqueue<TBlocking>(task);
+                queue.m_spQueueImpl->template enqueue<TBlocking>(std::forward<UTask>(task));
             }
         };
 

--- a/include/alpaka/queue/sycl/QueueGenericSyclBase.hpp
+++ b/include/alpaka/queue/sycl/QueueGenericSyclBase.hpp
@@ -126,6 +126,9 @@ namespace alpaka
                 return m_last_event;
             }
 
+            // Perfect forwarding of the task is a backend-specific workaround for oneAPI SYCL internally converting
+            // host tasks to std::function&&. The portable way is to pass the task by const reference, as done by
+            // the other backends.
             template<bool TBlocking, typename TTask>
             auto enqueue(TTask&& task) -> void
             {

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -42,11 +42,28 @@ TEMPLATE_LIST_TEST_CASE("queueCallbackIsWorking", "[queue]", TestQueues)
     using Fixture = alpaka::test::QueueTestFixture<DevQueue>;
     Fixture f;
 
-    std::promise<bool> promise;
+    // Lambda callable
+    {
+        std::promise<bool> promise;
+        alpaka::enqueue(f.m_queue, [&]() { promise.set_value(true); });
+        CHECK(promise.get_future().get());
+    }
 
-    alpaka::enqueue(f.m_queue, [&]() { promise.set_value(true); });
+    // std::function rvalue
+    {
+        std::promise<bool> promise;
+        std::function<void()> callback = [&]() { promise.set_value(true); };
+        alpaka::enqueue(f.m_queue, std::move(callback));
+        CHECK(promise.get_future().get());
+    }
 
-    CHECK(promise.get_future().get());
+    // std::function lvalue
+    {
+        std::promise<bool> promise;
+        std::function<void()> callback = [&]() { promise.set_value(true); };
+        alpaka::enqueue(f.m_queue, callback);
+        CHECK(promise.get_future().get());
+    }
 }
 
 TEMPLATE_LIST_TEST_CASE("queueTaskValueCategories", "[queue]", TestQueues)


### PR DESCRIPTION
Changing the SYCL queue's `enqueue` to use perfect forwarding instead of accepting arguments by const ref.

With oneAPI 2025, passing a host callback in form of `std::function` to `enqueue` method gives a compilation error. This is because oneAPI internally accepts the argument by `std::function&&`:

- Passing a non-`std::function` callable by const ref works because it is converted to a temporary `std::function`.
- Passing a `const std::function&` does not work, since it can't be converted to rvalue `std::function` and gives following error

```
/opt/intel/oneapi/compiler/2025.0/bin/compiler/../../include/sycl/handler.hpp:1878:5: error: no matching member function for call to 'SetHostTask'
 1878 |     SetHostTask(std::move(Func));
      |     ^~~~~~~~~~~
/opt/intel/oneapi/compiler/2025.0/bin/compiler/../../include/sycl/handler.hpp:2100:5: note: in instantiation of function template specialization 'sycl::handler::host_task_impl<const std::function<void ()> &>' requested here
 2100 |     host_task_impl(Func);
      |     ^
/__w/acts/acts/build/_deps/alpaka-src/include/alpaka/queue/sycl/QueueGenericSyclBase.hpp:153:41: note: in instantiation of function template specialization 'sycl::handler::host_task<const std::function<void ()> &>' requested here
  153 |                                     cgh.host_task(task);
      |                                         ^
/__w/acts/acts/build/_deps/alpaka-src/include/alpaka/queue/sycl/QueueGenericSyclBase.hpp:248:47: note: in instantiation of function template specialization 'alpaka::detail::QueueGenericSyclImpl::enqueue<false, std::function<void ()>>' requested here
  248 |                 queue.m_spQueueImpl->template enqueue<TBlocking>(task);
      |                                               ^
/__w/acts/acts/build/_deps/alpaka-src/include/alpaka/queue/Traits.hpp:49:54: note: in instantiation of member function 'alpaka::trait::Enqueue<alpaka::detail::QueueGenericSyclBase<alpaka::TagGpuSyclIntel, false>, std::function<void ()>>::enqueue' requested here
   49 |         trait::Enqueue<TQueue, std::decay_t<TTask>>::enqueue(queue, std::forward<TTask>(task));
      |                                                      ^
/__w/acts/acts/Traccc/device/alpaka/src/utils/queue.cpp:60:13: note: in instantiation of function template specialization 'alpaka::enqueue<alpaka::detail::QueueGenericSyclBase<alpaka::TagGpuSyclIntel, false>, std::function<void ()>>' requested here
   60 |   ::alpaka::enqueue(*m_impl->m_queue, std::move(func));
      |             ^
/opt/intel/oneapi/compiler/2025.0/bin/compiler/../../include/sycl/handler.hpp:1863:8: note: candidate function not viable: 1st argument ('typename std::remove_reference<const function<void ()> &>::type' (aka 'const std::function<void ()>')) would lose const qualifier
 1863 |   void SetHostTask(std::function<void()> &&Func);
      |        ^           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/intel/oneapi/compiler/2025.0/bin/compiler/../../include/sycl/handler.hpp:1864:8: note: candidate function not viable: no known conversion from 'function<void ()>' to 'function<void (interop_handle)>' for 1st argument
 1864 |   void SetHostTask(std::function<void(interop_handle)> &&Func);
      |        ^           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

As I propose, perfect forwarding preserves the task's value categor, allowing `std::function` rvalues to reach `host_task` without being converted to const ref and avoiding the compilation error.

This change makes the SYCL backend's enqueue implementation differ from the other accelerator backends, which still accept tasks by const ref. Those backends are unaffected because they internally don't require forwarding it as an rvalue.