### PR TITLE
CI: fix empty special pipeline

### DIFF
--- a/script/job_generator/src/alpaka_bashi/special_jobs/writer.py
+++ b/script/job_generator/src/alpaka_bashi/special_jobs/writer.py
@@ -3,13 +3,13 @@
 import re
 from typing import Dict, Any
 from typeguard import typechecked
+from alpaka_bashi.ci_yaml.writer import get_dummy_job_yaml
 from .clang_analysis import get_clang_debug_analysis_job, get_clang_asan_job
 from .cuda import (
     get_nvcc_relocatable_device_code_job,
     get_nvcc_extended_lambda_off_job,
     get_cuda_only_job,
 )
-from alpaka_bashi.ci_yaml.writer import get_dummy_job_yaml
 
 
 @typechecked

--- a/script/job_generator/src/alpaka_bashi/special_jobs/writer.py
+++ b/script/job_generator/src/alpaka_bashi/special_jobs/writer.py
@@ -9,6 +9,7 @@ from .cuda import (
     get_nvcc_extended_lambda_off_job,
     get_cuda_only_job,
 )
+from alpaka_bashi.ci_yaml.writer import get_dummy_job_yaml
 
 
 @typechecked
@@ -80,5 +81,8 @@ def get_special_jobs(
             for job_name, job_body in special_jobs.items()
             if compiled_regex.match(job_name) or job_name == "stages"
         }
+
+    if len(special_jobs) == 0 or (len(special_jobs) == 1 and "stages" in special_jobs):
+        special_jobs = get_dummy_job_yaml(stage_name)
 
     return special_jobs


### PR DESCRIPTION
If all special jobs does not match a CI filter rule, the pipeline is empty and a dummy job should be generated, that the CI pipeline does not fail.

fix: #2655 

Because we should not merge PRs which filter CI jobs, the filter feature cannot tested with the final commit. Instead I tested it in the first commit of this PR with the filter rule `CI_FILTER: nope`. Therefore all pipelines uses dummy jobs. Here is the result: https://gitlab.com/hzdr/crp/alpaka/-/pipelines/2837215658 