### PR TITLE
Simplify the use of `alpaka::concepts` namespace

### DIFF
--- a/include/alpaka/algo/Transform.hpp
+++ b/include/alpaka/algo/Transform.hpp
@@ -102,7 +102,7 @@ namespace alpaka
      * and stores the result in the semi-open output range [`out_begin`,`out_end`), using the accelerator
      * back-end identified by `Tag`.
      */
-    template<alpaka::concepts::Tag TTag, typename TQueue, typename T, typename TFn>
+    template<concepts::Tag TTag, typename TQueue, typename T, typename TFn>
     void transform(TQueue& queue, T* out_begin, T* out_end, TFn&& fn, T* in)
     {
         using Idx = typename std::iterator_traits<T*>::difference_type;
@@ -130,7 +130,7 @@ namespace alpaka
      * and stores the result in the corresponding elements of the output buffer `out`,
      * using the accelerator back-end identified by `Tag`.
      */
-    template<alpaka::concepts::Tag TTag, typename TQueue, typename TBuf, typename TFn, typename TConstBuf>
+    template<concepts::Tag TTag, typename TQueue, typename TBuf, typename TFn, typename TConstBuf>
     void transform(TQueue& queue, TBuf& out, TFn&& fn, TConstBuf const& in)
     {
         // Check that the input and output buffers have compatible types.

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -435,7 +435,7 @@ namespace alpaka
     namespace concepts
     {
         template<typename T>
-        concept DeviceProvider = alpaka::concepts::Device<T> || alpaka::concepts::Queue<T>;
+        concept DeviceProvider = Device<T> || Queue<T>;
     } // namespace concepts
 
     namespace detail
@@ -515,7 +515,7 @@ namespace alpaka
         template<typename TDeviceProvider>
         auto getDeviceFromProvider(TDeviceProvider const& provider)
         {
-            if constexpr(alpaka::concepts::Device<TDeviceProvider>)
+            if constexpr(concepts::Device<TDeviceProvider>)
             {
                 return provider;
             }

--- a/include/alpaka/mem/view/ViewAccessOps.hpp
+++ b/include/alpaka/mem/view/ViewAccessOps.hpp
@@ -42,7 +42,7 @@ namespace alpaka::concepts
 namespace alpaka::internal
 {
 
-    template<alpaka::concepts::View TView>
+    template<concepts::View TView>
     struct BaseViewAccessor
     {
     private:
@@ -137,10 +137,10 @@ namespace alpaka::internal
 #endif
     };
 
-    template<alpaka::concepts::View TView>
+    template<concepts::View TView>
     using DeviceViewAccessor = BaseViewAccessor<TView>;
 
-    template<alpaka::concepts::View TView>
+    template<concepts::View TView>
     struct HostViewAccessor : BaseViewAccessor<TView>
     {
     private:


### PR DESCRIPTION
The code base uses just `concepts` most of the time, except for a few cases that used explicitly `alpaka::concepts`.
Simplify those to use just `concepts`, or no namespace at all if already inside the `alpaka::concepts` namespace.