### PR TITLE
Suppress a false-positive warning from icpx 2025.3

### DIFF
--- a/test/unit/core/src/CallbackThread.cpp
+++ b/test/unit/core/src/CallbackThread.cpp
@@ -10,9 +10,19 @@ TEST_CASE("callbackthread", "[core]")
 {
     alpaka::core::CallbackThread cbt;
 
+#if defined(ALPAKA_COMP_ICPX) && ALPAKA_COMP_ICPX >= ALPAKA_VERSION_NUMBER(2025, 3, 0)                                \
+    && ALPAKA_COMP_ICPX < ALPAKA_VERSION_NUMBER(2026, 0, 0)
+    // This triggers a false positive with icpx 2025.3.x.
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
     auto f1 = cbt.submit([] { throw std::runtime_error("42"); });
     auto f2 = cbt.submit([] { throw 42; });
-    auto f3 = cbt.submit([] {});
+    auto f3 = cbt.submit([]() noexcept {});
+#if defined(ALPAKA_COMP_ICPX) && ALPAKA_COMP_ICPX >= ALPAKA_VERSION_NUMBER(2025, 3, 0)                                \
+    && ALPAKA_COMP_ICPX < ALPAKA_VERSION_NUMBER(2026, 0, 0)
+#    pragma clang diagnostic pop
+#endif
 
     CHECK_THROWS_AS(f1.get(), std::runtime_error);
 

--- a/test/unit/core/src/ThreadPool.cpp
+++ b/test/unit/core/src/ThreadPool.cpp
@@ -10,9 +10,19 @@ TEST_CASE("threadpool", "[core]")
 {
     alpaka::core::detail::ThreadPool tp{2};
 
+#if defined(ALPAKA_COMP_ICPX) && ALPAKA_COMP_ICPX >= ALPAKA_VERSION_NUMBER(2025, 3, 0)                                \
+    && ALPAKA_COMP_ICPX < ALPAKA_VERSION_NUMBER(2026, 0, 0)
+    // This triggers a false positive with icpx 2025.3.x.
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wmissing-noreturn"
+#endif
     auto f1 = tp.enqueueTask([] { throw std::runtime_error("42"); });
     auto f2 = tp.enqueueTask([] { throw 42; });
     auto f3 = tp.enqueueTask([]() noexcept {});
+#if defined(ALPAKA_COMP_ICPX) && ALPAKA_COMP_ICPX >= ALPAKA_VERSION_NUMBER(2025, 3, 0)                                \
+    && ALPAKA_COMP_ICPX < ALPAKA_VERSION_NUMBER(2026, 0, 0)
+#    pragma clang diagnostic pop
+#endif
 
     CHECK_THROWS_AS(f1.get(), std::runtime_error);
 


### PR DESCRIPTION
icpx 2025.3.x warns about lambdas without a `[[noreturn]]` attribute, even though adding them is not possible with C++ 20 and requires C++ 23.

icpx 2025.2.x and earlier, and 2026.0.x and later, do not have this problem.