### PR TITLE
Add concepts for `Device`, `Queue` and `Platform`

### DIFF
--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -59,9 +59,16 @@ namespace alpaka
 
     struct ConceptDev;
 
+    namespace concepts
+    {
+        template<typename TDev>
+        concept Device = requires { requires interface::ImplementsInterface<ConceptDev, std::decay_t<TDev>>::value; };
+    } // namespace concepts
+
     //! True if TDev is a device, i.e. if it implements the ConceptDev concept.
     template<typename TDev>
-    inline constexpr bool isDevice = interface::ImplementsInterface<ConceptDev, std::decay_t<TDev>>::value;
+    [[deprecated("use the alpaka::concepts::Device instead.")]] inline constexpr bool isDevice
+        = concepts::Device<TDev>;
 
     //! \return The device this object is bound to.
     template<typename T>

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -435,7 +435,7 @@ namespace alpaka
     namespace concepts
     {
         template<typename T>
-        concept DeviceProvider = alpaka::isDevice<T> || alpaka::isQueue<T>;
+        concept DeviceProvider = alpaka::concepts::Device<T> || alpaka::concepts::Queue<T>;
     } // namespace concepts
 
     namespace detail
@@ -515,7 +515,7 @@ namespace alpaka
         template<typename TDeviceProvider>
         auto getDeviceFromProvider(TDeviceProvider const& provider)
         {
-            if constexpr(alpaka::isDevice<TDeviceProvider>)
+            if constexpr(alpaka::concepts::Device<TDeviceProvider>)
             {
                 return provider;
             }

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2025 Andrea Bocci, Bernhard Manfred Gruber, Jan Stephan, Simone Balducci
+/* Copyright 2026 Andrea Bocci, Bernhard Manfred Gruber, Jan Stephan, Simone Balducci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -21,11 +21,10 @@ namespace alpaka
     class DevCpu;
 } // namespace alpaka
 
-namespace alpaka::internal
+namespace alpaka::concepts
 {
-
     template<typename TView>
-    concept ViewType = requires {
+    concept View = requires {
         typename Idx<TView>;
         typename Dim<TView>;
         {
@@ -38,8 +37,12 @@ namespace alpaka::internal
             getExtents(std::declval<TView>())
         };
     };
+} // namespace alpaka::concepts
 
-    template<ViewType TView>
+namespace alpaka::internal
+{
+
+    template<alpaka::concepts::View TView>
     struct BaseViewAccessor
     {
     private:
@@ -134,10 +137,10 @@ namespace alpaka::internal
 #endif
     };
 
-    template<ViewType TView>
+    template<alpaka::concepts::View TView>
     using DeviceViewAccessor = BaseViewAccessor<TView>;
 
-    template<ViewType TView>
+    template<alpaka::concepts::View TView>
     struct HostViewAccessor : BaseViewAccessor<TView>
     {
     private:
@@ -246,14 +249,14 @@ namespace alpaka::internal
     template<typename TDev>
     struct ViewAccessor
     {
-        template<ViewType TView>
+        template<concepts::View TView>
         using AccessorType = DeviceViewAccessor<TView>;
     };
 
     template<>
     struct ViewAccessor<alpaka::DevCpu>
     {
-        template<ViewType TView>
+        template<concepts::View TView>
         using AccessorType = HostViewAccessor<TView>;
     };
 
@@ -261,12 +264,12 @@ namespace alpaka::internal
     template<>
     struct ViewAccessor<alpaka::DevGenericSycl<alpaka::TagCpuSycl>>
     {
-        template<ViewType TView>
+        template<concepts::View TView>
         using AccessorType = HostViewAccessor<TView>;
     };
 #endif
 
-    template<typename TDev, ViewType TView>
+    template<typename TDev, concepts::View TView>
     using ViewAccessorType = typename ViewAccessor<TDev>::template AccessorType<TView>;
 
 } // namespace alpaka::internal

--- a/include/alpaka/platform/Traits.hpp
+++ b/include/alpaka/platform/Traits.hpp
@@ -18,9 +18,17 @@ namespace alpaka
     {
     };
 
+    namespace concepts
+    {
+        template<typename TPlatform>
+        concept Platform
+            = requires { requires interface::ImplementsInterface<ConceptPlatform, std::decay_t<TPlatform>>::value; };
+    } // namespace concepts
+
     //! True if TPlatform is a platform, i.e. if it implements the ConceptPlatform concept.
     template<typename TPlatform>
-    inline constexpr bool isPlatform = interface::ImplementsInterface<ConceptPlatform, TPlatform>::value;
+    [[deprecated("use the alpaka::concepts::Platform instead.")]] inline constexpr bool isPlatform
+        = concepts::Platform<TPlatform>;
 
     //! The platform traits.
     namespace trait

--- a/include/alpaka/queue/Traits.hpp
+++ b/include/alpaka/queue/Traits.hpp
@@ -15,9 +15,16 @@ namespace alpaka
 {
     struct ConceptQueue;
 
+    namespace concepts
+    {
+        template<typename TQueue>
+        concept Queue
+            = requires { requires interface::ImplementsInterface<ConceptQueue, std::decay_t<TQueue>>::value; };
+    } // namespace concepts
+
     //! True if TQueue is a queue, i.e. if it implements the ConceptQueue concept.
     template<typename TQueue>
-    inline constexpr bool isQueue = interface::ImplementsInterface<ConceptQueue, std::decay_t<TQueue>>::value;
+    [[deprecated("use the alpaka::concepts::Queue instead.")]] inline constexpr bool isQueue = concepts::Queue<TQueue>;
 
     //! The queue traits.
     namespace trait

--- a/test/unit/dev/src/DevWarpSizeTest.cpp
+++ b/test/unit/dev/src/DevWarpSizeTest.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2024 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan, Andrea Bocci
+/* Copyright 2026 Sergei Bastrakov, Bernhard Manfred Gruber, Jan Stephan, Andrea Bocci, Simone Balducci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -30,9 +30,9 @@ TEMPLATE_LIST_TEST_CASE("getPreferredWarpSize", "[dev]", alpaka::test::TestAccs)
     REQUIRE(preferredWarpSize > 0);
 }
 
-TEMPLATE_LIST_TEST_CASE("isDevice", "[dev]", alpaka::test::TestAccs)
+TEMPLATE_LIST_TEST_CASE("concepts::Device", "[dev]", alpaka::test::TestAccs)
 {
     auto const platform = alpaka::Platform<TestType>{};
     auto const dev = alpaka::getDevByIdx(platform, 0);
-    REQUIRE(alpaka::isDevice<decltype(dev)>);
+    REQUIRE(alpaka::concepts::Device<decltype(dev)>);
 }

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 Axel Hübl, Benjamin Worpitz, Bernhard Manfred Gruber, Jan Stephan
+/* Copyright 2026 Axel Hübl, Benjamin Worpitz, Bernhard Manfred Gruber, Jan Stephan, Simone Balducci
  * SPDX-License-Identifier: MPL-2.0
  */
 
@@ -289,13 +289,13 @@ TEMPLATE_LIST_TEST_CASE("enqueueBenchmark", "[queue]", alpaka::test::TestQueues)
     };
 }
 
-TEMPLATE_LIST_TEST_CASE("isQueue", "[queue]", alpaka::test::TestQueues)
+TEMPLATE_LIST_TEST_CASE("concepts::Queue", "[queue]", alpaka::test::TestQueues)
 {
     using DevQueue = TestType;
     using Fixture = alpaka::test::QueueTestFixture<DevQueue>;
     Fixture f;
 
-    REQUIRE(alpaka::isQueue<decltype(f.m_queue)>);
+    REQUIRE(alpaka::concepts::Queue<decltype(f.m_queue)>);
 }
 
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) || defined(ALPAKA_ACC_GPU_HIP_ENABLED)


### PR DESCRIPTION
This PR adds concepts for `Device`, `Queue` and `Platform`, marking the pre-existing traits as deprecated.
It also moves the `View` concept to the public interface.