### PR TITLE
fix special job

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,10 +36,10 @@ repos:
   rev: v0.2.1
   hooks:
     - id: ruff
-      types_or: [ python, pyi, jupyter ]
-      # The ignores in here are chosen to conform with the currently
-      # existing code and not motivated any other way.
-      args: [ --fix, --ignore, "F403,F405,E731"]
+      types_or: [python, pyi, jupyter]
+      exclude: ^script/job_generator/
+      args: [--fix, --ignore, "F403,F405,E731"]
     - id: ruff-format
-      types_or: [ python, pyi, jupyter ]
-      args: ["--line-length", "120"]
+      types_or: [python, pyi, jupyter]
+      exclude: ^script/job_generator/
+      args: [--line-length, "120"]

--- a/script/job_generator/src/alpaka_bashi/special_jobs/cuda.py
+++ b/script/job_generator/src/alpaka_bashi/special_jobs/cuda.py
@@ -204,7 +204,7 @@ def get_cuda_only_job(
 
     return {
         f"linux_special_nvcc{nvcc_version}_gcc{gcc_version}"
-        "_release_extended_lambda_off_compile_only": job_body
+        "_release_extended_cudaonly_on_compile_only": job_body
     }
 
 


### PR DESCRIPTION
fix #2647

The name of the job should be `cuda only` and not `extended lambda off`, because the test where the lambdas are disabled, we have a special template.

The first commit removes `script/job_generator` from pre-commit because the rules of black, mypy-linter and pylint-linter collide with the alpaka coding styles we agreed on.

Note: The first commit is also in #2649 but the merge order is independent.