### PR TITLE
Provide clearer errors for incorrect kernel arguments

### DIFF
--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -261,23 +261,6 @@ namespace alpaka
         };
     } // namespace trait
 
-    namespace detail
-    {
-        //! specialization of the TKernelFnObj return type evaluation
-        //
-        // It is not possible to determine the result type of a __device__ lambda for CUDA on the host side.
-        // https://github.com/alpaka-group/alpaka/pull/695#issuecomment-446103194
-        // The execution task TaskKernelGpuUniformCudaHipRt is therefore performing this check on device side.
-        template<typename TApi, typename TDim, typename TIdx>
-        struct CheckFnReturnType<AccGpuUniformCudaHipRt<TApi, TDim, TIdx>>
-        {
-            template<typename TKernelFnObj, typename... TArgs>
-            void operator()(TKernelFnObj const&, TArgs const&...)
-            {
-            }
-        };
-    } // namespace detail
-
     namespace trait
     {
         //! The GPU CUDA accelerator execution task type trait specialization.

--- a/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
+++ b/include/alpaka/acc/AccGpuUniformCudaHipRt.hpp
@@ -261,6 +261,23 @@ namespace alpaka
         };
     } // namespace trait
 
+    namespace detail
+    {
+        //! specialization of the kernel invocability check
+        //
+        // It is not possible to determine the invocability of a __device__ lambda for CUDA on the host side.
+        // https://github.com/alpaka-group/alpaka/pull/695#issuecomment-446103194
+        // The execution task TaskKernelGpuUniformCudaHipRt is therefore performing this check on device side.
+        template<typename TApi, typename TDim, typename TIdx>
+        struct CheckFnReturnType<AccGpuUniformCudaHipRt<TApi, TDim, TIdx>>
+        {
+            template<typename TKernelFnObj, typename... TArgs>
+            void operator()(TKernelFnObj const&, TArgs&&...)
+            {
+            }
+        };
+    } // namespace detail
+
     namespace trait
     {
         //! The GPU CUDA accelerator execution task type trait specialization.

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -279,6 +279,18 @@ namespace alpaka
         {
             static_assert(isKernelArgumentTriviallyCopyable<T>, "The kernel argument T must be trivially copyable!");
         }
+
+        template<typename TAcc, typename TSfinae = void>
+        struct CheckFnReturnType
+        {
+            template<typename TKernelFnObj, typename... TArgs>
+            void operator()(TKernelFnObj const&, TArgs&&...)
+            {
+                static_assert(
+                    std::is_invocable_r_v<void, TKernelFnObj, TAcc const&, TArgs&&...>,
+                    "The kernel is not invocable with the given arguments!");
+            }
+        };
     } // namespace detail
 
     //! Check if the kernel type is trivially copyable
