### PR TITLE
Add support for oneAPI 2026.0

### DIFF
--- a/include/alpaka/platform/PlatformGenericSycl.hpp
+++ b/include/alpaka/platform/PlatformGenericSycl.hpp
@@ -239,7 +239,7 @@ namespace alpaka
                 std::cout << "Aspects: " << '\n';
 
 #        if defined(ALPAKA_COMP_ICPX)
-#            if ALPAKA_COMP_ICPX >= ALPAKA_VERSION_NUMBER(53, 2, 0)
+#            if ALPAKA_COMP_ICPX >= ALPAKA_VERSION_NUMBER(2023, 2, 0)
                 // These aspects are missing from oneAPI versions < 2023.2.0
                 if(device.has(sycl::aspect::emulated))
                     std::cout << "\t* emulated\n";
@@ -554,7 +554,7 @@ namespace alpaka
                 print_memory_orders(mem_orders);
 
 #        if defined(ALPAKA_COMP_ICPX)
-#            if ALPAKA_COMP_ICPX >= ALPAKA_VERSION_NUMBER(53, 2, 0)
+#            if ALPAKA_COMP_ICPX >= ALPAKA_VERSION_NUMBER(2023, 2, 0)
                 // Not implemented in oneAPI < 2023.2.0
                 std::cout << "Supported memory orderings for sycl::atomic_fence: ";
                 auto const fence_orders = device.get_info<sycl::info::device::atomic_fence_order_capabilities>();
@@ -598,7 +598,7 @@ namespace alpaka
                 print_memory_scopes(mem_scopes);
 
 #        if defined(ALPAKA_COMP_ICPX)
-#            if ALPAKA_COMP_ICPX >= ALPAKA_VERSION_NUMBER(53, 2, 0)
+#            if ALPAKA_COMP_ICPX >= ALPAKA_VERSION_NUMBER(2023, 2, 0)
                 // Not implemented in oneAPI < 2023.2.0
                 std::cout << "Supported memory scopes for sycl::atomic_fence: ";
                 auto const fence_scopes = device.get_info<sycl::info::device::atomic_fence_scope_capabilities>();

--- a/include/alpaka/warp/WarpGenericSycl.hpp
+++ b/include/alpaka/warp/WarpGenericSycl.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "alpaka/core/Assert.hpp"
+#include "alpaka/core/Config.hpp"
 #include "alpaka/warp/Traits.hpp"
 
 #include <cstdint>
@@ -38,6 +39,13 @@ namespace alpaka::warp
 
 namespace alpaka::warp::trait
 {
+    // oneAPI up to 2025.3 uses sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group(),
+    // while oneAPI 2026.0 uses sycl::ext::oneapi::experimental::this_work_item::get_opportunistic_group()
+#    if ALPAKA_COMP_ICPX >= ALPAKA_VERSION_NUMBER(2026, 0, 0)
+    using sycl::ext::oneapi::experimental::this_work_item::get_opportunistic_group;
+#    else
+    using sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group;
+#    endif
 
     template<typename TDim>
     struct GetSize<warp::WarpGenericSycl<TDim>>
@@ -91,7 +99,7 @@ namespace alpaka::warp::trait
     {
         static auto all(warp::WarpGenericSycl<TDim> const& /*warp*/, std::int32_t predicate) -> std::int32_t
         {
-            auto activegroup = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
+            auto activegroup = get_opportunistic_group();
             return static_cast<std::int32_t>(sycl::all_of_group(activegroup, static_cast<bool>(predicate)));
         }
     };
@@ -101,7 +109,7 @@ namespace alpaka::warp::trait
     {
         static auto any(warp::WarpGenericSycl<TDim> const& /*warp*/, std::int32_t predicate) -> std::int32_t
         {
-            auto activegroup = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
+            auto activegroup = get_opportunistic_group();
             return static_cast<std::int32_t>(sycl::any_of_group(activegroup, static_cast<bool>(predicate)));
         }
     };
@@ -145,7 +153,7 @@ namespace alpaka::warp::trait
                Example: If we assume a sub-group size of 32 and a width of 16 we will receive two subdivisions:
                The first starts at sub-group index 0 and the second at sub-group index 16. For srcLane = 4 the
                first subdivision will access the value at sub-group index 4 and the second at sub-group index 20. */
-            auto actual_group = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
+            auto actual_group = get_opportunistic_group();
             std::uint32_t const w = static_cast<std::uint32_t>(width);
             std::uint32_t const start_index = actual_group.get_local_linear_id() / w * w;
             return sycl::select_from_group(actual_group, value, start_index + static_cast<std::uint32_t>(srcLane) % w);
@@ -162,7 +170,7 @@ namespace alpaka::warp::trait
             std::uint32_t offset, /* must be the same for all work-items in the group */
             std::int32_t width)
         {
-            auto actual_group = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
+            auto actual_group = get_opportunistic_group();
             std::uint32_t const w = static_cast<std::uint32_t>(width);
             std::uint32_t const id = actual_group.get_local_linear_id();
             std::uint32_t const start_index = id / w * w;
@@ -185,7 +193,7 @@ namespace alpaka::warp::trait
             std::uint32_t offset,
             std::int32_t width)
         {
-            auto actual_group = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
+            auto actual_group = get_opportunistic_group();
             std::uint32_t const w = static_cast<std::uint32_t>(width);
             std::uint32_t const id = actual_group.get_local_linear_id();
             std::uint32_t const end_index = (id / w + 1) * w;
@@ -208,7 +216,7 @@ namespace alpaka::warp::trait
             std::int32_t mask,
             std::int32_t width)
         {
-            auto actual_group = sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group();
+            auto actual_group = get_opportunistic_group();
             std::uint32_t const w = static_cast<std::uint32_t>(width);
             std::uint32_t const id = actual_group.get_local_linear_id();
             std::uint32_t const start_index = id / w * w;

--- a/test/unit/warp/src/Activemask.cpp
+++ b/test/unit/warp/src/Activemask.cpp
@@ -76,7 +76,7 @@ TEMPLATE_LIST_TEST_CASE("activemask", "[warp]", alpaka::test::TestAccs)
                      alpaka::TagFpgaSyclIntel,
                      alpaka::TagGenericSycl>)
     {
-        WARN("Test disabled for SYCL");
+        WARN("Test disabled for SYCL with oneAPI 2025.2 and older");
         return;
     }
 #else

