### PR TITLE
Handle `-Wnrvo` starting from LLVM/clang 21.1.0

### DIFF
--- a/include/alpaka/core/DemangleTypeNames.hpp
+++ b/include/alpaka/core/DemangleTypeNames.hpp
@@ -81,12 +81,12 @@ namespace alpaka::core
             std::array<char, length + 1> storage{};
             std::copy(embeddedType.data() + start, embeddedType.data() + end, storage.data());
             storage[length] = '\0';
-#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 0, 0)
+#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 1, 0)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wnrvo"
 #endif
             return storage;
-#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 0, 0)
+#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 1, 0)
 #    pragma clang diagnostic pop
 #endif
         }

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -97,12 +97,12 @@ namespace alpaka
             if constexpr(dim > 1)
                 for(TIdx i = TDim::value - 1; i > 0; i--)
                     pitchBytes[i - 1] = extent[i] * pitchBytes[i];
-#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 0, 0)
+#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 1, 0)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wnrvo"
 #endif
             return pitchBytes;
-#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 0, 0)
+#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 1, 0)
 #    pragma clang diagnostic pop
 #endif
         }
@@ -128,12 +128,12 @@ namespace alpaka
             if constexpr(dim > 2)
                 for(TIdx i = TDim::value - 2; i > 0; i--)
                     pitchBytes[i - 1] = extent[i] * pitchBytes[i];
-#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 0, 0)
+#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 1, 0)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wnrvo"
 #endif
             return pitchBytes;
-#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 0, 0)
+#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 1, 0)
 #    pragma clang diagnostic pop
 #endif
         }

--- a/include/alpaka/test/Extent.hpp
+++ b/include/alpaka/test/Extent.hpp
@@ -10,7 +10,7 @@
 
 namespace alpaka::test
 {
-#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 0, 0)
+#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 1, 0)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wnrvo"
 #endif
@@ -43,7 +43,7 @@ namespace alpaka::test
                 v[i] = 2 + i;
         return v;
     }();
-#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 0, 0)
+#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 1, 0)
 #    pragma clang diagnostic pop
 #endif
 } // namespace alpaka::test

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -161,12 +161,12 @@ namespace alpaka
             Vec r;
             for(DimLoopInd i(0u); i < TDim::value; ++i)
                 r[i] = core::divCeil(gridElemExtent[i], clippedThreadElemExtent[i]);
-#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 0, 0)
+#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 1, 0)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wnrvo"
 #endif
             return r;
-#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 0, 0)
+#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 1, 0)
 #    pragma clang diagnostic pop
 #endif
         }();
@@ -300,12 +300,12 @@ namespace alpaka
             Vec r;
             for(DimLoopInd i = 0; i < TDim::value; ++i)
                 r[i] = core::divCeil(gridThreadExtent[i], blockThreadExtent[i]);
-#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 0, 0)
+#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 1, 0)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wnrvo"
 #endif
             return r;
-#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 0, 0)
+#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 1, 0)
 #    pragma clang diagnostic pop
 #endif
         }();

--- a/test/unit/mem/buf/src/ConstBufTest.cpp
+++ b/test/unit/mem/buf/src/ConstBufTest.cpp
@@ -34,7 +34,7 @@ namespace buftest
         alpaka::memcpy(queueAcc, buf, bufHost);
         alpaka::wait(queueAcc);
 
-#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 0, 0)
+#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 1, 0)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wnrvo"
 #endif
@@ -43,7 +43,7 @@ namespace buftest
         auto const constBuf = alpaka::makeConstBuf(std::move(buf));
         return constBuf;
 
-#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 0, 0)
+#if ALPAKA_COMP_CLANG >= ALPAKA_VERSION_NUMBER(21, 1, 0)
 #    pragma clang diagnostic pop
 #endif
     }


### PR DESCRIPTION
Check for a clang version >= 21.1.0:
- the first production version of clang with the `-Wnrvo` option is 21.1.0;
- ROCm 7.1.x does not have the `-Wnrvo` option and reports clang version 20.0.0;
- ROCm 7.2.x has the `-Wnrvo` option and reports clang version 22.0.0;
- oneAPI 2025.2.x does not have the `-Wnrvo` option and reports clang version 21.0.0;
- oneAPI 2025.3.x has the `-Wnrvo` option and reports clang version 21.1.1.
