### PR TITLE
update mdspan

### DIFF
--- a/cmake/alpakaCommon.cmake
+++ b/cmake/alpakaCommon.cmake
@@ -904,10 +904,10 @@ if (alpaka_USE_MDSPAN STREQUAL "SYSTEM")
 elseif (alpaka_USE_MDSPAN STREQUAL "FETCH")
     include(FetchContent)
     FetchContent_Declare(
-        # kokkos/mdspan as of 2025.12.11
+        # kokkos/mdspan as of 2026.08.19
         mdspan
         GIT_REPOSITORY https://github.com/kokkos/mdspan.git
-        GIT_TAG bcfcc9ea8fc5390b99261a4d8450c3f2fc18a7f2
+        GIT_TAG ef0adc1ca08b6eda520a7fd3fcfd8125662518e7
     )
     # we don't use FetchContent_MakeAvailable(mdspan) since it would also install mdspan
     # see also: https://stackoverflow.com/questions/65527126/how-to-disable-installation-a-fetchcontent-dependency

--- a/include/alpaka/core/CudaHipCommon.hpp
+++ b/include/alpaka/core/CudaHipCommon.hpp
@@ -32,6 +32,10 @@
 #                pragma clang diagnostic pop
 #            endif
 #        endif
+#        ifdef ALPAKA_USE_MDSPAN
+// needs to be included that cuda::std::numeric_limits is defined and in the correct namespace
+#            include "alpaka/core/mdspan.hpp"
+#        endif
 #    endif
 
 #    ifdef ALPAKA_ACC_GPU_HIP_ENABLED

--- a/include/alpaka/core/mdspan.hpp
+++ b/include/alpaka/core/mdspan.hpp
@@ -1,0 +1,63 @@
+/* Copyright 2026 Axel Hübl, Benjamin Worpitz, Matthias Werner, Andrea Bocci, Jan Stephan, Bernhard Manfred Gruber,
+ *                Aurora Perego, Simone Balducci
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// no pragma once, because the header defines alias namespaces
+
+#ifdef ALPAKA_USE_MDSPAN
+#    ifdef ALPAKA_HAS_STD_MDSPAN
+//       mdspan from the standard library
+#        include <mdspan>
+#        include <version>
+
+namespace alpaka::experimental
+{
+    // Import C++23 mdspan into alpaka::experimental namespace.
+    // See https://wg21.link/P0009R18 .
+    using ::std::default_accessor;
+    using ::std::dextents;
+    using ::std::extents;
+    using ::std::layout_left;
+    using ::std::layout_right;
+    using ::std::layout_stride;
+    using ::std::mdspan;
+#        ifdef __cpp_lib_submdspan
+    // Import C++26 submdspan into alpaka::experimental namespace.
+    // See https://wg21.link/P2630R4 .
+    using ::std::full_extent;
+    using ::std::submdspan;
+#        endif
+} // namespace alpaka::experimental
+
+#    else
+
+#        ifdef ALPAKA_ACC_SYCL_ENABLED
+//           do not expose the macro definition of printf
+#            pragma push_macro("printf")
+#            ifdef printf
+#                undef printf
+#            endif
+#        endif // ALPAKA_ACC_SYCL_ENABLED
+
+#        if defined(ALPAKA_ACC_SYCL_ENABLED) && (defined(ALPAKA_SYCL_ONEAPI_FPGA) || defined(ALPAKA_SYCL_TARGET_FPGA))
+//           the fpga compiler does not handle well the [[no_unique_address]] attribute, resulting in:
+//               GEP has !intel-tbaa annotation but its "shape" is unexpected!
+//               /opt/intel/oneapi/compiler/2025.0/bin/compiler/llvm-link: error: linked module is broken!
+//               icpx: error: sycl-link command failed with exit code 1 (use -v to see invocation)
+#            include <experimental/__p0009_bits/config.hpp>
+#            undef MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS
+#            undef MDSPAN_IMPL_NO_UNIQUE_ADDRESS
+#            define MDSPAN_IMPL_NO_UNIQUE_ADDRESS
+#        endif
+
+//       mdspan from the Kokkos reference implementation
+#        define MDSPAN_IMPL_STANDARD_NAMESPACE alpaka::experimental
+#        include <experimental/mdspan>
+
+#        ifdef ALPAKA_ACC_SYCL_ENABLED
+//           restore the macro definition of printf
+#            pragma pop_macro("printf")
+#        endif // ALPAKA_ACC_SYCL_ENABLED
+#    endif
+#endif

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -7,6 +7,7 @@
 
 #include "alpaka/core/Common.hpp"
 #include "alpaka/core/Unreachable.hpp"
+#include "alpaka/core/mdspan.hpp"
 #include "alpaka/dev/Traits.hpp"
 #include "alpaka/dim/Traits.hpp"
 #include "alpaka/elem/Traits.hpp"
@@ -24,63 +25,6 @@
 #include <iosfwd>
 #include <type_traits>
 #include <vector>
-
-#ifdef ALPAKA_USE_MDSPAN
-#    ifdef ALPAKA_HAS_STD_MDSPAN
-//       mdspan from the standard library
-#        include <mdspan>
-#        include <version>
-
-namespace alpaka::experimental
-{
-    // Import C++23 mdspan into alpaka::experimental namespace.
-    // See https://wg21.link/P0009R18 .
-    using ::std::default_accessor;
-    using ::std::dextents;
-    using ::std::extents;
-    using ::std::layout_left;
-    using ::std::layout_right;
-    using ::std::layout_stride;
-    using ::std::mdspan;
-#        ifdef __cpp_lib_submdspan
-    // Import C++26 submdspan into alpaka::experimental namespace.
-    // See https://wg21.link/P2630R4 .
-    using ::std::full_extent;
-    using ::std::submdspan;
-#        endif
-} // namespace alpaka::experimental
-
-#    else
-
-#        ifdef ALPAKA_ACC_SYCL_ENABLED
-//           do not expose the macro definition of printf
-#            pragma push_macro("printf")
-#            ifdef printf
-#                undef printf
-#            endif
-#        endif // ALPAKA_ACC_SYCL_ENABLED
-
-#        if defined(ALPAKA_ACC_SYCL_ENABLED) && (defined(ALPAKA_SYCL_ONEAPI_FPGA) || defined(ALPAKA_SYCL_TARGET_FPGA))
-//           the fpga compiler does not handle well the [[no_unique_address]] attribute, resulting in:
-//               GEP has !intel-tbaa annotation but its "shape" is unexpected!
-//               /opt/intel/oneapi/compiler/2025.0/bin/compiler/llvm-link: error: linked module is broken!
-//               icpx: error: sycl-link command failed with exit code 1 (use -v to see invocation)
-#            include <experimental/__p0009_bits/config.hpp>
-#            undef MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS
-#            undef MDSPAN_IMPL_NO_UNIQUE_ADDRESS
-#            define MDSPAN_IMPL_NO_UNIQUE_ADDRESS
-#        endif
-
-//       mdspan from the Kokkos reference implementation
-#        define MDSPAN_IMPL_STANDARD_NAMESPACE alpaka::experimental
-#        include <experimental/mdspan>
-
-#        ifdef ALPAKA_ACC_SYCL_ENABLED
-//           restore the macro definition of printf
-#            pragma pop_macro("printf")
-#        endif // ALPAKA_ACC_SYCL_ENABLED
-#    endif
-#endif
 
 namespace alpaka
 {


### PR DESCRIPTION
- solve a compiler bug for CUDA 13.2
- Mdspan uses cuda::std::numeric_limits now. The cuda backend include mdspan by default if enable that the class is defined and in the correct namespace.