--- a/test/unit/warp/src/All.cpp
+++ b/test/unit/warp/src/All.cpp
@@ -78,7 +78,7 @@ TEMPLATE_LIST_TEST_CASE("all", "[warp]", alpaka::test::TestAccs)
                      alpaka::TagFpgaSyclIntel,
                      alpaka::TagGenericSycl>)
     {
-        WARN("Test disabled for SYCL");
+        WARN("Test disabled for SYCL with oneAPI 2025.2 and older");
         return;
     }
 #else

--- a/test/unit/warp/src/Any.cpp
+++ b/test/unit/warp/src/Any.cpp
@@ -68,7 +68,7 @@ TEMPLATE_LIST_TEST_CASE("any", "[warp]", alpaka::test::TestAccs)
 {
     using Acc = TestType;
 
-#if defined(ALPAKA_ACC_SYCL_ENABLED) && defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20'250'300
+#if defined(ALPAKA_ACC_SYCL_ENABLED) && ALPAKA_COMP_ICPX < ALPAKA_VERSION_NUMBER(2025, 3, 0)
     if constexpr(alpaka::accMatchesTags<
                      Acc,
                      alpaka::TagCpuSycl,
@@ -78,7 +78,7 @@ TEMPLATE_LIST_TEST_CASE("any", "[warp]", alpaka::test::TestAccs)
                      alpaka::TagFpgaSyclIntel,
                      alpaka::TagGenericSycl>)
     {
-        WARN("Test disabled for SYCL");
+        WARN("Test disabled for SYCL with oneAPI 2025.2 and older");
         return;
     }
 #else

--- a/test/unit/warp/src/Ballot.cpp
+++ b/test/unit/warp/src/Ballot.cpp
@@ -86,7 +86,7 @@ TEMPLATE_LIST_TEST_CASE("ballot", "[warp]", alpaka::test::TestAccs)
                      alpaka::TagFpgaSyclIntel,
                      alpaka::TagGenericSycl>)
     {
-        WARN("Test disabled for SYCL");
+        WARN("Test disabled for SYCL with oneAPI 2025.2 and older");
         return;
     }
 #else

--- a/test/unit/warp/src/Shfl.cpp
+++ b/test/unit/warp/src/Shfl.cpp
@@ -108,7 +108,7 @@ TEMPLATE_LIST_TEST_CASE("shfl", "[warp]", alpaka::test::TestAccs)
                      alpaka::TagFpgaSyclIntel,
                      alpaka::TagGenericSycl>)
     {
-        WARN("Test disabled for SYCL");
+        WARN("Test disabled for SYCL with oneAPI 2025.2 and older");
         return;
     }
 #else

--- a/test/unit/warp/src/ShflDown.cpp
+++ b/test/unit/warp/src/ShflDown.cpp
@@ -132,7 +132,7 @@ TEMPLATE_LIST_TEST_CASE("shfl_down", "[warp]", alpaka::test::TestAccs)
                      alpaka::TagFpgaSyclIntel,
                      alpaka::TagGenericSycl>)
     {
-        WARN("Test disabled for SYCL");
+        WARN("Test disabled for SYCL with oneAPI 2025.2 and older");
         return;
     }
 #else

--- a/test/unit/warp/src/ShflUp.cpp
+++ b/test/unit/warp/src/ShflUp.cpp
@@ -128,7 +128,7 @@ TEMPLATE_LIST_TEST_CASE("shfl_up", "[warp]", alpaka::test::TestAccs)
                      alpaka::TagFpgaSyclIntel,
                      alpaka::TagGenericSycl>)
     {
-        WARN("Test disabled for SYCL");
+        WARN("Test disabled for SYCL with oneAPI 2025.2 and older");
         return;
     }
 #else

--- a/test/unit/warp/src/ShflXor.cpp
+++ b/test/unit/warp/src/ShflXor.cpp
@@ -113,7 +113,7 @@ TEMPLATE_LIST_TEST_CASE("shfl_xor", "[warp]", alpaka::test::TestAccs)
                      alpaka::TagFpgaSyclIntel,
                      alpaka::TagGenericSycl>)
     {
-        WARN("Test disabled for SYCL");
+        WARN("Test disabled for SYCL with oneAPI 2025.2 and older");
         return;
     }
 #else


### PR DESCRIPTION
Import `get_opportunistic_group()` from a different experimental namespace depending on the oneAPI version: oneAPI up to 2025.3 uses `sycl::ext::oneapi::experimental::this_kernel::get_opportunistic_group()`, while oneAPI 2026.0 uses `sycl::ext::oneapi::experimental::this_work_item::get_opportunistic_group()`.

Use `ALPAKA_VERSION_NUMBER` to check oneAPI version more consistently.