### PR TITLE
Bump actions and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Keep dependencies for GitHub Actions up-to-date
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
   clang-format:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - uses: DoozyX/clang-format-lint-action@v0.16.2
       with:
         clangFormatVersion: 16
@@ -86,7 +86,7 @@ jobs:
         inplace: True
     - run: |
         git diff --exit-code > format.patch
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: format.patch
@@ -190,7 +190,7 @@ jobs:
     - name: check filter
       if: (contains(github.event.head_commit.message, 'ci_filter') && !contains(github.event.head_commit.message, matrix.name ))
       run: exit 1
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     # Print the environment variables in an additional step so that the environment variables can be displayed if the job is still running.
     # Call ./script/set_default_env_vars.sh in each step, as the environment variables are not shared between the steps by default.
     - name: print environment variables

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,14 +8,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Build Doxygen Documentation
         uses: mattnotmitt/doxygen-action@v1.9
         with:
           working-directory: docs
       - name: Upload HTML output as artifact
         id: deployment
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/doxygen/html
 
@@ -33,4 +33,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/job-generator.yml
+++ b/.github/workflows/job-generator.yml
@@ -5,7 +5,7 @@ jobs:
     name: runner black code formatter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: psf/black@stable
         with:
           options: "--check --verbose"
@@ -16,9 +16,9 @@ jobs:
     name: run mypy linter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           architecture: x64
@@ -36,9 +36,9 @@ jobs:
     name: run pylint linter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           architecture: x64
@@ -56,9 +56,9 @@ jobs:
     name: run unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
           architecture: x64

--- a/.github/workflows/single-header.yml
+++ b/.github/workflows/single-header.yml
@@ -11,7 +11,7 @@ jobs:
   single-header:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: clone single-header
       run: |
         git clone -b single-header --single-branch https://x-access-token:${{secrets.github_token}}@github.com/${{github.repository}}.git single-header

--- a/.github/workflows/verify-readme.yml
+++ b/.github/workflows/verify-readme.yml
@@ -8,7 +8,7 @@ jobs:
   check-readme:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: verify that the compiler support table is up to date
       run: |
         ./script/readme_generator/generate_supported_compilers.py --verify


### PR DESCRIPTION
Checking the job logs for another actions I noticed deprecation warnings on several actions used in the CI.
I suggest to add a depenbabot config so github will periodically check and open a PR if a new version of used action was released so they don't get outdated again