### PR TITLE
fix unknown `activeMask` with HIP 6.3.0

### DIFF
--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -13,7 +13,7 @@
 #endif
 
 #if ALPAKA_LANG_HIP
-#    if ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0) && ALPAKA_COMP_HIP < ALPAKA_VERSION_NUMBER(7, 0, 0)
+#    if ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 3, 1) && ALPAKA_COMP_HIP < ALPAKA_VERSION_NUMBER(7, 0, 0)
 #        define HIP_ENABLE_WARP_SYNC_BUILTINS
 #    endif
 // HIP defines some keywords like __forceinline__ in header files.

--- a/include/alpaka/core/CudaHipCommon.hpp
+++ b/include/alpaka/core/CudaHipCommon.hpp
@@ -35,7 +35,7 @@
 #    endif
 
 #    ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-#        if ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0) && ALPAKA_COMP_HIP < ALPAKA_VERSION_NUMBER(7, 0, 0)
+#        if ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 3, 1) && ALPAKA_COMP_HIP < ALPAKA_VERSION_NUMBER(7, 0, 0)
 #            define HIP_ENABLE_WARP_SYNC_BUILTINS
 #        endif
 #        include <hip/hip_runtime.h>

--- a/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -476,7 +476,7 @@ namespace alpaka::trait
 
 #ifdef ALPAKA_ACC_GPU_HIP_ENABLED
 
-#    if ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0) && ALPAKA_COMP_HIP < ALPAKA_VERSION_NUMBER(7, 0, 0)
+#    if ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 3, 1) && ALPAKA_COMP_HIP < ALPAKA_VERSION_NUMBER(7, 0, 0)
 #        define HIP_ENABLE_WARP_SYNC_BUILTINS
 #    endif
 #    include <hip/hip_runtime.h>

--- a/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
+++ b/include/alpaka/warp/WarpUniformCudaHipBuiltIn.hpp
@@ -113,7 +113,7 @@ namespace alpaka::warp
 #        endif
             {
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
-            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 3, 1))
                 return __activemask();
 #        else
                 // No HIP intrinsic for it, emulate via ballot
@@ -130,7 +130,7 @@ namespace alpaka::warp
                 std::int32_t predicate) -> std::int32_t
             {
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
-            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 3, 1))
                 return __all_sync(activemask(warp), predicate);
 #        else
                 return __all(predicate);
@@ -146,7 +146,7 @@ namespace alpaka::warp
                 std::int32_t predicate) -> std::int32_t
             {
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
-            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 3, 1))
                 return __any_sync(activemask(warp), predicate);
 #        else
                 return __any(predicate);
@@ -168,7 +168,7 @@ namespace alpaka::warp
 #        endif
             {
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
-            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 3, 1))
                 return __ballot_sync(activemask(warp), predicate);
 #        else
                 return __ballot(predicate);
@@ -187,7 +187,7 @@ namespace alpaka::warp
                 std::int32_t width) -> T
             {
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
-            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 3, 1))
                 return __shfl_sync(activemask(warp), val, srcLane, width);
 #        else
                 return __shfl(val, srcLane, width);
@@ -206,7 +206,7 @@ namespace alpaka::warp
                 std::int32_t width) -> T
             {
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
-            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 3, 1))
                 return __shfl_up_sync(activemask(warp), val, offset, width);
 #        else
                 return __shfl_up(val, offset, width);
@@ -225,7 +225,7 @@ namespace alpaka::warp
                 std::int32_t width) -> T
             {
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
-            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 3, 1))
                 return __shfl_down_sync(activemask(warp), val, offset, width);
 #        else
                 return __shfl_down(val, offset, width);
@@ -244,7 +244,7 @@ namespace alpaka::warp
                 std::int32_t width) -> T
             {
 #        if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)                                                                      \
-            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 2, 0))
+            || (defined(ALPAKA_ACC_GPU_HIP_ENABLED) && ALPAKA_COMP_HIP >= ALPAKA_VERSION_NUMBER(6, 3, 1))
                 return __shfl_xor_sync(activemask(warp), val, mask, width);
 #        else
                 return __shfl_xor(val, mask, width);

--- a/script/install_cuda.sh
+++ b/script/install_cuda.sh
@@ -214,6 +214,12 @@ else
     fi
 fi
 
+# If the CI set the architecture of the GPU use it
+# CI_GPU_ARCH is provided by the HZDR Gitlab CI
+if [ -n "${CI_GPU_ARCH:-}" ]; then
+    export CMAKE_CUDA_ARCHITECTURES=${CI_GPU_ARCH}
+fi
+
 if [ "${ALPAKA_CI_CUDA_COMPILER}" == "nvcc" ]
 then
     export CMAKE_CUDA_COMPILER=$(which nvcc)


### PR DESCRIPTION
The warp mask feature was introduced with HIP 6.3.1 see https://rocm.docs.amd.com/en/docs-6.3.1/about/release-notes.html#hip-6-3-1

The bug was introduced with #2585 where we check for 6.3 instead of 6.3.1.

```
warp/WarpUniformCudaHipBuiltIn.hpp:120:24: error: use of undeclared identifier '__activemask'; did you mean 'Activemask'?
  120 |                 return __activemask();
      |                        ^
```

Found with picongpu where we still use HIP 6.3.0 https://gitlab.com/hzdr/crp/picongpu/-/jobs/16151713214