@@ -365,9 +377,7 @@ namespace alpaka
     ALPAKA_FN_HOST auto exec(TQueue& queue, TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
         -> void
     {
-        static_assert(
-            std::is_invocable_r_v<void, TKernelFnObj, TAcc const&, decltype(std::forward<TArgs>(args))...>,
-            "The kernel is not invocable with the given arguments!");
+        detail::CheckFnReturnType<TAcc>{}(kernelFnObj, std::forward<TArgs>(args)...);
         enqueue(queue, createTaskKernel<TAcc>(workDiv, kernelFnObj, std::forward<TArgs>(args)...));
     }
 
@@ -391,9 +401,7 @@ namespace alpaka
         -> void
     {
         using Acc = TagToAcc<TTag, Dim<std::decay_t<TWorkDiv>>, Idx<std::decay_t<TWorkDiv>>>;
-        static_assert(
-            std::is_invocable_r_v<void, TKernelFnObj, Acc const&, decltype(std::forward<TArgs>(args))...>,
-            "The kernel is not invocable with the given arguments!");
+        detail::CheckFnReturnType<Acc>{}(kernelFnObj, std::forward<TArgs>(args)...);
         enqueue(queue, createTaskKernel<Acc>(workDiv, kernelFnObj, std::forward<TArgs>(args)...));
     }
 

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -272,18 +272,6 @@ namespace alpaka
 
     namespace detail
     {
-        //! Check that the return of TKernelFnObj is void
-        template<typename TAcc, typename TSfinae = void>
-        struct CheckFnReturnType
-        {
-            template<typename TKernelFnObj, typename... TArgs>
-            void operator()(TKernelFnObj const&, TArgs const&...)
-            {
-                using Result = std::invoke_result_t<TKernelFnObj, TAcc const&, TArgs const&...>;
-                static_assert(std::is_same_v<Result, void>, "The TKernelFnObj is required to return void!");
-            }
-        };
-
         // asserts that T is trivially copyable. We put this in a separate function so we can see which T would fail
         // the test, when called from a fold expression.
         template<typename T>
@@ -333,9 +321,6 @@ namespace alpaka
     template<typename TAcc, typename TWorkDiv, typename TKernelFnObj, typename... TArgs>
     ALPAKA_FN_HOST auto createTaskKernel(TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
     {
-        // check for void return type
-        detail::CheckFnReturnType<TAcc>{}(kernelFnObj, args...);
-
 #if ALPAKA_COMP_NVCC
         static_assert(
             isKernelTriviallyCopyable<TKernelFnObj>,
@@ -380,6 +365,9 @@ namespace alpaka
     ALPAKA_FN_HOST auto exec(TQueue& queue, TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
         -> void
     {
+        static_assert(
+            std::is_invocable_r_v<void, TKernelFnObj, TAcc const&, decltype(std::forward<TArgs>(args))...>,
+            "The kernel is not invocable with the given arguments!");
         enqueue(queue, createTaskKernel<TAcc>(workDiv, kernelFnObj, std::forward<TArgs>(args)...));
     }
 
@@ -402,12 +390,11 @@ namespace alpaka
     ALPAKA_FN_HOST auto exec(TQueue& queue, TWorkDiv const& workDiv, TKernelFnObj const& kernelFnObj, TArgs&&... args)
         -> void
     {
-        enqueue(
-            queue,
-            createTaskKernel<TagToAcc<TTag, Dim<std::decay_t<TWorkDiv>>, Idx<std::decay_t<TWorkDiv>>>>(
-                workDiv,
-                kernelFnObj,
-                std::forward<TArgs>(args)...));
+        using Acc = TagToAcc<TTag, Dim<std::decay_t<TWorkDiv>>, Idx<std::decay_t<TWorkDiv>>>;
+        static_assert(
+            std::is_invocable_r_v<void, TKernelFnObj, Acc const&, decltype(std::forward<TArgs>(args))...>,
+            "The kernel is not invocable with the given arguments!");
+        enqueue(queue, createTaskKernel<Acc>(workDiv, kernelFnObj, std::forward<TArgs>(args)...));
     }
 
 } // namespace alpaka


### PR DESCRIPTION
This PR adds a static assertion inside `alpaka::exec` checking if a kernel can be invoked with the arguments passed. This provides a clearer error message stating exactly what was causing the compilation to fail.

**Before:**
```shell
/usr/include/c++/16/type_traits: In substitution of ‘template<class _Fn, class ... _Args> using std::invoke_result_t = typename std::invoke_result::type [with _Fn = VectorAddKernel1D; _Args = {const alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 1>, long int>&, const alpaka::BufCpu<float, std::integral_constant<long unsigned int, 1>, long int>&, float* const&, float* const&, const alpaka::Vec<std::integral_constant<long unsigned int, 1>, long int>&}]’:
/home/sbaldu/Work/alpaka/include/alpaka/kernel/Traits.hpp:282:23:   required from ‘void alpaka::detail::CheckFnReturnType<TAcc, TSfinae>::operator()(const TKernelFnObj&, const TArgs& ...) [with TKernelFnObj = VectorAddKernel1D; TArgs = {alpaka::BufCpu<float, std::integral_constant<long unsigned int, 1>, long int>, float*, float*, alpaka::Vec<std::integral_constant<long unsigned int, 1>, long int>}; TAcc = alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 1>, long int>; TSfinae = void]’
  282 |                 using Result = std::invoke_result_t<TKernelFnObj, TAcc const&, TArgs const&...>;
      |                       ^~~~~~
/home/sbaldu/Work/alpaka/include/alpaka/kernel/Traits.hpp:337:42:   required from ‘auto alpaka::createTaskKernel(const TWorkDiv&, const TKernelFnObj&, TArgs&& ...) [with TAcc = AccCpuSerial<std::integral_constant<long unsigned int, 1>, long int>; TWorkDiv = WorkDivMembers<std::integral_constant<long unsigned int, 1>, long int>; TKernelFnObj = VectorAddKernel1D; TArgs = {BufCpu<float, std::integral_constant<long unsigned int, 1>, long int>&, float*, float*, Vec<std::integral_constant<long unsigned int, 1>, long int>&}]’
  337 |         detail::CheckFnReturnType<TAcc>{}(kernelFnObj, args...);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
/home/sbaldu/Work/alpaka/include/alpaka/kernel/Traits.hpp:383:46:   required from ‘void alpaka::exec(TQueue&, const TWorkDiv&, const TKernelFnObj&, TArgs&& ...) [with TAcc = AccCpuSerial<std::integral_constant<long unsigned int, 1>, long int>; TQueue = QueueGenericThreadsNonBlocking<DevCpu>; TWorkDiv = WorkDivMembers<std::integral_constant<long unsigned int, 1>, long int>; TKernelFnObj = VectorAddKernel1D; TArgs = {BufCpu<float, std::integral_constant<long unsigned int, 1>, long int>&, float*, float*, Vec<std::integral_constant<long unsigned int, 1>, long int>&}]’
  383 |         enqueue(queue, createTaskKernel<TAcc>(workDiv, kernelFnObj, std::forward<TArgs>(args)...));
      |                        ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/sbaldu/Work/alpaka/test/unit/exec/src/UniformElements.cpp:542:26:   required from ‘void testVectorAddKernelND(alpaka::Vec<typename alpaka::trait::DimType<T>::type, typename alpaka::trait::IdxType<T>::type>, alpaka::Vec<typename alpaka::trait::DimType<T>::type, typename alpaka::trait::IdxType<T>::type>, alpaka::Vec<typename alpaka::trait::DimType<T>::type, typename alpaka::trait::IdxType<T>::type>, TKernel) [with TAcc = alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 1>, long int>; TKernel = VectorAddKernel1D; typename alpaka::trait::DimType<T>::type = std::integral_constant<long unsigned int, 1>; typename alpaka::trait::IdxType<T>::type = long int]’
  542 |         alpaka::exec<Acc>(queue, div, kernel, in1_d, in2_d.data(), out_d.data(), problem_size);
      |         ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/sbaldu/Work/alpaka/test/unit/exec/src/UniformElements.cpp:575:63:   required from ‘void CATCH2_INTERNAL_TEMPLATE_TEST_3() [with TestType = alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 1>, long int>]’
  575 |             testVectorAddKernelND<TestType, VectorAddKernel1D>(Vec{10000}, Vec{32}, Vec{32}, VectorAddKernel1D{});
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/sbaldu/Work/alpaka/test/unit/exec/src/UniformElements.cpp:560:1:   required from ‘void {anonymous}::ns_CATCH2_INTERNAL_TEMPLATE_TEST_4::CATCH2_INTERNAL_TEMPLATE_TEST_4<Types>::reg_tests() [with Types = {alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 1>, long int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 2>, long int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 3>, long int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 4>, long int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 1>, long unsigned int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 2>, long unsigned int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 3>, long unsigned int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 4>, long unsigned int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 1>, int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 2>, int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 3>, int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 4>, int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 1>, unsigned int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 2>, unsigned int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 3>, unsigned int>, alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 4>, unsigned int>}]’
  560 | TEMPLATE_LIST_TEST_CASE("UniformElements", "[exec]", alpaka::test::TestAccs)
      | ^~~~~~~~~~~~~~~~~~~~~~~
/home/sbaldu/Work/alpaka/test/unit/exec/src/UniformElements.cpp:560:1:   required from here
  560 | TEMPLATE_LIST_TEST_CASE("UniformElements", "[exec]", alpaka::test::TestAccs)
      | ^~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/16/type_traits:3413:11: error: no type named ‘type’ in ‘struct std::invoke_result<VectorAddKernel1D, const alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 1>, long int>&, const alpaka::BufCpu<float, std::integral_constant<long unsigned int, 1>, long int>&, float* const&, float* const&, const alpaka::Vec<std::integral_constant<long unsigned int, 1>, long int>&>’
 3413 |     using invoke_result_t = typename invoke_result<_Fn, _Args...>::type;
      |           ^~~~~~~~~~~~~~~
```
**After:**
```shell
/home/sbaldu/Work/alpaka/include/alpaka/kernel/Traits.hpp:369:18: error: static assertion failed: The kernel is not invocable with the provided invocation arguments!
  369 |             std::is_invocable_r_v<void, TKernelFnObj, TAcc const&, decltype(std::forward<TArgs>(args))...>,
      |             ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  • ‘std::is_invocable_r_v<void, VectorAddKernel2D, const alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 2>, unsigned int>&, alpaka::BufCpu<float, std::integral_constant<long unsigned int, 1>, unsigned int>&, float*&&, float*&&, alpaka::Vec<std::integral_constant<long unsigned int, 2>, unsigned int>&>’ evaluates to false
/home/sbaldu/Work/alpaka/include/alpaka/kernel/Traits.hpp: In instantiation of ‘void alpaka::exec(TQueue&, const TWorkDiv&, const TKernelFnObj&, TArgs&& ...) [with TAcc = AccCpuSerial<std::integral_constant<long unsigned int, 3>, unsigned int>; TQueue = QueueGenericThreadsNonBlocking<DevCpu>; TWorkDiv = WorkDivMembers<std::integral_constant<long unsigned int, 3>, unsigned int>; TKernelFnObj = VectorAddKernel3D; TArgs = {BufCpu<float, std::integral_constant<long unsigned int, 1>, unsigned int>&, float*, float*, Vec<std::integral_constant<long unsigned int, 3>, unsigned int>&}]’:
/home/sbaldu/Work/alpaka/test/unit/exec/src/UniformElements.cpp:542:26:   required from ‘void testVectorAddKernelND(alpaka::Vec<typename alpaka::trait::DimType<T>::type, typename alpaka::trait::IdxType<T>::type>, alpaka::Vec<typename alpaka::trait::DimType<T>::type, typename alpaka::trait::IdxType<T>::type>, alpaka::Vec<typename alpaka::trait::DimType<T>::type, typename alpaka::trait::IdxType<T>::type>, TKernel) [with TAcc = alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 3>, unsigned int>; TKernel = VectorAddKernel3D; typename alpaka::trait::DimType<T>::type = std::integral_constant<long unsigned int, 3>; typename alpaka::trait::IdxType<T>::type = unsigned int]’
  542 |         alpaka::exec<Acc>(queue, div, kernel, in1_d, in2_d.data(), out_d.data(), problem_size);
      |         ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/sbaldu/Work/alpaka/test/unit/exec/src/UniformElements.cpp:615:44:   required from ‘void CATCH2_INTERNAL_TEMPLATE_TEST_3() [with TestType = alpaka::AccCpuSerial<std::integral_constant<long unsigned int, 3>, unsigned int>]’
  615 |             testVectorAddKernelND<TestType>({50, 25, 16}, {5, 2, 2}, {2, 4, 4}, VectorAddKernel3D{});
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```