### PR TITLE
Remove CUDA/HIP attributes from deduction guides

### DIFF
--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -522,8 +522,10 @@ namespace alpaka
     };
 
     template<typename TFirstIndex, typename... TRestIndices>
-    ALPAKA_FN_HOST_ACC Vec(TFirstIndex&&, TRestIndices&&...)
-        -> Vec<DimInt<1 + sizeof...(TRestIndices)>, std::decay_t<TFirstIndex>>;
+#if ALPAKA_COMP_CLANG < ALPAKA_VERSION_NUMBER(22, 1, 0)
+    ALPAKA_FN_HOST_ACC
+#endif
+    Vec(TFirstIndex&&, TRestIndices&&...) -> Vec<DimInt<1 + sizeof...(TRestIndices)>, std::decay_t<TFirstIndex>>;
 
     template<typename T>
     inline constexpr bool isVec = false;

--- a/include/alpaka/workdiv/WorkDivMembers.hpp
+++ b/include/alpaka/workdiv/WorkDivMembers.hpp
@@ -97,9 +97,8 @@ namespace alpaka
     };
 
     //! Deduction guide for the constructor which can be called without explicit template type parameters
-    ALPAKA_NO_HOST_ACC_WARNING
     template<typename TDim, typename TIdx>
-    ALPAKA_FN_HOST_ACC WorkDivMembers(
+    WorkDivMembers(
         alpaka::Vec<TDim, TIdx> const& gridBlockExtent,
         alpaka::Vec<TDim, TIdx> const& blockThreadExtent,
         alpaka::Vec<TDim, TIdx> const& elemExtent) -> WorkDivMembers<TDim, TIdx>;


### PR DESCRIPTION
With the latest clang versions the use of CUDA/HIP `__host__` and `__device__` attributes in deduction guides is deprecated, so this PR removes them.